### PR TITLE
docs(stories): remove bindEvent from examples

### DIFF
--- a/packages/instantsearch.js/src/types/templates.ts
+++ b/packages/instantsearch.js/src/types/templates.ts
@@ -24,6 +24,7 @@ export type TemplateParams = {
     Snippet: typeof Snippet;
     ReverseSnippet: typeof ReverseSnippet;
   };
+  sendEvent?: SendEventForHits;
 };
 
 interface TemplateWithBindEventParams extends TemplateParams {

--- a/packages/instantsearch.js/src/types/templates.ts
+++ b/packages/instantsearch.js/src/types/templates.ts
@@ -24,7 +24,6 @@ export type TemplateParams = {
     Snippet: typeof Snippet;
     ReverseSnippet: typeof ReverseSnippet;
   };
-  sendEvent?: SendEventForHits;
 };
 
 interface TemplateWithBindEventParams extends TemplateParams {

--- a/packages/instantsearch.js/stories/hits.stories.ts
+++ b/packages/instantsearch.js/stories/hits.stories.ts
@@ -209,10 +209,10 @@ storiesOf('Results/Hits', module)
           instantsearch.widgets.hits({
             container,
             templates: {
-              item: (item, bindEvent) => `
+              item: (item, { html, sendEvent }) => html`
                 <h4>${item.name}</h4>
                 <button
-                  ${bindEvent(
+                  onClick=${sendEvent?.(
                     'clickedObjectIDsAfterSearch',
                     [item],
                     'Add to cart'

--- a/packages/instantsearch.js/stories/hits.stories.ts
+++ b/packages/instantsearch.js/stories/hits.stories.ts
@@ -212,11 +212,12 @@ storiesOf('Results/Hits', module)
               item: (item, { html, sendEvent }) => html`
                 <h4>${item.name}</h4>
                 <button
-                  onClick=${sendEvent(
-                    'clickedObjectIDsAfterSearch',
-                    [item],
-                    'Add to cart'
-                  )}
+                  onClick=${() =>
+                    sendEvent(
+                      'clickedObjectIDsAfterSearch',
+                      [item],
+                      'Add to cart'
+                    )}
                 >
                   Add to cart
                 </button>

--- a/packages/instantsearch.js/stories/hits.stories.ts
+++ b/packages/instantsearch.js/stories/hits.stories.ts
@@ -212,7 +212,7 @@ storiesOf('Results/Hits', module)
               item: (item, { html, sendEvent }) => html`
                 <h4>${item.name}</h4>
                 <button
-                  onClick=${sendEvent?.(
+                  onClick=${sendEvent(
                     'clickedObjectIDsAfterSearch',
                     [item],
                     'Add to cart'

--- a/packages/instantsearch.js/stories/infinite-hits.stories.ts
+++ b/packages/instantsearch.js/stories/infinite-hits.stories.ts
@@ -70,10 +70,10 @@ storiesOf('Results/InfiniteHits', module)
           instantsearch.widgets.infiniteHits({
             container,
             templates: {
-              item: (item, bindEvent) => `
+              item: (item, { html, sendEvent }) => html`
                 <h4>${item.name}</h4>
                 <button
-                  ${bindEvent(
+                  onClick=${sendEvent(
                     'clickedObjectIDsAfterSearch',
                     [item],
                     'Add to cart'

--- a/packages/instantsearch.js/stories/infinite-hits.stories.ts
+++ b/packages/instantsearch.js/stories/infinite-hits.stories.ts
@@ -73,11 +73,12 @@ storiesOf('Results/InfiniteHits', module)
               item: (item, { html, sendEvent }) => html`
                 <h4>${item.name}</h4>
                 <button
-                  onClick=${sendEvent(
-                    'clickedObjectIDsAfterSearch',
-                    [item],
-                    'Add to cart'
-                  )}
+                  onClick=${() =>
+                    sendEvent(
+                      'clickedObjectIDsAfterSearch',
+                      [item],
+                      'Add to cart'
+                    )}
                 >
                   Add to cart
                 </button>

--- a/packages/instantsearch.js/stories/infinite-hits.stories.ts
+++ b/packages/instantsearch.js/stories/infinite-hits.stories.ts
@@ -73,7 +73,7 @@ storiesOf('Results/InfiniteHits', module)
               item: (item, { html, sendEvent }) => html`
                 <h4>${item.name}</h4>
                 <button
-                  onClick=${sendEvent?.(
+                  onClick=${sendEvent(
                     'clickedObjectIDsAfterSearch',
                     [item],
                     'Add to cart'

--- a/packages/instantsearch.js/stories/infinite-hits.stories.ts
+++ b/packages/instantsearch.js/stories/infinite-hits.stories.ts
@@ -73,7 +73,7 @@ storiesOf('Results/InfiniteHits', module)
               item: (item, { html, sendEvent }) => html`
                 <h4>${item.name}</h4>
                 <button
-                  onClick=${sendEvent(
+                  onClick=${sendEvent?.(
                     'clickedObjectIDsAfterSearch',
                     [item],
                     'Add to cart'


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

it doesn't work with `html`, so there's no point in continuing to have examples using it.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

bindEvent is no longer used in examples
