### PR TITLE
chore(jest): use local InstantSearch.js

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -40,6 +40,8 @@ const config = {
     '^react-instantsearch-(.*[^v6])$':
       '<rootDir>/packages/react-instantsearch-$1/src/',
     '^instantsearch.js$': '<rootDir>/packages/instantsearch.js/src/',
+    '^instantsearch.js/es(.*)$': '<rootDir>/packages/instantsearch.js/src$1',
+    '^instantsearch.js/(.*)$': '<rootDir>/packages/instantsearch.js/$1',
   },
   modulePathIgnorePatterns: [
     '<rootDir>/packages/create-instantsearch-app/src/templates',

--- a/scripts/babel/__tests__/extension-resolver.test.js
+++ b/scripts/babel/__tests__/extension-resolver.test.js
@@ -9,7 +9,7 @@ describe('babel-plugin-extension-resolver', () => {
   const pluginOptions = {
     modulesToResolve: [
       // in workspace (in local path)
-      'instantsearch.js',
+      '@instantsearch/babel-testfixture',
       // not in workspace (in node_modules)
       'algoliasearch-v3',
     ],
@@ -97,8 +97,8 @@ describe('babel-plugin-extension-resolver', () => {
 
     expect(
       await transformAsync(
-        'import workspaceRoot from "instantsearch.js";\n' +
-          'import workspacePath from "instantsearch.js/es/widgets/index/index";\n' +
+        'import workspaceRoot from "@instantsearch/babel-testfixture";\n' +
+          'import workspacePath from "@instantsearch/babel-testfixture/nested/index/index";\n' +
           'import nodeModulesRoot from "algoliasearch-v3";\n' +
           'import nodeModulesPath from "algoliasearch-v3/src/browser/builds/algoliasearch";\n' +
           'import otherRoot from "different-module";\n' +
@@ -107,8 +107,8 @@ describe('babel-plugin-extension-resolver', () => {
       )
     ).toHaveProperty(
       'code',
-      'import workspaceRoot from "instantsearch.js";\n' +
-        'import workspacePath from "instantsearch.js/es/widgets/index/index.js";\n' +
+      'import workspaceRoot from "@instantsearch/babel-testfixture";\n' +
+        'import workspacePath from "@instantsearch/babel-testfixture/nested/index/index.js";\n' +
         'import nodeModulesRoot from "algoliasearch-v3";\n' +
         'import nodeModulesPath from "algoliasearch-v3/src/browser/builds/algoliasearch.js";\n' +
         'import otherRoot from "different-module";\n' +
@@ -170,11 +170,11 @@ describe('babel-plugin-extension-resolver', () => {
 
     await expect(() =>
       transformAsync(
-        'import other from "instantsearch.js/non-existing-folder-this-can-never-exist/qsdf/gh/jklm";',
+        'import other from "@instantsearch/babel-testfixture/non-existing-folder-this-can-never-exist/qsdf/gh/jklm";',
         options
       )
     ).rejects.toThrow(
-      "/path/to/src/file.js: Cannot find module 'instantsearch.js/non-existing-folder-this-can-never-exist/qsdf/gh/jklm' from 'scripts/babel/extension-resolver.js'"
+      "/path/to/src/file.js: Cannot find module '@instantsearch/babel-testfixture/non-existing-folder-this-can-never-exist/qsdf/gh/jklm' from 'scripts/babel/extension-resolver.js'"
     );
   });
 });

--- a/tests/babel-testfixture/nested/index/index.js
+++ b/tests/babel-testfixture/nested/index/index.js
@@ -1,0 +1,1 @@
+// @instantsearch/babel-testfixture/nested/index/index.js

--- a/tests/babel-testfixture/package.json
+++ b/tests/babel-testfixture/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@instantsearch/babel-testfixture",
+  "private": true,
+  "description": "A package to use as a test in extension-resolver",
+  "version": "0.0.0",
+  "main": "nested/index"
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

mapping all files (widgets, connectors, utils) allows us to run `jest --watch` without ever needing to build to see updates


FX-2617


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

you can run `yarn jest --watch` without needing to build InstantSearch.js, even for Vue InstantSearch or React InstantSearch Hooks

Fix the babel extension resolver plugin to not assume that the package name is verbatim in the path

> Note: this PR should be rebased, not squashed, as the two commits work separately