### PR TITLE
feat(index): introduce setIndexUiState

### DIFF
--- a/packages/instantsearch.js/src/types/index.ts
+++ b/packages/instantsearch.js/src/types/index.ts
@@ -22,3 +22,6 @@ export * from './widget';
 export * from './ui-state';
 export * from './render-state';
 export * from './templates';
+
+// from specific widgets
+export type { IndexWidget } from '../widgets/index/index';

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -2903,7 +2903,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
   });
 
   describe('setIndexUiState', () => {
-    it('updates main ui state with object', () => {
+    it('updates main UI state with an object', () => {
       const instance = index({ indexName: 'indexName' });
       const instantSearchInstance = instantsearch({
         indexName: 'root',
@@ -2926,7 +2926,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       });
     });
 
-    it('updates main ui state with function', () => {
+    it('updates main UI state with a function', () => {
       const instance = index({ indexName: 'indexName' });
       const instantSearchInstance = instantsearch({
         indexName: 'root',

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -24,8 +24,13 @@ import InstantSearch from '../../../lib/InstantSearch';
 import index from '../index';
 import { warning } from '../../../lib/utils';
 import { refinementList } from '../..';
-import { connectHits } from '../../../connectors';
+import {
+  connectHits,
+  connectPagination,
+  connectSearchBox,
+} from '../../../connectors';
 import { castToJestMock } from '../../../../../../tests/utils';
+import instantsearch from '../../../index.es';
 
 describe('index', () => {
   const createSearchBox = (args: Partial<Widget> = {}): Widget =>
@@ -2891,6 +2896,64 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       }).not.toWarnDev(
         '[InstantSearch.js]: The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
       );
+    });
+  });
+
+  describe('setIndexUiState', () => {
+    it('updates main ui state with object', () => {
+      const instance = index({ indexName: 'indexName' });
+      const instantSearchInstance = instantsearch({
+        indexName: 'root',
+        searchClient: createSearchClient(),
+      });
+      instantSearchInstance.start();
+      instantSearchInstance.addWidgets([
+        instance.addWidgets([virtualSearchBox({})]),
+      ]);
+
+      instance.setIndexUiState({
+        query: 'iphone',
+      });
+
+      expect(instantSearchInstance.getUiState()).toEqual({
+        root: {},
+        indexName: {
+          query: 'iphone',
+        },
+      });
+    });
+
+    it('updates main ui state with function', () => {
+      const instance = index({ indexName: 'indexName' });
+      const instantSearchInstance = instantsearch({
+        indexName: 'root',
+        searchClient: createSearchClient(),
+      });
+      instantSearchInstance.start();
+      instantSearchInstance.addWidgets([
+        instance.addWidgets([virtualPagination({})]),
+      ]);
+      instance.setIndexUiState((uiState) => ({
+        page: (uiState.page || 1) + 1,
+      }));
+
+      expect(instantSearchInstance.getUiState()).toEqual({
+        root: {},
+        indexName: {
+          page: 2,
+        },
+      });
+
+      instance.setIndexUiState((uiState) => ({
+        page: (uiState.page || 1) + 1,
+      }));
+
+      expect(instantSearchInstance.getUiState()).toEqual({
+        root: {},
+        indexName: {
+          page: 3,
+        },
+      });
     });
   });
 

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -109,6 +109,9 @@ describe('index', () => {
       ...args,
     });
 
+  const virtualSearchBox = connectSearchBox(() => {});
+  const virtualPagination = connectPagination(() => {});
+
   it('throws without argument', () => {
     expect(() => {
       // @ts-expect-error

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -58,7 +58,7 @@ export type IndexWidgetDescription = {
   $$widgetType: 'ais.index';
 };
 
-export type IndexWidget = Omit<
+export type IndexWidget<TUiState extends UiState = UiState> = Omit<
   Widget<IndexWidgetDescription & { widgetParams: IndexWidgetParams }>,
   'getWidgetUiState' | 'getWidgetState'
 > & {
@@ -82,14 +82,28 @@ export type IndexWidget = Omit<
    * @deprecated
    */
   getWidgetState(uiState: UiState): UiState;
-  getWidgetUiState<TUiState extends UiState = UiState>(
-    uiState: TUiState
-  ): TUiState;
+  getWidgetUiState<TSpecificUiState extends UiState = TUiState>(
+    uiState: TSpecificUiState
+  ): TSpecificUiState;
   getWidgetSearchParameters(
     searchParameters: SearchParameters,
     searchParametersOptions: { uiState: IndexUiState }
   ): SearchParameters;
+  /**
+   * Set this index' UI state back to the state defined by the widgets.
+   * Can only be called after `init`.
+   */
   refreshUiState(): void;
+  /**
+   * Set this index' UI state and search. This is the equivalent of calling
+   * a spread `setUiState` on the InstantSearch instance.
+   * Can only be called after `init`.
+   */
+  setIndexUiState(
+    indexUiState:
+      | TUiState[string]
+      | ((previousIndexUiState: TUiState[string]) => TUiState[string])
+  ): void;
 };
 
 /**
@@ -697,6 +711,22 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         },
         localUiState
       );
+    },
+
+    setIndexUiState<TIndexUiState extends IndexUiState = IndexUiState>(
+      indexUiState:
+        | TIndexUiState
+        | ((previousIndexUiState: TIndexUiState) => TIndexUiState)
+    ) {
+      const nextIndexUiState =
+        typeof indexUiState === 'function'
+          ? indexUiState(localUiState as TIndexUiState)
+          : indexUiState;
+
+      localInstantSearchInstance!.setUiState((state) => ({
+        ...state,
+        [indexId]: nextIndexUiState,
+      }));
     },
   };
 };

--- a/packages/react-instantsearch-hooks/src/lib/useIndexContext.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useIndexContext.ts
@@ -4,8 +4,13 @@ import { invariant } from '../lib/invariant';
 
 import { IndexContext } from './IndexContext';
 
-export function useIndexContext() {
-  const context = useContext(IndexContext);
+import type { IndexWidget, UiState } from 'instantsearch.js';
+import type { Context } from 'react';
+
+export function useIndexContext<TUiState extends UiState = UiState>() {
+  const context = useContext(
+    IndexContext as Context<IndexWidget<TUiState> | null>
+  );
 
   invariant(
     context !== null,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This function is visible in useInstantSearch, so it has potential to supplant the usage of `helper.setState().search` in the future.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- adds index.setIndexUiState
- use index.setUiState in useInstantSearch
- allow IndexWidget type to be generic
