### PR TITLE
ci(release): publish only tags that have changed

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -5,13 +5,18 @@ const packages = JSON.parse(
     silent: true,
   })
 );
+const changedPackages = JSON.parse(
+  shell.exec('yarn run --silent lerna list --toposort --json', {
+    silent: true,
+  })
+);
 
 module.exports = {
   shouldPrepare: () => {
     return true;
   },
   getTagName: () =>
-    packages.map((package) => `${package.name}@${package.version}`),
+    changedPackages.map((package) => `${package.name}@${package.version}`),
   getStagingBranchName: () => `chore/release-${Date.now()}`,
   version({ exec }) {
     exec(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

As we don't publish everything anymore (since tags now get annotated https://github.com/algolia/instantsearch/pull/5420), we need to ensure we only try to tag what is taggable.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

no failure in CI on release task, as only packages that have changed (same as `lerna version`) will be tagged.