### PR TITLE
feat(insights): automatically load search-insights if not passed

### DIFF
--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -97,16 +97,16 @@ describe('insights', () => {
 
   beforeEach(() => {
     warning.cache = {};
+
+    (window as any).AlgoliaAnalyticsObject = undefined;
+    (window as any).aa = undefined;
+
+    document.body.innerHTML = '';
   });
 
   describe('usage', () => {
-    it('throws when insightsClient is not given', () => {
-      expect(() =>
-        // @ts-expect-error
-        createInsightsMiddleware()
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"The \`insightsClient\` option is required if you want userToken to be automatically set in search calls. If you don't want this behaviour, set it to \`null\`."`
-      );
+    it('passes when insightsClient is not given', () => {
+      expect(() => createInsightsMiddleware()).not.toThrow();
     });
 
     it('passes with insightsClient: null', () => {
@@ -116,6 +116,54 @@ describe('insights', () => {
         })
       ).not.toThrow();
     });
+  });
+
+  describe('insightsClient', () => {
+    it('does nothing when insightsClient is passed', () => {
+      createInsightsMiddleware({ insightsClient: () => {} });
+
+      expect(document.body).toMatchInlineSnapshot(`<body />`);
+      expect((window as any).AlgoliaAnalyticsObject).toBe(undefined);
+      expect((window as any).aa).toBe(undefined);
+    });
+
+    it('does nothing when insightsClient is null', () => {
+      createInsightsMiddleware({ insightsClient: null });
+
+      expect(document.body).toMatchInlineSnapshot(`<body />`);
+      expect((window as any).AlgoliaAnalyticsObject).toBe(undefined);
+      expect((window as any).aa).toBe(undefined);
+    });
+
+    it('does nothing when insightsClient is already present', () => {
+      (window as any).AlgoliaAnalyticsObject = 'aa';
+      const aa = () => {};
+      (window as any).aa = aa;
+
+      createInsightsMiddleware();
+
+      expect(document.body).toMatchInlineSnapshot(`<body />`);
+      expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
+      expect((window as any).aa).toBe(aa);
+    });
+
+    it('loads the script when insightsClient is not passed', () => {
+      createInsightsMiddleware();
+
+      expect(document.body).toMatchInlineSnapshot(`
+        <body>
+          <script
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.3.0/dist/search-insights.min.js"
+          />
+        </body>
+      `);
+      expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
+      expect((window as any).aa).toEqual(expect.any(Function));
+    });
+
+    it.todo('notifies when the script fails to be added');
+
+    it.todo('notifies when the script fails to load');
   });
 
   describe('initialize', () => {

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -81,11 +81,11 @@ export function createInsightsMiddleware<
           script.async = true;
           script.src = ALGOLIA_INSIGHTS_SRC;
           script.onerror = () => {
-            // @TODO: what can be notified of this error?
+            // @TODO: it would be useful to track errors
           };
           document.body.appendChild(script);
         } catch (e) {
-          // @TODO: what can be notified of this error?
+          // @TODO: it would be useful to track errors
         }
       }
     });

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -5,7 +5,13 @@ import type {
   Hit,
 } from '../types';
 import { getInsightsAnonymousUserTokenInternal } from '../helpers';
-import { warning, noop, getAppIdAndApiKey, find } from '../lib/utils';
+import {
+  warning,
+  noop,
+  getAppIdAndApiKey,
+  find,
+  safelyRunOnBrowser,
+} from '../lib/utils';
 import type {
   AlgoliaSearchHelper,
   PlainSearchParameters,
@@ -21,9 +27,12 @@ export type InsightsEvent = {
 };
 
 export type InsightsProps<
-  TInsightsClient extends null | InsightsClient = InsightsClient | null
+  TInsightsClient extends InsightsClient | null | undefined =
+    | InsightsClient
+    | null
+    | undefined
 > = {
-  insightsClient: TInsightsClient;
+  insightsClient?: TInsightsClient;
   insightsInitParams?: {
     userHasOptedOut?: boolean;
     useCookie?: boolean;
@@ -33,31 +42,54 @@ export type InsightsProps<
   onEvent?: (event: InsightsEvent, insightsClient: TInsightsClient) => void;
 };
 
+const ALGOLIA_INSIGHTS_SRC =
+  'https://cdn.jsdelivr.net/npm/search-insights@2.3.0/dist/search-insights.min.js';
+
 export type CreateInsightsMiddleware = typeof createInsightsMiddleware;
 
 export function createInsightsMiddleware<
   TInsightsClient extends null | InsightsClient
->(props: InsightsProps<TInsightsClient>): InternalMiddleware {
+>(props: InsightsProps<TInsightsClient> = {}): InternalMiddleware {
   const {
     insightsClient: _insightsClient,
     insightsInitParams,
     onEvent,
-  } = props || {};
-  if (_insightsClient !== null && !_insightsClient) {
-    if (__DEV__) {
-      throw new Error(
-        "The `insightsClient` option is required if you want userToken to be automatically set in search calls. If you don't want this behaviour, set it to `null`."
-      );
-    } else {
-      throw new Error(
-        'The `insightsClient` option is required. To disable, set it to `null`.'
-      );
-    }
-  }
+  } = props;
 
-  const hasInsightsClient = Boolean(_insightsClient);
-  const insightsClient: InsightsClient =
-    _insightsClient === null ? noop : _insightsClient;
+  let insightsClient: InsightsClient = _insightsClient || noop;
+
+  if (_insightsClient !== null && !_insightsClient) {
+    safelyRunOnBrowser(({ window }: { window: any }) => {
+      const pointer = window.AlgoliaAnalyticsObject || 'aa';
+
+      if (typeof pointer === 'string') {
+        insightsClient = window[pointer];
+      }
+
+      if (!insightsClient) {
+        window.AlgoliaAnalyticsObject = pointer;
+        window[pointer] =
+          window[pointer] ||
+          function (...args: any[]) {
+            (window[pointer].queue = window[pointer].queue || []).push(args);
+          };
+
+        insightsClient = window[pointer];
+
+        try {
+          const script = document.createElement('script');
+          script.async = true;
+          script.src = ALGOLIA_INSIGHTS_SRC;
+          script.onerror = () => {
+            // @TODO: what can be notified of this error?
+          };
+          document.body.appendChild(script);
+        } catch (e) {
+          // @TODO: what can be notified of this error?
+        }
+      }
+    });
+  }
 
   return ({ instantSearchInstance }) => {
     const [appId, apiKey] = getAppIdAndApiKey(instantSearchInstance.client);
@@ -131,7 +163,7 @@ export function createInsightsMiddleware<
         };
 
         const anonymousUserToken = getInsightsAnonymousUserTokenInternal();
-        if (hasInsightsClient && anonymousUserToken) {
+        if (anonymousUserToken) {
           // When `aa('init', { ... })` is called, it creates an anonymous user token in cookie.
           // We can set it as userToken.
           setUserTokenToSearch(anonymousUserToken);
@@ -152,7 +184,7 @@ export function createInsightsMiddleware<
 
         instantSearchInstance.sendEventToInsights = (event: InsightsEvent) => {
           if (onEvent) {
-            onEvent(event, _insightsClient);
+            onEvent(event, _insightsClient as TInsightsClient);
           } else if (event.insightsMethod) {
             const hasUserToken = Boolean(
               (helper.state as PlainSearchParameters).userToken

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -69,11 +69,14 @@ export function createInsightsMiddleware<
 
       if (!insightsClient) {
         window.AlgoliaAnalyticsObject = pointer;
-        window[pointer] =
-          window[pointer] ||
-          function (...args: any[]) {
-            (window[pointer].queue = window[pointer].queue || []).push(args);
+        if (!window[pointer]) {
+          window[pointer] = (...args: any[]) => {
+            if (!window[pointer].queue) {
+              window[pointer].queue = [];
+            }
+            window[pointer].queue.push(args);
           };
+        }
 
         insightsClient = window[pointer];
         needsToLoadInsightsClient = true;


### PR DESCRIPTION



**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

When the insights middleware is instantiated, it will attempt to extract or load a search-insights client.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- insights middleware makes `insightsClient` optional
- first it checks if there's an unlinked existing insights client
- then it loads search-insights from jsDelivr
- if there's an error in this loading, nothing happens

FX-2244
