### PR TITLE
feat(react-instantsearch-hooks): Add useStats hook

### DIFF
--- a/packages/react-instantsearch-hooks/src/connectors/__tests__/useStats.test.tsx
+++ b/packages/react-instantsearch-hooks/src/connectors/__tests__/useStats.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { createInstantSearchTestWrapper } from '../../../../../tests/utils';
+import { useStats } from '../useStats';
+
+describe('useMenu', () => {
+  test('returns the connector render state', async () => {
+    const wrapper = createInstantSearchTestWrapper();
+    const { result, waitForNextUpdate } = renderHook(() => useStats(), {
+      wrapper,
+    });
+
+    // Initial render state from manual `getWidgetRenderState`
+    expect(result.current).toEqual({
+      canRefine: false,
+      canToggleShowMore: false,
+      createURL: expect.any(Function),
+      isShowingMore: false,
+      items: [],
+      refine: expect.any(Function),
+      sendEvent: expect.any(Function),
+      toggleShowMore: expect.any(Function),
+    });
+
+    await waitForNextUpdate();
+
+    // InstantSearch.js state from the `render` lifecycle step
+    expect(result.current).toEqual({
+      canRefine: false,
+      canToggleShowMore: false,
+      createURL: expect.any(Function),
+      isShowingMore: false,
+      items: [],
+      refine: expect.any(Function),
+      sendEvent: expect.any(Function),
+      toggleShowMore: expect.any(Function),
+    });
+  });
+});

--- a/packages/react-instantsearch-hooks/src/connectors/__tests__/useStats.test.tsx
+++ b/packages/react-instantsearch-hooks/src/connectors/__tests__/useStats.test.tsx
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { createInstantSearchTestWrapper } from '../../../../../tests/utils';
 import { useStats } from '../useStats';
 
-describe('useMenu', () => {
+describe('useStats', () => {
   test('returns the connector render state', async () => {
     const wrapper = createInstantSearchTestWrapper();
     const { result, waitForNextUpdate } = renderHook(() => useStats(), {
@@ -12,28 +12,28 @@ describe('useMenu', () => {
 
     // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
-      canRefine: false,
-      canToggleShowMore: false,
-      createURL: expect.any(Function),
-      isShowingMore: false,
-      items: [],
-      refine: expect.any(Function),
-      sendEvent: expect.any(Function),
-      toggleShowMore: expect.any(Function),
+      areHitsSorted: false,
+      hitsPerPage: 20,
+      nbHits: 0,
+      nbPages: 0,
+      nbSortedHits: undefined,
+      page: 0,
+      processingTimeMS: 0,
+      query: '',
     });
 
     await waitForNextUpdate();
 
     // InstantSearch.js state from the `render` lifecycle step
     expect(result.current).toEqual({
-      canRefine: false,
-      canToggleShowMore: false,
-      createURL: expect.any(Function),
-      isShowingMore: false,
-      items: [],
-      refine: expect.any(Function),
-      sendEvent: expect.any(Function),
-      toggleShowMore: expect.any(Function),
+      areHitsSorted: false,
+      hitsPerPage: 20,
+      nbHits: 0,
+      nbPages: 0,
+      nbSortedHits: undefined,
+      page: 0,
+      processingTimeMS: 0,
+      query: '',
     });
   });
 });

--- a/packages/react-instantsearch-hooks/src/connectors/useStats.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useStats.ts
@@ -1,12 +1,12 @@
+import connectStats from 'instantsearch.js/es/connectors/stats/connectStats';
+
+import { useConnector } from '../hooks/useConnector';
+
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
 import type {
   StatsConnectorParams,
   StatsWidgetDescription,
 } from 'instantsearch.js/es/connectors/stats/connectStats';
-import connectStats from 'instantsearch.js/es/connectors/stats/connectStats';
-import {
-  AdditionalWidgetProperties,
-  useConnector,
-} from '../hooks/useConnector';
 
 export type UseStatsProps = StatsConnectorParams;
 

--- a/packages/react-instantsearch-hooks/src/connectors/useStats.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useStats.ts
@@ -1,0 +1,22 @@
+import type {
+  StatsConnectorParams,
+  StatsWidgetDescription,
+} from 'instantsearch.js/es/connectors/stats/connectStats';
+import connectStats from 'instantsearch.js/es/connectors/stats/connectStats';
+import {
+  AdditionalWidgetProperties,
+  useConnector,
+} from '../hooks/useConnector';
+
+export type UseStatsProps = StatsConnectorParams;
+
+export function useStats(
+  props?: UseStatsProps,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
+  return useConnector<StatsConnectorParams, StatsWidgetDescription>(
+    connectStats,
+    props,
+    additionalWidgetProperties
+  );
+}


### PR DESCRIPTION
**Summary**

Add a hook for `useStats` to `react-instantsearch-hooks`.

The goal is to be able to use use this hook to provide a widget, as well as replace the 'not implemented' documentation: https://www.algolia.com/doc/api-reference/widgets/stats/react-hooks/#about

**Result**

Review added test for basic functionality / expectation.

**Next Steps**
- Add a widget to `react-instantsearch-hooks`
- Update examples
- Update documentation
