### PR TITLE
fix(breadcrumb): guard against undefined facets

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common.test.tsx
@@ -3,6 +3,7 @@
  */
 import {
   createHierarchicalMenuTests,
+  createBreadcrumbTests,
   createRefinementListTests,
   createPaginationTests,
   createMenuTests,
@@ -11,6 +12,7 @@ import {
 import instantsearch from '../index.es';
 import {
   hierarchicalMenu,
+  breadcrumb,
   menu,
   refinementList,
   pagination,
@@ -24,6 +26,30 @@ createHierarchicalMenuTests(({ instantSearchOptions, widgetParams }) => {
       hierarchicalMenu({
         container: document.body.appendChild(document.createElement('div')),
         ...widgetParams,
+      }),
+    ])
+    .on('error', () => {
+      /*
+       * prevent rethrowing InstantSearch errors, so tests can be asserted.
+       * IRL this isn't needed, as the error doesn't stop execution.
+       */
+    })
+    .start();
+});
+
+createBreadcrumbTests(({ instantSearchOptions, widgetParams }) => {
+  const { transformItems, templates, ...hierarchicalWidgetParams } =
+    widgetParams;
+
+  instantsearch(instantSearchOptions)
+    .addWidgets([
+      breadcrumb({
+        container: document.body.appendChild(document.createElement('div')),
+        ...widgetParams,
+      }),
+      hierarchicalMenu({
+        container: document.body.appendChild(document.createElement('div')),
+        ...hierarchicalWidgetParams,
       }),
     ])
     .on('error', () => {

--- a/packages/instantsearch.js/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/packages/instantsearch.js/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -293,6 +293,57 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/breadcrumb/
       });
     });
 
+    it('returns an empty array of items if no hierarchicalFacets result exist', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createBreadcrumb = connectBreadcrumb(renderFn, unmountFn);
+      const breadcrumb = createBreadcrumb({
+        attributes: ['category', 'subCategory'],
+      });
+      const helper = algoliasearchHelper(
+        createSearchClient(),
+        'indexName',
+        breadcrumb.getWidgetSearchParameters!(new SearchParameters(), {
+          uiState: {},
+        })
+      );
+
+      const results = new algoliasearchHelper.SearchResults(
+        new SearchParameters({ index: helper.state.index }),
+        [
+          {
+            query: helper.state.query ?? '',
+            page: helper.state.page ?? 0,
+            hitsPerPage: helper.state.hitsPerPage ?? 20,
+            hits: [],
+            nbHits: 0,
+            nbPages: 0,
+            params: '',
+            exhaustiveNbHits: true,
+            exhaustiveFacetsCount: true,
+            processingTimeMS: 0,
+            index: helper.state.index,
+          },
+        ]
+      );
+
+      const renderState = breadcrumb.getWidgetRenderState(
+        createRenderOptions({
+          helper,
+          results,
+          state: helper.state,
+        })
+      );
+
+      expect(renderState).toEqual({
+        canRefine: false,
+        createURL: expect.any(Function),
+        items: [],
+        refine: expect.any(Function),
+        widgetParams: { attributes: ['category', 'subCategory'] },
+      });
+    });
+
     test('refine method called with null does not mutate the current helper state if no hierarchicalFacets exist', () => {
       const renderFn = jest.fn();
       const unmountFn = jest.fn();

--- a/packages/instantsearch.js/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/packages/instantsearch.js/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -194,14 +194,17 @@ const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
 
           const [{ name: facetName }] = state.hierarchicalFacets;
 
-          const facetValues = results.getFacetValues(
-            facetName,
-            {}
-          ) as SearchResults.HierarchicalFacet;
-          const data = Array.isArray(facetValues.data) ? facetValues.data : [];
-          const items = transformItems(shiftItemsValues(prepareItems(data)), {
-            results,
-          });
+          const facetValues = results.getFacetValues(facetName, {});
+          const facetItems =
+            facetValues && !Array.isArray(facetValues) && facetValues.data
+              ? facetValues.data
+              : [];
+          const items = transformItems(
+            shiftItemsValues(prepareItems(facetItems)),
+            {
+              results,
+            }
+          );
 
           return items;
         }

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common.test.tsx
@@ -4,6 +4,7 @@
 import {
   createRefinementListTests,
   createHierarchicalMenuTests,
+  createBreadcrumbTests,
   createMenuTests,
   createPaginationTests,
   createInfiniteHitsTests,
@@ -15,6 +16,7 @@ import {
   InstantSearch,
   RefinementList,
   HierarchicalMenu,
+  Breadcrumb,
   Menu,
   Pagination,
   InfiniteHits,
@@ -45,6 +47,17 @@ createHierarchicalMenuTests(({ instantSearchOptions, widgetParams }) => {
   render(
     <InstantSearch {...instantSearchOptions}>
       <HierarchicalMenu {...widgetParams} />
+      <GlobalErrorSwallower />
+    </InstantSearch>
+  );
+}, act);
+
+createBreadcrumbTests(({ instantSearchOptions, widgetParams }) => {
+  const { transformItems, ...hierarchicalWidgetParams } = widgetParams;
+  render(
+    <InstantSearch {...instantSearchOptions}>
+      <Breadcrumb {...widgetParams} />
+      <HierarchicalMenu {...hierarchicalWidgetParams} />
       <GlobalErrorSwallower />
     </InstantSearch>
   );

--- a/packages/vue-instantsearch/src/__tests__/common.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common.test.js
@@ -4,6 +4,7 @@
 import {
   createRefinementListTests,
   createHierarchicalMenuTests,
+  createBreadcrumbTests,
   createMenuTests,
   createPaginationTests,
   createInfiniteHitsTests,
@@ -15,6 +16,7 @@ import {
   AisInstantSearch,
   AisRefinementList,
   AisHierarchicalMenu,
+  AisBreadcrumb,
   AisMenu,
   AisPagination,
   AisInfiniteHits,
@@ -59,6 +61,25 @@ createHierarchicalMenuTests(async ({ instantSearchOptions, widgetParams }) => {
       render: renderCompat((h) =>
         h(AisInstantSearch, { props: instantSearchOptions }, [
           h(AisHierarchicalMenu, { props: widgetParams }),
+          h(GlobalErrorSwallower),
+        ])
+      ),
+    },
+    document.body.appendChild(document.createElement('div'))
+  );
+
+  await nextTick();
+});
+
+createBreadcrumbTests(async ({ instantSearchOptions, widgetParams }) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { transformItems, ...hierarchicalWidgetParams } = widgetParams;
+  mountApp(
+    {
+      render: renderCompat((h) =>
+        h(AisInstantSearch, { props: instantSearchOptions }, [
+          h(AisBreadcrumb, { props: widgetParams }),
+          h(AisHierarchicalMenu, { props: hierarchicalWidgetParams }),
           h(GlobalErrorSwallower),
         ])
       ),

--- a/tests/common/index.ts
+++ b/tests/common/index.ts
@@ -1,4 +1,5 @@
 export * from './widgets/hierarchical-menu';
+export * from './widgets/breadcrumb';
 export * from './widgets/refinement-list';
 export * from './widgets/menu';
 export * from './widgets/pagination';

--- a/tests/common/widgets/breadcrumb/index.ts
+++ b/tests/common/widgets/breadcrumb/index.ts
@@ -1,0 +1,22 @@
+import type { BreadcrumbWidget } from 'instantsearch.js/es/widgets/breadcrumb/breadcrumb';
+import type { Act, TestSetup } from '../../common';
+import { fakeAct } from '../../common';
+import { createOptimisticUiTests } from './optimistic-ui';
+
+type WidgetParams = Parameters<BreadcrumbWidget>[0];
+export type BreadcrumbSetup = TestSetup<{
+  widgetParams: Omit<WidgetParams, 'container'>;
+}>;
+
+export function createBreadcrumbTests(
+  setup: BreadcrumbSetup,
+  act: Act = fakeAct
+) {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('Breadcrumb common tests', () => {
+    createOptimisticUiTests(setup, act);
+  });
+}

--- a/tests/common/widgets/breadcrumb/optimistic-ui.ts
+++ b/tests/common/widgets/breadcrumb/optimistic-ui.ts
@@ -1,0 +1,253 @@
+import { wait } from '@instantsearch/testutils';
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import type { BreadcrumbSetup } from '.';
+import type { Act } from '../../common';
+import userEvent from '@testing-library/user-event';
+import { screen } from '@testing-library/dom';
+
+export function createOptimisticUiTests(setup: BreadcrumbSetup, act: Act) {
+  describe('optimistic UI', () => {
+    test('checks the clicked refinement immediately regardless of network latency', async () => {
+      const delay = 100;
+      const margin = 10;
+      const attributes = ['1', '2'];
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {
+              hierarchicalMenu: {
+                [attributes[0]]: ['Apple > iPhone'],
+              },
+            },
+          },
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attributes[0]]: {
+                        Samsung: 100,
+                        Apple: 200,
+                      },
+                      [attributes[1]]: {
+                        'Apple > iPad': 100,
+                        'Apple > iPhone': 100,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attributes },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      // Initial state, before interaction
+      {
+        expect(document.querySelectorAll('.ais-Breadcrumb-item')).toHaveLength(
+          3
+        );
+        expect(
+          document.querySelectorAll('.ais-Breadcrumb-item--selected')
+        ).toHaveLength(1);
+        expect(
+          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
+        ).toMatch(/> ?iPhone/);
+      }
+
+      // Select a refinement
+      {
+        const firstItem = screen.getByRole('link', {
+          name: 'Apple',
+        });
+        await act(async () => {
+          userEvent.click(firstItem);
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has changed immediately after the user interaction
+        // @TODO: menu doesn't have any accessible way to determine if an item is selected, so we use the class name (https://github.com/algolia/instantsearch/issues/5187)
+        expect(
+          document.querySelectorAll('.ais-Breadcrumb-item--selected')
+        ).toHaveLength(1);
+        expect(
+          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
+        ).toMatch(/> ?Apple/);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(
+          document.querySelectorAll('.ais-Breadcrumb-item--selected')
+        ).toHaveLength(1);
+        expect(
+          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
+        ).toMatch(/> ?Apple/);
+      }
+    });
+
+    test('reverts back to previous state on error', async () => {
+      const delay = 100;
+      const margin = 10;
+      const attributes = ['1', '2'];
+      let errors = false;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {
+              hierarchicalMenu: {
+                [attributes[0]]: ['Apple > iPhone'],
+              },
+            },
+          },
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              if (errors) {
+                throw new Error('Network error!');
+              }
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attributes[0]]: {
+                        Samsung: 100,
+                        Apple: 200,
+                      },
+                      [attributes[1]]: {
+                        'Apple > iPad': 100,
+                        'Apple > iPhone': 100,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attributes },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      // Initial state, before interaction
+      {
+        expect(document.querySelectorAll('.ais-Breadcrumb-item')).toHaveLength(
+          3
+        );
+        expect(
+          document.querySelectorAll('.ais-Breadcrumb-item--selected')
+        ).toHaveLength(1);
+        expect(
+          document.querySelector('.ais-Breadcrumb-item--selected')?.textContent
+        ).toMatch(/> ?iPhone/);
+      }
+
+      // start erroring
+      errors = true;
+
+      // Select a refinement
+      {
+        const firstItem = screen.getByRole('link', {
+          name: 'Apple',
+        });
+        await act(async () => {
+          firstItem.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has changed immediately after the user interaction
+        expect(
+          document.querySelectorAll('.ais-Breadcrumb-item--selected')
+        ).toHaveLength(1);
+        expect(
+          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
+        ).toMatch(/> ?Apple/);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+          await wait(0);
+        });
+
+        // refinement has reverted back to previous state
+        expect(
+          document.querySelectorAll('.ais-Breadcrumb-item--selected')
+        ).toHaveLength(1);
+        expect(
+          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
+        ).toMatch(/> ?iPhone/);
+      }
+
+      // stop erroring
+      errors = false;
+
+      // Select the refinement again
+      {
+        const firstItem = screen.getByRole('link', {
+          name: 'Apple',
+        });
+        await act(async () => {
+          firstItem.click();
+          await wait(0);
+          await wait(0);
+        });
+
+        // UI has changed immediately after the user interaction
+        expect(
+          document.querySelectorAll('.ais-Breadcrumb-item--selected')
+        ).toHaveLength(1);
+        expect(
+          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
+        ).toMatch(/> ?Apple/);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+          await wait(0);
+        });
+
+        // refinement is consistent with clicks again
+        expect(
+          document.querySelectorAll('.ais-Breadcrumb-item--selected')
+        ).toHaveLength(1);
+        expect(
+          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
+        ).toMatch(/> ?Apple/);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/breadcrumb/optimistic-ui.ts
+++ b/tests/common/widgets/breadcrumb/optimistic-ui.ts
@@ -67,8 +67,8 @@ export function createOptimisticUiTests(setup: BreadcrumbSetup, act: Act) {
           document.querySelectorAll('.ais-Breadcrumb-item--selected')
         ).toHaveLength(1);
         expect(
-          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
-        ).toMatch(/> ?iPhone/);
+          document.querySelector('.ais-Breadcrumb-item--selected')
+        ).toHaveTextContent(/> ?iPhone/);
       }
 
       // Select a refinement
@@ -88,8 +88,8 @@ export function createOptimisticUiTests(setup: BreadcrumbSetup, act: Act) {
           document.querySelectorAll('.ais-Breadcrumb-item--selected')
         ).toHaveLength(1);
         expect(
-          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
-        ).toMatch(/> ?Apple/);
+          document.querySelector('.ais-Breadcrumb-item--selected')
+        ).toHaveTextContent(/> ?Apple/);
       }
 
       // Wait for new results to come in
@@ -102,8 +102,8 @@ export function createOptimisticUiTests(setup: BreadcrumbSetup, act: Act) {
           document.querySelectorAll('.ais-Breadcrumb-item--selected')
         ).toHaveLength(1);
         expect(
-          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
-        ).toMatch(/> ?Apple/);
+          document.querySelector('.ais-Breadcrumb-item--selected')
+        ).toHaveTextContent(/> ?Apple/);
       }
     });
 
@@ -167,8 +167,8 @@ export function createOptimisticUiTests(setup: BreadcrumbSetup, act: Act) {
           document.querySelectorAll('.ais-Breadcrumb-item--selected')
         ).toHaveLength(1);
         expect(
-          document.querySelector('.ais-Breadcrumb-item--selected')?.textContent
-        ).toMatch(/> ?iPhone/);
+          document.querySelector('.ais-Breadcrumb-item--selected')
+        ).toHaveTextContent(/> ?iPhone/);
       }
 
       // start erroring
