### PR TITLE
fix(infiniteHits): read cache correctly when search is loading

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common.test.tsx
@@ -6,9 +6,17 @@ import {
   createRefinementListTests,
   createPaginationTests,
   createMenuTests,
+  createInfiniteHitsTests,
 } from '@instantsearch/tests';
 import instantsearch from '../index.es';
-import { hierarchicalMenu, menu, refinementList, pagination } from '../widgets';
+import {
+  hierarchicalMenu,
+  menu,
+  refinementList,
+  pagination,
+  infiniteHits,
+  searchBox,
+} from '../widgets';
 
 createHierarchicalMenuTests(({ instantSearchOptions, widgetParams }) => {
   instantsearch(instantSearchOptions)
@@ -65,6 +73,26 @@ createPaginationTests(({ instantSearchOptions, widgetParams }) => {
   instantsearch(instantSearchOptions)
     .addWidgets([
       pagination({
+        container: document.body.appendChild(document.createElement('div')),
+        ...widgetParams,
+      }),
+    ])
+    .on('error', () => {
+      /*
+       * prevent rethrowing InstantSearch errors, so tests can be asserted.
+       * IRL this isn't needed, as the error doesn't stop execution.
+       */
+    })
+    .start();
+});
+
+createInfiniteHitsTests(({ instantSearchOptions, widgetParams }) => {
+  instantsearch(instantSearchOptions)
+    .addWidgets([
+      searchBox({
+        container: document.body.appendChild(document.createElement('div')),
+      }),
+      infiniteHits({
         container: document.body.appendChild(document.createElement('div')),
         ...widgetParams,
       }),

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -292,9 +292,16 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
         };
       },
 
-      getWidgetRenderState({ results, helper, state, instantSearchInstance }) {
+      getWidgetRenderState({ results, helper, parent, instantSearchInstance }) {
         let isFirstPage: boolean;
         let currentPageHits: Array<Hit<THit>> = [];
+        /**
+         * We bail out of optimistic UI here, as the cache is based on search
+         * parameters, and we don't want to invalidate the cache when the search
+         * is loading.
+         */
+        const state = parent.getPreviousState()!;
+
         const cachedHits = cache.read({ state }) || {};
 
         if (!results) {

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -66,6 +66,7 @@ export type IndexWidget = Omit<
   getIndexId(): string;
   getHelper(): Helper | null;
   getResults(): SearchResults | null;
+  getPreviousState(): SearchParameters | null;
   getScopedResults(): ScopedResult[];
   getParent(): IndexWidget | null;
   getWidgets(): Array<Widget | IndexWidget>;
@@ -241,6 +242,10 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       derivedHelper.lastResults._state = helper!.state;
 
       return derivedHelper.lastResults;
+    },
+
+    getPreviousState() {
+      return lastValidSearchParameters || helper?.state || null;
     },
 
     getScopedResults() {

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common.test.tsx
@@ -6,6 +6,7 @@ import {
   createHierarchicalMenuTests,
   createMenuTests,
   createPaginationTests,
+  createInfiniteHitsTests,
 } from '@instantsearch/tests';
 import { act, render } from '@testing-library/react';
 import React from 'react';
@@ -16,6 +17,8 @@ import {
   HierarchicalMenu,
   Menu,
   Pagination,
+  InfiniteHits,
+  SearchBox,
   useInstantSearch,
 } from '..';
 
@@ -60,6 +63,16 @@ createPaginationTests(({ instantSearchOptions, widgetParams }) => {
   render(
     <InstantSearch {...instantSearchOptions}>
       <Pagination {...widgetParams} />
+      <GlobalErrorSwallower />
+    </InstantSearch>
+  );
+}, act);
+
+createInfiniteHitsTests(({ instantSearchOptions, widgetParams }) => {
+  render(
+    <InstantSearch {...instantSearchOptions}>
+      <SearchBox />
+      <InfiniteHits {...widgetParams} />
       <GlobalErrorSwallower />
     </InstantSearch>
   );

--- a/packages/vue-instantsearch/src/__tests__/common.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common.test.js
@@ -6,6 +6,7 @@ import {
   createHierarchicalMenuTests,
   createMenuTests,
   createPaginationTests,
+  createInfiniteHitsTests,
 } from '@instantsearch/tests';
 
 import { nextTick, mountApp } from '../../test/utils';
@@ -16,6 +17,8 @@ import {
   AisHierarchicalMenu,
   AisMenu,
   AisPagination,
+  AisInfiniteHits,
+  AisSearchBox,
   createWidgetMixin,
 } from '../instantsearch';
 jest.unmock('instantsearch.js/es');
@@ -88,6 +91,23 @@ createPaginationTests(async ({ instantSearchOptions, widgetParams }) => {
       render: renderCompat((h) =>
         h(AisInstantSearch, { props: instantSearchOptions }, [
           h(AisPagination, { props: widgetParams }),
+          h(GlobalErrorSwallower),
+        ])
+      ),
+    },
+    document.body.appendChild(document.createElement('div'))
+  );
+
+  await nextTick();
+});
+
+createInfiniteHitsTests(async ({ instantSearchOptions, widgetParams }) => {
+  mountApp(
+    {
+      render: renderCompat((h) =>
+        h(AisInstantSearch, { props: instantSearchOptions }, [
+          h(AisSearchBox),
+          h(AisInfiniteHits, { props: widgetParams }),
           h(GlobalErrorSwallower),
         ])
       ),

--- a/tests/common/index.ts
+++ b/tests/common/index.ts
@@ -2,3 +2,4 @@ export * from './widgets/hierarchical-menu';
 export * from './widgets/refinement-list';
 export * from './widgets/menu';
 export * from './widgets/pagination';
+export * from './widgets/infinite-hits';

--- a/tests/common/widgets/infinite-hits/index.ts
+++ b/tests/common/widgets/infinite-hits/index.ts
@@ -1,0 +1,22 @@
+import type { InfiniteHitsWidget } from 'instantsearch.js/es/widgets/infinite-hits/infinite-hits';
+import type { Act, TestSetup } from '../../common';
+import { fakeAct } from '../../common';
+import { createOptimisticUiTests } from './optimistic-ui';
+
+type WidgetParams = Parameters<InfiniteHitsWidget>[0];
+export type InfiniteHitsSetup = TestSetup<{
+  widgetParams: Omit<WidgetParams, 'container'>;
+}>;
+
+export function createInfiniteHitsTests(
+  setup: InfiniteHitsSetup,
+  act: Act = fakeAct
+) {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('InfiniteHits common tests', () => {
+    createOptimisticUiTests(setup, act);
+  });
+}

--- a/tests/common/widgets/infinite-hits/optimistic-ui.ts
+++ b/tests/common/widgets/infinite-hits/optimistic-ui.ts
@@ -1,0 +1,276 @@
+import { wait } from '@instantsearch/testutils';
+import { screen } from '@testing-library/dom';
+import type { MockSearchClient } from '@instantsearch/mocks';
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import type { InfiniteHitsSetup } from '.';
+import type { Act } from '../../common';
+import type { SearchClient } from 'instantsearch.js';
+import userEvent from '@testing-library/user-event';
+
+export function createOptimisticUiTests(setup: InfiniteHitsSetup, act: Act) {
+  describe('optimistic UI', () => {
+    test('shows the correct hits, regardless of network latency', async () => {
+      const delay = 100;
+      const margin = 10;
+      const hitsPerPage = 20;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(
+                  ({ params }: Parameters<SearchClient['search']>[0][number]) =>
+                    createSingleSearchResponse({
+                      hits: Array.from({ length: hitsPerPage }).map(
+                        (_, index) => ({
+                          objectID: `${params!.page! * hitsPerPage + index}`,
+                        })
+                      ),
+                      query: params!.query,
+                      page: params!.page,
+                      nbPages: 20,
+                    })
+                )
+              );
+            }) as MockSearchClient['search'],
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      // Initial state, before interaction
+      {
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+      }
+
+      // Load the next page
+      {
+        const nextPage = screen.getByRole('button', {
+          name: 'Show more results',
+        });
+        await act(async () => {
+          nextPage.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has not changed yet
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(2 * hitsPerPage);
+      }
+    });
+
+    test('shows the correct hits when refining in a different widget, regardless of network latency', async () => {
+      const delay = 100;
+      const margin = 10;
+      const hitsPerPage = 20;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(
+                  ({ params }: Parameters<SearchClient['search']>[0][number]) =>
+                    createSingleSearchResponse({
+                      hits: Array.from({ length: hitsPerPage }).map(
+                        (_, index) => ({
+                          objectID: `${params!.page! * hitsPerPage + index}`,
+                        })
+                      ),
+                      query: params!.query,
+                      page: params!.page,
+                      nbPages: 20,
+                    })
+                )
+              );
+            }) as MockSearchClient['search'],
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      // Initial state, before interaction
+      {
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+      }
+
+      // Do a refinement on a different widget
+      {
+        const searchBox = screen.getByRole('searchbox');
+
+        await act(async () => {
+          userEvent.type(searchBox, 'a');
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has not changed yet
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+      }
+    });
+
+    test('reverts back to previous state on error', async () => {
+      const delay = 100;
+      const margin = 10;
+      const hitsPerPage = 20;
+      let errors = false;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              if (errors) {
+                throw new Error('Network error!');
+              }
+              return createMultiSearchResponse(
+                ...requests.map(
+                  ({ params }: Parameters<SearchClient['search']>[0][number]) =>
+                    createSingleSearchResponse({
+                      hits: Array.from({ length: hitsPerPage }).map(
+                        (_, index) => ({
+                          objectID: `${params!.page! * hitsPerPage + index}`,
+                        })
+                      ),
+                      query: params!.query,
+                      page: params!.page,
+                      nbPages: 20,
+                    })
+                )
+              );
+            }) as MockSearchClient['search'],
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      // Initial state, before interaction
+      {
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+      }
+
+      errors = true;
+
+      // Load the next page
+      {
+        const nextPage = screen.getByRole('button', {
+          name: 'Show more results',
+        });
+        await act(async () => {
+          nextPage.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has not changed yet
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+      }
+
+      errors = false;
+
+      // Load the next page
+      {
+        const nextPage = screen.getByRole('button', {
+          name: 'Show more results',
+        });
+        await act(async () => {
+          nextPage.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has not changed yet
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(
+          document.querySelectorAll('.ais-InfiniteHits-item')
+        ).toHaveLength(2 * hitsPerPage);
+      }
+    });
+  });
+}


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

The cache is based on search parameters (minus page), so when the state updates, we want to still use the previous state, as the previous hits are still valid.

One thing that could change this design is if the cache wasn't purely based on the parameters, and somehow was persisted too, so we could ask for the "last result", but that's not possible without major change in the cache.

Alternatives I tried before settling on this solution:
- exposing previousState to all calls of `getWidgetRenderState`
  - possible, but a large diff, and needs to be handled in all widgets, types, useConnector
- skipping render if status is `loading`
  - this is not sufficient, as React InstantSearch Hooks calls `getWidgetRenderState` itself, and thus gets to the mismatched cache case as well


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

infiniteHits never renders empty hits on external interaction.

fixes https://algolia.atlassian.net/browse/CR-2769 (mostly, the customer has another bug that would show up when you have no results, and then results again, but that wasn't related to optimistic UI)
