### PR TITLE
fix(templates): cd into proper build dir

### DIFF
--- a/.github/workflows/release-templates.yml
+++ b/.github/workflows/release-templates.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: 🚀  push templates
         run: |
-          cd build
+          cd packages/create-instantsearch-app/build
           UNCOMMITTED_CHANGES=`git status --porcelain`
           if [ ! -z "$UNCOMMITTED_CHANGES" ]; then
             git config --global user.name "InstantSearch"


### PR DESCRIPTION
**Summary**

We didn't `cd` into the proper build folder so this action was failing : https://github.com/algolia/instantsearch/actions/runs/4173320532/jobs/7225507147

