### PR TITLE
feat(metadata): register metadata around middleware

### DIFF
--- a/packages/instantsearch.js/src/lib/routers/history.ts
+++ b/packages/instantsearch.js/src/lib/routers/history.ts
@@ -36,6 +36,7 @@ const setWindowTitle = (title?: string): void => {
 };
 
 class BrowserHistory<TRouteState> implements Router<TRouteState> {
+  public $$type = 'ais.browser';
   /**
    * Transforms a UI state into a title for the page.
    */

--- a/packages/instantsearch.js/src/lib/stateMappings/simple.ts
+++ b/packages/instantsearch.js/src/lib/stateMappings/simple.ts
@@ -14,6 +14,8 @@ export default function simpleStateMapping<
   TUiState extends UiState = UiState
 >(): StateMapping<TUiState, TUiState> {
   return {
+    $$type: 'ais.simple',
+
     stateToRoute(uiState) {
       return Object.keys(uiState).reduce(
         (state, indexId) => ({

--- a/packages/instantsearch.js/src/lib/stateMappings/singleIndex.ts
+++ b/packages/instantsearch.js/src/lib/stateMappings/singleIndex.ts
@@ -13,6 +13,7 @@ export default function singleIndexStateMapping<
   indexName: keyof TUiState
 ): StateMapping<TUiState, TUiState[typeof indexName]> {
   return {
+    $$type: 'ais.singleIndex',
     stateToRoute(uiState) {
       return getIndexStateWithoutConfigure(uiState[indexName] || {});
     },

--- a/packages/instantsearch.js/src/middlewares/__tests__/createMetadataMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createMetadataMiddleware.ts
@@ -206,7 +206,7 @@ describe('createMetadataMiddleware', () => {
       expect(document.head).toMatchInlineSnapshot(`
         <head>
           <meta
-            content="{\\"widgets\\":[{\\"middleware\\":true,\\"type\\":\\"ais.router\\",\\"internal\\":true},{\\"middleware\\":true,\\"type\\":\\"ais.insights\\",\\"internal\\":true},{\\"middleware\\":true,\\"type\\":\\"ais.metadata\\",\\"internal\\":true},{\\"middleware\\":true,\\"type\\":\\"test\\",\\"internal\\":false},{\\"middleware\\":true,\\"type\\":\\"__unknown__\\",\\"internal\\":false}]}"
+            content="{\\"widgets\\":[{\\"middleware\\":true,\\"type\\":\\"ais.router({router:ais.browser, stateMapping:ais.simple})\\",\\"internal\\":true},{\\"middleware\\":true,\\"type\\":\\"ais.insights\\",\\"internal\\":true},{\\"middleware\\":true,\\"type\\":\\"ais.metadata\\",\\"internal\\":true},{\\"middleware\\":true,\\"type\\":\\"test\\",\\"internal\\":false},{\\"middleware\\":true,\\"type\\":\\"__unknown__\\",\\"internal\\":false}]}"
             name="instantsearch:widgets"
           />
         </head>
@@ -218,7 +218,7 @@ describe('createMetadataMiddleware', () => {
           {
             "internal": true,
             "middleware": true,
-            "type": "ais.router",
+            "type": "ais.router({router:ais.browser, stateMapping:ais.simple})",
           },
           {
             "internal": true,

--- a/packages/instantsearch.js/src/middlewares/__tests__/createMetadataMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createMetadataMiddleware.ts
@@ -127,52 +127,120 @@ describe('createMetadataMiddleware', () => {
       expect(document.head).toMatchInlineSnapshot(`
         <head>
           <meta
-            content="{\\"widgets\\":[{\\"type\\":\\"ais.searchBox\\",\\"widgetType\\":\\"ais.searchBox\\",\\"params\\":[]},{\\"type\\":\\"ais.searchBox\\",\\"widgetType\\":\\"ais.searchBox\\",\\"params\\":[]},{\\"type\\":\\"ais.hits\\",\\"widgetType\\":\\"ais.hits\\",\\"params\\":[\\"escapeHTML\\"]},{\\"type\\":\\"ais.index\\",\\"widgetType\\":\\"ais.index\\",\\"params\\":[]},{\\"type\\":\\"ais.pagination\\",\\"widgetType\\":\\"ais.pagination\\",\\"params\\":[]},{\\"type\\":\\"ais.configure\\",\\"widgetType\\":\\"ais.configure\\",\\"params\\":[\\"searchParameters\\"]}]}"
+            content="{\\"widgets\\":[{\\"type\\":\\"ais.searchBox\\",\\"widgetType\\":\\"ais.searchBox\\",\\"params\\":[]},{\\"type\\":\\"ais.searchBox\\",\\"widgetType\\":\\"ais.searchBox\\",\\"params\\":[]},{\\"type\\":\\"ais.hits\\",\\"widgetType\\":\\"ais.hits\\",\\"params\\":[\\"escapeHTML\\"]},{\\"type\\":\\"ais.index\\",\\"widgetType\\":\\"ais.index\\",\\"params\\":[]},{\\"type\\":\\"ais.pagination\\",\\"widgetType\\":\\"ais.pagination\\",\\"params\\":[]},{\\"type\\":\\"ais.configure\\",\\"widgetType\\":\\"ais.configure\\",\\"params\\":[\\"searchParameters\\"]},{\\"middleware\\":true,\\"type\\":\\"ais.insights\\",\\"internal\\":true},{\\"middleware\\":true,\\"type\\":\\"ais.metadata\\",\\"internal\\":true}]}"
             name="instantsearch:widgets"
           />
         </head>
       `);
 
-      expect(JSON.parse(document.head.querySelector('meta')!.content))
+      expect(JSON.parse(document.head.querySelector('meta')!.content).widgets)
         .toMatchInlineSnapshot(`
-        {
-          "widgets": [
-            {
-              "params": [],
-              "type": "ais.searchBox",
-              "widgetType": "ais.searchBox",
-            },
-            {
-              "params": [],
-              "type": "ais.searchBox",
-              "widgetType": "ais.searchBox",
-            },
-            {
-              "params": [
-                "escapeHTML",
-              ],
-              "type": "ais.hits",
-              "widgetType": "ais.hits",
-            },
-            {
-              "params": [],
-              "type": "ais.index",
-              "widgetType": "ais.index",
-            },
-            {
-              "params": [],
-              "type": "ais.pagination",
-              "widgetType": "ais.pagination",
-            },
-            {
-              "params": [
-                "searchParameters",
-              ],
-              "type": "ais.configure",
-              "widgetType": "ais.configure",
-            },
-          ],
-        }
+        [
+          {
+            "params": [],
+            "type": "ais.searchBox",
+            "widgetType": "ais.searchBox",
+          },
+          {
+            "params": [],
+            "type": "ais.searchBox",
+            "widgetType": "ais.searchBox",
+          },
+          {
+            "params": [
+              "escapeHTML",
+            ],
+            "type": "ais.hits",
+            "widgetType": "ais.hits",
+          },
+          {
+            "params": [],
+            "type": "ais.index",
+            "widgetType": "ais.index",
+          },
+          {
+            "params": [],
+            "type": "ais.pagination",
+            "widgetType": "ais.pagination",
+          },
+          {
+            "params": [
+              "searchParameters",
+            ],
+            "type": "ais.configure",
+            "widgetType": "ais.configure",
+          },
+          {
+            "internal": true,
+            "middleware": true,
+            "type": "ais.insights",
+          },
+          {
+            "internal": true,
+            "middleware": true,
+            "type": "ais.metadata",
+          },
+        ]
+      `);
+    });
+
+    it('fills it with metadata after start', async () => {
+      // not using createMetadataMiddleware() here,
+      // since metadata is built into instantsearch
+      const search = instantsearch({
+        searchClient: createSearchClient(),
+        indexName: 'test',
+        routing: true,
+      });
+
+      search.use(
+        () => ({ $$type: 'test', $$internal: false }),
+        // @ts-expect-error (unknown middleware, shouldn't error)
+        () => ({})
+      );
+
+      search.start();
+
+      await wait(100);
+
+      expect(document.head).toMatchInlineSnapshot(`
+        <head>
+          <meta
+            content="{\\"widgets\\":[{\\"middleware\\":true,\\"type\\":\\"ais.router\\",\\"internal\\":true},{\\"middleware\\":true,\\"type\\":\\"ais.insights\\",\\"internal\\":true},{\\"middleware\\":true,\\"type\\":\\"ais.metadata\\",\\"internal\\":true},{\\"middleware\\":true,\\"type\\":\\"test\\",\\"internal\\":false},{\\"middleware\\":true,\\"type\\":\\"__unknown__\\",\\"internal\\":false}]}"
+            name="instantsearch:widgets"
+          />
+        </head>
+      `);
+
+      expect(JSON.parse(document.head.querySelector('meta')!.content).widgets)
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "internal": true,
+            "middleware": true,
+            "type": "ais.router",
+          },
+          {
+            "internal": true,
+            "middleware": true,
+            "type": "ais.insights",
+          },
+          {
+            "internal": true,
+            "middleware": true,
+            "type": "ais.metadata",
+          },
+          {
+            "internal": false,
+            "middleware": true,
+            "type": "test",
+          },
+          {
+            "internal": false,
+            "middleware": true,
+            "type": "__unknown__",
+          },
+        ]
       `);
     });
 
@@ -203,7 +271,7 @@ describe('createMetadataMiddleware', () => {
           ua: expect.stringMatching(
             /^Algolia for JavaScript \(4\.(\d+\.?)+\); Node\.js \((\d+\.?)+\); instantsearch\.js \((\d+\.?)+\); JS Helper \((\d+\.?)+\)$/
           ),
-          widgets: [],
+          widgets: expect.any(Array),
         });
       });
 
@@ -235,7 +303,7 @@ describe('createMetadataMiddleware', () => {
           ua: expect.stringMatching(
             /^Algolia for JavaScript \(4\.(\d+\.?)+\); Node\.js \((\d+\.?)+\); instantsearch\.js \((\d+\.?)+\); JS Helper \((\d+\.?)+\); test \(cool\)$/
           ),
-          widgets: [],
+          widgets: expect.any(Array),
         });
       });
 
@@ -264,7 +332,7 @@ describe('createMetadataMiddleware', () => {
           ua: expect.stringMatching(
             /^Algolia for JavaScript \(3\.(\d+\.?)+\); Node\.js \((\d+\.?)+\); instantsearch\.js \((\d+\.?)+\); JS Helper \((\d+\.?)+\)$/
           ),
-          widgets: [],
+          widgets: expect.any(Array),
         });
       });
 
@@ -295,7 +363,7 @@ describe('createMetadataMiddleware', () => {
           ua: expect.stringMatching(
             /^Algolia for JavaScript \(3\.(\d+\.?)+\); Node\.js \((\d+\.?)+\); instantsearch\.js \((\d+\.?)+\); JS Helper \((\d+\.?)+\); test \(cool\)$/
           ),
-          widgets: [],
+          widgets: expect.any(Array),
         });
       });
 
