### PR TITLE
ci: use environment variables from context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ workflows:
   version: 2
   ci:
     jobs:
-      - build
+      - build:
+          context: fx-libraries
       - test metadata
       - lint:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,11 @@ workflows:
           requires:
             - build
       - e2e tests:
+          context: fx-libraries
           requires:
             - examples
       - release if needed:
+          context: fx-libraries
           requires:
             - build
             - lint
@@ -77,7 +79,8 @@ workflows:
               only:
                 - master
     jobs:
-      - prepare release
+      - prepare release:
+          context: fx-libraries
 
 jobs:
   build:


### PR DESCRIPTION
This PR updates the CircleCI config file so that jobs retrieve relevant environment variables from context. Doing this will allow us to use the same tokens in similar projects.