### PR TITLE
feat(rendering): revert search state on error

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common.test.tsx
@@ -18,6 +18,12 @@ createHierarchicalMenuTests(({ instantSearchOptions, widgetParams }) => {
         ...widgetParams,
       }),
     ])
+    .on('error', () => {
+      /*
+       * prevent rethrowing InstantSearch errors, so tests can be asserted.
+       * IRL this isn't needed, as the error doesn't stop execution.
+       */
+    })
     .start();
 });
 
@@ -29,6 +35,12 @@ createRefinementListTests(({ instantSearchOptions, widgetParams }) => {
         ...widgetParams,
       }),
     ])
+    .on('error', () => {
+      /*
+       * prevent rethrowing InstantSearch errors, so tests can be asserted.
+       * IRL this isn't needed, as the error doesn't stop execution.
+       */
+    })
     .start();
 });
 
@@ -40,6 +52,12 @@ createMenuTests(({ instantSearchOptions, widgetParams }) => {
         ...widgetParams,
       }),
     ])
+    .on('error', () => {
+      /*
+       * prevent rethrowing InstantSearch errors, so tests can be asserted.
+       * IRL this isn't needed, as the error doesn't stop execution.
+       */
+    })
     .start();
 });
 
@@ -51,5 +69,11 @@ createPaginationTests(({ instantSearchOptions, widgetParams }) => {
         ...widgetParams,
       }),
     ])
+    .on('error', () => {
+      /*
+       * prevent rethrowing InstantSearch errors, so tests can be asserted.
+       * IRL this isn't needed, as the error doesn't stop execution.
+       */
+    })
     .start();
 });

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -212,6 +212,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
   let localParent: IndexWidget | null = null;
   let helper: Helper | null = null;
   let derivedHelper: DerivedHelper | null = null;
+  let lastValidSearchParameters: SearchParameters | null = null;
 
   return {
     $$type: 'ais.index',
@@ -512,6 +513,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         // does not have access to lastResults, which it used to in pre-federated
         // search behavior.
         helper!.lastResults = results;
+        lastValidSearchParameters = results._state;
       });
 
       // We compute the render state before calling `init` in a separate loop