@@ -319,7 +387,7 @@ describe('createMetadataMiddleware', () => {
         expect(
           JSON.parse(document.head.querySelector('meta')!.content)
         ).toEqual({
-          widgets: [],
+          widgets: expect.any(Array),
         });
       });
     });

--- a/packages/instantsearch.js/src/middlewares/createMetadataMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createMetadataMiddleware.ts
@@ -2,18 +2,24 @@ import { createInitArgs, safelyRunOnBrowser } from '../lib/utils';
 import type { InstantSearch, InternalMiddleware, Widget } from '../types';
 import type { IndexWidget } from '../widgets/index/index';
 
-type WidgetMetaData = {
-  type: string | undefined;
-  widgetType: string | undefined;
-  params: string[];
-};
+type WidgetMetadata =
+  | {
+      type: string | undefined;
+      widgetType: string | undefined;
+      params: string[];
+    }
+  | {
+      type: string;
+      middleware: true;
+      internal: boolean;
+    };
 
 type Payload = {
-  widgets: WidgetMetaData[];
+  widgets: WidgetMetadata[];
   ua?: string;
 };
 
-function extractPayload(
+function extractWidgetPayload(
   widgets: Array<Widget | IndexWidget>,
   instantSearchInstance: InstantSearch,
   payload: Payload
@@ -48,7 +54,7 @@ function extractPayload(
     });
 
     if (widget.$$type === 'ais.index') {
-      extractPayload(
+      extractWidgetPayload(
         (widget as IndexWidget).getWidgets(),
         instantSearchInstance,
         payload
@@ -98,10 +104,18 @@ export function createMetadataMiddleware({
               ? client.transporter.userAgent.value
               : client._ua;
 
-          extractPayload(
+          extractWidgetPayload(
             instantSearchInstance.mainIndex.getWidgets(),
             instantSearchInstance,
             payload
+          );
+
+          instantSearchInstance.middleware.forEach((middleware) =>
+            payload.widgets.push({
+              middleware: true,
+              type: middleware.instance.$$type,
+              internal: middleware.instance.$$internal,
+            })
           );
 
           payloadContainer.content = JSON.stringify(payload);

--- a/packages/instantsearch.js/src/middlewares/createRouterMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createRouterMiddleware.ts
@@ -68,7 +68,9 @@ export const createRouterMiddleware = <
     const initialUiState = instantSearchInstance._initialUiState;
 
     return {
-      $$type: 'ais.router',
+      $$type: `ais.router({router:${
+        router.$$type || '__unknown__'
+      }, stateMapping:${stateMapping.$$type || '__unknown__'}})`,
       $$internal,
       onStateChange({ uiState }) {
         const routeState = stateMapping.stateToRoute(uiState);

--- a/packages/instantsearch.js/src/types/router.ts
+++ b/packages/instantsearch.js/src/types/router.ts
@@ -35,6 +35,11 @@ export type Router<TRouteState = UiState> = {
    * Called when InstantSearch is disposed. Used to remove subscriptions.
    */
   dispose(): void;
+
+  /**
+   * Identifier for this router. Used to differentiate between routers.
+   */
+  $$type?: string;
 };
 
 /**
@@ -57,4 +62,9 @@ export type StateMapping<TUiState = UiState, TRouteState = TUiState> = {
    * The format is the output of `stateToRoute`.
    */
   routeToState(routeState: TRouteState): TUiState;
+
+  /**
+   * Identifier for this stateMapping. Used to differentiate between stateMappings.
+   */
+  $$type?: string;
 };

--- a/packages/react-instantsearch-hooks-router-nextjs/src/index.ts
+++ b/packages/react-instantsearch-hooks-router-nextjs/src/index.ts
@@ -165,6 +165,7 @@ export function createInstantSearchRouterNext<TRouteState = UiState>(
     ...routerOptions,
   });
   router._isNextRouter = true;
+  router.$$type = 'ais.nextjs';
 
   return router;
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Since `$$type` and `$$internal` are added in #5488, we can use this to give some information around middleware in metadata

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

A new type of `widgets` is available, with a shape like this: 

```json
{
  "widgets": [{ "middleware": true, "type": "ais.insights", "internal": false }]
}
```

We don't know the parameters passed by the users, as it's defaulted early on in the arguments and there's no equivalent to getWidgetRenderState().widgetParams.

However, in the router middleware, the router and state mapping are also identified in the `$$type`

This is the same as #5491, but in the existing `widgets` key.
