### PR TITLE
fix(vue-instantsearch): compute initial state from helper instead of results

### DIFF
--- a/examples/vue/nuxt/package.json
+++ b/examples/vue/nuxt/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "algoliasearch": "4.14.3",
     "cross-env": "^5.2.0",
+    "css-loader": "^4.3.0",
     "nuxt": "^2.4.5",
     "vue-instantsearch": "4.7.0",
     "vue-server-renderer": "2.7.14"

--- a/packages/vue-instantsearch/src/util/createServerRootMixin.js
+++ b/packages/vue-instantsearch/src/util/createServerRootMixin.js
@@ -137,16 +137,17 @@ function augmentInstantSearch(instantSearchOptions, cloneComponent) {
       .then(() => {
         initialResults = {};
         walkIndex(instance.mainIndex, (widget) => {
-          const { _state, _rawResults } = widget.getResults();
-
           initialResults[widget.getIndexId()] = {
             // copy just the values of SearchParameters, not the functions
-            state: Object.keys(_state).reduce((acc, key) => {
-              // eslint-disable-next-line no-param-reassign
-              acc[key] = _state[key];
-              return acc;
-            }, {}),
-            results: _rawResults,
+            state: Object.entries(widget.getHelper().state).reduce(
+              (acc, [key, value]) => {
+                // eslint-disable-next-line no-param-reassign
+                acc[key] = value;
+                return acc;
+              },
+              {}
+            ),
+            results: widget.getResults()._rawResults,
           };
         });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Currently, for SSR, we compute `initialResults` on the server using the helper results. This is used for initial rendering as well as for hydration. Because nested indices inherit from their parent, they are set with a merged state which prevent correct inheritance behavior later on, when interacting with InstantSearch client-side.

This PR instead relies on the index's helper "request" state, which isn't merged and allows expected behavior.

[CR-2516](https://algolia.atlassian.net/browse/CR-2516)
fixes https://github.com/algolia/instantsearch/issues/5383