### PR TITLE
fix(url): add widgets early always (WIP)

### DIFF
--- a/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
@@ -4,7 +4,6 @@ import { dequal } from '../lib/dequal';
 import { getIndexSearchResults } from '../lib/getIndexSearchResults';
 import { useIndexContext } from '../lib/useIndexContext';
 import { useInstantSearchContext } from '../lib/useInstantSearchContext';
-import { useInstantSearchServerContext } from '../lib/useInstantSearchServerContext';
 import { useStableValue } from '../lib/useStableValue';
 import { useWidget } from '../lib/useWidget';
 
@@ -25,7 +24,6 @@ export function useConnector<
   props: TProps = {} as TProps,
   additionalWidgetProperties: AdditionalWidgetProperties = {}
 ): TDescription['renderState'] {
-  const serverContext = useInstantSearchServerContext();
   const search = useInstantSearchContext();
   const parentIndex = useIndexContext();
   const stableProps = useStableValue(props);

--- a/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
@@ -136,7 +136,7 @@ export function useConnector<
     widget,
     parentIndex,
     props: stableProps,
-    shouldSsr: Boolean(serverContext),
+    shouldSsr: true,
   });
 
   return state;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

see: https://github.com/algolia/instantsearch/issues/5236

This should fix it in theory, although i can only reproduce this in real-life situations so far. Tests aren't yet adjusted.

As shouldSsr is set to true in connectors, it probably also be set to true in useConnector, and therefore probably just set to true always. It is slightly more expensive as the widget is checked in the list first.

sandbox showing this: https://codesandbox.io/s/silly-sanne-8q6tqt

TO DO:

- [ ] check whether this is the correct solution
- [ ] update tests
- [ ] consider whether shouldSsr should be true on useIndex
- [ ] consider whether shouldSsr logic is needed
- [ ] consider whether "widget already added" logic is needed

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

As widgets get added before the createURL for example is calculated, this means all widgets are already added when anything is rendered.
