### PR TITLE
chore(examples): correct peer dependencies

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,6 @@ const clean = (x) => x.filter(Boolean);
 
 module.exports = (api) => {
   const isTest = api.env('test');
-  const isWebpack = api.env('webpack');
   const modules = isTest || isCJS ? 'commonjs' : false;
   const targets = {};
 
@@ -27,7 +26,8 @@ module.exports = (api) => {
 
   const buildPlugins = clean([
     '@babel/plugin-proposal-class-properties',
-    !isWebpack && '@babel/plugin-transform-react-constant-elements',
+    (isCJS || isES || isUMD || isRollup) &&
+      '@babel/plugin-transform-react-constant-elements',
     'babel-plugin-transform-react-pure-class-to-function',
     wrapWarningWithDevCheck,
     isRollup && 'babel-plugin-transform-react-remove-prop-types',

--- a/examples/js/e-commerce/package.json
+++ b/examples/js/e-commerce/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.15.5",
+    "@parcel/core": "2.8.0",
     "@parcel/packager-raw-url": "2.8.0",
     "@parcel/transformer-webmanifest": "2.8.0",
     "parcel": "2.8.0"

--- a/examples/js/media/package.json
+++ b/examples/js/media/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.15.5",
+    "@parcel/core": "2.8.0",
     "@parcel/packager-raw-url": "2.8.0",
     "@parcel/transformer-webmanifest": "2.8.0",
     "parcel": "2.8.0"

--- a/examples/js/tourism/package.json
+++ b/examples/js/tourism/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.15.5",
+    "@parcel/core": "2.8.0",
     "@parcel/packager-raw-url": "2.8.0",
     "@parcel/transformer-webmanifest": "2.8.0",
     "parcel": "2.8.0"

--- a/examples/react-hooks/default-theme/package.json
+++ b/examples/react-hooks/default-theme/package.json
@@ -14,6 +14,9 @@
     "react-instantsearch-hooks-web": "6.38.1"
   },
   "devDependencies": {
+    "@parcel/core": "2.8.0",
+    "@parcel/packager-raw-url": "2.8.0",
+    "@parcel/transformer-webmanifest": "2.8.0",
     "parcel": "2.8.0"
   }
 }

--- a/examples/react-hooks/e-commerce/package.json
+++ b/examples/react-hooks/e-commerce/package.json
@@ -17,6 +17,7 @@
     "react-instantsearch-hooks-web": "6.38.1"
   },
   "devDependencies": {
+    "@parcel/core": "2.8.0",
     "@parcel/packager-raw-url": "2.8.0",
     "@parcel/transformer-webmanifest": "2.8.0",
     "parcel": "2.8.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@babel/preset-typescript": "7.15.0",
     "@googlemaps/jest-mocks": "2.7.5",
     "@microsoft/api-extractor": "7.18.0",
-    "@parcel/transformer-webmanifest": "2.8.0",
     "@storybook/addon-a11y": "5.3.9",
     "@storybook/addon-actions": "5.3.9",
     "@storybook/addon-knobs": "5.3.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30634,7 +30634,7 @@ regenerate@^1.4.2:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
-  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
+  integrity sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
Small changes in examples:

- babel file will skip the constant elements transform in both webpack and parcel (both behave wrong)
- correct peer dependencies for parcel deps