### PR TITLE
fix(bindEvent): skip view event if search isn't stable

### DIFF
--- a/packages/instantsearch.js/src/connectors/hits/connectHits.ts
+++ b/packages/instantsearch.js/src/connectors/hits/connectHits.ts
@@ -136,6 +136,7 @@ const connectHits: HitsConnector = function connectHits(
           bindEvent = createBindEventForHits({
             index: helper.getIndex(),
             widgetType: this.$$type,
+            instantSearchInstance,
           });
         }
 

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -308,6 +308,7 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
           bindEvent = createBindEventForHits({
             index: helper.getIndex(),
             widgetType: this.$$type,
+            instantSearchInstance,
           });
           isFirstPage =
             state.page === undefined ||

--- a/packages/instantsearch.js/src/lib/utils/__tests__/createSendEventForHits-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/createSendEventForHits-test.ts
@@ -27,6 +27,7 @@ const createTestEnvironment = ({ nbHits = 2 }: { nbHits?: number } = {}) => {
   const bindEvent = createBindEventForHits({
     index,
     widgetType,
+    instantSearchInstance,
   });
   return {
     instantSearchInstance,
@@ -198,6 +199,26 @@ describe('createSendEventForHits', () => {
       },
       widgetType: 'ais.testWidget',
     });
+  });
+
+  it('skips view event when search is not idle', () => {
+    const { sendEvent, instantSearchInstance, hits } = createTestEnvironment();
+
+    instantSearchInstance.status = 'loading';
+    sendEvent('view', hits);
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledTimes(0);
+
+    instantSearchInstance.status = 'error';
+    sendEvent('view', hits);
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledTimes(0);
+
+    instantSearchInstance.status = 'stalled';
+    sendEvent('view', hits);
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledTimes(0);
+
+    instantSearchInstance.status = 'idle';
+    sendEvent('view', hits);
+    expect(instantSearchInstance.sendEventToInsights).toHaveBeenCalledTimes(1);
   });
 
   it('sends click event', () => {
@@ -389,6 +410,51 @@ describe('createBindEventForHits', () => {
     expect(payload.startsWith('data-insights-event=')).toBe(true);
     return deserializePayload(payload.substr('data-insights-event='.length));
   }
+
+  it('returns a payload for view event', () => {
+    const { bindEvent, hits } = createTestEnvironment();
+    const parsedPayload = parsePayload(bindEvent('view', hits));
+    expect(parsedPayload).toEqual([
+      {
+        eventType: 'view',
+        hits: [
+          {
+            __position: 0,
+            __queryID: 'test-query-id',
+            objectID: 'obj0',
+          },
+          {
+            __position: 1,
+            __queryID: 'test-query-id',
+            objectID: 'obj1',
+          },
+        ],
+        insightsMethod: 'viewedObjectIDs',
+        payload: {
+          eventName: 'Hits Viewed',
+          index: 'testIndex',
+          objectIDs: ['obj0', 'obj1'],
+        },
+        widgetType: 'ais.testWidget',
+      },
+    ]);
+  });
+
+  it('skips payload for view event when search is not idle', () => {
+    const { bindEvent, hits, instantSearchInstance } = createTestEnvironment();
+
+    instantSearchInstance.status = 'loading';
+    expect(bindEvent('view', hits)).toHaveLength(0);
+
+    instantSearchInstance.status = 'error';
+    expect(bindEvent('view', hits)).toHaveLength(0);
+
+    instantSearchInstance.status = 'stalled';
+    expect(bindEvent('view', hits)).toHaveLength(0);
+
+    instantSearchInstance.status = 'idle';
+    expect(bindEvent('view', hits)).not.toHaveLength(0);
+  });
 
   it('returns a payload for click event', () => {
     const { bindEvent, hits } = createTestEnvironment();

--- a/packages/instantsearch.js/src/lib/utils/createSendEventForHits.ts
+++ b/packages/instantsearch.js/src/lib/utils/createSendEventForHits.ts
@@ -31,13 +31,13 @@ const buildPayloads = ({
   widgetType,
   methodName,
   args,
-  invalidStatus,
+  instantSearchInstance,
 }: {
   widgetType: string;
   index: string;
   methodName: 'sendEvent' | 'bindEvent';
   args: any[];
-  invalidStatus: boolean;
+  instantSearchInstance: InstantSearch;
 }): InsightsEvent[] => {
   // when there's only one argument, that means it's custom
   if (args.length === 1 && typeof args[0] === 'object') {
@@ -87,7 +87,7 @@ const buildPayloads = ({
   );
 
   if (eventType === 'view') {
-    if (invalidStatus) {
+    if (instantSearchInstance.status !== 'idle') {
       return [];
     }
     return hitsChunks.map((batch, i) => {
@@ -163,7 +163,7 @@ export function createSendEventForHits({
       index,
       methodName: 'sendEvent',
       args,
-      invalidStatus: instantSearchInstance.status !== 'idle',
+      instantSearchInstance,
     });
 
     payloads.forEach((payload) =>
@@ -176,9 +176,11 @@ export function createSendEventForHits({
 export function createBindEventForHits({
   index,
   widgetType,
+  instantSearchInstance,
 }: {
   index: string;
   widgetType: string;
+  instantSearchInstance: InstantSearch;
 }): BindEventForHits {
   const bindEventForHits: BindEventForHits = (...args: any[]) => {
     const payloads = buildPayloads({
@@ -186,7 +188,7 @@ export function createBindEventForHits({
       index,
       methodName: 'bindEvent',
       args,
-      invalidStatus: false,
+      instantSearchInstance,
     });
 
     return payloads.length


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This cleans up the logic of sendEventForHits/bindEventForHits and always skips payload if search is not idle for both bindEvent and sendEvent (before this PR only sendEvent had this logic)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

bindEvent won't add keys to the dom when the search is currently not idle **for view events**, as you can't view something when it's not the initial view.
