### PR TITLE
fix(sendEvent):  correct types in template

### DIFF
--- a/packages/instantsearch.js/src/lib/templating/renderTemplate.ts
+++ b/packages/instantsearch.js/src/lib/templating/renderTemplate.ts
@@ -72,7 +72,7 @@ export function renderTemplate({
     const params = (bindEvent || {}) as TemplateParams;
 
     params.html = html;
-    params.sendEvent = sendEvent;
+    (params as any).sendEvent = sendEvent;
     params.components = {
       Highlight,
       ReverseHighlight,
@@ -80,7 +80,9 @@ export function renderTemplate({
       ReverseSnippet,
     };
 
-    return template(data, params);
+    // @MAJOR remove the `as any` when string templates are removed
+    // needed because not every template receives sendEvent
+    return template(data, params as any);
   }
 
   const transformedHelpers = transformHelpersToHogan(

--- a/packages/instantsearch.js/src/lib/utils/createSendEventForHits.ts
+++ b/packages/instantsearch.js/src/lib/utils/createSendEventForHits.ts
@@ -10,12 +10,14 @@ type BuiltInSendEventForHits = (
 type CustomSendEventForHits = (customPayload: any) => void;
 export type SendEventForHits = BuiltInSendEventForHits & CustomSendEventForHits;
 
-type BuiltInBindEventForHits = (
+export type BuiltInBindEventForHits = (
   eventType: string,
   hits: Hit | Hit[],
   eventName?: string
 ) => string;
-type CustomBindEventForHits = (customPayload: any) => string;
+
+export type CustomBindEventForHits = (customPayload: any) => string;
+
 export type BindEventForHits = BuiltInBindEventForHits & CustomBindEventForHits;
 
 function chunk<TItem>(arr: TItem[], chunkSize: number = 20): TItem[][] {

--- a/packages/instantsearch.js/src/types/templates.ts
+++ b/packages/instantsearch.js/src/types/templates.ts
@@ -6,13 +6,17 @@ import type {
   Snippet,
 } from '../helpers/components';
 import type { html } from 'htm/preact';
-import type { BindEventForHits, SendEventForHits } from '../lib/utils';
+import type {
+  BuiltInBindEventForHits,
+  CustomBindEventForHits,
+  SendEventForHits,
+} from '../lib/utils';
 
 export type Template<TTemplateData = void> =
   | string
   | ((data: TTemplateData, params: TemplateParams) => VNode | VNode[] | string);
 
-export type TemplateParams = BindEventForHits & {
+export type TemplateParams = {
   html: typeof html;
   components: {
     Highlight: typeof Highlight;
@@ -20,12 +24,26 @@ export type TemplateParams = BindEventForHits & {
     Snippet: typeof Snippet;
     ReverseSnippet: typeof ReverseSnippet;
   };
-  sendEvent?: SendEventForHits;
 };
+
+interface TemplateWithBindEventParams extends TemplateParams {
+  /** @deprecated use sendEvent instead */
+  (
+    ...args: Parameters<BuiltInBindEventForHits>
+  ): ReturnType<BuiltInBindEventForHits>;
+  /** @deprecated use sendEvent instead */
+  (
+    ...args: Parameters<CustomBindEventForHits>
+  ): ReturnType<CustomBindEventForHits>;
+  sendEvent: SendEventForHits;
+}
 
 export type TemplateWithBindEvent<TTemplateData = void> =
   | string
-  | ((data: TTemplateData, params: TemplateParams) => VNode | VNode[] | string);
+  | ((
+      data: TTemplateData,
+      params: TemplateWithBindEventParams
+    ) => VNode | VNode[] | string);
 
 export type Templates = {
   [key: string]: Template<any> | TemplateWithBindEvent<any> | undefined;

--- a/packages/instantsearch.js/src/types/templates.ts
+++ b/packages/instantsearch.js/src/types/templates.ts
@@ -24,6 +24,7 @@ export type TemplateParams = {
     Snippet: typeof Snippet;
     ReverseSnippet: typeof ReverseSnippet;
   };
+  sendEvent?: SendEventForHits;
 };
 
 interface TemplateWithBindEventParams extends TemplateParams {


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

sendEvent is only passed in cases bindEvent is as well (hits, infinitehits), and this means  `?.` in the docs can be removed before sendEvent

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

when using `sendEvent` in a template, you  no longer need a conditional (`sendEvent?.(` -> `sendEvent`), as it was never actually required