### PR TITLE
feat(insights): option to disable automatic insights middleware

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -136,7 +136,7 @@ export type InstantSearchOptions<
   /**
    * Automatically enables the Insights middleware and loads the Insights library
    * if not already loaded.
-   * 
+   *
    * The Insights middleware sends view and click events automatically, and lets
    * you set up your own events.
    *

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -134,8 +134,11 @@ export type InstantSearchOptions<
   routing?: RouterProps<TUiState, TRouteState> | boolean;
 
   /**
-   * Enables the insights middleware. This middleware will send view and click events,
-   * as well as allowing to set up your own events.
+   * Automatically enables the Insights middleware and loads the Insights library
+   * if not already loaded.
+   * 
+   * The Insights middleware sends view and click events automatically, and lets
+   * you set up your own events.
    *
    * @default true
    */

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -134,6 +134,14 @@ export type InstantSearchOptions<
   routing?: RouterProps<TUiState, TRouteState> | boolean;
 
   /**
+   * Enables the insights middleware. This middleware will send view and click events,
+   * as well as allowing to set up your own events.
+   *
+   * @default true
+   */
+  insights?: boolean;
+
+  /**
    * the instance of search-insights to use for sending insights events inside
    * widgets like `hits`.
    *
@@ -211,6 +219,7 @@ Use \`InstantSearch.status === "stalled"\` instead.`
       numberLocale,
       initialUiState = {} as TUiState,
       routing = null,
+      insights = true,
       searchFunction,
       stalledSearchDelay = 200,
       searchClient = null,
@@ -305,7 +314,9 @@ See ${createDocumentationLink({
 
     // This is the default middleware,
     // any user-provided middleware will be added later and override this one.
-    this.use(createInsightsMiddleware({ $$internal: true }));
+    if (insights) {
+      this.use(createInsightsMiddleware({ $$internal: true }));
+    }
 
     if (isMetadataEnabled()) {
       this.use(createMetadataMiddleware({ $$internal: true }));

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -41,12 +41,14 @@ describe('insights', () => {
   const createTestEnvironment = ({
     searchClient = searchClientWithCredentials,
     started = true,
+    insights = false,
   } = {}) => {
     const { analytics, insightsClient } = createInsights();
     const indexName = 'my-index';
     const instantSearchInstance = instantsearch({
       searchClient,
       indexName,
+      insights,
     });
     if (started) {
       instantSearchInstance.start();
@@ -78,6 +80,7 @@ describe('insights', () => {
           },
         },
       }),
+      insights: false,
       indexName,
     });
     instantSearchInstance.start();
@@ -420,7 +423,9 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
     });
 
     it('removes default middleware if user adds a custom one', () => {
-      const { instantSearchInstance } = createTestEnvironment();
+      const { instantSearchInstance } = createTestEnvironment({
+        insights: true,
+      });
 
       // just the internal one
       expect(instantSearchInstance.middleware).toHaveLength(1);
@@ -440,7 +445,9 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
         ]
       `);
 
-      instantSearchInstance.use(createInsightsMiddleware({}));
+      instantSearchInstance.use(
+        createInsightsMiddleware({ insightsClient: () => {} })
+      );
 
       // just the user-provided one
       expect(instantSearchInstance.middleware).toHaveLength(1);


### PR DESCRIPTION
instead of passing your own middleware, where timing could be tricky, to disable the internal middleware you pass `insights: false` to InstantSearch. Note that the internal middleware will still be removed when a different middleware is passed to allow easy customisation

FX-2250