### PR TITLE
fix(events): prevent sending duplicate view events

### DIFF
--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -534,6 +534,49 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
       });
     });
 
+    it('skips sending duplicate events', () => {
+      const { insightsClient, instantSearchInstance, analytics } =
+        createTestEnvironment();
+
+      instantSearchInstance.use(
+        createInsightsMiddleware({
+          insightsClient,
+        })
+      );
+      insightsClient('setUserToken', 'token');
+
+      instantSearchInstance.sendEventToInsights({
+        insightsMethod: 'viewedObjectIDs',
+        widgetType: 'ais.customWidget',
+        eventType: 'view',
+        payload: {
+          index: 'my-index',
+          eventName: 'My Hits Viewed',
+          objectIDs: ['obj1'],
+        },
+      });
+
+      expect(analytics.viewedObjectIDs).toHaveBeenCalledTimes(1);
+      expect(analytics.viewedObjectIDs).toHaveBeenCalledWith({
+        index: 'my-index',
+        eventName: 'My Hits Viewed',
+        objectIDs: ['obj1'],
+      });
+
+      instantSearchInstance.sendEventToInsights({
+        insightsMethod: 'viewedObjectIDs',
+        widgetType: 'ais.customWidget',
+        eventType: 'view',
+        payload: {
+          index: 'my-index',
+          eventName: 'My Hits Viewed',
+          objectIDs: ['obj1'],
+        },
+      });
+
+      expect(analytics.viewedObjectIDs).toHaveBeenCalledTimes(1);
+    });
+
     it('calls onEvent when given', () => {
       const { insightsClient, instantSearchInstance, analytics } =
         createTestEnvironment();

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -150,6 +150,8 @@ export function createInsightsMiddleware<
           immediate: true,
         });
 
+        const viewEventCache: Record<string, boolean> = {};
+
         instantSearchInstance.sendEventToInsights = (event: InsightsEvent) => {
           if (onEvent) {
             onEvent(event, _insightsClient);
@@ -158,6 +160,14 @@ export function createInsightsMiddleware<
               (helper.state as PlainSearchParameters).userToken
             );
             if (hasUserToken) {
+              if (event.insightsMethod === 'viewedObjectIDs') {
+                const hits = JSON.stringify(event.payload.hits);
+                if (viewEventCache[hits]) {
+                  return;
+                } else {
+                  viewEventCache[hits] = true;
+                }
+              }
               insightsClient(event.insightsMethod, event.payload);
             } else {
               warning(


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Quick and dirty solution where we keep track of which hits have been sent and skip duplicates.

Technically this is a memory leak, but i don't know what condition to use to clear the cache?

fixes #5442

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

duplicate view events don't get sent multiple times