@@ -190,8 +190,8 @@ export function createOptimisticUiTests(setup: BreadcrumbSetup, act: Act) {
           document.querySelectorAll('.ais-Breadcrumb-item--selected')
         ).toHaveLength(1);
         expect(
-          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
-        ).toMatch(/> ?Apple/);
+          document.querySelector('.ais-Breadcrumb-item--selected')
+        ).toHaveTextContent(/> ?Apple/);
       }
 
       // Wait for new results to come in
@@ -206,8 +206,8 @@ export function createOptimisticUiTests(setup: BreadcrumbSetup, act: Act) {
           document.querySelectorAll('.ais-Breadcrumb-item--selected')
         ).toHaveLength(1);
         expect(
-          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
-        ).toMatch(/> ?iPhone/);
+          document.querySelector('.ais-Breadcrumb-item--selected')
+        ).toHaveTextContent(/> ?iPhone/);
       }
 
       // stop erroring
@@ -229,8 +229,8 @@ export function createOptimisticUiTests(setup: BreadcrumbSetup, act: Act) {
           document.querySelectorAll('.ais-Breadcrumb-item--selected')
         ).toHaveLength(1);
         expect(
-          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
-        ).toMatch(/> ?Apple/);
+          document.querySelector('.ais-Breadcrumb-item--selected')
+        ).toHaveTextContent(/> ?Apple/);
       }
 
       // Wait for new results to come in
@@ -245,8 +245,8 @@ export function createOptimisticUiTests(setup: BreadcrumbSetup, act: Act) {
           document.querySelectorAll('.ais-Breadcrumb-item--selected')
         ).toHaveLength(1);
         expect(
-          document.querySelector('.ais-Breadcrumb-item--selected')!.textContent
-        ).toMatch(/> ?Apple/);
+          document.querySelector('.ais-Breadcrumb-item--selected')
+        ).toHaveTextContent(/> ?Apple/);
       }
     });
   });


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

If a breadcrumb widget gets "its" hierarchical menu added dynamically, there will be a render where getFacetValues returns `undefined`.

I checked, and all other cases of `getFacetValues` guard already for its result possibly being undefined.

Also added the common test for optimistic UI for breadcrumb, as it's a related fix.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

No error when hierarchical menu for a breadcrumb gets added dynamically
