### PR TITLE
ci: run e2e job on bigger environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,7 @@ jobs:
 
   e2e tests:
     <<: *defaults
+    resource_class: large
     steps:
       - checkout
       - *attach_workspace


### PR DESCRIPTION
This PR uses a larger docker environment to run the e2e tests job. While it still takes a while to run (which could be attributed in part to our saucelabs opensource plan), the tests seem to run more reliably (no retries) and the CPU usage doesn't hit 100%.