### PR TITLE
fix(HierarchicalMenu): don't give --parent class if data is empty

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/ui/HierarchicalMenu.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/HierarchicalMenu.tsx
@@ -90,6 +90,10 @@ function HierarchicalList({
   createURL,
   onNavigate,
 }: HierarchicalListProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
   return (
     <ul className={cx('ais-HierarchicalMenu-list', classNames.list, className)}>
       {items.map((item) => (

--- a/packages/react-instantsearch-hooks-web/src/ui/HierarchicalMenu.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/HierarchicalMenu.tsx
@@ -99,6 +99,7 @@ function HierarchicalList({
             'ais-HierarchicalMenu-item',
             classNames.item,
             item.data &&
+              item.data.length > 0 &&
               cx('ais-HierarchicalMenu-item--parent', classNames.parentItem),
             item.isRefined &&
               cx('ais-HierarchicalMenu-item--selected', classNames.selectedItem)

--- a/packages/react-instantsearch-hooks-web/src/ui/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/__tests__/HierarchicalMenu.test.tsx
@@ -39,6 +39,13 @@ describe('HierarchicalMenu', () => {
           ],
         },
         {
+          label: 'Microsoft',
+          value: 'Microsoft',
+          count: 120,
+          isRefined: true,
+          data: [],
+        },
+        {
           label: 'Samsung',
           value: 'Samsung',
           count: 100,
@@ -132,6 +139,25 @@ describe('HierarchicalMenu', () => {
                   </a>
                 </li>
               </ul>
+            </li>
+            <li
+              class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected"
+            >
+              <a
+                class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected"
+                href="#Microsoft"
+              >
+                <span
+                  class="ais-HierarchicalMenu-label"
+                >
+                  Microsoft
+                </span>
+                <span
+                  class="ais-HierarchicalMenu-count"
+                >
+                  120
+                </span>
+              </a>
             </li>
             <li
               class="ais-HierarchicalMenu-item"
@@ -243,6 +269,25 @@ describe('HierarchicalMenu', () => {
                     </a>
                   </li>
                 </ul>
+              </li>
+              <li
+                class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected"
+              >
+                <a
+                  class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected"
+                  href="#Microsoft"
+                >
+                  <span
+                    class="ais-HierarchicalMenu-label"
+                  >
+                    Microsoft
+                  </span>
+                  <span
+                    class="ais-HierarchicalMenu-count"
+                  >
+                    120
+                  </span>
+                </a>
               </li>
               <li
                 class="ais-HierarchicalMenu-item"
@@ -381,6 +426,25 @@ describe('HierarchicalMenu', () => {
                   </a>
                 </li>
               </ul>
+            </li>
+            <li
+              class="ais-HierarchicalMenu-item ITEM ais-HierarchicalMenu-item--selected SELECTEDITEM"
+            >
+              <a
+                class="ais-HierarchicalMenu-link LINK ais-HierarchicalMenu-link--selected SELECTEDITEMLINK"
+                href="#Microsoft"
+              >
+                <span
+                  class="ais-HierarchicalMenu-label LABEL"
+                >
+                  Microsoft
+                </span>
+                <span
+                  class="ais-HierarchicalMenu-count COUNT"
+                >
+                  120
+                </span>
+              </a>
             </li>
             <li
               class="ais-HierarchicalMenu-item ITEM"

--- a/packages/vue-instantsearch/src/components/HierarchicalMenuList.vue
+++ b/packages/vue-instantsearch/src/components/HierarchicalMenuList.vue
@@ -11,7 +11,7 @@
       :key="item.value"
       :class="[
         suit('item'),
-        item.data && suit('item', 'parent'),
+        item.data && item.data.length > 0 && suit('item', 'parent'),
         item.isRefined && suit('item', 'selected'),
       ]"
     >

--- a/packages/vue-instantsearch/src/components/HierarchicalMenuList.vue
+++ b/packages/vue-instantsearch/src/components/HierarchicalMenuList.vue
@@ -1,5 +1,6 @@
 <template>
   <ul
+    v-if="items.length > 0"
     :class="[
       suit('list'),
       level > 0 && suit('list', 'child'),

--- a/packages/vue-instantsearch/src/components/__tests__/HierarchicalMenu.js
+++ b/packages/vue-instantsearch/src/components/__tests__/HierarchicalMenu.js
@@ -98,6 +98,14 @@ const microsoft = {
   data: null,
 };
 
+const google = {
+  label: 'Google',
+  value: 'Google',
+  isRefined: true,
+  count: 2,
+  data: [],
+};
+
 const defaultState = {
   items: [
     {
@@ -116,6 +124,7 @@ const defaultState = {
       data: [galaxy, note],
     },
     microsoft,
+    google,
   ],
   refine: () => {},
   createURL: () => {},

--- a/packages/vue-instantsearch/src/components/__tests__/__snapshots__/HierarchicalMenu.js.snap
+++ b/packages/vue-instantsearch/src/components/__tests__/__snapshots__/HierarchicalMenu.js.snap
@@ -48,6 +48,13 @@ exports[`custom default render renders correctly 1`] = `
           Microsoft - 20
         </a>
       </li>
+      <li>
+        <a>
+          Google - 2
+        </a>
+        <ol>
+        </ol>
+      </li>
     </ol>
     <button>
       View more
@@ -103,6 +110,13 @@ exports[`custom default render renders correctly with a disabled show more butto
         <a>
           Microsoft - 20
         </a>
+      </li>
+      <li>
+        <a>
+          Google - 2
+        </a>
+        <ol>
+        </ol>
       </li>
     </ol>
     <button disabled="disabled">
@@ -160,6 +174,13 @@ exports[`custom default render renders correctly with a limit 1`] = `
           Microsoft - 20
         </a>
       </li>
+      <li>
+        <a>
+          Google - 2
+        </a>
+        <ol>
+        </ol>
+      </li>
     </ol>
     <button>
       View more
@@ -215,6 +236,13 @@ exports[`custom default render renders correctly with a show more button toggled
         <a>
           Microsoft - 20
         </a>
+      </li>
+      <li>
+        <a>
+          Google - 2
+        </a>
+        <ol>
+        </ol>
       </li>
     </ol>
     <button>
@@ -272,6 +300,13 @@ exports[`custom default render renders correctly with a show more button toggled
           Microsoft - 20
         </a>
       </li>
+      <li>
+        <a>
+          Google - 2
+        </a>
+        <ol>
+        </ol>
+      </li>
     </ol>
     <button>
       View less
@@ -327,6 +362,13 @@ exports[`custom default render renders correctly with an URL for the href 1`] = 
         <a href="/categories/Microsoft">
           Microsoft - 20
         </a>
+      </li>
+      <li>
+        <a href="/categories/Google">
+          Google - 2
+        </a>
+        <ol>
+        </ol>
       </li>
     </ol>
     <button>
@@ -467,6 +509,16 @@ exports[`custom showMoreLabel render renders correctly with a custom show more l
         </span>
       </a>
     </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected">
+      <a class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected">
+        <span class="ais-HierarchicalMenu-label">
+          Google
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          2
+        </span>
+      </a>
+    </li>
   </ul>
   <button class="ais-HierarchicalMenu-showMore">
     <span>
@@ -595,6 +647,16 @@ exports[`custom showMoreLabel render renders correctly with a custom show more l
         </span>
       </a>
     </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected">
+      <a class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected">
+        <span class="ais-HierarchicalMenu-label">
+          Google
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          2
+        </span>
+      </a>
+    </li>
   </ul>
   <button class="ais-HierarchicalMenu-showMore">
     <span>
@@ -720,6 +782,16 @@ exports[`default render renders correctly 1`] = `
         </span>
         <span class="ais-HierarchicalMenu-count">
           20
+        </span>
+      </a>
+    </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected">
+      <a class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected">
+        <span class="ais-HierarchicalMenu-label">
+          Google
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          2
         </span>
       </a>
     </li>
@@ -991,6 +1063,18 @@ exports[`default render renders correctly with a URL for the href 1`] = `
         </span>
       </a>
     </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected">
+      <a class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected"
+         href="/categories/Google"
+      >
+        <span class="ais-HierarchicalMenu-label">
+          Google
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          2
+        </span>
+      </a>
+    </li>
   </ul>
 </div>
 `;
@@ -1114,6 +1198,16 @@ exports[`default render renders correctly with show more disabled 1`] = `
         </span>
       </a>
     </li>
+    <li class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected">
+      <a class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected">
+        <span class="ais-HierarchicalMenu-label">
+          Google
+        </span>
+        <span class="ais-HierarchicalMenu-count">
+          2
+        </span>
+      </a>
+    </li>
   </ul>
   <button class="ais-HierarchicalMenu-showMore ais-HierarchicalMenu-showMore--disabled"
           disabled="disabled"
@@ -1137,7 +1231,5 @@ exports[`default render renders correctly with show more label toggled 1`] = `
 
 exports[`default render renders correctly without refinement 1`] = `
 <div class="ais-HierarchicalMenu ais-HierarchicalMenu--noRefinement">
-  <ul class="ais-HierarchicalMenu-list ais-HierarchicalMenu-list--lvl0">
-  </ul>
 </div>
 `;


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This happens when the item is refined, but there's no items in the lower level. In InstantSearch.js and React InstantSearch Dom, we avoid adding the class in this case already:

https://github.com/algolia/instantsearch/blob/f84c01b2f66ac279f7e33fafe5f1cd559436edef/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx#L175-L179

https://github.com/algolia/instantsearch/blob/f84c01b2f66ac279f7e33fafe5f1cd559436edef/packages/react-instantsearch-dom/src/components/List.js#L64-L75

detected in https://github.com/algolia/instantsearch/discussions/5456

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

`ais-HierarchicalMenu-item--parent` is not applied when children are empty, even if it is refined. This makes React InstantSearch Hooks and Vue InstantSearch consistent with the other flavours.