### PR TITLE
items can be null in getWidgetRenderState

### DIFF
--- a/packages/instantsearch.js/src/connectors/menu/connectMenu.ts
+++ b/packages/instantsearch.js/src/connectors/menu/connectMenu.ts
@@ -316,7 +316,7 @@ const connectMenu: MenuConnector = function connectMenu(
           createURL: _createURL,
           refine: _refine,
           sendEvent,
-          canRefine: items.length > 0,
+          canRefine: items ? (items.length > 0) : false,
           widgetParams,
           isShowingMore,
           toggleShowMore: cachedToggleShowMore,


### PR DESCRIPTION
I've installed your latest Magento module and found that in certain situations (which I could not clearly identify), this variable items can be null, causing an exception when trying to filter on a sub category.

When checking the nullity of this variable as I've done in the PR, the issue is fixed.

Here is a screenshot of the JS error when trying to filter "Lave-linge" at this url https://www.gacd.fr/amenagement/cuisine-electromenager/gros-electromenager.html

(I will fix this issue by patching in some way so the error won't be visible for long)

![image](https://user-images.githubusercontent.com/5746666/208957952-91660c4f-0f1d-4971-854b-56e3fbeaaf81.png)

