### PR TITLE
fix(getServerState): correctly forward asynchronous errors

### DIFF
--- a/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
@@ -129,13 +129,33 @@ describe('getServerState', () => {
     );
   });
 
-  test('throws when the search client errors', async () => {
+  test('throws when the search client errors, async', async () => {
+    const searchClient = createSearchClient({
+      // Function is async to match the real search client.
+      // a synchronous error would be caught by the derived helper, async by InstantSearch.
+      // eslint-disable-next-line require-await
+      search: async () => {
+        throw new Error('Search client error');
+      },
+    });
+    const { App } = createTestEnvironment({
+      searchClient,
+    });
+
+    await expect(getServerState(<App />)).rejects.toThrow(
+      /Search client error/
+    );
+  });
+
+  test('throws when the search client errors, sync', async () => {
     const searchClient = createSearchClient({
       search: () => {
         throw new Error('Search client error');
       },
     });
-    const { App } = createTestEnvironment({ searchClient });
+    const { App } = createTestEnvironment({
+      searchClient,
+    });
 
     await expect(getServerState(<App />)).rejects.toThrow(
       /Search client error/

--- a/packages/react-instantsearch-hooks-server/src/getServerState.tsx
+++ b/packages/react-instantsearch-hooks-server/src/getServerState.tsx
@@ -142,6 +142,8 @@ function waitForResults(search: InstantSearch) {
 
     // However, we listen to errors that can happen on any derived helper because
     // any error is critical.
+    helper.on('error', (error) => reject(error));
+    search.on('error', (error) => reject(error));
     helper.derivedHelpers.forEach((derivedHelper) =>
       derivedHelper.on('error', (error) => {
         reject(error);


### PR DESCRIPTION



<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

What happens is that a synchronous error (as we had in the test, but not really in real life) gets caught by the derived helper as it happens before the response, but an async (regular) error happens in the response parsing, and thus before the derived helper even receives the result.

It gets rethrown by InstantSearch, but we also catch the errors in the main helper, just in case there's another case not covered here.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

fixes https://github.com/algolia/instantsearch/issues/5233

Any type of error in the flow of getServerState rejects the promise, allowing people to handle the error as they want.

In a future iteration we may consider catching the errors there to let the client gracefully correct, but for now that's not yet required.