@@ -583,6 +585,15 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
     render({ instantSearchInstance }: IndexRenderOptions) {
       if (!this.getResults()) {
         return;
+      }
+
+      // we can't attach a listener to the error event of search, as the error
+      // then would no longer be thrown for global handlers.
+      if (
+        instantSearchInstance.status === 'error' &&
+        !instantSearchInstance.mainHelper!.hasPendingRequests()
+      ) {
+        helper!.setState(lastValidSearchParameters!);
       }
 
       localWidgets.forEach((widget) => {

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common.test.tsx
@@ -16,12 +16,24 @@ import {
   HierarchicalMenu,
   Menu,
   Pagination,
+  useInstantSearch,
 } from '..';
+
+/**
+ * prevent rethrowing InstantSearch errors, so tests can be asserted.
+ * IRL this isn't needed, as the error doesn't stop execution.
+ */
+function GlobalErrorSwallower() {
+  useInstantSearch({ catchError: true });
+
+  return null;
+}
 
 createRefinementListTests(({ instantSearchOptions, widgetParams }) => {
   render(
     <InstantSearch {...instantSearchOptions}>
       <RefinementList {...widgetParams} />
+      <GlobalErrorSwallower />
     </InstantSearch>
   );
 }, act);
@@ -30,6 +42,7 @@ createHierarchicalMenuTests(({ instantSearchOptions, widgetParams }) => {
   render(
     <InstantSearch {...instantSearchOptions}>
       <HierarchicalMenu {...widgetParams} />
+      <GlobalErrorSwallower />
     </InstantSearch>
   );
 }, act);
@@ -38,6 +51,7 @@ createMenuTests(({ instantSearchOptions, widgetParams }) => {
   render(
     <InstantSearch {...instantSearchOptions}>
       <Menu {...widgetParams} />
+      <GlobalErrorSwallower />
     </InstantSearch>
   );
 }, act);
@@ -46,6 +60,7 @@ createPaginationTests(({ instantSearchOptions, widgetParams }) => {
   render(
     <InstantSearch {...instantSearchOptions}>
       <Pagination {...widgetParams} />
+      <GlobalErrorSwallower />
     </InstantSearch>
   );
 }, act);

--- a/packages/vue-instantsearch/src/__tests__/common.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common.test.js
@@ -16,8 +16,23 @@ import {
   AisHierarchicalMenu,
   AisMenu,
   AisPagination,
+  createWidgetMixin,
 } from '../instantsearch';
 jest.unmock('instantsearch.js/es');
+
+/**
+ * prevent rethrowing InstantSearch errors, so tests can be asserted.
+ * IRL this isn't needed, as the error doesn't stop execution.
+ */
+const GlobalErrorSwallower = {
+  mixins: [createWidgetMixin({ connector: true })],
+  mounted() {
+    this.instantSearchInstance.on('error', () => {});
+  },
+  render() {
+    return null;
+  },
+};
 
 createRefinementListTests(async ({ instantSearchOptions, widgetParams }) => {
   mountApp(
@@ -25,6 +40,7 @@ createRefinementListTests(async ({ instantSearchOptions, widgetParams }) => {
       render: renderCompat((h) =>
         h(AisInstantSearch, { props: instantSearchOptions }, [
           h(AisRefinementList, { props: widgetParams }),
+          h(GlobalErrorSwallower),
         ])
       ),
     },
@@ -40,6 +56,7 @@ createHierarchicalMenuTests(async ({ instantSearchOptions, widgetParams }) => {
       render: renderCompat((h) =>
         h(AisInstantSearch, { props: instantSearchOptions }, [
           h(AisHierarchicalMenu, { props: widgetParams }),
+          h(GlobalErrorSwallower),
         ])
       ),
     },
@@ -55,6 +72,7 @@ createMenuTests(async ({ instantSearchOptions, widgetParams }) => {
       render: renderCompat((h) =>
         h(AisInstantSearch, { props: instantSearchOptions }, [
           h(AisMenu, { props: widgetParams }),
+          h(GlobalErrorSwallower),
         ])
       ),
     },
@@ -70,6 +88,7 @@ createPaginationTests(async ({ instantSearchOptions, widgetParams }) => {
       render: renderCompat((h) =>
         h(AisInstantSearch, { props: instantSearchOptions }, [
           h(AisPagination, { props: widgetParams }),
+          h(GlobalErrorSwallower),
         ])
       ),
     },

--- a/tests/common/widgets/menu/optimistic-ui.ts
+++ b/tests/common/widgets/menu/optimistic-ui.ts
@@ -68,14 +68,21 @@ export function createOptimisticUiTests(setup: MenuSetup, act: Act) {
         });
 
         // UI has changed immediately after the user interaction
-        // @TODO: menu doesn't have any accessible way to determine if an item is selected, so we use the class name (https://github.com/algolia/instantsearch/issues/5187)
         expect(
           document.querySelectorAll('.ais-Menu-item--selected')
         ).toHaveLength(1);
+        // @TODO: menu doesn't have any accessible way to determine if an item is selected, so we use the class name (https://github.com/algolia/instantsearch/issues/5187)
+        expect(document.querySelector('.ais-Menu-item--selected a')).toEqual(
+          firstItem
+        );
       }
 
       // Wait for new results to come in
       {
+        const firstItem = screen.getByRole('link', {
+          name: 'Apple 200',
+        });
+
         await act(async () => {
           await wait(delay + margin);
         });
@@ -83,6 +90,9 @@ export function createOptimisticUiTests(setup: MenuSetup, act: Act) {
         expect(
           document.querySelectorAll('.ais-Menu-item--selected')
         ).toHaveLength(1);
+        expect(document.querySelector('.ais-Menu-item--selected a')).toEqual(
+          firstItem
+        );
       }
 
       // Unselect the refinement
@@ -113,6 +123,134 @@ export function createOptimisticUiTests(setup: MenuSetup, act: Act) {
         expect(
           document.querySelectorAll('.ais-Menu-item--selected')
         ).toHaveLength(0);
+      }
+    });
+
+    test('reverts back to previous state on error', async () => {
+      const delay = 100;
+      const margin = 10;
+      const attribute = 'brand';
+      let errors = false;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              if (errors) {
+                throw new Error('Network error!');
+              }
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attribute]: {
+                        Samsung: 100,
+                        Apple: 200,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attribute },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      // Initial state, before interaction
+      {
+        expect(document.querySelectorAll('.ais-Menu-item')).toHaveLength(2);
+        expect(
+          document.querySelectorAll('.ais-Menu-item--selected')
+        ).toHaveLength(0);
+      }
+
+      // start erroring
+      errors = true;
+
+      // Select a refinement
+      {
+        const firstItem = screen.getByRole('link', {
+          name: 'Apple 200',
+        });
+        await act(async () => {
+          firstItem.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has changed immediately after the user interaction
+        expect(
+          document.querySelectorAll('.ais-Menu-item--selected')
+        ).toHaveLength(1);
+        expect(document.querySelector('.ais-Menu-item--selected a')).toEqual(
+          firstItem
+        );
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+          await wait(0);
+        });
+
+        // refinement has reverted back to previous state
+        expect(
+          document.querySelectorAll('.ais-Menu-item--selected')
+        ).toHaveLength(0);
+      }
+
+      // stop erroring
+      errors = false;
+
+      // Select the refinement again
+      {
+        const firstItem = screen.getByRole('link', {
+          name: 'Apple 200',
+        });
+        await act(async () => {
+          firstItem.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has changed immediately after the user interaction
+        expect(
+          document.querySelectorAll('.ais-Menu-item--selected')
+        ).toHaveLength(1);
+        expect(document.querySelector('.ais-Menu-item--selected a')).toEqual(
+          firstItem
+        );
+      }
+
+      // Wait for new results to come in
+      {
+        const firstItem = screen.getByRole('link', {
+          name: 'Apple 200',
+        });
+
+        await act(async () => {
+          await wait(delay + margin);
+          await wait(0);
+        });
+
+        // refinement is consistent with clicks again
+        expect(
+          document.querySelectorAll('.ais-Menu-item--selected')
+        ).toHaveLength(1);
+        expect(document.querySelector('.ais-Menu-item--selected a')).toEqual(
+          firstItem
+        );
       }
     });
   });

--- a/tests/common/widgets/pagination/optimistic-ui.ts
+++ b/tests/common/widgets/pagination/optimistic-ui.ts
@@ -130,5 +130,134 @@ export function createOptimisticUiTests(setup: PaginationSetup, act: Act) {
         ).toHaveLength(1);
       }
     });
+
+    test('reverts back to previous state on error', async () => {
+      const delay = 100;
+      const margin = 10;
+      let errors = false;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              if (errors) {
+                throw new Error('Network error!');
+              }
+              return createMultiSearchResponse(
+                ...requests.map(({ params }) =>
+                  createSingleSearchResponse({
+                    page: params!.page,
+                    nbPages: 20,
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      // Initial state, before interaction
+      {
+        const firstPrev = 2;
+        const nextLast = 2;
+        const current = 1;
+        const padding = 2 * 3;
+        expect(document.querySelectorAll('.ais-Pagination-item')).toHaveLength(
+          firstPrev + current + padding + nextLast
+        );
+        expect(
+          document.querySelectorAll('.ais-Pagination-item--selected')
+        ).toHaveLength(1);
+        expect(
+          document.querySelector('.ais-Pagination-item--selected')
+        ).toHaveTextContent('1');
+      }
+
+      // start erroring
+      errors = true;
+
+      // Select a refinement
+      {
+        const secondPage = screen.getByRole('link', { name: 'Page 2' });
+        await act(async () => {
+          secondPage.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has changed immediately after the user interaction
+        expect(secondPage.parentNode).toHaveClass(
+          'ais-Pagination-item--selected'
+        );
+        expect(
+          document.querySelectorAll('.ais-Pagination-item--selected')
+        ).toHaveLength(1);
+      }
+
+      // Wait for new results to come in
+      {
+        // refinement has reverted back to previous state
+        const firstPage = screen.getByRole('link', { name: 'Page 1' });
+
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(firstPage.parentNode).toHaveClass(
+          'ais-Pagination-item--selected'
+        );
+        expect(
+          document.querySelectorAll('.ais-Pagination-item--selected')
+        ).toHaveLength(1);
+      }
+
+      // stop erroring
+      errors = false;
+
+      // Select a refinement
+      {
+        const secondPage = screen.getByRole('link', { name: 'Page 2' });
+        await act(async () => {
+          secondPage.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has changed immediately after the user interaction
+        expect(secondPage.parentNode).toHaveClass(
+          'ais-Pagination-item--selected'
+        );
+        expect(
+          document.querySelectorAll('.ais-Pagination-item--selected')
+        ).toHaveLength(1);
+      }
+
+      // Wait for new results to come in
+      {
+        // refinement is consistent with clicks again
+        const secondPage = screen.getByRole('link', { name: 'Page 2' });
+
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(secondPage.parentNode).toHaveClass(
+          'ais-Pagination-item--selected'
+        );
+        expect(
+          document.querySelectorAll('.ais-Pagination-item--selected')
+        ).toHaveLength(1);
+      }
+    });
   });
 }

--- a/tests/common/widgets/refinement-list/optimistic-ui.ts
+++ b/tests/common/widgets/refinement-list/optimistic-ui.ts
@@ -125,5 +125,134 @@ export function createOptimisticUiTests(setup: RefinementListSetup, act: Act) {
         ).toHaveLength(0);
       }
     });
+
+    test('reverts back to previous state on error', async () => {
+      const delay = 100;
+      const margin = 10;
+      const attribute = 'brand';
+      let errors = false;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              if (errors) {
+                throw new Error('Network error!');
+              }
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attribute]: {
+                        Samsung: 100,
+                        Apple: 200,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attribute },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      // Initial state, before interaction
+      {
+        expect(
+          document.querySelectorAll('.ais-RefinementList-item')
+        ).toHaveLength(2);
+        expect(
+          document.querySelectorAll('.ais-RefinementList-item--selected')
+        ).toHaveLength(0);
+      }
+
+      // start erroring
+      errors = true;
+
+      // Select a refinement
+      {
+        const firstItem = screen.getByRole('checkbox', {
+          name: 'Apple 200',
+        });
+        await act(async () => {
+          firstItem.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has changed immediately after the user interaction
+        expect(firstItem).toBeChecked();
+        expect(
+          document.querySelectorAll('.ais-RefinementList-item--selected')
+        ).toHaveLength(1);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+          await wait(0);
+        });
+
+        const firstItem = screen.getByRole('checkbox', {
+          name: 'Apple 200',
+        });
+
+        // refinement has reverted back to previous state
+        expect(firstItem).not.toBeChecked();
+        expect(
+          document.querySelectorAll('.ais-RefinementList-item--selected')
+        ).toHaveLength(0);
+      }
+
+      // stop erroring
+      errors = false;
+
+      // Select the refinement again
+      {
+        const firstItem = screen.getByRole('checkbox', {
+          name: 'Apple 200',
+        });
+        await act(async () => {
+          firstItem.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has changed immediately after the user interaction
+        expect(firstItem).toBeChecked();
+        expect(
+          document.querySelectorAll('.ais-RefinementList-item--selected')
+        ).toHaveLength(1);
+      }
+
+      // Wait for new results to come in
+      {
+        // refinement is consistent with clicks again
+        const firstItem = screen.getByRole('checkbox', {
+          name: 'Apple 200',
+        });
+
+        await act(async () => {
+          await wait(delay + margin);
+          await wait(0);
+        });
+
+        expect(firstItem).toBeChecked();
+        expect(
+          document.querySelectorAll('.ais-RefinementList-item--selected')
+        ).toHaveLength(1);
+      }
+    });
   });
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

going a step further than #5429, we want to also when there's an error revert to the last known good state.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

This goes back to the previous (non-optimistic) behaviour when an error happens, with a caveat that the state will be fully consistent. That means UiState and the URL also update back to the previous state