### PR TITLE
refactor(imports): order imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -148,6 +148,21 @@ const config = {
         '@typescript-eslint/consistent-type-assertions': 'off',
         // We don't ship PropTypes in the next version of the library.
         'react/prop-types': 'off',
+        'import/extensions': ['error', 'never'],
+      },
+      settings: {
+        'import/parsers': {
+          '@typescript-eslint/parser': ['.ts', '.tsx'],
+        },
+      },
+    },
+    {
+      files: [
+        'packages/instantsearch.js/**/*',
+        'packages/react-instantsearch-hooks/**/*',
+        'packages/react-instantsearch-hooks-*/**/*',
+      ],
+      rules: {
         'import/order': [
           'error',
           {
@@ -174,13 +189,7 @@ const config = {
             pathGroupsExcludedImportTypes: ['builtin'],
           },
         ],
-        'import/extensions': ['error', 'never'],
-      },
-      settings: {
-        'import/parsers': {
-          '@typescript-eslint/parser': ['.ts', '.tsx'],
-        },
-      },
+      }
     },
     {
       files: 'packages/**/*',

--- a/packages/instantsearch.js/scripts/rollup/rollup.config.js
+++ b/packages/instantsearch.js/scripts/rollup/rollup.config.js
@@ -1,9 +1,10 @@
-import resolve from 'rollup-plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
+import commonjs from 'rollup-plugin-commonjs';
+import filesize from 'rollup-plugin-filesize';
+import resolve from 'rollup-plugin-node-resolve';
 import replace from 'rollup-plugin-replace';
 import { uglify } from 'rollup-plugin-uglify';
-import filesize from 'rollup-plugin-filesize';
+
 import packageJson from '../../package.json';
 
 const version =

--- a/packages/instantsearch.js/scripts/typescript/extract.js
+++ b/packages/instantsearch.js/scripts/typescript/extract.js
@@ -3,6 +3,8 @@
 /* eslint-disable import/no-commonjs, no-console */
 
 const path = require('path');
+
+const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
 const shell = require('shelljs');
 
 console.log(`Compiling definitions...`);
@@ -29,8 +31,6 @@ shell.sed(
 
 console.log();
 console.log(`Validating definitions...`);
-
-const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
 
 const extractorConfig = ExtractorConfig.loadFileAndPrepare(
   path.resolve(path.join(__dirname, 'api-extractor.json'))

--- a/packages/instantsearch.js/src/__tests__/common.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common.test.tsx
@@ -9,6 +9,7 @@ import {
   createMenuTests,
   createInfiniteHitsTests,
 } from '@instantsearch/tests';
+
 import instantsearch from '../index.es';
 import {
   hierarchicalMenu,

--- a/packages/instantsearch.js/src/components/Answers/Answers.tsx
+++ b/packages/instantsearch.js/src/components/Answers/Answers.tsx
@@ -1,14 +1,16 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h } from 'preact';
+
+import { warning } from '../../lib/utils';
 import Template from '../Template/Template';
+
+import type { ComponentCSSClasses, Hit } from '../../types';
 import type {
   AnswersCSSClasses,
   AnswersTemplates,
 } from '../../widgets/answers/answers';
-import type { ComponentCSSClasses, Hit } from '../../types';
-import { warning } from '../../lib/utils';
 
 export type AnswersComponentCSSClasses = ComponentCSSClasses<AnswersCSSClasses>;
 

--- a/packages/instantsearch.js/src/components/Answers/__tests__/Answers-test.tsx
+++ b/packages/instantsearch.js/src/components/Answers/__tests__/Answers-test.tsx
@@ -3,10 +3,12 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render } from '@testing-library/preact';
-import type { AnswersProps } from '../Answers';
+import { h } from 'preact';
+
 import Answers from '../Answers';
+
+import type { AnswersProps } from '../Answers';
 
 const defaultProps: AnswersProps = {
   hits: [],

--- a/packages/instantsearch.js/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/instantsearch.js/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,15 +1,17 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h } from 'preact';
+
 import Template from '../Template/Template';
+
+import type { BreadcrumbConnectorParamsItem } from '../../connectors/breadcrumb/connectBreadcrumb';
+import type { PreparedTemplateProps } from '../../lib/templating';
+import type { ComponentCSSClasses } from '../../types';
 import type {
   BreadcrumbCSSClasses,
   BreadcrumbTemplates,
 } from '../../widgets/breadcrumb/breadcrumb';
-import type { ComponentCSSClasses } from '../../types';
-import type { PreparedTemplateProps } from '../../lib/templating';
-import type { BreadcrumbConnectorParamsItem } from '../../connectors/breadcrumb/connectBreadcrumb';
 
 export type BreadcrumbComponentCSSClasses =
   ComponentCSSClasses<BreadcrumbCSSClasses>;

--- a/packages/instantsearch.js/src/components/Breadcrumb/__tests__/Breadcrumb-test.tsx
+++ b/packages/instantsearch.js/src/components/Breadcrumb/__tests__/Breadcrumb-test.tsx
@@ -3,12 +3,14 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render, fireEvent } from '@testing-library/preact';
-import type { BreadcrumbProps } from '../Breadcrumb';
-import Breadcrumb from '../Breadcrumb';
+import { h } from 'preact';
+
 import { prepareTemplateProps } from '../../../lib/templating';
 import defaultTemplates from '../../../widgets/breadcrumb/defaultTemplates';
+import Breadcrumb from '../Breadcrumb';
+
+import type { BreadcrumbProps } from '../Breadcrumb';
 
 const defaultProps: BreadcrumbProps = {
   items: [],

--- a/packages/instantsearch.js/src/components/ClearRefinements/ClearRefinements.tsx
+++ b/packages/instantsearch.js/src/components/ClearRefinements/ClearRefinements.tsx
@@ -1,15 +1,17 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h } from 'preact';
+
 import Template from '../Template/Template';
+
 import type { ClearRefinementsRenderState } from '../../connectors/clear-refinements/connectClearRefinements';
+import type { PreparedTemplateProps } from '../../lib/templating';
+import type { ComponentCSSClasses } from '../../types';
 import type {
   ClearRefinementsCSSClasses,
   ClearRefinementsTemplates,
 } from '../../widgets/clear-refinements/clear-refinements';
-import type { ComponentCSSClasses } from '../../types';
-import type { PreparedTemplateProps } from '../../lib/templating';
 
 export type ClearRefinementsComponentCSSClasses =
   ComponentCSSClasses<ClearRefinementsCSSClasses>;

--- a/packages/instantsearch.js/src/components/ClearRefinements/__tests__/ClearRefinements-test.tsx
+++ b/packages/instantsearch.js/src/components/ClearRefinements/__tests__/ClearRefinements-test.tsx
@@ -3,11 +3,12 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
-import ClearRefinements from '../ClearRefinements';
 import { mount } from '@instantsearch/testutils/enzyme';
+import { h } from 'preact';
+
 import { prepareTemplateProps } from '../../../lib/templating';
 import defaultTemplates from '../../../widgets/clear-refinements/defaultTemplates';
+import ClearRefinements from '../ClearRefinements';
 
 describe('ClearRefinements', () => {
   const defaultProps = {

--- a/packages/instantsearch.js/src/components/CurrentRefinements/CurrentRefinements.tsx
+++ b/packages/instantsearch.js/src/components/CurrentRefinements/CurrentRefinements.tsx
@@ -1,14 +1,16 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h } from 'preact';
+
 import { isSpecialClick, capitalize } from '../../lib/utils';
+
 import type {
   CurrentRefinementsConnectorParamsItem,
   CurrentRefinementsConnectorParamsRefinement,
 } from '../../connectors/current-refinements/connectCurrentRefinements';
-import type { CurrentRefinementsCSSClasses } from '../../widgets/current-refinements/current-refinements';
 import type { ComponentCSSClasses } from '../../types';
+import type { CurrentRefinementsCSSClasses } from '../../widgets/current-refinements/current-refinements';
 
 export type CurrentRefinementsComponentCSSClasses =
   ComponentCSSClasses<CurrentRefinementsCSSClasses>;

--- a/packages/instantsearch.js/src/components/CurrentRefinements/__tests__/CurrentRefinements-test.tsx
+++ b/packages/instantsearch.js/src/components/CurrentRefinements/__tests__/CurrentRefinements-test.tsx
@@ -3,8 +3,9 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render } from '@testing-library/preact';
+import { h } from 'preact';
+
 import CurrentRefinements from '../CurrentRefinements';
 
 describe('CurrentRefinements', () => {

--- a/packages/instantsearch.js/src/components/GeoSearchControls/GeoSearchButton.tsx
+++ b/packages/instantsearch.js/src/components/GeoSearchControls/GeoSearchButton.tsx
@@ -1,7 +1,8 @@
 /** @jsx h */
 
-import type { ComponentChildren } from 'preact';
 import { h } from 'preact';
+
+import type { ComponentChildren } from 'preact';
 
 type Props = {
   className: string;

--- a/packages/instantsearch.js/src/components/GeoSearchControls/GeoSearchControls.tsx
+++ b/packages/instantsearch.js/src/components/GeoSearchControls/GeoSearchControls.tsx
@@ -1,16 +1,19 @@
 /** @jsx h */
 
-import { h, Fragment } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, Fragment } from 'preact';
+
 import Template from '../Template/Template';
+
 import GeoSearchButton from './GeoSearchButton';
 import GeoSearchToggle from './GeoSearchToggle';
+
+import type { PreparedTemplateProps } from '../../lib/templating';
+import type { ComponentCSSClasses } from '../../types';
 import type {
   GeoSearchCSSClasses,
   GeoSearchTemplates,
 } from '../../widgets/geo-search/geo-search';
-import type { ComponentCSSClasses } from '../../types';
-import type { PreparedTemplateProps } from '../../lib/templating';
 
 type Props = {
   cssClasses: ComponentCSSClasses<GeoSearchCSSClasses>;

--- a/packages/instantsearch.js/src/components/GeoSearchControls/GeoSearchToggle.tsx
+++ b/packages/instantsearch.js/src/components/GeoSearchControls/GeoSearchToggle.tsx
@@ -1,7 +1,8 @@
 /** @jsx h */
 
-import type { ComponentChildren } from 'preact';
 import { h } from 'preact';
+
+import type { ComponentChildren } from 'preact';
 
 type Props = {
   classNameLabel: string;

--- a/packages/instantsearch.js/src/components/GeoSearchControls/__tests__/GeoSearchButton-test.tsx
+++ b/packages/instantsearch.js/src/components/GeoSearchControls/__tests__/GeoSearchButton-test.tsx
@@ -3,8 +3,9 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { shallow } from '@instantsearch/testutils/enzyme';
+import { h } from 'preact';
+
 import GeoSearchButton from '../GeoSearchButton';
 
 describe('GeoSearchButton', () => {

--- a/packages/instantsearch.js/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.tsx
+++ b/packages/instantsearch.js/src/components/GeoSearchControls/__tests__/GeoSearchControls-test.tsx
@@ -3,10 +3,11 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render, fireEvent } from '@testing-library/preact';
-import GeoSearchControls from '../GeoSearchControls';
+import { h } from 'preact';
+
 import { prepareTemplateProps } from '../../../lib/templating';
+import GeoSearchControls from '../GeoSearchControls';
 
 describe('GeoSearchControls', () => {
   const CSSClassesDefaultProps = {

--- a/packages/instantsearch.js/src/components/GeoSearchControls/__tests__/GeoSearchToggle-test.tsx
+++ b/packages/instantsearch.js/src/components/GeoSearchControls/__tests__/GeoSearchToggle-test.tsx
@@ -3,8 +3,9 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { shallow } from '@instantsearch/testutils/enzyme';
+import { h } from 'preact';
+
 import GeoSearchToggle from '../GeoSearchToggle';
 
 describe('GeoSearchToggle', () => {

--- a/packages/instantsearch.js/src/components/Hits/Hits.tsx
+++ b/packages/instantsearch.js/src/components/Hits/Hits.tsx
@@ -1,14 +1,16 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
-import Template from '../Template/Template';
-import type { SearchResults } from 'algoliasearch-helper';
-import type { BindEventForHits, SendEventForHits } from '../../lib/utils';
+import { h } from 'preact';
+
 import { warning } from '../../lib/utils';
+import Template from '../Template/Template';
+
 import type { PreparedTemplateProps } from '../../lib/templating';
+import type { BindEventForHits, SendEventForHits } from '../../lib/utils';
 import type { ComponentCSSClasses, Hit } from '../../types';
 import type { HitsCSSClasses, HitsTemplates } from '../../widgets/hits/hits';
+import type { SearchResults } from 'algoliasearch-helper';
 
 export type HitsComponentCSSClasses = ComponentCSSClasses<HitsCSSClasses>;
 export type HitsComponentTemplates = Required<HitsTemplates>;

--- a/packages/instantsearch.js/src/components/Hits/__tests__/Hits-test.tsx
+++ b/packages/instantsearch.js/src/components/Hits/__tests__/Hits-test.tsx
@@ -3,17 +3,19 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
-import { shallow, mount } from '@instantsearch/testutils/enzyme';
-import { highlight } from '../../../helpers';
-import { TAG_REPLACEMENT } from '../../../lib/utils';
-import { prepareTemplateProps } from '../../../lib/templating';
-import Template from '../../Template/Template';
-import type { HitsProps } from '../Hits';
-import Hits from '../Hits';
 import { createSingleSearchResponse } from '@instantsearch/mocks';
+import { shallow, mount } from '@instantsearch/testutils/enzyme';
 import { SearchParameters, SearchResults } from 'algoliasearch-helper';
+import { h } from 'preact';
+
+import { highlight } from '../../../helpers';
+import { prepareTemplateProps } from '../../../lib/templating';
+import { TAG_REPLACEMENT } from '../../../lib/utils';
 import defaultTemplates from '../../../widgets/hits/defaultTemplates';
+import Template from '../../Template/Template';
+import Hits from '../Hits';
+
+import type { HitsProps } from '../Hits';
 
 describe('Hits', () => {
   const cssClasses = {

--- a/packages/instantsearch.js/src/components/InfiniteHits/InfiniteHits.tsx
+++ b/packages/instantsearch.js/src/components/InfiniteHits/InfiniteHits.tsx
@@ -1,16 +1,18 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h } from 'preact';
+
+import { warning } from '../../lib/utils';
 import Template from '../Template/Template';
-import type { SearchResults } from 'algoliasearch-helper';
+
+import type { SendEventForHits, BindEventForHits } from '../../lib/utils';
 import type { ComponentCSSClasses, Hit } from '../../types';
 import type {
   InfiniteHitsCSSClasses,
   InfiniteHitsTemplates,
 } from '../../widgets/infinite-hits/infinite-hits';
-import type { SendEventForHits, BindEventForHits } from '../../lib/utils';
-import { warning } from '../../lib/utils';
+import type { SearchResults } from 'algoliasearch-helper';
 
 export type InfiniteHitsComponentCSSClasses =
   ComponentCSSClasses<InfiniteHitsCSSClasses>;

--- a/packages/instantsearch.js/src/components/InfiniteHits/__tests__/InfiniteHits-test.tsx
+++ b/packages/instantsearch.js/src/components/InfiniteHits/__tests__/InfiniteHits-test.tsx
@@ -3,12 +3,14 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
+import { createSingleSearchResponse } from '@instantsearch/mocks';
 import { render } from '@testing-library/preact';
 import { SearchParameters, SearchResults } from 'algoliasearch-helper';
+import { h } from 'preact';
+
 import InfiniteHits from '../InfiniteHits';
+
 import type { Hit, SearchResponse } from '../../../types';
-import { createSingleSearchResponse } from '@instantsearch/mocks';
 
 function createResults(partialResults: Partial<SearchResponse<any>>) {
   return new SearchResults(new SearchParameters(), [

--- a/packages/instantsearch.js/src/components/InternalHighlight/__tests__/InternalHighlight.test.tsx
+++ b/packages/instantsearch.js/src/components/InternalHighlight/__tests__/InternalHighlight.test.tsx
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import type { ComponentChildren } from '@algolia/ui-components-shared';
 import { render } from '@testing-library/preact';
 import { h } from 'preact';
 
 import { InternalHighlight } from '../InternalHighlight';
+
+import type { ComponentChildren } from '@algolia/ui-components-shared';
 
 describe('Highlight', () => {
   test('renders only wrapper with empty match', () => {

--- a/packages/instantsearch.js/src/components/MenuSelect/MenuSelect.tsx
+++ b/packages/instantsearch.js/src/components/MenuSelect/MenuSelect.tsx
@@ -1,15 +1,17 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h } from 'preact';
+
 import { find } from '../../lib/utils';
 import Template from '../Template/Template';
+
+import type { MenuRenderState } from '../../connectors/menu/connectMenu';
+import type { ComponentCSSClasses } from '../../types';
 import type {
   MenuSelectCSSClasses,
   MenuSelectTemplates,
 } from '../../widgets/menu-select/menu-select';
-import type { MenuRenderState } from '../../connectors/menu/connectMenu';
-import type { ComponentCSSClasses } from '../../types';
 
 export type MenuSelectComponentCSSClasses =
   ComponentCSSClasses<MenuSelectCSSClasses>;

--- a/packages/instantsearch.js/src/components/MenuSelect/__tests__/MenuSelect-test.tsx
+++ b/packages/instantsearch.js/src/components/MenuSelect/__tests__/MenuSelect-test.tsx
@@ -3,10 +3,11 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
-import MenuSelect from '../MenuSelect';
 import { mount } from '@instantsearch/testutils/enzyme';
+import { h } from 'preact';
+
 import defaultTemplates from '../../../widgets/menu-select/defaultTemplates';
+import MenuSelect from '../MenuSelect';
 
 describe('MenuSelect', () => {
   const cssClasses = {

--- a/packages/instantsearch.js/src/components/Pagination/Pagination.tsx
+++ b/packages/instantsearch.js/src/components/Pagination/Pagination.tsx
@@ -1,14 +1,15 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h } from 'preact';
 
 import { isSpecialClick } from '../../lib/utils';
+
+import type { ComponentCSSClasses } from '../../types';
 import type {
   PaginationCSSClasses,
   PaginationTemplates,
 } from '../../widgets/pagination/pagination';
-import type { ComponentCSSClasses } from '../../types';
 
 export type PaginationComponentCSSClasses =
   ComponentCSSClasses<PaginationCSSClasses>;

--- a/packages/instantsearch.js/src/components/Pagination/__tests__/Pagination-test.tsx
+++ b/packages/instantsearch.js/src/components/Pagination/__tests__/Pagination-test.tsx
@@ -3,11 +3,13 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render, fireEvent, createEvent } from '@testing-library/preact';
-import type { PaginationProps } from '../Pagination';
-import Pagination from '../Pagination';
+import { h } from 'preact';
+
 import Paginator from '../../../connectors/pagination/Paginator';
+import Pagination from '../Pagination';
+
+import type { PaginationProps } from '../Pagination';
 
 describe('Pagination', () => {
   const pager = new Paginator({

--- a/packages/instantsearch.js/src/components/Panel/Panel.tsx
+++ b/packages/instantsearch.js/src/components/Panel/Panel.tsx
@@ -1,15 +1,17 @@
 /** @jsx h */
 
+import { cx } from '@algolia/ui-components-shared';
 import { h } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
-import { cx } from '@algolia/ui-components-shared';
+
 import Template from '../Template/Template';
+
+import type { ComponentCSSClasses, UnknownWidgetFactory } from '../../types';
 import type {
   PanelCSSClasses,
   PanelSharedOptions,
   PanelTemplates,
 } from '../../widgets/panel/panel';
-import type { ComponentCSSClasses, UnknownWidgetFactory } from '../../types';
 
 export type PanelComponentCSSClasses = ComponentCSSClasses<
   // `collapseIcon` is only used in the default templates of the widget

--- a/packages/instantsearch.js/src/components/Panel/__tests__/Panel-test.tsx
+++ b/packages/instantsearch.js/src/components/Panel/__tests__/Panel-test.tsx
@@ -3,11 +3,13 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render, fireEvent } from '@testing-library/preact';
-import type { PanelProps } from '../Panel';
-import Panel from '../Panel';
+import { h } from 'preact';
+
 import { createRenderOptions } from '../../../../test/createWidget';
+import Panel from '../Panel';
+
+import type { PanelProps } from '../Panel';
 
 const cssClasses = {
   root: 'root',

--- a/packages/instantsearch.js/src/components/PoweredBy/PoweredBy.tsx
+++ b/packages/instantsearch.js/src/components/PoweredBy/PoweredBy.tsx
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import { h } from 'preact';
+
 import type { ComponentCSSClasses } from '../../types';
 import type { PoweredByCSSClasses } from '../../widgets/powered-by/powered-by';
 

--- a/packages/instantsearch.js/src/components/PoweredBy/__tests__/PoweredBy-test.tsx
+++ b/packages/instantsearch.js/src/components/PoweredBy/__tests__/PoweredBy-test.tsx
@@ -3,8 +3,8 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render } from '@testing-library/preact';
+import { h } from 'preact';
 
 import PoweredBy from '../PoweredBy';
 

--- a/packages/instantsearch.js/src/components/QueryRuleCustomData/QueryRuleCustomData.tsx
+++ b/packages/instantsearch.js/src/components/QueryRuleCustomData/QueryRuleCustomData.tsx
@@ -1,12 +1,14 @@
 /** @jsx h */
 
 import { h } from 'preact';
+
+import Template from '../Template/Template';
+
 import type { ComponentCSSClasses } from '../../types';
 import type {
   QueryRuleCustomDataCSSClasses,
   QueryRuleCustomDataTemplates,
 } from '../../widgets/query-rule-custom-data/query-rule-custom-data';
-import Template from '../Template/Template';
 
 export type QueryRuleCustomDataComponentCSSClasses =
   ComponentCSSClasses<QueryRuleCustomDataCSSClasses>;

--- a/packages/instantsearch.js/src/components/QueryRuleCustomData/__tests__/QueryRuleCustomData-test.tsx
+++ b/packages/instantsearch.js/src/components/QueryRuleCustomData/__tests__/QueryRuleCustomData-test.tsx
@@ -3,8 +3,9 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render } from '@testing-library/preact';
+import { h } from 'preact';
+
 import QueryRuleCustomData from '../QueryRuleCustomData';
 
 type QueryRuleItem = {

--- a/packages/instantsearch.js/src/components/RangeInput/RangeInput.tsx
+++ b/packages/instantsearch.js/src/components/RangeInput/RangeInput.tsx
@@ -1,17 +1,19 @@
 /** @jsx h */
 
-import { h, Component } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, Component } from 'preact';
+
 import Template from '../Template/Template';
-import type {
-  RangeInputCSSClasses,
-  RangeInputTemplates,
-} from '../../widgets/range-input/range-input';
+
 import type {
   Range,
   RangeBoundaries,
 } from '../../connectors/range/connectRange';
 import type { ComponentCSSClasses } from '../../types';
+import type {
+  RangeInputCSSClasses,
+  RangeInputTemplates,
+} from '../../widgets/range-input/range-input';
 
 export type RangeInputComponentCSSClasses =
   ComponentCSSClasses<RangeInputCSSClasses>;

--- a/packages/instantsearch.js/src/components/RangeInput/__tests__/RangeInput-test.tsx
+++ b/packages/instantsearch.js/src/components/RangeInput/__tests__/RangeInput-test.tsx
@@ -3,11 +3,13 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { shallow } from '@instantsearch/testutils/enzyme';
 import { render, fireEvent } from '@testing-library/preact';
-import type { RangeInputProps } from '../RangeInput';
+import { h } from 'preact';
+
 import RangeInput from '../RangeInput';
+
+import type { RangeInputProps } from '../RangeInput';
 
 describe('RangeInput', () => {
   const defaultProps: RangeInputProps = {

--- a/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
@@ -1,22 +1,25 @@
 /** @jsx h */
 
-import type { JSX } from 'preact';
-import { h, createRef, Component } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, createRef, Component } from 'preact';
+
 import { isSpecialClick, isEqual } from '../../lib/utils';
-import type { PreparedTemplateProps } from '../../lib/templating';
+import SearchBox from '../SearchBox/SearchBox';
 import Template from '../Template/Template';
+
 import RefinementListItem from './RefinementListItem';
+
+import type { HierarchicalMenuItem } from '../../connectors/hierarchical-menu/connectHierarchicalMenu';
+import type { PreparedTemplateProps } from '../../lib/templating';
+import type { ComponentCSSClasses, CreateURL, Templates } from '../../types';
+import type { HierarchicalMenuComponentCSSClasses } from '../../widgets/hierarchical-menu/hierarchical-menu';
+import type { RatingMenuComponentCSSClasses } from '../../widgets/rating-menu/rating-menu';
+import type { RefinementListOwnCSSClasses } from '../../widgets/refinement-list/refinement-list';
 import type {
   SearchBoxComponentCSSClasses,
   SearchBoxComponentTemplates,
 } from '../SearchBox/SearchBox';
-import SearchBox from '../SearchBox/SearchBox';
-import type { HierarchicalMenuItem } from '../../connectors/hierarchical-menu/connectHierarchicalMenu';
-import type { ComponentCSSClasses, CreateURL, Templates } from '../../types';
-import type { RefinementListOwnCSSClasses } from '../../widgets/refinement-list/refinement-list';
-import type { RatingMenuComponentCSSClasses } from '../../widgets/rating-menu/rating-menu';
-import type { HierarchicalMenuComponentCSSClasses } from '../../widgets/hierarchical-menu/hierarchical-menu';
+import type { JSX } from 'preact';
 
 // CSS types
 type RefinementListOptionalClasses =

--- a/packages/instantsearch.js/src/components/RefinementList/RefinementListItem.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/RefinementListItem.tsx
@@ -1,8 +1,10 @@
 /** @jsx h */
 
-import type { JSX } from 'preact';
 import { h } from 'preact';
+
 import Template from '../Template/Template';
+
+import type { JSX } from 'preact';
 
 export type RefinementListItemProps = {
   facetValueToRefine: string;

--- a/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementList-test.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementList-test.tsx
@@ -3,15 +3,17 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render, fireEvent } from '@testing-library/preact';
-import type { RefinementListProps } from '../RefinementList';
-import RefinementList from '../RefinementList';
+import { h } from 'preact';
+
 import defaultTemplates from '../../../widgets/refinement-list/defaultTemplates';
+import RefinementList from '../RefinementList';
+
 import type {
   RefinementListItemData,
   RefinementListTemplates,
 } from '../../../widgets/refinement-list/refinement-list';
+import type { RefinementListProps } from '../RefinementList';
 
 const defaultProps = {
   createURL: () => '#',

--- a/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementListItem-test.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementListItem-test.tsx
@@ -3,10 +3,12 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { shallow } from '@instantsearch/testutils/enzyme';
-import type { RefinementListItemProps } from '../RefinementListItem';
+import { h } from 'preact';
+
 import RefinementListItem from '../RefinementListItem';
+
+import type { RefinementListItemProps } from '../RefinementListItem';
 
 describe('RefinementListItem', () => {
   const props: RefinementListItemProps = {

--- a/packages/instantsearch.js/src/components/RelevantSort/RelevantSort.tsx
+++ b/packages/instantsearch.js/src/components/RelevantSort/RelevantSort.tsx
@@ -1,12 +1,14 @@
 /** @jsx h */
 
 import { h } from 'preact';
+
 import Template from '../Template/Template';
+
+import type { ComponentCSSClasses } from '../../types';
 import type {
   RelevantSortCSSClasses,
   RelevantSortTemplates,
 } from '../../widgets/relevant-sort/relevant-sort';
-import type { ComponentCSSClasses } from '../../types';
 
 export type RelevantSortComponentCSSClasses =
   ComponentCSSClasses<RelevantSortCSSClasses>;

--- a/packages/instantsearch.js/src/components/RelevantSort/__tests__/RelevantSort-test.tsx
+++ b/packages/instantsearch.js/src/components/RelevantSort/__tests__/RelevantSort-test.tsx
@@ -3,11 +3,12 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render, fireEvent } from '@testing-library/preact';
+import { h } from 'preact';
+
+import RelevantSort from '../RelevantSort';
 
 import type { RelevantSortComponentTemplates } from '../RelevantSort';
-import RelevantSort from '../RelevantSort';
 
 const cssClasses = {
   root: 'root',

--- a/packages/instantsearch.js/src/components/SearchBox/SearchBox.tsx
+++ b/packages/instantsearch.js/src/components/SearchBox/SearchBox.tsx
@@ -1,13 +1,15 @@
 /** @jsx h */
 
 import { h, createRef, Component } from 'preact';
+
 import { noop } from '../../lib/utils';
 import Template from '../Template/Template';
+
+import type { ComponentCSSClasses } from '../../types';
 import type {
   SearchBoxCSSClasses,
   SearchBoxTemplates,
 } from '../../widgets/search-box/search-box';
-import type { ComponentCSSClasses } from '../../types';
 
 export type SearchBoxComponentCSSClasses =
   ComponentCSSClasses<SearchBoxCSSClasses>;

--- a/packages/instantsearch.js/src/components/SearchBox/__tests__/SearchBox-test.tsx
+++ b/packages/instantsearch.js/src/components/SearchBox/__tests__/SearchBox-test.tsx
@@ -3,9 +3,10 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { mount } from '@instantsearch/testutils/enzyme';
 import { render, fireEvent } from '@testing-library/preact';
+import { h } from 'preact';
+
 import SearchBox from '../SearchBox';
 
 const defaultProps = {

--- a/packages/instantsearch.js/src/components/Selector/Selector.tsx
+++ b/packages/instantsearch.js/src/components/Selector/Selector.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h } from 'preact';
 
 export type SelectorOption = {
   value?: string | number;

--- a/packages/instantsearch.js/src/components/Selector/__tests__/Selector-test.tsx
+++ b/packages/instantsearch.js/src/components/Selector/__tests__/Selector-test.tsx
@@ -3,9 +3,10 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
-import Selector from '../Selector';
 import { mount } from '@instantsearch/testutils/enzyme';
+import { h } from 'preact';
+
+import Selector from '../Selector';
 
 describe('Selector', () => {
   it('should render <Selector/> with strings', () => {

--- a/packages/instantsearch.js/src/components/Slider/Pit.tsx
+++ b/packages/instantsearch.js/src/components/Slider/Pit.tsx
@@ -1,7 +1,8 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h } from 'preact';
+
 import type { PitProps } from './Rheostat';
 
 const Pit = ({ style, children }: PitProps) => {

--- a/packages/instantsearch.js/src/components/Slider/Rheostat.tsx
+++ b/packages/instantsearch.js/src/components/Slider/Rheostat.tsx
@@ -6,8 +6,9 @@
 
 /** @jsx h */
 
-import type { ComponentChildren, ComponentType, JSX } from 'preact';
 import { h, Component, createRef } from 'preact';
+
+import type { ComponentChildren, ComponentType, JSX } from 'preact';
 
 type BoundingBox = {
   height: number;

--- a/packages/instantsearch.js/src/components/Slider/Slider.tsx
+++ b/packages/instantsearch.js/src/components/Slider/Slider.tsx
@@ -1,17 +1,20 @@
 /** @jsx h */
 
-import { h, Component } from 'preact';
-import type { HandleProps } from './Rheostat';
-import Rheostat from './Rheostat';
 import { cx } from '@algolia/ui-components-shared';
+import { h, Component } from 'preact';
+
 import { range } from '../../lib/utils';
+
 import Pit from './Pit';
+import Rheostat from './Rheostat';
+
 import type { RangeBoundaries } from '../../connectors/range/connectRange';
+import type { ComponentCSSClasses } from '../../types';
 import type {
   RangeSliderCssClasses,
   RangeSliderWidgetParams,
 } from '../../widgets/range-slider/range-slider';
-import type { ComponentCSSClasses } from '../../types';
+import type { HandleProps } from './Rheostat';
 
 export type RangeSliderComponentCSSClasses =
   ComponentCSSClasses<RangeSliderCssClasses>;

--- a/packages/instantsearch.js/src/components/Slider/__tests__/Slider-test.tsx
+++ b/packages/instantsearch.js/src/components/Slider/__tests__/Slider-test.tsx
@@ -3,10 +3,12 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { shallow } from '@instantsearch/testutils/enzyme';
-import type { SliderProps } from '../Slider';
+import { h } from 'preact';
+
 import Slider from '../Slider';
+
+import type { SliderProps } from '../Slider';
 
 describe('Slider', () => {
   it('expect to render correctly', () => {

--- a/packages/instantsearch.js/src/components/Stats/Stats.tsx
+++ b/packages/instantsearch.js/src/components/Stats/Stats.tsx
@@ -1,13 +1,15 @@
 /** @jsx h */
 
-import { h } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h } from 'preact';
+
+import Template from '../Template/Template';
+
+import type { ComponentCSSClasses } from '../../types';
 import type {
   StatsCSSClasses,
   StatsTemplates,
 } from '../../widgets/stats/stats';
-import Template from '../Template/Template';
-import type { ComponentCSSClasses } from '../../types';
 
 export type StatsComponentCSSClasses = ComponentCSSClasses<StatsCSSClasses>;
 

--- a/packages/instantsearch.js/src/components/Stats/__tests__/Stats-test.tsx
+++ b/packages/instantsearch.js/src/components/Stats/__tests__/Stats-test.tsx
@@ -3,12 +3,13 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { mount } from '@instantsearch/testutils/enzyme';
 import { render } from '@testing-library/preact';
-import Stats from '../Stats';
-import defaultTemplates from '../../../widgets/stats/defaultTemplates';
+import { h } from 'preact';
+
 import createHelpers from '../../../lib/createHelpers';
+import defaultTemplates from '../../../widgets/stats/defaultTemplates';
+import Stats from '../Stats';
 
 describe('Stats', () => {
   const cssClasses = {

--- a/packages/instantsearch.js/src/components/Template/Template.tsx
+++ b/packages/instantsearch.js/src/components/Template/Template.tsx
@@ -1,13 +1,14 @@
 /** @jsx h */
 
-import type { JSX } from 'preact';
 import { h, Component } from 'preact';
-import { warning, isEqual } from '../../lib/utils';
-import { renderTemplate } from '../../lib/templating';
 
-import type { BindEventForHits, SendEventForHits } from '../../lib/utils';
+import { renderTemplate } from '../../lib/templating';
+import { warning, isEqual } from '../../lib/utils';
+
 import type { PreparedTemplateProps } from '../../lib/templating';
+import type { BindEventForHits, SendEventForHits } from '../../lib/utils';
 import type { Templates } from '../../types';
+import type { JSX } from 'preact';
 
 const defaultProps = {
   data: {},

--- a/packages/instantsearch.js/src/components/Template/__tests__/Template-test.tsx
+++ b/packages/instantsearch.js/src/components/Template/__tests__/Template-test.tsx
@@ -3,12 +3,14 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
-import type { TemplateProps } from '../Template';
-import Template from '../Template';
 import { mount, shallow } from '@instantsearch/testutils/enzyme';
 import { render } from '@testing-library/preact';
+import { h } from 'preact';
+
 import { warning } from '../../../lib/utils';
+import Template from '../Template';
+
+import type { TemplateProps } from '../Template';
 
 function getProps({
   templates = { test: '' },

--- a/packages/instantsearch.js/src/components/ToggleRefinement/ToggleRefinement.tsx
+++ b/packages/instantsearch.js/src/components/ToggleRefinement/ToggleRefinement.tsx
@@ -1,6 +1,9 @@
 /** @jsx h */
 
 import { h } from 'preact';
+
+import Template from '../Template/Template';
+
 import type {
   ToggleRefinementRenderState,
   ToggleRefinementValue,
@@ -11,8 +14,6 @@ import type {
   ToggleRefinementTemplates,
   ToggleRefinementCSSClasses,
 } from '../../widgets/toggle-refinement/toggle-refinement';
-
-import Template from '../Template/Template';
 
 export type ToggleRefinementComponentCSSClasses =
   ComponentCSSClasses<ToggleRefinementCSSClasses>;

--- a/packages/instantsearch.js/src/components/VoiceSearch/VoiceSearch.tsx
+++ b/packages/instantsearch.js/src/components/VoiceSearch/VoiceSearch.tsx
@@ -1,14 +1,15 @@
 /** @jsx h */
 
 import { h } from 'preact';
+
 import Template from '../Template/Template';
 
+import type { VoiceListeningState } from '../../lib/voiceSearchHelper/types';
+import type { ComponentCSSClasses } from '../../types';
 import type {
   VoiceSearchCSSClasses,
   VoiceSearchTemplates,
 } from '../../widgets/voice-search/voice-search';
-import type { VoiceListeningState } from '../../lib/voiceSearchHelper/types';
-import type { ComponentCSSClasses } from '../../types';
 
 export type VoiceSearchComponentCSSClasses =
   ComponentCSSClasses<VoiceSearchCSSClasses>;

--- a/packages/instantsearch.js/src/components/VoiceSearch/__tests__/VoiceSearch-test.tsx
+++ b/packages/instantsearch.js/src/components/VoiceSearch/__tests__/VoiceSearch-test.tsx
@@ -3,10 +3,12 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render, fireEvent } from '@testing-library/preact';
-import type { VoiceSearchProps } from '../VoiceSearch';
+import { h } from 'preact';
+
 import VoiceSearch from '../VoiceSearch';
+
+import type { VoiceSearchProps } from '../VoiceSearch';
 
 const defaultProps: VoiceSearchProps = {
   cssClasses: {

--- a/packages/instantsearch.js/src/connectors/answers/__tests__/connectAnswers-test.ts
+++ b/packages/instantsearch.js/src/connectors/answers/__tests__/connectAnswers-test.ts
@@ -1,14 +1,15 @@
-import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { wait } from '@instantsearch/testutils/wait';
 import connectAnswers from '../connectAnswers';
 
 const defaultRenderDebounceTime = 10;

--- a/packages/instantsearch.js/src/connectors/answers/connectAnswers.ts
+++ b/packages/instantsearch.js/src/connectors/answers/connectAnswers.ts
@@ -8,6 +8,7 @@ import {
   noop,
   escapeHits,
 } from '../../lib/utils';
+
 import type { DebouncedFunction } from '../../lib/utils';
 import type {
   Connector,

--- a/packages/instantsearch.js/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/packages/instantsearch.js/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -1,23 +1,25 @@
-import algoliasearchHelper, {
-  SearchResults,
-  SearchParameters,
-} from 'algoliasearch-helper';
-import {
-  createInitOptions,
-  createRenderOptions,
-  createDisposeOptions,
-} from '../../../../test/createWidget';
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import type { AutocompleteRenderState } from '../connectAutocomplete';
-import connectAutocomplete from '../connectAutocomplete';
-import { TAG_PLACEHOLDER } from '../../../lib/utils';
-import type { SearchClient, SearchResponse } from '../../../types';
 import { wait } from '@instantsearch/testutils/wait';
+import algoliasearchHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+
+import {
+  createInitOptions,
+  createRenderOptions,
+  createDisposeOptions,
+} from '../../../../test/createWidget';
 import instantsearch from '../../../index.es';
+import { TAG_PLACEHOLDER } from '../../../lib/utils';
+import connectAutocomplete from '../connectAutocomplete';
+
+import type { SearchClient, SearchResponse } from '../../../types';
+import type { AutocompleteRenderState } from '../connectAutocomplete';
 
 describe('connectAutocomplete', () => {
   const getInitializedWidget = (config = {}) => {

--- a/packages/instantsearch.js/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/packages/instantsearch.js/src/connectors/autocomplete/connectAutocomplete.ts
@@ -1,5 +1,3 @@
-import type { SearchResults } from 'algoliasearch-helper';
-import type { SendEventForHits } from '../../lib/utils';
 import {
   escapeHits,
   TAG_PLACEHOLDER,
@@ -9,7 +7,10 @@ import {
   noop,
   warning,
 } from '../../lib/utils';
+
+import type { SendEventForHits } from '../../lib/utils';
 import type { Hit, Connector, WidgetRenderState } from '../../types';
+import type { SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'autocomplete',

--- a/packages/instantsearch.js/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
+++ b/packages/instantsearch.js/src/connectors/breadcrumb/__tests__/connectBreadcrumb-test.ts
@@ -1,18 +1,19 @@
-import algoliasearchHelper, {
-  SearchResults,
-  SearchParameters,
-} from 'algoliasearch-helper';
-import { warning } from '../../../lib/utils';
-import connectBreadcrumb from '../connectBreadcrumb';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import algoliasearchHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import { warning } from '../../../lib/utils';
+import connectBreadcrumb from '../connectBreadcrumb';
 
 describe('connectBreadcrumb', () => {
   describe('Usage', () => {

--- a/packages/instantsearch.js/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/packages/instantsearch.js/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -5,13 +5,14 @@ import {
   isEqual,
   noop,
 } from '../../lib/utils';
-import type { SearchParameters, SearchResults } from 'algoliasearch-helper';
+
 import type {
   Connector,
   TransformItems,
   CreateURL,
   WidgetRenderState,
 } from '../../types';
+import type { SearchParameters, SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'breadcrumb',

--- a/packages/instantsearch.js/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
+++ b/packages/instantsearch.js/src/connectors/clear-refinements/__tests__/connectClearRefinements-test.ts
@@ -1,14 +1,15 @@
+import {
+  createSingleSearchResponse,
+  createSearchClient,
+} from '@instantsearch/mocks';
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
 import connectClearRefinements from '../connectClearRefinements';
-import {
-  createSingleSearchResponse,
-  createSearchClient,
-} from '@instantsearch/mocks';
 
 describe('connectClearRefinements', () => {
   describe('Usage', () => {

--- a/packages/instantsearch.js/src/connectors/clear-refinements/connectClearRefinements.ts
+++ b/packages/instantsearch.js/src/connectors/clear-refinements/connectClearRefinements.ts
@@ -1,4 +1,3 @@
-import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
 import {
   checkRendering,
   clearRefinements,
@@ -8,6 +7,7 @@ import {
   uniq,
   mergeSearchParameters,
 } from '../../lib/utils';
+
 import type {
   TransformItems,
   CreateURL,
@@ -15,6 +15,7 @@ import type {
   WidgetRenderState,
   ScopedResult,
 } from '../../types';
+import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'clear-refinements',

--- a/packages/instantsearch.js/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test-bridge.ts
+++ b/packages/instantsearch.js/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test-bridge.ts
@@ -1,6 +1,7 @@
-import connectConfigureRelatedItems from '../connectConfigureRelatedItems';
-import connectConfigure from '../../configure/connectConfigure';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+
+import connectConfigure from '../../configure/connectConfigure';
+import connectConfigureRelatedItems from '../connectConfigureRelatedItems';
 
 jest.mock('../../configure/connectConfigure');
 

--- a/packages/instantsearch.js/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
+++ b/packages/instantsearch.js/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
@@ -1,9 +1,11 @@
-import connectConfigureRelatedItems from '../connectConfigureRelatedItems';
-import instantsearch from '../../..';
 import { createSearchClient } from '@instantsearch/mocks';
-import type { AlgoliaHit } from '../../../types';
-import { noop } from '../../../lib/utils';
 import { wait } from '@instantsearch/testutils/wait';
+
+import instantsearch from '../../..';
+import { noop } from '../../../lib/utils';
+import connectConfigureRelatedItems from '../connectConfigureRelatedItems';
+
+import type { AlgoliaHit } from '../../../types';
 
 const hit: AlgoliaHit = {
   objectID: '1',

--- a/packages/instantsearch.js/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
+++ b/packages/instantsearch.js/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
@@ -1,17 +1,19 @@
-import type {
-  SearchParameters,
-  PlainSearchParameters,
-} from 'algoliasearch-helper';
 import algoliasearchHelper from 'algoliasearch-helper';
-import type { AlgoliaHit, Connector } from '../../types';
+
 import {
   createDocumentationMessageGenerator,
   getObjectType,
   warning,
   getPropertyByPath,
 } from '../../lib/utils';
-import type { ConfigureWidgetDescription } from '../configure/connectConfigure';
 import connectConfigure from '../configure/connectConfigure';
+
+import type { AlgoliaHit, Connector } from '../../types';
+import type { ConfigureWidgetDescription } from '../configure/connectConfigure';
+import type {
+  SearchParameters,
+  PlainSearchParameters,
+} from 'algoliasearch-helper';
 
 export type MatchingPatterns = {
   [attribute: string]: {

--- a/packages/instantsearch.js/src/connectors/configure/__tests__/connectConfigure-test.ts
+++ b/packages/instantsearch.js/src/connectors/configure/__tests__/connectConfigure-test.ts
@@ -1,14 +1,15 @@
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import { createSearchClient } from '@instantsearch/mocks';
 import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 
-import { createSearchClient } from '@instantsearch/mocks';
-import connectConfigure from '../connectConfigure';
 import {
   createInitOptions,
   createRenderOptions,
   createDisposeOptions,
 } from '../../../../test/createWidget';
 import { noop } from '../../../lib/utils';
+import connectConfigure from '../connectConfigure';
+
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
 describe('connectConfigure', () => {
   let helper: AlgoliaSearchHelper;

--- a/packages/instantsearch.js/src/connectors/configure/connectConfigure.ts
+++ b/packages/instantsearch.js/src/connectors/configure/connectConfigure.ts
@@ -1,16 +1,18 @@
-import type {
-  SearchParameters,
-  PlainSearchParameters,
-  AlgoliaSearchHelper,
-} from 'algoliasearch-helper';
 import algoliasearchHelper from 'algoliasearch-helper';
-import type { Connector, WidgetRenderState } from '../../types';
+
 import {
   createDocumentationMessageGenerator,
   isPlainObject,
   mergeSearchParameters,
   noop,
 } from '../../lib/utils';
+
+import type { Connector, WidgetRenderState } from '../../types';
+import type {
+  SearchParameters,
+  PlainSearchParameters,
+  AlgoliaSearchHelper,
+} from 'algoliasearch-helper';
 
 /**
  * Refine the given search parameters.

--- a/packages/instantsearch.js/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
+++ b/packages/instantsearch.js/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
@@ -1,19 +1,21 @@
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper, {
-  SearchResults,
-  SearchParameters,
-} from 'algoliasearch-helper';
-import type { CurrentRefinementsConnectorParamsItem } from '../connectCurrentRefinements';
-import connectCurrentRefinements from '../connectCurrentRefinements';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import algoliasearchHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import connectCurrentRefinements from '../connectCurrentRefinements';
+
+import type { CurrentRefinementsConnectorParamsItem } from '../connectCurrentRefinements';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
 describe('connectCurrentRefinements', () => {
   describe('Usage', () => {

--- a/packages/instantsearch.js/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/packages/instantsearch.js/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -1,8 +1,3 @@
-import type {
-  AlgoliaSearchHelper,
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
 import {
   getRefinements,
   checkRendering,
@@ -10,6 +5,7 @@ import {
   noop,
   warning,
 } from '../../lib/utils';
+
 import type {
   Refinement,
   FacetRefinement,
@@ -21,6 +17,11 @@ import type {
   CreateURL,
   WidgetRenderState,
 } from '../../types';
+import type {
+  AlgoliaSearchHelper,
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
 
 export type CurrentRefinementsConnectorParamsRefinement = {
   /**

--- a/packages/instantsearch.js/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/packages/instantsearch.js/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -1,24 +1,26 @@
-import { connectMenu, connectDynamicWidgets } from '../..';
-import { index } from '../../../widgets';
-import { widgetSnapshotSerializer } from '@instantsearch/testutils';
-import {
-  createDisposeOptions,
-  createInitOptions,
-  createRenderOptions,
-} from '../../../../test/createWidget';
-import { wait } from '@instantsearch/testutils/wait';
-import algoliasearchHelper, {
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
 import {
   createMultiSearchResponse,
   createSingleSearchResponse,
   createSearchClient,
 } from '@instantsearch/mocks';
+import { widgetSnapshotSerializer } from '@instantsearch/testutils';
+import { wait } from '@instantsearch/testutils/wait';
+import algoliasearchHelper, {
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
+
+import { connectMenu, connectDynamicWidgets } from '../..';
+import {
+  createDisposeOptions,
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/createWidget';
+import { index } from '../../../widgets';
 import connectHierarchicalMenu from '../../hierarchical-menu/connectHierarchicalMenu';
-import type { DynamicWidgetsConnectorParams } from '../connectDynamicWidgets';
 import connectRefinementList from '../../refinement-list/connectRefinementList';
+
+import type { DynamicWidgetsConnectorParams } from '../connectDynamicWidgets';
 
 expect.addSnapshotSerializer(widgetSnapshotSerializer);
 

--- a/packages/instantsearch.js/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
+++ b/packages/instantsearch.js/src/connectors/dynamic-widgets/connectDynamicWidgets.ts
@@ -5,6 +5,7 @@ import {
   noop,
   warning,
 } from '../../lib/utils';
+
 import type {
   Connector,
   TransformItems,

--- a/packages/instantsearch.js/src/connectors/geo-search/__tests__/connectGeoSearch-test.ts
+++ b/packages/instantsearch.js/src/connectors/geo-search/__tests__/connectGeoSearch-test.ts
@@ -1,21 +1,23 @@
-import algoliasearchHelper, {
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
-import connectGeoSearch from '../connectGeoSearch';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
+import algoliasearchHelper, {
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
 import instantsearch from '../../../index.es';
-import { wait } from '@instantsearch/testutils/wait';
+import connectGeoSearch from '../connectGeoSearch';
+
 import type { SearchResponse } from '../../../types';
 
 describe('connectGeoSearch', () => {

--- a/packages/instantsearch.js/src/connectors/geo-search/connectGeoSearch.ts
+++ b/packages/instantsearch.js/src/connectors/geo-search/connectGeoSearch.ts
@@ -1,8 +1,3 @@
-import type {
-  AlgoliaSearchHelper,
-  SearchParameters,
-} from 'algoliasearch-helper';
-import type { SendEventForHits } from '../../lib/utils';
 import {
   checkRendering,
   aroundLatLngToPosition,
@@ -11,6 +6,8 @@ import {
   createSendEventForHits,
   noop,
 } from '../../lib/utils';
+
+import type { SendEventForHits } from '../../lib/utils';
 import type {
   BaseHit,
   Connector,
@@ -21,6 +18,10 @@ import type {
   TransformItems,
   WidgetRenderState,
 } from '../../types';
+import type {
+  AlgoliaSearchHelper,
+  SearchParameters,
+} from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'geo-search',

--- a/packages/instantsearch.js/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
+++ b/packages/instantsearch.js/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts
@@ -1,19 +1,20 @@
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-import { warning } from '../../../lib/utils';
-import connectHierarchicalMenu from '../connectHierarchicalMenu';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
+import { warning } from '../../../lib/utils';
+import connectHierarchicalMenu from '../connectHierarchicalMenu';
 
 describe('connectHierarchicalMenu', () => {
   describe('Usage', () => {

--- a/packages/instantsearch.js/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
+++ b/packages/instantsearch.js/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
@@ -1,4 +1,3 @@
-import type { SendEventForFacet } from '../../lib/utils';
 import {
   checkRendering,
   warning,
@@ -7,7 +6,8 @@ import {
   isEqual,
   noop,
 } from '../../lib/utils';
-import type { SearchResults } from 'algoliasearch-helper';
+
+import type { SendEventForFacet } from '../../lib/utils';
 import type {
   Connector,
   CreateURL,
@@ -17,6 +17,7 @@ import type {
   SortBy,
   WidgetRenderState,
 } from '../../types';
+import type { SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'hierarchical-menu',

--- a/packages/instantsearch.js/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
+++ b/packages/instantsearch.js/src/connectors/hits-per-page/__tests__/connectHitsPerPage-test.ts
@@ -1,18 +1,20 @@
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import algoliasearchHelper, {
   SearchParameters,
   SearchResults,
 } from 'algoliasearch-helper';
+
 import { connectHitsPerPage } from '../..';
-import type { HitsPerPageConnectorParams } from '../connectHitsPerPage';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+
+import type { HitsPerPageConnectorParams } from '../connectHitsPerPage';
 
 describe('connectHitsPerPage', () => {
   describe('Usage', () => {

--- a/packages/instantsearch.js/src/connectors/hits-per-page/connectHitsPerPage.ts
+++ b/packages/instantsearch.js/src/connectors/hits-per-page/connectHitsPerPage.ts
@@ -6,10 +6,6 @@ import {
 } from '../../lib/utils';
 
 import type {
-  AlgoliaSearchHelper,
-  SearchParameters,
-} from 'algoliasearch-helper';
-import type {
   Connector,
   TransformItems,
   CreateURL,
@@ -17,6 +13,10 @@ import type {
   RenderOptions,
   WidgetRenderState,
 } from '../../types';
+import type {
+  AlgoliaSearchHelper,
+  SearchParameters,
+} from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'hits-per-page',

--- a/packages/instantsearch.js/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/packages/instantsearch.js/src/connectors/hits/__tests__/connectHits-test.ts
@@ -2,31 +2,33 @@
  * @jest-environment jsdom
  */
 
-import algoliasearchHelper, {
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
-import { TAG_PLACEHOLDER, deserializePayload } from '../../../lib/utils';
-import connectHits from '../connectHits';
-import {
-  createDisposeOptions,
-  createInitOptions,
-  createRenderOptions,
-} from '../../../../test/createWidget';
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
+import algoliasearchHelper, {
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
+import {
+  createDisposeOptions,
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/createWidget';
+import instantsearch from '../../../index.es';
+import { TAG_PLACEHOLDER, deserializePayload } from '../../../lib/utils';
+import connectHits from '../connectHits';
+
 import type {
   EscapedHits,
   Hit,
   HitAttributeHighlightResult,
   SearchResponse,
 } from '../../../types';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
-import { wait } from '@instantsearch/testutils/wait';
-import instantsearch from '../../../index.es';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({
   // The real implementation creates a new array instance, which can cause bugs,

--- a/packages/instantsearch.js/src/connectors/hits/__tests__/connectHitsWithInsights-test.ts
+++ b/packages/instantsearch.js/src/connectors/hits/__tests__/connectHitsWithInsights-test.ts
@@ -1,8 +1,9 @@
-import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+
 import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
@@ -10,6 +11,7 @@ import {
   createRenderOptions,
 } from '../../../../test/createWidget';
 import connectHitsWithInsights from '../connectHitsWithInsights';
+
 import type { Hit } from '../../../types';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({

--- a/packages/instantsearch.js/src/connectors/hits/connectHits.ts
+++ b/packages/instantsearch.js/src/connectors/hits/connectHits.ts
@@ -1,4 +1,3 @@
-import type { SendEventForHits, BindEventForHits } from '../../lib/utils';
 import {
   escapeHits,
   TAG_PLACEHOLDER,
@@ -10,6 +9,8 @@ import {
   createBindEventForHits,
   noop,
 } from '../../lib/utils';
+
+import type { SendEventForHits, BindEventForHits } from '../../lib/utils';
 import type {
   TransformItems,
   Connector,

--- a/packages/instantsearch.js/src/connectors/hits/connectHitsWithInsights.ts
+++ b/packages/instantsearch.js/src/connectors/hits/connectHitsWithInsights.ts
@@ -1,7 +1,9 @@
 import { withInsights } from '../../lib/insights';
-import type { HitsConnectorParams, HitsWidgetDescription } from './connectHits';
+
 import connectHits from './connectHits';
+
 import type { Connector } from '../../types';
+import type { HitsConnectorParams, HitsWidgetDescription } from './connectHits';
 
 /**
  * Due to https://github.com/microsoft/web-build-tools/issues/1050, we need

--- a/packages/instantsearch.js/src/connectors/index.ts
+++ b/packages/instantsearch.js/src/connectors/index.ts
@@ -1,5 +1,22 @@
 import { deprecate } from '../lib/utils';
 
+import connectAnswers from './answers/connectAnswers';
+import connectDynamicWidgets from './dynamic-widgets/connectDynamicWidgets';
+
+/** @deprecated answers is no longer supported */
+export const EXPERIMENTAL_connectAnswers = deprecate(
+  connectAnswers,
+  'answers is no longer supported'
+);
+
+/** @deprecated use connectDynamicWidgets */
+export const EXPERIMENTAL_connectDynamicWidgets = deprecate(
+  connectDynamicWidgets,
+  'use connectDynamicWidgets'
+);
+
+export { connectDynamicWidgets };
+
 export { default as connectClearRefinements } from './clear-refinements/connectClearRefinements';
 export { default as connectCurrentRefinements } from './current-refinements/connectCurrentRefinements';
 export { default as connectHierarchicalMenu } from './hierarchical-menu/connectHierarchicalMenu';
@@ -26,21 +43,4 @@ export { default as EXPERIMENTAL_connectConfigureRelatedItems } from './configur
 export { default as connectAutocomplete } from './autocomplete/connectAutocomplete';
 export { default as connectQueryRules } from './query-rules/connectQueryRules';
 export { default as connectVoiceSearch } from './voice-search/connectVoiceSearch';
-import connectAnswers from './answers/connectAnswers';
-
-/** @deprecated answers is no longer supported */
-export const EXPERIMENTAL_connectAnswers = deprecate(
-  connectAnswers,
-  'answers is no longer supported'
-);
-
 export { default as connectRelevantSort } from './relevant-sort/connectRelevantSort';
-
-import connectDynamicWidgets from './dynamic-widgets/connectDynamicWidgets';
-export { connectDynamicWidgets };
-
-/** @deprecated use connectDynamicWidgets */
-export const EXPERIMENTAL_connectDynamicWidgets = deprecate(
-  connectDynamicWidgets,
-  'use connectDynamicWidgets'
-);

--- a/packages/instantsearch.js/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -2,8 +2,24 @@
  * @jest-environment jsdom
  */
 
-import type { SearchParameters } from 'algoliasearch-helper';
+import {
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+  createSearchClient,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
+import {
+  createDisposeOptions,
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/createWidget';
+import instantsearch from '../../../index.es';
+import { TAG_PLACEHOLDER, deserializePayload } from '../../../lib/utils';
+import connectInfiniteHits from '../connectInfiniteHits';
+
 import type {
   SearchClient,
   HitAttributeHighlightResult,
@@ -11,21 +27,7 @@ import type {
   EscapedHits,
   SearchResponse,
 } from '../../../types';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
-import {
-  createDisposeOptions,
-  createInitOptions,
-  createRenderOptions,
-} from '../../../../test/createWidget';
-import {
-  createMultiSearchResponse,
-  createSingleSearchResponse,
-  createSearchClient,
-} from '@instantsearch/mocks';
-import { TAG_PLACEHOLDER, deserializePayload } from '../../../lib/utils';
-import connectInfiniteHits from '../connectInfiniteHits';
-import instantsearch from '../../../index.es';
-import { wait } from '@instantsearch/testutils/wait';
+import type { SearchParameters } from 'algoliasearch-helper';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({
   // The real implementation creates a new array instance, which can cause bugs,

--- a/packages/instantsearch.js/src/connectors/infinite-hits/__tests__/connectInfiniteHitsWithInsights-test.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/__tests__/connectInfiniteHitsWithInsights-test.ts
@@ -1,21 +1,23 @@
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import connectInfiniteHitsWithInsights from '../connectInfiniteHitsWithInsights';
+
 import type {
   InstantSearch,
   InitOptions,
   RenderOptions,
   Hit,
 } from '../../../types';
-import connectInfiniteHitsWithInsights from '../connectInfiniteHitsWithInsights';
 
 jest.mock('../../../lib/utils/hits-absolute-position', () => ({
   addAbsolutePosition: (hits: Hit[]) => hits,

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -1,17 +1,3 @@
-import type {
-  AlgoliaSearchHelper as Helper,
-  PlainSearchParameters,
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
-import type {
-  Connector,
-  TransformItems,
-  Hit,
-  WidgetRenderState,
-  BaseHit,
-} from '../../types';
-import type { SendEventForHits, BindEventForHits } from '../../lib/utils';
 import {
   escapeHits,
   TAG_PLACEHOLDER,
@@ -24,6 +10,21 @@ import {
   createSendEventForHits,
   createBindEventForHits,
 } from '../../lib/utils';
+
+import type { SendEventForHits, BindEventForHits } from '../../lib/utils';
+import type {
+  Connector,
+  TransformItems,
+  Hit,
+  WidgetRenderState,
+  BaseHit,
+} from '../../types';
+import type {
+  AlgoliaSearchHelper as Helper,
+  PlainSearchParameters,
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
 
 export type InfiniteHitsCachedHits<THit extends BaseHit> = {
   [page: number]: Array<Hit<THit>>;

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHitsWithInsights.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHitsWithInsights.ts
@@ -1,10 +1,12 @@
 import { withInsights } from '../../lib/insights';
+
+import connectInfiniteHits from './connectInfiniteHits';
+
+import type { Connector } from '../../types';
 import type {
   InfiniteHitsWidgetDescription,
   InfiniteHitsConnectorParams,
 } from './connectInfiniteHits';
-import connectInfiniteHits from './connectInfiniteHits';
-import type { Connector } from '../../types';
 
 /**
  * Due to https://github.com/microsoft/web-build-tools/issues/1050, we need

--- a/packages/instantsearch.js/src/connectors/menu/__tests__/connectMenu-test.ts
+++ b/packages/instantsearch.js/src/connectors/menu/__tests__/connectMenu-test.ts
@@ -1,24 +1,26 @@
-import jsHelper, {
-  SearchResults,
-  SearchParameters,
-} from 'algoliasearch-helper';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import jsHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+
 import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import connectMenu from '../connectMenu';
+
+import type { WidgetFactory } from '../../../types';
 import type {
   MenuConnectorParams,
   MenuRenderState,
   MenuWidgetDescription,
 } from '../connectMenu';
-import connectMenu from '../connectMenu';
-import type { WidgetFactory } from '../../../types';
 
 describe('connectMenu', () => {
   let rendering: jest.Mock<any, [MenuRenderState, boolean]>;

--- a/packages/instantsearch.js/src/connectors/menu/connectMenu.ts
+++ b/packages/instantsearch.js/src/connectors/menu/connectMenu.ts
@@ -1,11 +1,11 @@
-import type { SearchResults } from 'algoliasearch-helper';
-import type { SendEventForFacet } from '../../lib/utils';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
   createSendEventForFacet,
   noop,
 } from '../../lib/utils';
+
+import type { SendEventForFacet } from '../../lib/utils';
 import type {
   Connector,
   CreateURL,
@@ -15,6 +15,7 @@ import type {
   Widget,
   WidgetRenderState,
 } from '../../types';
+import type { SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'menu',

--- a/packages/instantsearch.js/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/packages/instantsearch.js/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -2,25 +2,27 @@
  * @jest-environment jsdom
  */
 
-import jsHelper, {
-  SearchResults,
-  SearchParameters,
-} from 'algoliasearch-helper';
-import type {
-  NumericMenuConnectorParamsItem,
-  NumericMenuRenderState,
-  NumericMenuRenderStateItem,
-} from '../connectNumericMenu';
-import connectNumericMenu from '../connectNumericMenu';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import jsHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import connectNumericMenu from '../connectNumericMenu';
+
+import type {
+  NumericMenuConnectorParamsItem,
+  NumericMenuRenderState,
+  NumericMenuRenderStateItem,
+} from '../connectNumericMenu';
 
 const encodeValue = (
   start: NumericMenuConnectorParamsItem['start'],

--- a/packages/instantsearch.js/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/packages/instantsearch.js/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -1,10 +1,12 @@
-import type { SendEventForFacet } from '../../lib/utils';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
   isFiniteNumber,
   noop,
 } from '../../lib/utils';
+
+import type { SendEventForFacet } from '../../lib/utils';
+import type { InsightsEvent } from '../../middlewares';
 import type {
   Connector,
   CreateURL,
@@ -13,7 +15,6 @@ import type {
   WidgetRenderState,
 } from '../../types';
 import type { SearchParameters } from 'algoliasearch-helper';
-import type { InsightsEvent } from '../../middlewares';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'numeric-menu',

--- a/packages/instantsearch.js/src/connectors/pagination/__tests__/connectPagination-test.ts
+++ b/packages/instantsearch.js/src/connectors/pagination/__tests__/connectPagination-test.ts
@@ -1,22 +1,23 @@
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import type {
-  PaginationConnectorParams,
-  PaginationRenderState,
-} from '../connectPagination';
-import connectPagination from '../connectPagination';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import connectPagination from '../connectPagination';
+
+import type {
+  PaginationConnectorParams,
+  PaginationRenderState,
+} from '../connectPagination';
 
 describe('connectPagination', () => {
   const getInitializedWidget = (

--- a/packages/instantsearch.js/src/connectors/pagination/connectPagination.ts
+++ b/packages/instantsearch.js/src/connectors/pagination/connectPagination.ts
@@ -3,7 +3,9 @@ import {
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
+
 import Paginator from './Paginator';
+
 import type { Connector, CreateURL, WidgetRenderState } from '../../types';
 import type { SearchParameters } from 'algoliasearch-helper';
 

--- a/packages/instantsearch.js/src/connectors/powered-by/__tests__/connectPoweredBy-test.ts
+++ b/packages/instantsearch.js/src/connectors/powered-by/__tests__/connectPoweredBy-test.ts
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 
-import jsHelper from 'algoliasearch-helper';
 import { createSearchClient } from '@instantsearch/mocks';
+import jsHelper from 'algoliasearch-helper';
+
 import {
   createDisposeOptions,
   createInitOptions,

--- a/packages/instantsearch.js/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
+++ b/packages/instantsearch.js/src/connectors/query-rules/__tests__/connectQueryRules-test.ts
@@ -1,20 +1,22 @@
-import type { AlgoliaSearchHelper as Helper } from 'algoliasearch-helper';
-import algoliasearchHelper, {
-  SearchResults,
-  SearchParameters,
-} from 'algoliasearch-helper';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import algoliasearchHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
 import connectQueryRules from '../connectQueryRules';
+
 import type { TransformItems } from '../../../types';
+import type { AlgoliaSearchHelper as Helper } from 'algoliasearch-helper';
 
 describe('connectQueryRules', () => {
   function createWidget() {

--- a/packages/instantsearch.js/src/connectors/query-rules/connectQueryRules.ts
+++ b/packages/instantsearch.js/src/connectors/query-rules/connectQueryRules.ts
@@ -1,8 +1,3 @@
-import type {
-  AlgoliaSearchHelper as Helper,
-  SearchParameters,
-} from 'algoliasearch-helper';
-import type { Connector, TransformItems, WidgetRenderState } from '../../types';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -11,10 +6,16 @@ import {
   isEqual,
   noop,
 } from '../../lib/utils';
+
 import type {
   Refinement as InternalRefinement,
   NumericRefinement as InternalNumericRefinement,
 } from '../../lib/utils';
+import type { Connector, TransformItems, WidgetRenderState } from '../../types';
+import type {
+  AlgoliaSearchHelper as Helper,
+  SearchParameters,
+} from 'algoliasearch-helper';
 
 type TrackedFilterRefinement = string | number | boolean;
 

--- a/packages/instantsearch.js/src/connectors/range/__tests__/connectRange-test.ts
+++ b/packages/instantsearch.js/src/connectors/range/__tests__/connectRange-test.ts
@@ -1,20 +1,22 @@
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import jsHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-import connectRange from '../connectRange';
+
+import instantsearch from '../../..';
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
-import instantsearch from '../../..';
+import connectRange from '../connectRange';
+
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
 function createFacetStatsResults({
   helper,

--- a/packages/instantsearch.js/src/connectors/range/connectRange.ts
+++ b/packages/instantsearch.js/src/connectors/range/connectRange.ts
@@ -1,5 +1,3 @@
-import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
-import type { SendEventForFacet } from '../../lib/utils';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -7,8 +5,11 @@ import {
   find,
   noop,
 } from '../../lib/utils';
+
+import type { SendEventForFacet } from '../../lib/utils';
 import type { InsightsEvent } from '../../middlewares';
 import type { Connector, InstantSearch, WidgetRenderState } from '../../types';
+import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator(
   { name: 'range-input', connector: true },

--- a/packages/instantsearch.js/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
+++ b/packages/instantsearch.js/src/connectors/rating-menu/__tests__/connectRatingMenu-test.ts
@@ -1,18 +1,19 @@
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import jsHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-import connectRatingMenu from '../connectRatingMenu';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
+import connectRatingMenu from '../connectRatingMenu';
 
 describe('connectRatingMenu', () => {
   const getInitializedWidget = (config = {}, unmount = () => {}) => {

--- a/packages/instantsearch.js/src/connectors/rating-menu/connectRatingMenu.ts
+++ b/packages/instantsearch.js/src/connectors/rating-menu/connectRatingMenu.ts
@@ -1,8 +1,3 @@
-import type {
-  AlgoliaSearchHelper,
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
 import {
   checkRendering,
   createDocumentationLink,
@@ -10,13 +5,19 @@ import {
   noop,
   warning,
 } from '../../lib/utils';
+
+import type { InsightsEvent } from '../../middlewares';
 import type {
   Connector,
   InstantSearch,
   CreateURL,
   WidgetRenderState,
 } from '../../types';
-import type { InsightsEvent } from '../../middlewares';
+import type {
+  AlgoliaSearchHelper,
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'rating-menu',

--- a/packages/instantsearch.js/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
+++ b/packages/instantsearch.js/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
@@ -1,20 +1,21 @@
+import {
+  createSingleSearchResponse,
+  createSearchClient,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
 import jsHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-import { TAG_PLACEHOLDER } from '../../../lib/utils';
-import connectRefinementList from '../connectRefinementList';
+
 import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import {
-  createSingleSearchResponse,
-  createSearchClient,
-} from '@instantsearch/mocks';
-import { wait } from '@instantsearch/testutils/wait';
+import { TAG_PLACEHOLDER } from '../../../lib/utils';
+import connectRefinementList from '../connectRefinementList';
 
 describe('connectRefinementList', () => {
   const createWidgetFactory = () => {

--- a/packages/instantsearch.js/src/connectors/refinement-list/connectRefinementList.ts
+++ b/packages/instantsearch.js/src/connectors/refinement-list/connectRefinementList.ts
@@ -1,5 +1,3 @@
-import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
-import type { SendEventForFacet } from '../../lib/utils';
 import {
   escapeFacets,
   TAG_PLACEHOLDER,
@@ -9,6 +7,8 @@ import {
   createSendEventForFacet,
   noop,
 } from '../../lib/utils';
+
+import type { SendEventForFacet } from '../../lib/utils';
 import type {
   Connector,
   TransformItems,
@@ -20,6 +20,7 @@ import type {
   CreateURL,
   WidgetRenderState,
 } from '../../types';
+import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'refinement-list',

--- a/packages/instantsearch.js/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
+++ b/packages/instantsearch.js/src/connectors/relevant-sort/__tests__/connectRelevantSort-test.ts
@@ -1,18 +1,19 @@
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import algoliasearchHelper, {
   SearchParameters,
   SearchResults,
 } from 'algoliasearch-helper';
-import connectRelevantSort from '../connectRelevantSort';
+
 import {
   createInitOptions,
   createRenderOptions,
   createDisposeOptions,
 } from '../../../../test/createWidget';
 import { noop } from '../../../lib/utils';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import connectRelevantSort from '../connectRelevantSort';
 
 const createHelper = () => {
   return algoliasearchHelper(createSearchClient(), '', {});

--- a/packages/instantsearch.js/src/connectors/relevant-sort/connectRelevantSort.ts
+++ b/packages/instantsearch.js/src/connectors/relevant-sort/connectRelevantSort.ts
@@ -1,5 +1,6 @@
-import type { Connector, WidgetRenderState } from '../../types';
 import { noop } from '../../lib/utils';
+
+import type { Connector, WidgetRenderState } from '../../types';
 
 export type RelevantSortConnectorParams = Record<string, unknown>;
 

--- a/packages/instantsearch.js/src/connectors/search-box/__tests__/connectSearchBox-test.ts
+++ b/packages/instantsearch.js/src/connectors/search-box/__tests__/connectSearchBox-test.ts
@@ -1,18 +1,19 @@
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-import connectSearchBox from '../connectSearchBox';
+
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
 import InstantSearch from '../../../lib/InstantSearch';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import connectSearchBox from '../connectSearchBox';
 
 describe('connectSearchBox', () => {
   const getInitializedWidget = (config = {}) => {

--- a/packages/instantsearch.js/src/connectors/search-box/connectSearchBox.ts
+++ b/packages/instantsearch.js/src/connectors/search-box/connectSearchBox.ts
@@ -3,6 +3,7 @@ import {
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
+
 import type { Connector, WidgetRenderState } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({

--- a/packages/instantsearch.js/src/connectors/sort-by/__tests__/connectSortBy-test.ts
+++ b/packages/instantsearch.js/src/connectors/sort-by/__tests__/connectSortBy-test.ts
@@ -1,21 +1,22 @@
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import type { SortByRenderState } from '../connectSortBy';
-import connectSortBy from '../connectSortBy';
-import index from '../../../widgets/index/index';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
 import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import index from '../../../widgets/index/index';
+import connectSortBy from '../connectSortBy';
+
+import type { SortByRenderState } from '../connectSortBy';
 
 describe('connectSortBy', () => {
   describe('Usage', () => {

--- a/packages/instantsearch.js/src/connectors/sort-by/connectSortBy.ts
+++ b/packages/instantsearch.js/src/connectors/sort-by/connectSortBy.ts
@@ -5,6 +5,7 @@ import {
   warning,
   noop,
 } from '../../lib/utils';
+
 import type { Connector, TransformItems, WidgetRenderState } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({

--- a/packages/instantsearch.js/src/connectors/stats/__tests__/connectStats-test.ts
+++ b/packages/instantsearch.js/src/connectors/stats/__tests__/connectStats-test.ts
@@ -1,17 +1,18 @@
-import jsHelper from 'algoliasearch-helper';
-const SearchResults = jsHelper.SearchResults;
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import jsHelper from 'algoliasearch-helper';
+const SearchResults = jsHelper.SearchResults;
+
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import connectStats from '../connectStats';
 
 import type { StatsRenderState } from '../connectStats';
-import connectStats from '../connectStats';
 
 describe('connectStats', () => {
   const getInitializedWidget = (config = {}) => {

--- a/packages/instantsearch.js/src/connectors/stats/connectStats.ts
+++ b/packages/instantsearch.js/src/connectors/stats/connectStats.ts
@@ -3,6 +3,7 @@ import {
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
+
 import type { Connector, WidgetRenderState } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({

--- a/packages/instantsearch.js/src/connectors/toggle-refinement/__tests__/connectToggleRefinement-test.ts
+++ b/packages/instantsearch.js/src/connectors/toggle-refinement/__tests__/connectToggleRefinement-test.ts
@@ -1,19 +1,21 @@
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import jsHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
-import type { ToggleRefinementRenderState } from '../connectToggleRefinement';
-import connectToggleRefinement from '../connectToggleRefinement';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
+import connectToggleRefinement from '../connectToggleRefinement';
+
+import type { ToggleRefinementRenderState } from '../connectToggleRefinement';
 
 describe('connectToggleRefinement', () => {
   const createInitializedWidget = () => {

--- a/packages/instantsearch.js/src/connectors/toggle-refinement/connectToggleRefinement.ts
+++ b/packages/instantsearch.js/src/connectors/toggle-refinement/connectToggleRefinement.ts
@@ -1,8 +1,3 @@
-import type {
-  AlgoliaSearchHelper,
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
 import {
   checkRendering,
   escapeFacetValue,
@@ -11,12 +6,18 @@ import {
   noop,
   toArray,
 } from '../../lib/utils';
+
 import type {
   Connector,
   CreateURL,
   InstantSearch,
   WidgetRenderState,
 } from '../../types';
+import type {
+  AlgoliaSearchHelper,
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'toggle-refinement',

--- a/packages/instantsearch.js/src/connectors/voice-search/__tests__/connectVoiceSearch-test.ts
+++ b/packages/instantsearch.js/src/connectors/voice-search/__tests__/connectVoiceSearch-test.ts
@@ -1,11 +1,13 @@
+import { createSearchClient } from '@instantsearch/mocks';
 import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
-import connectVoiceSearch from '../connectVoiceSearch';
+
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { createSearchClient } from '@instantsearch/mocks';
+import connectVoiceSearch from '../connectVoiceSearch';
+
 import type {
   VoiceSearchHelperParams,
   VoiceSearchHelper,

--- a/packages/instantsearch.js/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/packages/instantsearch.js/src/connectors/voice-search/connectVoiceSearch.ts
@@ -1,15 +1,16 @@
-import type { PlainSearchParameters } from 'algoliasearch-helper';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
   noop,
 } from '../../lib/utils';
-import type { Connector, WidgetRenderState } from '../../types';
 import builtInCreateVoiceSearchHelper from '../../lib/voiceSearchHelper';
+
 import type {
   CreateVoiceSearchHelper,
   VoiceListeningState,
 } from '../../lib/voiceSearchHelper/types';
+import type { Connector, WidgetRenderState } from '../../types';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'voice-search',

--- a/packages/instantsearch.js/src/helpers/__tests__/get-insights-anonymous-user-token-test.ts
+++ b/packages/instantsearch.js/src/helpers/__tests__/get-insights-anonymous-user-token-test.ts
@@ -2,10 +2,10 @@
  * @jest-environment jsdom
  */
 
+import { warning } from '../../lib/utils';
 import getInsightsAnonymousUserToken, {
   ANONYMOUS_TOKEN_COOKIE_KEY,
 } from '../get-insights-anonymous-user-token';
-import { warning } from '../../lib/utils';
 
 const DAY = 86400000; /* 1 day in ms*/
 const DATE_TOMORROW = new Date(Date.now() + DAY).toUTCString();

--- a/packages/instantsearch.js/src/helpers/__tests__/insights-test.ts
+++ b/packages/instantsearch.js/src/helpers/__tests__/insights-test.ts
@@ -2,12 +2,12 @@
  * @jest-environment jsdom
  */
 
+import { warning, serializePayload } from '../../lib/utils';
 import insights, {
   writeDataAttributes,
   readDataAttributes,
   hasDataAttributes,
 } from '../insights';
-import { warning, serializePayload } from '../../lib/utils';
 
 const makeDomElement = (html: string): HTMLElement => {
   const div = document.createElement('div');

--- a/packages/instantsearch.js/src/helpers/components/Highlight.tsx
+++ b/packages/instantsearch.js/src/helpers/components/Highlight.tsx
@@ -10,13 +10,13 @@ import {
   getHighlightedParts,
 } from '../../lib/utils';
 
+import type { HighlightProps as HighlightUiComponentProps } from '../../components/Highlight/Highlight';
 import type {
   BaseHit,
   Hit,
   HitAttributeHighlightResult,
   PartialKeys,
 } from '../../types';
-import type { HighlightProps as HighlightUiComponentProps } from '../../components/Highlight/Highlight';
 
 export type HighlightProps<THit extends Hit<BaseHit>> = {
   hit: THit;

--- a/packages/instantsearch.js/src/helpers/components/ReverseHighlight.tsx
+++ b/packages/instantsearch.js/src/helpers/components/ReverseHighlight.tsx
@@ -10,13 +10,13 @@ import {
   getHighlightedParts,
 } from '../../lib/utils';
 
+import type { ReverseHighlightProps as ReverseHighlightUiComponentProps } from '../../components/ReverseHighlight/ReverseHighlight';
 import type {
   BaseHit,
   Hit,
   HitAttributeHighlightResult,
   PartialKeys,
 } from '../../types';
-import type { ReverseHighlightProps as ReverseHighlightUiComponentProps } from '../../components/ReverseHighlight/ReverseHighlight';
 
 export type ReverseHighlightProps<THit extends Hit<BaseHit>> = {
   hit: THit;

--- a/packages/instantsearch.js/src/helpers/components/ReverseSnippet.tsx
+++ b/packages/instantsearch.js/src/helpers/components/ReverseSnippet.tsx
@@ -10,13 +10,13 @@ import {
   getHighlightedParts,
 } from '../../lib/utils';
 
+import type { ReverseSnippetProps as ReverseSnippetUiComponentProps } from '../../components/ReverseSnippet/ReverseSnippet';
 import type {
   BaseHit,
   Hit,
   HitAttributeSnippetResult,
   PartialKeys,
 } from '../../types';
-import type { ReverseSnippetProps as ReverseSnippetUiComponentProps } from '../../components/ReverseSnippet/ReverseSnippet';
 
 export type ReverseSnippetProps<THit extends Hit<BaseHit>> = {
   hit: THit;

--- a/packages/instantsearch.js/src/helpers/components/Snippet.tsx
+++ b/packages/instantsearch.js/src/helpers/components/Snippet.tsx
@@ -10,13 +10,13 @@ import {
   getHighlightedParts,
 } from '../../lib/utils';
 
+import type { SnippetProps as SnippetUiComponentProps } from '../../components/Snippet/Snippet';
 import type {
   BaseHit,
   Hit,
   HitAttributeSnippetResult,
   PartialKeys,
 } from '../../types';
-import type { SnippetProps as SnippetUiComponentProps } from '../../components/Snippet/Snippet';
 
 export type SnippetProps<THit extends Hit<BaseHit>> = {
   hit: THit;

--- a/packages/instantsearch.js/src/helpers/components/__tests__/Highlight.test.tsx
+++ b/packages/instantsearch.js/src/helpers/components/__tests__/Highlight.test.tsx
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import type { ComponentChildren } from '@algolia/ui-components-shared';
 import { render } from '@testing-library/preact';
 import { h } from 'preact';
 
 import { Highlight } from '../Highlight';
+
+import type { ComponentChildren } from '@algolia/ui-components-shared';
 
 describe('Highlight', () => {
   test('renders single match', () => {

--- a/packages/instantsearch.js/src/helpers/components/__tests__/ReverseHighlight.test.tsx
+++ b/packages/instantsearch.js/src/helpers/components/__tests__/ReverseHighlight.test.tsx
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import type { ComponentChildren } from '@algolia/ui-components-shared';
 import { render } from '@testing-library/preact';
 import { h } from 'preact';
 
 import { ReverseHighlight } from '../ReverseHighlight';
+
+import type { ComponentChildren } from '@algolia/ui-components-shared';
 
 describe('ReverseHighlight', () => {
   test('renders single match', () => {

--- a/packages/instantsearch.js/src/helpers/components/__tests__/ReverseSnippet.test.tsx
+++ b/packages/instantsearch.js/src/helpers/components/__tests__/ReverseSnippet.test.tsx
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import type { ComponentChildren } from '@algolia/ui-components-shared';
 import { render } from '@testing-library/preact';
 import { h } from 'preact';
 
 import { ReverseSnippet } from '../ReverseSnippet';
+
+import type { ComponentChildren } from '@algolia/ui-components-shared';
 
 describe('Snippet', () => {
   test('renders single match', () => {

--- a/packages/instantsearch.js/src/helpers/components/__tests__/Snippet.test.tsx
+++ b/packages/instantsearch.js/src/helpers/components/__tests__/Snippet.test.tsx
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import type { ComponentChildren } from '@algolia/ui-components-shared';
 import { render } from '@testing-library/preact';
 import { h } from 'preact';
 
 import { Snippet } from '../Snippet';
+
+import type { ComponentChildren } from '@algolia/ui-components-shared';
 
 describe('Snippet', () => {
   test('renders single match', () => {

--- a/packages/instantsearch.js/src/helpers/highlight.ts
+++ b/packages/instantsearch.js/src/helpers/highlight.ts
@@ -1,6 +1,7 @@
-import type { Hit } from '../types';
 import { component } from '../lib/suit';
 import { getPropertyByPath, TAG_REPLACEMENT, warning } from '../lib/utils';
+
+import type { Hit } from '../types';
 
 export type HighlightOptions = {
   // @MAJOR string should no longer be allowed to be a path, only array can be a path

--- a/packages/instantsearch.js/src/helpers/insights.ts
+++ b/packages/instantsearch.js/src/helpers/insights.ts
@@ -1,5 +1,6 @@
-import type { InsightsClientMethod, InsightsClientPayload } from '../types';
 import { warning, serializePayload, deserializePayload } from '../lib/utils';
+
+import type { InsightsClientMethod, InsightsClientPayload } from '../types';
 
 export function readDataAttributes(domElement: HTMLElement): {
   method: InsightsClientMethod;

--- a/packages/instantsearch.js/src/helpers/reverseHighlight.ts
+++ b/packages/instantsearch.js/src/helpers/reverseHighlight.ts
@@ -1,4 +1,4 @@
-import type { Hit } from '../types';
+import { component } from '../lib/suit';
 import {
   TAG_REPLACEMENT,
   getPropertyByPath,
@@ -7,7 +7,8 @@ import {
   concatHighlightedParts,
   warning,
 } from '../lib/utils';
-import { component } from '../lib/suit';
+
+import type { Hit } from '../types';
 
 export type ReverseHighlightOptions = {
   // @MAJOR string should no longer be allowed to be a path, only array can be a path

--- a/packages/instantsearch.js/src/helpers/reverseSnippet.ts
+++ b/packages/instantsearch.js/src/helpers/reverseSnippet.ts
@@ -1,4 +1,4 @@
-import type { Hit } from '../types';
+import { component } from '../lib/suit';
 import {
   TAG_REPLACEMENT,
   getPropertyByPath,
@@ -7,7 +7,8 @@ import {
   concatHighlightedParts,
   warning,
 } from '../lib/utils';
-import { component } from '../lib/suit';
+
+import type { Hit } from '../types';
 
 export type ReverseSnippetOptions = {
   // @MAJOR string should no longer be allowed to be a path, only array can be a path

--- a/packages/instantsearch.js/src/helpers/snippet.ts
+++ b/packages/instantsearch.js/src/helpers/snippet.ts
@@ -1,6 +1,7 @@
-import type { Hit } from '../types';
 import { component } from '../lib/suit';
 import { TAG_REPLACEMENT, getPropertyByPath, warning } from '../lib/utils';
+
+import type { Hit } from '../types';
 
 export type SnippetOptions = {
   // @MAJOR string should no longer be allowed to be a path, only array can be a path

--- a/packages/instantsearch.js/src/index.es.ts
+++ b/packages/instantsearch.js/src/index.es.ts
@@ -1,7 +1,3 @@
-import type { Expand, UiState } from './types';
-import type { InstantSearchOptions } from './lib/InstantSearch';
-import InstantSearch from './lib/InstantSearch';
-import version from './lib/version';
 import {
   snippet,
   reverseSnippet,
@@ -11,7 +7,12 @@ import {
   getInsightsAnonymousUserToken,
 } from './helpers';
 import { createInfiniteHitsSessionStorageCache } from './lib/infiniteHitsCache';
+import InstantSearch from './lib/InstantSearch';
 import { deprecate } from './lib/utils';
+import version from './lib/version';
+
+import type { InstantSearchOptions } from './lib/InstantSearch';
+import type { Expand, UiState } from './types';
 
 type InstantSearchModule = {
   <TUiState = Record<string, unknown>, TRouteState = TUiState>(

--- a/packages/instantsearch.js/src/index.ts
+++ b/packages/instantsearch.js/src/index.ts
@@ -1,17 +1,15 @@
-import type { InstantSearchOptions } from './lib/InstantSearch';
-import InstantSearch from './lib/InstantSearch';
-import type { Expand, UiState } from './types';
-
-import version from './lib/version';
-
 import * as connectors from './connectors/index';
-import * as widgets from './widgets/index';
 import * as helpers from './helpers/index';
-import * as middlewares from './middlewares/index';
-
+import { createInfiniteHitsSessionStorageCache } from './lib/infiniteHitsCache/index';
+import InstantSearch from './lib/InstantSearch';
 import * as routers from './lib/routers/index';
 import * as stateMappings from './lib/stateMappings/index';
-import { createInfiniteHitsSessionStorageCache } from './lib/infiniteHitsCache/index';
+import version from './lib/version';
+import * as middlewares from './middlewares/index';
+import * as widgets from './widgets/index';
+
+import type { InstantSearchOptions } from './lib/InstantSearch';
+import type { Expand, UiState } from './types';
 
 type InstantSearchModule = {
   <TUiState = Record<string, unknown>, TRouteState = TUiState>(

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -1,10 +1,13 @@
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper from 'algoliasearch-helper';
 import EventEmitter from '@algolia/events';
+import algoliasearchHelper from 'algoliasearch-helper';
 
-import type { IndexWidget } from '../widgets/index/index';
+import {
+  createMetadataMiddleware,
+  isMetadataEnabled,
+} from '../middlewares/createMetadataMiddleware';
+import { createRouterMiddleware } from '../middlewares/createRouterMiddleware';
 import index from '../widgets/index/index';
-import version from './version';
+
 import createHelpers from './createHelpers';
 import {
   createDocumentationMessageGenerator,
@@ -14,6 +17,10 @@ import {
   warning,
   setIndexHelperState,
 } from './utils';
+import version from './version';
+
+import type { InsightsEvent } from '../middlewares/createInsightsMiddleware';
+import type { RouterProps } from '../middlewares/createRouterMiddleware';
 import type {
   InsightsClient as AlgoliaInsightsClient,
   SearchClient,
@@ -25,13 +32,8 @@ import type {
   RenderState,
   InitialResults,
 } from '../types';
-import type { RouterProps } from '../middlewares/createRouterMiddleware';
-import { createRouterMiddleware } from '../middlewares/createRouterMiddleware';
-import type { InsightsEvent } from '../middlewares/createInsightsMiddleware';
-import {
-  createMetadataMiddleware,
-  isMetadataEnabled,
-} from '../middlewares/createMetadataMiddleware';
+import type { IndexWidget } from '../widgets/index/index';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'instantsearch',

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -2,13 +2,15 @@
  * @jest-environment jsdom
  */
 
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
 import { getByText, fireEvent } from '@testing-library/dom';
+
+import { connectConfigure, connectSearchBox } from '../../connectors';
 import instantsearch from '../../index.es';
 import { configure, searchBox } from '../../widgets';
-import { connectConfigure, connectSearchBox } from '../../connectors';
-import { createSearchClient } from '@instantsearch/mocks';
+
 import type { MiddlewareDefinition } from '../../types';
-import { wait } from '@instantsearch/testutils/wait';
 
 describe('configure', () => {
   it('provides up-to-date uiState to onStateChange', () => {

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -3,22 +3,22 @@
  */
 /** @jsx h */
 
-import type { RefObject } from 'preact';
-import { h, render, createRef } from 'preact';
-import originalHelper from 'algoliasearch-helper';
-import InstantSearch from '../InstantSearch';
-import version from '../version';
-import { connectSearchBox, connectPagination } from '../../connectors';
-import { index } from '../../widgets';
-import { noop, warning } from '../utils';
 import {
   createSearchClient,
   createControlledSearchClient,
 } from '@instantsearch/mocks';
-import { createRenderOptions, createWidget } from '../../../test/createWidget';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
-import type { IndexWidget } from '../../widgets/index/index';
-import type { UiState, Widget } from '../../types';
+import { wait } from '@instantsearch/testutils/wait';
+import originalHelper from 'algoliasearch-helper';
+import { h, render, createRef } from 'preact';
+
+import { createRenderOptions, createWidget } from '../../../test/createWidget';
+import { connectSearchBox, connectPagination } from '../../connectors';
+import { index } from '../../widgets';
+import InstantSearch from '../InstantSearch';
+import { noop, warning } from '../utils';
+import version from '../version';
+
 import type {
   PaginationConnectorParams,
   PaginationWidgetDescription,
@@ -27,7 +27,9 @@ import type {
   SearchBoxWidgetDescription,
   SearchBoxConnectorParams,
 } from '../../connectors/search-box/connectSearchBox';
-import { wait } from '@instantsearch/testutils/wait';
+import type { UiState, Widget } from '../../types';
+import type { IndexWidget } from '../../widgets/index/index';
+import type { RefObject } from 'preact';
 
 type SearchBoxWidgetInstance = Widget<
   SearchBoxWidgetDescription & { widgetParams: SearchBoxConnectorParams }

--- a/packages/instantsearch.js/src/lib/__tests__/RoutingManager-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/RoutingManager-test.ts
@@ -2,15 +2,17 @@
  * @jest-environment jsdom-global
  */
 
-import qs from 'qs';
 import { createSearchClient } from '@instantsearch/mocks';
-import { createWidget } from '../../../test/createWidget';
 import { wait } from '@instantsearch/testutils/wait';
-import type { Router, UiState, StateMapping, IndexUiState } from '../../types';
-import historyRouter from '../routers/history';
+import qs from 'qs';
+
 import instantsearch from '../..';
-import type { JSDOM } from 'jsdom';
+import { createWidget } from '../../../test/createWidget';
 import { connectHitsPerPage, connectSearchBox } from '../../connectors';
+import historyRouter from '../routers/history';
+
+import type { Router, UiState, StateMapping, IndexUiState } from '../../types';
+import type { JSDOM } from 'jsdom';
 
 declare const jsdom: JSDOM;
 

--- a/packages/instantsearch.js/src/lib/__tests__/createHelpers.tests.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/createHelpers.tests.ts
@@ -2,9 +2,9 @@
  * @jest-environment jsdom
  */
 
-import { renderTemplate } from '../templating';
-import createHelpers from '../createHelpers';
 import { insights } from '../../helpers';
+import createHelpers from '../createHelpers';
+import { renderTemplate } from '../templating';
 
 describe('insights hogan helper', () => {
   const helpers = createHelpers({ numberLocale: 'en-US' });

--- a/packages/instantsearch.js/src/lib/__tests__/insights-client-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/insights-client-test.ts
@@ -1,8 +1,10 @@
-import { withInsights, inferInsightsPayload } from '../insights';
-import { SearchParameters, SearchResults } from 'algoliasearch-helper';
-import type { InstantSearch, Widget } from '../../types';
-import { createInstantSearch } from '../../../test/createInstantSearch';
 import { createSingleSearchResponse } from '@instantsearch/mocks';
+import { SearchParameters, SearchResults } from 'algoliasearch-helper';
+
+import { createInstantSearch } from '../../../test/createInstantSearch';
+import { withInsights, inferInsightsPayload } from '../insights';
+
+import type { InstantSearch, Widget } from '../../types';
 
 const connectHits =
   (renderFn: any, unmountFn: any) =>

--- a/packages/instantsearch.js/src/lib/__tests__/insights-listener-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/insights-listener-test.tsx
@@ -3,10 +3,11 @@
  */
 /** @jsx h */
 
-import { h } from 'preact';
 import { render, fireEvent } from '@testing-library/preact';
-import withInsightsListener from '../insights/listener';
+import { h } from 'preact';
+
 import { serializePayload } from '../../lib/utils';
+import withInsightsListener from '../insights/listener';
 
 describe('withInsightsListener', () => {
   it('should capture clicks performed on inner elements with data-insights-method defined', () => {

--- a/packages/instantsearch.js/src/lib/__tests__/routing/correct-urls.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/correct-urls.test.ts
@@ -3,11 +3,12 @@
  */
 
 import { createSearchClient } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
+import { wait } from '@instantsearch/testutils/wait';
+
 import { connectPagination, connectSearchBox } from '../../../connectors';
+import instantsearch from '../../../index.es';
 import { index } from '../../../widgets';
 import historyRouter from '../../routers/history';
-import { wait } from '@instantsearch/testutils/wait';
 
 beforeEach(() => {
   window.history.pushState({}, '', '/');

--- a/packages/instantsearch.js/src/lib/__tests__/routing/dispose-start-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/dispose-start-test.ts
@@ -4,9 +4,11 @@
 
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
-import historyRouter from '../../routers/history';
+
 import instantsearch from '../../..';
 import { connectSearchBox } from '../../../connectors';
+import historyRouter from '../../routers/history';
+
 import type InstantSearch from '../../InstantSearch';
 
 /* eslint no-lone-blocks: "off" */

--- a/packages/instantsearch.js/src/lib/__tests__/routing/duplicate-url-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/duplicate-url-test.ts
@@ -4,9 +4,10 @@
 
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
-import historyRouter from '../../routers/history';
+
 import instantsearch from '../../..';
 import { connectPagination, connectSearchBox } from '../../../connectors';
+import historyRouter from '../../routers/history';
 
 /* eslint no-lone-blocks: "off" */
 

--- a/packages/instantsearch.js/src/lib/__tests__/routing/external-influence-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/external-influence-test.ts
@@ -4,9 +4,10 @@
 
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
-import historyRouter from '../../routers/history';
+
 import instantsearch from '../../..';
 import { connectSearchBox } from '../../../connectors';
+import historyRouter from '../../routers/history';
 
 /* eslint no-lone-blocks: "off" */
 

--- a/packages/instantsearch.js/src/lib/__tests__/routing/modal-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/modal-test.ts
@@ -4,9 +4,10 @@
 
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
-import historyRouter from '../../routers/history';
+
 import instantsearch from '../../..';
 import { connectSearchBox } from '../../../connectors';
+import historyRouter from '../../routers/history';
 
 /* eslint no-lone-blocks: "off" */
 

--- a/packages/instantsearch.js/src/lib/__tests__/routing/spa-debounced-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/spa-debounced-test.ts
@@ -4,9 +4,10 @@
 
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
-import historyRouter from '../../routers/history';
+
 import instantsearch from '../../..';
 import { connectSearchBox } from '../../../connectors';
+import historyRouter from '../../routers/history';
 
 /* eslint no-lone-blocks: "off" */
 

--- a/packages/instantsearch.js/src/lib/__tests__/routing/spa-replace-state-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/spa-replace-state-test.ts
@@ -4,9 +4,10 @@
 
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
-import historyRouter from '../../routers/history';
+
 import instantsearch from '../../..';
 import { connectSearchBox } from '../../../connectors';
+import historyRouter from '../../routers/history';
 
 /* eslint no-lone-blocks: "off" */
 

--- a/packages/instantsearch.js/src/lib/__tests__/routing/spa-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/spa-test.ts
@@ -4,9 +4,10 @@
 
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
-import historyRouter from '../../routers/history';
+
 import instantsearch from '../../..';
 import { connectSearchBox } from '../../../connectors';
+import historyRouter from '../../routers/history';
 
 /* eslint no-lone-blocks: "off" */
 

--- a/packages/instantsearch.js/src/lib/__tests__/status.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/status.test.ts
@@ -1,7 +1,9 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
+
 import { connectSearchBox } from '../../connectors';
 import instantsearch from '../../index.es';
+
 import type InstantSearch from '../InstantSearch';
 
 function createDelayedSearchClient(timeout: number) {

--- a/packages/instantsearch.js/src/lib/createHelpers.ts
+++ b/packages/instantsearch.js/src/lib/createHelpers.ts
@@ -1,9 +1,3 @@
-import type {
-  HighlightOptions,
-  ReverseHighlightOptions,
-  SnippetOptions,
-  ReverseSnippetOptions,
-} from '../helpers';
 import {
   highlight,
   reverseHighlight,
@@ -11,13 +5,21 @@ import {
   reverseSnippet,
   insights,
 } from '../helpers';
+
+import { formatNumber } from './formatNumber';
+
+import type {
+  HighlightOptions,
+  ReverseHighlightOptions,
+  SnippetOptions,
+  ReverseSnippetOptions,
+} from '../helpers';
 import type {
   Hit,
   HoganHelpers,
   InsightsClientMethod,
   InsightsClientPayload,
 } from '../types';
-import { formatNumber } from './formatNumber';
 
 type DefaultHoganHelpers = HoganHelpers<
   | 'formatNumber'

--- a/packages/instantsearch.js/src/lib/infiniteHitsCache/sessionStorage.ts
+++ b/packages/instantsearch.js/src/lib/infiniteHitsCache/sessionStorage.ts
@@ -1,6 +1,7 @@
-import type { PlainSearchParameters } from 'algoliasearch-helper';
 import { isEqual, safelyRunOnBrowser } from '../utils';
+
 import type { InfiniteHitsCache } from '../../connectors/infinite-hits/connectInfiniteHits';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 
 function getStateWithoutPage(state: PlainSearchParameters) {
   const { page, ...rest } = state || {};

--- a/packages/instantsearch.js/src/lib/insights/__tests__/client-test.js
+++ b/packages/instantsearch.js/src/lib/insights/__tests__/client-test.js
@@ -1,5 +1,5 @@
-import withInsights from '../client';
 import { warning } from '../../utils';
+import withInsights from '../client';
 
 describe('withInsights', () => {
   it('shows a deprecation warning', () => {

--- a/packages/instantsearch.js/src/lib/insights/client.ts
+++ b/packages/instantsearch.js/src/lib/insights/client.ts
@@ -1,10 +1,10 @@
-import type { SearchResults } from 'algoliasearch-helper';
 import {
   uniq,
   find,
   createDocumentationMessageGenerator,
   warning,
 } from '../utils';
+
 import type {
   Hit,
   InsightsClient,
@@ -12,6 +12,7 @@ import type {
   InsightsClientPayload,
   Connector,
 } from '../../types';
+import type { SearchResults } from 'algoliasearch-helper';
 
 const getSelectedHits = (hits: Hit[], selectedObjectIDs: string[]): Hit[] => {
   return selectedObjectIDs.map((objectID) => {

--- a/packages/instantsearch.js/src/lib/insights/listener.tsx
+++ b/packages/instantsearch.js/src/lib/insights/listener.tsx
@@ -1,10 +1,12 @@
 /** @jsx h */
 
 import { h } from 'preact';
-import { deserializePayload } from '../utils';
+
 import { readDataAttributes, hasDataAttributes } from '../../helpers/insights';
-import type { InsightsClient } from '../../types';
+import { deserializePayload } from '../utils';
+
 import type { InsightsEvent } from '../../middlewares/createInsightsMiddleware';
+import type { InsightsClient } from '../../types';
 
 type WithInsightsListenerProps = {
   [key: string]: unknown;

--- a/packages/instantsearch.js/src/lib/routers/__tests__/history.test.ts
+++ b/packages/instantsearch.js/src/lib/routers/__tests__/history.test.ts
@@ -2,12 +2,14 @@
  * @jest-environment jsdom
  */
 
-import historyRouter from '../history';
-import type { UiState } from '../../../types';
-import { noop } from '../../utils';
 import { createSearchClient } from '@instantsearch/mocks';
+
 import instantsearch from '../../..';
 import { simple } from '../../stateMappings';
+import { noop } from '../../utils';
+import historyRouter from '../history';
+
+import type { UiState } from '../../../types';
 
 jest.useFakeTimers();
 

--- a/packages/instantsearch.js/src/lib/routers/history.ts
+++ b/packages/instantsearch.js/src/lib/routers/history.ts
@@ -1,6 +1,8 @@
 import qs from 'qs';
-import type { Router, UiState } from '../../types';
+
 import { safelyRunOnBrowser } from '../utils';
+
+import type { Router, UiState } from '../../types';
 
 type CreateURL<TRouteState> = (args: {
   qsModule: typeof qs;

--- a/packages/instantsearch.js/src/lib/stateMappings/__tests__/simple-test.ts
+++ b/packages/instantsearch.js/src/lib/stateMappings/__tests__/simple-test.ts
@@ -1,5 +1,6 @@
-import type { UiState } from '../../../types';
 import simpleStateMapping from '../simple';
+
+import type { UiState } from '../../../types';
 
 describe('simpleStateMapping', () => {
   describe('stateToRoute', () => {

--- a/packages/instantsearch.js/src/lib/stateMappings/__tests__/singleIndex-test.ts
+++ b/packages/instantsearch.js/src/lib/stateMappings/__tests__/singleIndex-test.ts
@@ -1,5 +1,6 @@
-import type { UiState } from '../../../types';
 import singleIndexStateMapping from '../singleIndex';
+
+import type { UiState } from '../../../types';
 
 describe('singleIndexStateMapping', () => {
   describe('stateToRoute', () => {

--- a/packages/instantsearch.js/src/lib/templating/__tests__/renderTemplate.test.ts
+++ b/packages/instantsearch.js/src/lib/templating/__tests__/renderTemplate.test.ts
@@ -1,5 +1,6 @@
-import type { HoganHelpers } from '../../../types';
 import { renderTemplate } from '../renderTemplate';
+
+import type { HoganHelpers } from '../../../types';
 
 describe('renderTemplate', () => {
   it('expect to process templates as string', () => {

--- a/packages/instantsearch.js/src/lib/templating/prepareTemplateProps.ts
+++ b/packages/instantsearch.js/src/lib/templating/prepareTemplateProps.ts
@@ -1,4 +1,5 @@
 import { uniq } from '../utils/uniq';
+
 import type { HoganHelpers, Templates } from '../../types';
 import type { HoganOptions } from 'hogan.js';
 

--- a/packages/instantsearch.js/src/lib/templating/renderTemplate.ts
+++ b/packages/instantsearch.js/src/lib/templating/renderTemplate.ts
@@ -1,17 +1,19 @@
-import type { HoganOptions, Template } from 'hogan.js';
 import hogan from 'hogan.js';
 import { html } from 'htm/preact';
+
 import {
   Highlight,
   ReverseHighlight,
   ReverseSnippet,
   Snippet,
 } from '../../helpers/components';
+
 import type { Templates, HoganHelpers, TemplateParams } from '../../types';
 import type {
   BindEventForHits,
   SendEventForHits,
 } from '../utils/createSendEventForHits';
+import type { HoganOptions, Template } from 'hogan.js';
 
 type TransformedHoganHelpers = {
   [helper: string]: () => (text: string) => string;

--- a/packages/instantsearch.js/src/lib/utils/__tests__/clearRefinements-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/clearRefinements-test.ts
@@ -1,5 +1,7 @@
-import { clearRefinements } from '../clearRefinements';
 import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
+
+import { clearRefinements } from '../clearRefinements';
+
 import type { SearchClient } from '../../../types';
 
 const initHelperWithRefinements = () => {

--- a/packages/instantsearch.js/src/lib/utils/__tests__/createSendEventForFacet-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/createSendEventForFacet-test.ts
@@ -1,11 +1,13 @@
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import algoliasearchHelper from 'algoliasearch-helper';
-import { createSendEventForFacet } from '../createSendEventForFacet';
-import type { SearchClient } from '../../../types';
+
 import { createInstantSearch } from '../../../../test/createInstantSearch';
+import { createSendEventForFacet } from '../createSendEventForFacet';
+import { isFacetRefined } from '../isFacetRefined';
+
+import type { SearchClient } from '../../../types';
 
 jest.mock('../isFacetRefined', () => ({ isFacetRefined: jest.fn() }));
-import { isFacetRefined } from '../isFacetRefined';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 
 const createTestEnvironment = () => {
   const instantSearchInstance = createInstantSearch();

--- a/packages/instantsearch.js/src/lib/utils/__tests__/createSendEventForHits-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/createSendEventForHits-test.ts
@@ -3,11 +3,12 @@
  */
 
 import { createInstantSearch } from '../../../../test/createInstantSearch';
+import { deserializePayload } from '../../utils';
 import {
   createBindEventForHits,
   createSendEventForHits,
 } from '../createSendEventForHits';
-import { deserializePayload } from '../../utils';
+
 import type { EscapedHits } from '../../../types';
 
 const createTestEnvironment = ({ nbHits = 2 }: { nbHits?: number } = {}) => {

--- a/packages/instantsearch.js/src/lib/utils/__tests__/debounce-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/debounce-test.ts
@@ -1,4 +1,5 @@
 import { wait } from '@instantsearch/testutils/wait';
+
 import { debounce } from '../debounce';
 
 describe('debounce', () => {

--- a/packages/instantsearch.js/src/lib/utils/__tests__/geo-search-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/geo-search-test.ts
@@ -1,8 +1,9 @@
-import type { LatLng } from '../geo-search';
 import {
   aroundLatLngToPosition,
   insideBoundingBoxToBoundingBox,
 } from '../geo-search';
+
+import type { LatLng } from '../geo-search';
 
 describe('aroundLatLngToPosition', () => {
   it.each([

--- a/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
@@ -1,6 +1,7 @@
-import { getAppIdAndApiKey } from '../getAppIdAndApiKey';
 import algoliasearchV4 from 'algoliasearch';
 import algoliasearchV3 from 'algoliasearch-v3';
+
+import { getAppIdAndApiKey } from '../getAppIdAndApiKey';
 
 const APP_ID = 'myAppId';
 const API_KEY = 'myApiKey';

--- a/packages/instantsearch.js/src/lib/utils/__tests__/getHighlightFromSiblings-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/getHighlightFromSiblings-test.ts
@@ -1,5 +1,6 @@
-import type { HighlightedParts } from '../../../types';
 import { getHighlightFromSiblings } from '../getHighlightFromSiblings';
+
+import type { HighlightedParts } from '../../../types';
 
 const oneMatch: HighlightedParts[] = [
   { isHighlighted: true, value: 'Amazon' },

--- a/packages/instantsearch.js/src/lib/utils/__tests__/getRefinements-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/getRefinements-test.ts
@@ -1,13 +1,15 @@
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper, {
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
 import {
   createSingleSearchResponse,
   createSearchClient,
 } from '@instantsearch/mocks';
+import algoliasearchHelper, {
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
+
 import { getRefinements } from '../getRefinements';
+
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
 describe('getRefinements', () => {
   let helper: AlgoliaSearchHelper;

--- a/packages/instantsearch.js/src/lib/utils/__tests__/mergeSearchParameters-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/mergeSearchParameters-test.ts
@@ -1,4 +1,5 @@
 import algoliasearchHelper from 'algoliasearch-helper';
+
 import { mergeSearchParameters } from '../mergeSearchParameters';
 
 describe('mergeSearchParameters', () => {

--- a/packages/instantsearch.js/src/lib/utils/checkIndexUiState.ts
+++ b/packages/instantsearch.js/src/lib/utils/checkIndexUiState.ts
@@ -1,8 +1,9 @@
 import { capitalize } from './capitalize';
 import { warning } from './logger';
-import type { IndexWidget } from '../../widgets/index/index';
-import type { Widget, IndexUiState } from '../../types';
 import { keys } from './typedObject';
+
+import type { Widget, IndexUiState } from '../../types';
+import type { IndexWidget } from '../../widgets/index/index';
 
 // Some connectors are responsible for multiple widgets so we need
 // to map them.

--- a/packages/instantsearch.js/src/lib/utils/checkRendering.ts
+++ b/packages/instantsearch.js/src/lib/utils/checkRendering.ts
@@ -1,5 +1,6 @@
-import type { Renderer } from '../../types/connector';
 import { getObjectType } from './getObjectType';
+
+import type { Renderer } from '../../types/connector';
 
 export function checkRendering<TRenderOptions, TWidgetParams>(
   rendering: Renderer<TRenderOptions, TWidgetParams>,

--- a/packages/instantsearch.js/src/lib/utils/concatHighlightedParts.ts
+++ b/packages/instantsearch.js/src/lib/utils/concatHighlightedParts.ts
@@ -1,5 +1,6 @@
-import type { HighlightedParts } from '../../types';
 import { TAG_REPLACEMENT } from './escape-highlight';
+
+import type { HighlightedParts } from '../../types';
 
 export function concatHighlightedParts(parts: HighlightedParts[]) {
   const { highlightPreTag, highlightPostTag } = TAG_REPLACEMENT;

--- a/packages/instantsearch.js/src/lib/utils/createSendEventForFacet.ts
+++ b/packages/instantsearch.js/src/lib/utils/createSendEventForFacet.ts
@@ -1,6 +1,7 @@
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import type { InstantSearch } from '../../types';
 import { isFacetRefined } from './isFacetRefined';
+
+import type { InstantSearch } from '../../types';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
 type BuiltInSendEventForFacet = (
   eventType: string,

--- a/packages/instantsearch.js/src/lib/utils/createSendEventForHits.ts
+++ b/packages/instantsearch.js/src/lib/utils/createSendEventForHits.ts
@@ -1,6 +1,7 @@
-import type { InstantSearch, Hit, EscapedHits } from '../../types';
 import { serializePayload } from './serializer';
+
 import type { InsightsEvent } from '../../middlewares/createInsightsMiddleware';
+import type { InstantSearch, Hit, EscapedHits } from '../../types';
 
 type BuiltInSendEventForHits = (
   eventType: string,

--- a/packages/instantsearch.js/src/lib/utils/escape-highlight.ts
+++ b/packages/instantsearch.js/src/lib/utils/escape-highlight.ts
@@ -1,5 +1,6 @@
 import { escape } from './escape-html';
 import { isPlainObject } from './isPlainObject';
+
 import type { Hit, FacetHit, EscapedHits } from '../../types';
 
 export const TAG_PLACEHOLDER = {

--- a/packages/instantsearch.js/src/lib/utils/getHighlightFromSiblings.ts
+++ b/packages/instantsearch.js/src/lib/utils/getHighlightFromSiblings.ts
@@ -1,4 +1,5 @@
 import { unescape } from './escape-html';
+
 import type { HighlightedParts } from '../../types';
 
 const hasAlphanumeric = new RegExp(/\w/i);

--- a/packages/instantsearch.js/src/lib/utils/getRefinements.ts
+++ b/packages/instantsearch.js/src/lib/utils/getRefinements.ts
@@ -1,6 +1,7 @@
-import type { SearchParameters, SearchResults } from 'algoliasearch-helper';
-import { find } from './find';
 import { unescapeFacetValue, escapeFacetValue } from './escapeFacetValue';
+import { find } from './find';
+
+import type { SearchParameters, SearchResults } from 'algoliasearch-helper';
 
 export type FacetRefinement = {
   type: 'facet' | 'disjunctive' | 'hierarchical';

--- a/packages/instantsearch.js/src/lib/utils/mergeSearchParameters.ts
+++ b/packages/instantsearch.js/src/lib/utils/mergeSearchParameters.ts
@@ -1,6 +1,7 @@
-import type { SearchParameters } from 'algoliasearch-helper';
 import { findIndex } from './findIndex';
 import { uniq } from './uniq';
+
+import type { SearchParameters } from 'algoliasearch-helper';
 
 type Merger = (
   left: SearchParameters,

--- a/packages/instantsearch.js/src/lib/utils/resolveSearchParameters.ts
+++ b/packages/instantsearch.js/src/lib/utils/resolveSearchParameters.ts
@@ -1,5 +1,5 @@
-import type { SearchParameters } from 'algoliasearch-helper';
 import type { IndexWidget } from '../../widgets/index/index';
+import type { SearchParameters } from 'algoliasearch-helper';
 
 export function resolveSearchParameters(
   current: IndexWidget

--- a/packages/instantsearch.js/src/lib/utils/reverseHighlightedParts.ts
+++ b/packages/instantsearch.js/src/lib/utils/reverseHighlightedParts.ts
@@ -1,5 +1,6 @@
-import type { HighlightedParts } from '../../types';
 import { getHighlightFromSiblings } from './getHighlightFromSiblings';
+
+import type { HighlightedParts } from '../../types';
 
 export function reverseHighlightedParts(parts: HighlightedParts[]) {
   if (!parts.some((part) => part.isHighlighted)) {

--- a/packages/instantsearch.js/src/lib/utils/setIndexHelperState.ts
+++ b/packages/instantsearch.js/src/lib/utils/setIndexHelperState.ts
@@ -1,7 +1,8 @@
+import { checkIndexUiState } from './checkIndexUiState';
+import { isIndexWidget } from './isIndexWidget';
+
 import type { UiState } from '../../types';
 import type { IndexWidget } from '../../widgets/index/index';
-import { isIndexWidget } from './isIndexWidget';
-import { checkIndexUiState } from './checkIndexUiState';
 
 export function setIndexHelperState<TUiState extends UiState>(
   finalUiState: TUiState,

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -2,18 +2,20 @@
  * @jest-environment jsdom-global
  */
 
-import instantsearch from '../../index.es';
-import { createInsightsMiddleware } from '..';
 import {
   createInsights,
   createInsightsUmdVersion,
   createSearchClient,
 } from '@instantsearch/mocks';
-import { warning } from '../../lib/utils';
-import { history } from '../../lib/routers';
 import { wait } from '@instantsearch/testutils/wait';
-import type { JSDOM } from 'jsdom';
+
+import { createInsightsMiddleware } from '..';
+import instantsearch from '../../index.es';
+import { history } from '../../lib/routers';
+import { warning } from '../../lib/utils';
+
 import type { PlainSearchParameters } from 'algoliasearch-helper';
+import type { JSDOM } from 'jsdom';
 
 declare const jsdom: JSDOM;
 

--- a/packages/instantsearch.js/src/middlewares/__tests__/createMetadataMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createMetadataMiddleware.ts
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 
-import algoliasearch from 'algoliasearch';
-import algoliasearchV3 from 'algoliasearch-v3';
-import { createMetadataMiddleware } from '..';
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
+import algoliasearch from 'algoliasearch';
+import algoliasearchV3 from 'algoliasearch-v3';
+
+import { createMetadataMiddleware } from '..';
 import instantsearch from '../..';
 import { configure, hits, index, pagination, searchBox } from '../../widgets';
 import { isMetadataEnabled } from '../createMetadataMiddleware';

--- a/packages/instantsearch.js/src/middlewares/__tests__/createRouterMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createRouterMiddleware.ts
@@ -4,6 +4,7 @@
 
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
+
 import instantsearch from '../../index.es';
 import { searchBox } from '../../widgets';
 

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -1,11 +1,12 @@
+import { getInsightsAnonymousUserTokenInternal } from '../helpers';
+import { warning, noop, getAppIdAndApiKey, find } from '../lib/utils';
+
 import type {
   InsightsClient,
   InsightsClientMethod,
   InternalMiddleware,
   Hit,
 } from '../types';
-import { getInsightsAnonymousUserTokenInternal } from '../helpers';
-import { warning, noop, getAppIdAndApiKey, find } from '../lib/utils';
 import type {
   AlgoliaSearchHelper,
   PlainSearchParameters,

--- a/packages/instantsearch.js/src/middlewares/createMetadataMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createMetadataMiddleware.ts
@@ -1,4 +1,5 @@
 import { createInitArgs, safelyRunOnBrowser } from '../lib/utils';
+
 import type { InstantSearch, InternalMiddleware, Widget } from '../types';
 import type { IndexWidget } from '../widgets/index/index';
 

--- a/packages/instantsearch.js/src/middlewares/createRouterMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createRouterMiddleware.ts
@@ -1,5 +1,7 @@
-import simpleStateMapping from '../lib/stateMappings/simple';
 import historyRouter from '../lib/routers/history';
+import simpleStateMapping from '../lib/stateMappings/simple';
+import { isEqual } from '../lib/utils';
+
 import type {
   Router,
   StateMapping,
@@ -7,7 +9,6 @@ import type {
   InternalMiddleware,
   CreateURL,
 } from '../types';
-import { isEqual } from '../lib/utils';
 
 export type RouterProps<
   TUiState extends UiState = UiState,

--- a/packages/instantsearch.js/src/types/connector.ts
+++ b/packages/instantsearch.js/src/types/connector.ts
@@ -1,8 +1,8 @@
-import type { SearchResults } from 'algoliasearch-helper';
-import type { InstantSearch } from './instantsearch';
 import type { InsightsClient } from './insights';
+import type { InstantSearch } from './instantsearch';
 import type { Hit } from './results';
 import type { UnknownWidgetParams, Widget, WidgetDescription } from './widget';
+import type { SearchResults } from 'algoliasearch-helper';
 
 /**
  * The base renderer options. All render functions receive

--- a/packages/instantsearch.js/src/types/templates.ts
+++ b/packages/instantsearch.js/src/types/templates.ts
@@ -1,16 +1,16 @@
-import type { VNode } from 'preact';
 import type {
   Highlight,
   ReverseHighlight,
   ReverseSnippet,
   Snippet,
 } from '../helpers/components';
-import type { html } from 'htm/preact';
 import type {
   BuiltInBindEventForHits,
   CustomBindEventForHits,
   SendEventForHits,
 } from '../lib/utils';
+import type { html } from 'htm/preact';
+import type { VNode } from 'preact';
 
 export type Template<TTemplateData = void> =
   | string

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -1,13 +1,13 @@
 import type { IndexWidget } from '../widgets/index/index';
+import type { InstantSearch } from './instantsearch';
+import type { IndexRenderState, WidgetRenderState } from './render-state';
+import type { IndexUiState, UiState } from './ui-state';
+import type { Expand, RequiredKeys } from './utils';
 import type {
   AlgoliaSearchHelper as Helper,
   SearchParameters,
   SearchResults,
 } from 'algoliasearch-helper';
-import type { InstantSearch } from './instantsearch';
-import type { IndexUiState, UiState } from './ui-state';
-import type { IndexRenderState, WidgetRenderState } from './render-state';
-import type { Expand, RequiredKeys } from './utils';
 
 export type ScopedResult = {
   indexId: string;

--- a/packages/instantsearch.js/src/widgets/__tests__/index.test.ts
+++ b/packages/instantsearch.js/src/widgets/__tests__/index.test.ts
@@ -2,10 +2,11 @@
  * @jest-environment jsdom
  */
 /* global google */
-import type { PlacesInstance } from 'places.js';
 import * as widgets from '..';
+
 import type { UnknownWidgetFactory, Widget } from '../../types';
 import type { IndexWidget } from '../index/index';
+import type { PlacesInstance } from 'places.js';
 
 /**
  * Checklist when adding a new widget

--- a/packages/instantsearch.js/src/widgets/analytics/analytics.ts
+++ b/packages/instantsearch.js/src/widgets/analytics/analytics.ts
@@ -1,6 +1,7 @@
-import type { SearchParameters, SearchResults } from 'algoliasearch-helper';
 import { createDocumentationMessageGenerator, warning } from '../../lib/utils';
+
 import type { WidgetFactory, WidgetRenderState } from '../../types';
+import type { SearchParameters, SearchResults } from 'algoliasearch-helper';
 
 export type AnalyticsWidgetParamsPushFunction = (
   /**

--- a/packages/instantsearch.js/src/widgets/answers/__tests__/answers-test.ts
+++ b/packages/instantsearch.js/src/widgets/answers/__tests__/answers-test.ts
@@ -3,14 +3,15 @@
  */
 /** @jsx h */
 
-import algoliasearchHelper from 'algoliasearch-helper';
-import { fireEvent } from '@testing-library/preact';
-import instantsearch from '../../../index.es';
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
-import answers from '../answers';
-import searchBox from '../../search-box/search-box';
+import { fireEvent } from '@testing-library/preact';
+import algoliasearchHelper from 'algoliasearch-helper';
+
 import { createInitOptions } from '../../../../test/createWidget';
+import instantsearch from '../../../index.es';
+import searchBox from '../../search-box/search-box';
+import answers from '../answers';
 
 describe('answers', () => {
   describe('Usage', () => {

--- a/packages/instantsearch.js/src/widgets/answers/answers.tsx
+++ b/packages/instantsearch.js/src/widgets/answers/answers.tsx
@@ -1,27 +1,30 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
-import type { WidgetFactory, Template, Hit, Renderer } from '../../types';
-import defaultTemplates from './defaultTemplates';
+import { h, render } from 'preact';
+
+import Answers from '../../components/Answers/Answers';
+import connectAnswers from '../../connectors/answers/connectAnswers';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
 import {
   createDocumentationMessageGenerator,
   getContainerNode,
 } from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
+
+import defaultTemplates from './defaultTemplates';
+
 import type {
   AnswersComponentCSSClasses,
   AnswersComponentTemplates,
 } from '../../components/Answers/Answers';
-import Answers from '../../components/Answers/Answers';
 import type {
   AnswersRenderState,
   AnswersConnectorParams,
   AnswersWidgetDescription,
 } from '../../connectors/answers/connectAnswers';
-import connectAnswers from '../../connectors/answers/connectAnswers';
 import type { PreparedTemplateProps } from '../../lib/templating';
+import type { WidgetFactory, Template, Hit, Renderer } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'answers' });
 const suit = component('Answers');

--- a/packages/instantsearch.js/src/widgets/breadcrumb/__tests__/breadcrumb-test.ts
+++ b/packages/instantsearch.js/src/widgets/breadcrumb/__tests__/breadcrumb-test.ts
@@ -2,23 +2,25 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import breadcrumb from '../breadcrumb';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
-import {
-  createRenderOptions,
-  createInitOptions,
-} from '../../../../test/createWidget';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper, {
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliasearchHelper, {
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
+import {
+  createRenderOptions,
+  createInitOptions,
+} from '../../../../test/createWidget';
+import breadcrumb from '../breadcrumb';
+
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/breadcrumb/__tests__/breadcrumb.test.tsx
+++ b/packages/instantsearch.js/src/widgets/breadcrumb/__tests__/breadcrumb.test.tsx
@@ -2,17 +2,17 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
-import breadcrumb from '../breadcrumb';
+import { h } from 'preact';
+
 import { connectHierarchicalMenu } from '../../../connectors';
+import instantsearch from '../../../index.es';
+import breadcrumb from '../breadcrumb';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/breadcrumb/breadcrumb.tsx
+++ b/packages/instantsearch.js/src/widgets/breadcrumb/breadcrumb.tsx
@@ -1,27 +1,30 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
+import connectBreadcrumb from '../../connectors/breadcrumb/connectBreadcrumb';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import defaultTemplates from './defaultTemplates';
+
 import type {
   BreadcrumbComponentCSSClasses,
   BreadcrumbComponentTemplates,
 } from '../../components/Breadcrumb/Breadcrumb';
-import Breadcrumb from '../../components/Breadcrumb/Breadcrumb';
 import type {
   BreadcrumbWidgetDescription,
   BreadcrumbConnectorParams,
   BreadcrumbRenderState,
 } from '../../connectors/breadcrumb/connectBreadcrumb';
-import connectBreadcrumb from '../../connectors/breadcrumb/connectBreadcrumb';
-import defaultTemplates from './defaultTemplates';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
-import type { WidgetFactory, Template, Renderer } from '../../types';
 import type { PreparedTemplateProps } from '../../lib/templating';
+import type { WidgetFactory, Template, Renderer } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'breadcrumb' });
 const suit = component('Breadcrumb');

--- a/packages/instantsearch.js/src/widgets/clear-refinements/__tests__/clear-refinements-test.ts
+++ b/packages/instantsearch.js/src/widgets/clear-refinements/__tests__/clear-refinements-test.ts
@@ -2,17 +2,19 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
+import { createSearchClient } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import algoliasearchHelper from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
 import clearRefinements from '../clear-refinements';
-import { createSearchClient } from '@instantsearch/mocks';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+
 import type { ClearRefinementsProps } from '../../../components/ClearRefinements/ClearRefinements';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/clear-refinements/__tests__/clear-refinements.test.tsx
+++ b/packages/instantsearch.js/src/widgets/clear-refinements/__tests__/clear-refinements.test.tsx
@@ -2,14 +2,14 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
+import { fireEvent, within } from '@testing-library/dom';
 import { h } from 'preact';
 
-import { createSearchClient } from '@instantsearch/mocks';
 import instantsearch from '../../../index.es';
-import { wait } from '@instantsearch/testutils/wait';
-import clearRefinements from '../clear-refinements';
 import refinementList from '../../refinement-list/refinement-list';
-import { fireEvent, within } from '@testing-library/dom';
+import clearRefinements from '../clear-refinements';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/clear-refinements/clear-refinements.tsx
+++ b/packages/instantsearch.js/src/widgets/clear-refinements/clear-refinements.tsx
@@ -1,27 +1,30 @@
 /** @jsx h */
 
+import { cx } from '@algolia/ui-components-shared';
 import { h, render } from 'preact';
+
+import ClearRefinements from '../../components/ClearRefinements/ClearRefinements';
+import connectClearRefinements from '../../connectors/clear-refinements/connectClearRefinements';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import defaultTemplates from './defaultTemplates';
+
 import type {
   ClearRefinementsComponentCSSClasses,
   ClearRefinementsComponentTemplates,
 } from '../../components/ClearRefinements/ClearRefinements';
-import ClearRefinements from '../../components/ClearRefinements/ClearRefinements';
-import { cx } from '@algolia/ui-components-shared';
 import type {
   ClearRefinementsConnectorParams,
   ClearRefinementsRenderState,
   ClearRefinementsWidgetDescription,
 } from '../../connectors/clear-refinements/connectClearRefinements';
-import connectClearRefinements from '../../connectors/clear-refinements/connectClearRefinements';
-import defaultTemplates from './defaultTemplates';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
-import type { WidgetFactory, Template, Renderer } from '../../types';
 import type { PreparedTemplateProps } from '../../lib/templating';
+import type { WidgetFactory, Template, Renderer } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'clear-refinements',

--- a/packages/instantsearch.js/src/widgets/configure-related-items/__tests__/configure-related-items-test.ts
+++ b/packages/instantsearch.js/src/widgets/configure-related-items/__tests__/configure-related-items-test.ts
@@ -1,7 +1,9 @@
-import configureRelatedItems from '../configure-related-items';
-import type { ConfigureRelatedItemsConnectorParams } from '../../../connectors/configure-related-items/connectConfigureRelatedItems';
-import connectConfigureRelatedItems from '../../../connectors/configure-related-items/connectConfigureRelatedItems';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+
+import connectConfigureRelatedItems from '../../../connectors/configure-related-items/connectConfigureRelatedItems';
+import configureRelatedItems from '../configure-related-items';
+
+import type { ConfigureRelatedItemsConnectorParams } from '../../../connectors/configure-related-items/connectConfigureRelatedItems';
 
 jest.mock(
   '../../../connectors/configure-related-items/connectConfigureRelatedItems'

--- a/packages/instantsearch.js/src/widgets/configure-related-items/configure-related-items.ts
+++ b/packages/instantsearch.js/src/widgets/configure-related-items/configure-related-items.ts
@@ -1,11 +1,12 @@
-import type { PlainSearchParameters } from 'algoliasearch-helper';
+import connectConfigureRelatedItems from '../../connectors/configure-related-items/connectConfigureRelatedItems';
 import { noop } from '../../lib/utils';
+
 import type {
   ConfigureRelatedItemsConnectorParams,
   ConfigureRelatedItemsWidgetDescription,
 } from '../../connectors/configure-related-items/connectConfigureRelatedItems';
-import connectConfigureRelatedItems from '../../connectors/configure-related-items/connectConfigureRelatedItems';
 import type { WidgetFactory } from '../../types';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 
 export type ConfigureRelatedItemsWidget = WidgetFactory<
   ConfigureRelatedItemsWidgetDescription & {

--- a/packages/instantsearch.js/src/widgets/configure/configure.ts
+++ b/packages/instantsearch.js/src/widgets/configure/configure.ts
@@ -1,10 +1,11 @@
+import connectConfigure from '../../connectors/configure/connectConfigure';
+import { noop } from '../../lib/utils';
+
 import type {
   ConfigureConnectorParams,
   ConfigureWidgetDescription,
 } from '../../connectors/configure/connectConfigure';
-import connectConfigure from '../../connectors/configure/connectConfigure';
 import type { Widget } from '../../types';
-import { noop } from '../../lib/utils';
 
 /**
  * A list of [search parameters](https://www.algolia.com/doc/api-reference/search-api-parameters/)

--- a/packages/instantsearch.js/src/widgets/current-refinements/__tests__/current-refinements-test.ts
+++ b/packages/instantsearch.js/src/widgets/current-refinements/__tests__/current-refinements-test.ts
@@ -2,20 +2,22 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
-import currentRefinements from '../current-refinements';
-import type { CurrentRefinementsProps } from '../../../components/CurrentRefinements/CurrentRefinements';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import currentRefinements from '../current-refinements';
+
+import type { CurrentRefinementsProps } from '../../../components/CurrentRefinements/CurrentRefinements';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/current-refinements/current-refinements.tsx
+++ b/packages/instantsearch.js/src/widgets/current-refinements/current-refinements.tsx
@@ -1,19 +1,21 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
 import CurrentRefinements from '../../components/CurrentRefinements/CurrentRefinements';
+import connectCurrentRefinements from '../../connectors/current-refinements/connectCurrentRefinements';
+import { component } from '../../lib/suit';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
 import type {
   CurrentRefinementsConnectorParams,
   CurrentRefinementsRenderState,
   CurrentRefinementsWidgetDescription,
 } from '../../connectors/current-refinements/connectCurrentRefinements';
-import connectCurrentRefinements from '../../connectors/current-refinements/connectCurrentRefinements';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { component } from '../../lib/suit';
 import type { ComponentCSSClasses, Renderer, WidgetFactory } from '../../types';
 
 export type CurrentRefinementsCSSClasses = Partial<{

--- a/packages/instantsearch.js/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
+++ b/packages/instantsearch.js/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
@@ -3,20 +3,21 @@
  */
 
 import {
-  createInitOptions,
-  createRenderOptions,
-} from '../../../../test/createWidget';
-import { index, searchBox, menu, dynamicWidgets } from '../..';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
-import { SearchParameters, SearchResults } from 'algoliasearch-helper';
-import {
   createMultiSearchResponse,
   createSearchClient,
 } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
 import { widgetSnapshotSerializer } from '@instantsearch/testutils/widgetSnapshotSerializer';
-import refinementList from '../../refinement-list/refinement-list';
+import { SearchParameters, SearchResults } from 'algoliasearch-helper';
+
+import { index, searchBox, menu, dynamicWidgets } from '../..';
 import instantsearch from '../../..';
+import { createInstantSearch } from '../../../../test/createInstantSearch';
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/createWidget';
+import refinementList from '../../refinement-list/refinement-list';
 
 expect.addSnapshotSerializer(widgetSnapshotSerializer);
 

--- a/packages/instantsearch.js/src/widgets/dynamic-widgets/dynamic-widgets.ts
+++ b/packages/instantsearch.js/src/widgets/dynamic-widgets/dynamic-widgets.ts
@@ -1,7 +1,3 @@
-import type {
-  DynamicWidgetsConnectorParams,
-  DynamicWidgetsWidgetDescription,
-} from '../../connectors/dynamic-widgets/connectDynamicWidgets';
 import connectDynamicWidgets from '../../connectors/dynamic-widgets/connectDynamicWidgets';
 import { component } from '../../lib/suit';
 import {
@@ -9,6 +5,11 @@ import {
   getContainerNode,
   getWidgetAttribute,
 } from '../../lib/utils';
+
+import type {
+  DynamicWidgetsConnectorParams,
+  DynamicWidgetsWidgetDescription,
+} from '../../connectors/dynamic-widgets/connectDynamicWidgets';
 import type { Widget, WidgetFactory } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({

--- a/packages/instantsearch.js/src/widgets/geo-search/GeoSearchRenderer.js
+++ b/packages/instantsearch.js/src/widgets/geo-search/GeoSearchRenderer.js
@@ -1,8 +1,9 @@
 /** @jsx h */
 
 import { h, render } from 'preact';
-import { prepareTemplateProps } from '../../lib/templating';
+
 import GeoSearchControls from '../../components/GeoSearchControls/GeoSearchControls';
+import { prepareTemplateProps } from '../../lib/templating';
 
 const refineWithMap = ({ refine, mapInstance }) =>
   refine({

--- a/packages/instantsearch.js/src/widgets/geo-search/__tests__/geo-search-test.ts
+++ b/packages/instantsearch.js/src/widgets/geo-search/__tests__/geo-search-test.ts
@@ -3,22 +3,23 @@
  */
 
 /* global google */
-import { render as preactRender } from 'preact';
-import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
-import createHTMLMarker from '../createHTMLMarker';
-import originalRenderer from '../GeoSearchRenderer';
-import geoSearch from '../geo-search';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import createHTMLMarker from '../createHTMLMarker';
+import geoSearch from '../geo-search';
+import originalRenderer from '../GeoSearchRenderer';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/geo-search/__tests__/geo-search.test.tsx
+++ b/packages/instantsearch.js/src/widgets/geo-search/__tests__/geo-search.test.tsx
@@ -2,12 +2,12 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
 import { initialize } from '@googlemaps/jest-mocks';
-
 import { createSearchClient } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
 import geoSearch from '../geo-search';
 
 beforeEach(() => {

--- a/packages/instantsearch.js/src/widgets/geo-search/createHTMLMarker.ts
+++ b/packages/instantsearch.js/src/widgets/geo-search/createHTMLMarker.ts
@@ -1,5 +1,6 @@
 /* global google EventListener */
 import { render } from 'preact';
+
 import type { renderTemplate } from '../../lib/templating';
 
 export type HTMLMarkerArguments = {

--- a/packages/instantsearch.js/src/widgets/geo-search/defaultTemplates.tsx
+++ b/packages/instantsearch.js/src/widgets/geo-search/defaultTemplates.tsx
@@ -1,6 +1,7 @@
 /** @jsx h */
 
 import { h } from 'preact';
+
 import type { GeoSearchComponentTemplates } from './geo-search';
 
 const defaultTemplates: GeoSearchComponentTemplates = {

--- a/packages/instantsearch.js/src/widgets/geo-search/geo-search.ts
+++ b/packages/instantsearch.js/src/widgets/geo-search/geo-search.ts
@@ -2,23 +2,26 @@
 /* global google */
 import { cx } from '@algolia/ui-components-shared';
 import { render } from 'preact';
+
+import connectGeoSearch from '../../connectors/geo-search/connectGeoSearch';
+import { component } from '../../lib/suit';
+import { renderTemplate } from '../../lib/templating';
 import {
   getContainerNode,
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
-import { renderTemplate } from '../../lib/templating';
-import { component } from '../../lib/suit';
+
+import createHTMLMarker from './createHTMLMarker';
+import defaultTemplates from './defaultTemplates';
+import renderer from './GeoSearchRenderer';
+
 import type {
   GeoSearchConnectorParams,
   GeoSearchWidgetDescription,
   GeoHit,
 } from '../../connectors/geo-search/connectGeoSearch';
-import connectGeoSearch from '../../connectors/geo-search/connectGeoSearch';
-import renderer from './GeoSearchRenderer';
-import defaultTemplates from './defaultTemplates';
-import type { HTMLMarkerArguments } from './createHTMLMarker';
-import createHTMLMarker from './createHTMLMarker';
 import type { GeoLoc, Template, WidgetFactory } from '../../types';
+import type { HTMLMarkerArguments } from './createHTMLMarker';
 
 export type CreateMarker = (args: {
   item: GeoHit;

--- a/packages/instantsearch.js/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.ts
+++ b/packages/instantsearch.js/src/widgets/hierarchical-menu/__tests__/hierarchical-menu-test.ts
@@ -2,22 +2,24 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as originalRender } from 'preact';
-import type {
-  HierarchicalMenuComponentTemplates,
-  HierarchicalMenuWidgetParams,
-} from '../hierarchical-menu';
-import hierarchicalMenu from '../hierarchical-menu';
-import type { HierarchicalMenuConnectorParams } from '../../../connectors/hierarchical-menu/connectHierarchicalMenu';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
-import { wait } from '@instantsearch/testutils/wait';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import { wait } from '@instantsearch/testutils/wait';
+import { render as originalRender } from 'preact';
+
+import instantsearch from '../../../index.es';
+import hierarchicalMenu from '../hierarchical-menu';
+
 import type { RefinementListProps } from '../../../components/RefinementList/RefinementList';
+import type { HierarchicalMenuConnectorParams } from '../../../connectors/hierarchical-menu/connectHierarchicalMenu';
+import type {
+  HierarchicalMenuComponentTemplates,
+  HierarchicalMenuWidgetParams,
+} from '../hierarchical-menu';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(originalRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/hierarchical-menu/__tests__/hierarchical-menu.test.tsx
+++ b/packages/instantsearch.js/src/widgets/hierarchical-menu/__tests__/hierarchical-menu.test.tsx
@@ -2,18 +2,18 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-import { fireEvent, within } from '@testing-library/dom';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
-import hierarchicalMenu from '../hierarchical-menu';
+import { fireEvent, within } from '@testing-library/dom';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
 import { createInsightsMiddleware } from '../../../middlewares';
+import hierarchicalMenu from '../hierarchical-menu';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/hierarchical-menu/defaultTemplates.tsx
+++ b/packages/instantsearch.js/src/widgets/hierarchical-menu/defaultTemplates.tsx
@@ -1,8 +1,9 @@
 /** @jsx h */
+import { cx } from '@algolia/ui-components-shared';
 import { h } from 'preact';
 
 import { formatNumber } from '../../lib/formatNumber';
-import { cx } from '@algolia/ui-components-shared';
+
 import type { HierarchicalMenuComponentTemplates } from './hierarchical-menu';
 
 const defaultTemplates: HierarchicalMenuComponentTemplates = {

--- a/packages/instantsearch.js/src/widgets/hierarchical-menu/hierarchical-menu.tsx
+++ b/packages/instantsearch.js/src/widgets/hierarchical-menu/hierarchical-menu.tsx
@@ -1,22 +1,26 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
 import RefinementList from '../../components/RefinementList/RefinementList';
+import connectHierarchicalMenu from '../../connectors/hierarchical-menu/connectHierarchicalMenu';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import defaultTemplates from './defaultTemplates';
+
 import type {
   HierarchicalMenuItem,
   HierarchicalMenuConnectorParams,
   HierarchicalMenuRenderState,
   HierarchicalMenuWidgetDescription,
 } from '../../connectors/hierarchical-menu/connectHierarchicalMenu';
-import connectHierarchicalMenu from '../../connectors/hierarchical-menu/connectHierarchicalMenu';
-import defaultTemplates from './defaultTemplates';
 import type { PreparedTemplateProps } from '../../lib/templating';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
 import type {
   TransformItems,
   Template,
@@ -25,7 +29,6 @@ import type {
   SortBy,
   ComponentCSSClasses,
 } from '../../types';
-import { component } from '../../lib/suit';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'hierarchical-menu',

--- a/packages/instantsearch.js/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
+++ b/packages/instantsearch.js/src/widgets/hits-per-page/__tests__/hits-per-page-test.ts
@@ -2,26 +2,28 @@
  * @jest-environment jsdom
  */
 
-import type { VNode, ComponentChildren } from 'preact';
-import { render as preactRender } from 'preact';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper, {
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
-import type { HitsPerPageCSSClasses } from '../hits-per-page';
-import hitsPerPage from '../hits-per-page';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
-import type { SelectorProps } from '../../../components/Selector/Selector';
-import type { HitsPerPageConnectorParamsItem } from '../../../connectors/hits-per-page/connectHitsPerPage';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliasearchHelper, {
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import hitsPerPage from '../hits-per-page';
+
+import type { SelectorProps } from '../../../components/Selector/Selector';
+import type { HitsPerPageConnectorParamsItem } from '../../../connectors/hits-per-page/connectHitsPerPage';
+import type { HitsPerPageCSSClasses } from '../hits-per-page';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import type { VNode, ComponentChildren } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/hits-per-page/hits-per-page.tsx
+++ b/packages/instantsearch.js/src/widgets/hits-per-page/hits-per-page.tsx
@@ -1,20 +1,22 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
 import Selector from '../../components/Selector/Selector';
-import type {
-  HitsPerPageConnectorParams,
-  HitsPerPageRenderState,
-  HitsPerPageWidgetDescription,
-} from '../../connectors/hits-per-page/connectHitsPerPage';
 import connectHitsPerPage from '../../connectors/hits-per-page/connectHitsPerPage';
+import { component } from '../../lib/suit';
 import {
   getContainerNode,
   createDocumentationMessageGenerator,
   find,
 } from '../../lib/utils';
-import { component } from '../../lib/suit';
+
+import type {
+  HitsPerPageConnectorParams,
+  HitsPerPageRenderState,
+  HitsPerPageWidgetDescription,
+} from '../../connectors/hits-per-page/connectHitsPerPage';
 import type { ComponentCSSClasses, WidgetFactory } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({

--- a/packages/instantsearch.js/src/widgets/hits/__tests__/hits-integration-test.ts
+++ b/packages/instantsearch.js/src/widgets/hits/__tests__/hits-integration-test.ts
@@ -2,13 +2,13 @@
  * @jest-environment jsdom
  */
 
-import { getByText, fireEvent } from '@testing-library/dom';
-
-import instantsearch from '../../../index.es';
-import { hits, configure } from '../..';
-import { createInsightsMiddleware } from '../../../middlewares';
 import { createSingleSearchResponse } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
+import { getByText, fireEvent } from '@testing-library/dom';
+
+import { hits, configure } from '../..';
+import instantsearch from '../../../index.es';
+import { createInsightsMiddleware } from '../../../middlewares';
 
 const createSearchClient = ({
   hitsPerPage,

--- a/packages/instantsearch.js/src/widgets/hits/__tests__/hits-test.ts
+++ b/packages/instantsearch.js/src/widgets/hits/__tests__/hits-test.ts
@@ -2,23 +2,25 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import { createSingleSearchResponse } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import algoliasearchHelper, {
   SearchParameters,
   SearchResults,
 } from 'algoliasearch-helper';
-import type { SearchClient } from '../../../types';
-import hits from '../hits';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import { render as preactRender } from 'preact';
+
 import { createInstantSearch } from '../../../../test/createInstantSearch';
-import type { HitsProps } from '../../../components/Hits/Hits';
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { createSingleSearchResponse } from '@instantsearch/mocks';
+import hits from '../hits';
+
+import type { HitsProps } from '../../../components/Hits/Hits';
+import type { SearchClient } from '../../../types';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/hits/__tests__/hits.test.tsx
+++ b/packages/instantsearch.js/src/widgets/hits/__tests__/hits.test.tsx
@@ -2,19 +2,20 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { Fragment, h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
-import hits from '../hits';
-import type { SearchResponse } from '../../../../src/types';
-import searchBox from '../../search-box/search-box';
 import { within, fireEvent } from '@testing-library/dom';
+import { Fragment, h } from 'preact';
+
+import instantsearch from '../../../index.es';
+import searchBox from '../../search-box/search-box';
+import hits from '../hits';
+
+import type { SearchResponse } from '../../../../src/types';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/hits/defaultTemplates.ts
+++ b/packages/instantsearch.js/src/widgets/hits/defaultTemplates.ts
@@ -1,5 +1,6 @@
-import type { HitsComponentTemplates } from '../../components/Hits/Hits';
 import { omit } from '../../lib/utils';
+
+import type { HitsComponentTemplates } from '../../components/Hits/Hits';
 
 const defaultTemplates: HitsComponentTemplates = {
   empty() {

--- a/packages/instantsearch.js/src/widgets/hits/hits.tsx
+++ b/packages/instantsearch.js/src/widgets/hits/hits.tsx
@@ -1,26 +1,30 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import Hits from '../../components/Hits/Hits';
+import connectHits from '../../connectors/hits/connectHits';
+import { withInsights, withInsightsListener } from '../../lib/insights';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import defaultTemplates from './defaultTemplates';
+
+import type {
+  HitsComponentCSSClasses,
+  HitsComponentTemplates,
+} from '../../components/Hits/Hits';
 import type {
   HitsConnectorParams,
   HitsRenderState,
   HitsWidgetDescription,
 } from '../../connectors/hits/connectHits';
-import connectHits from '../../connectors/hits/connectHits';
-import type {
-  HitsComponentCSSClasses,
-  HitsComponentTemplates,
-} from '../../components/Hits/Hits';
-import Hits from '../../components/Hits/Hits';
-import defaultTemplates from './defaultTemplates';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
-import { withInsights, withInsightsListener } from '../../lib/insights';
+import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   Template,
   TemplateWithBindEvent,
@@ -29,7 +33,6 @@ import type {
   Renderer,
   InsightsClient,
 } from '../../types';
-import type { PreparedTemplateProps } from '../../lib/templating';
 import type { SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'hits' });

--- a/packages/instantsearch.js/src/widgets/index.ts
+++ b/packages/instantsearch.js/src/widgets/index.ts
@@ -1,28 +1,27 @@
 import { deprecate } from '../lib/utils';
 
-export { default as analytics } from './analytics/analytics';
-export { default as breadcrumb } from './breadcrumb/breadcrumb';
-export { default as clearRefinements } from './clear-refinements/clear-refinements';
-export { default as configure } from './configure/configure';
-export { default as currentRefinements } from './current-refinements/current-refinements';
-
 import answers from './answers/answers';
+import dynamicWidgets from './dynamic-widgets/dynamic-widgets';
+
 /** @deprecated answers is no longer supported */
 export const EXPERIMENTAL_answers = deprecate(
   answers,
   'answers is no longer supported'
 );
 
-export { default as EXPERIMENTAL_configureRelatedItems } from './configure-related-items/configure-related-items';
-
-import dynamicWidgets from './dynamic-widgets/dynamic-widgets';
-export { dynamicWidgets };
 /** @deprecated use dynamicWidgets */
 export const EXPERIMENTAL_dynamicWidgets = deprecate(
   dynamicWidgets,
   'use dynamicWidgets'
 );
+export { dynamicWidgets };
 
+export { default as analytics } from './analytics/analytics';
+export { default as breadcrumb } from './breadcrumb/breadcrumb';
+export { default as clearRefinements } from './clear-refinements/clear-refinements';
+export { default as configure } from './configure/configure';
+export { default as currentRefinements } from './current-refinements/current-refinements';
+export { default as EXPERIMENTAL_configureRelatedItems } from './configure-related-items/configure-related-items';
 export { default as geoSearch } from './geo-search/geo-search';
 export { default as hierarchicalMenu } from './hierarchical-menu/hierarchical-menu';
 export { default as hits } from './hits/hits';

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -2,34 +2,35 @@
  * @jest-environment jsdom
  */
 
-import type { PlainSearchParameters } from 'algoliasearch-helper';
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
 import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
 
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { castToJestMock } from '../../../../../../tests/utils';
 import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createWidget,
   createIndexInitOptions,
   createDisposeOptions,
 } from '../../../../test/createWidget';
-import { wait } from '@instantsearch/testutils/wait';
-import type { Widget } from '../../../types';
-import index from '../index';
-import { warning } from '../../../lib/utils';
 import {
   connectHits,
   connectPagination,
   connectRefinementList,
   connectSearchBox,
 } from '../../../connectors';
-import { castToJestMock } from '../../../../../../tests/utils';
 import instantsearch from '../../../index.es';
+import { warning } from '../../../lib/utils';
+import index from '../index';
+
+import type { Widget } from '../../../types';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 
 describe('index', () => {
   const createSearchBox = (args: Partial<Widget> = {}): Widget =>

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -1,21 +1,5 @@
-import type {
-  AlgoliaSearchHelper as Helper,
-  DerivedHelper,
-  PlainSearchParameters,
-  SearchParameters,
-  SearchResults,
-  AlgoliaSearchHelper,
-} from 'algoliasearch-helper';
 import algoliasearchHelper from 'algoliasearch-helper';
-import type {
-  InstantSearch,
-  UiState,
-  IndexUiState,
-  Widget,
-  ScopedResult,
-  SearchClient,
-  IndexRenderState,
-} from '../../types';
+
 import {
   checkIndexUiState,
   createDocumentationMessageGenerator,
@@ -26,6 +10,24 @@ import {
   createInitArgs,
   createRenderArgs,
 } from '../../lib/utils';
+
+import type {
+  InstantSearch,
+  UiState,
+  IndexUiState,
+  Widget,
+  ScopedResult,
+  SearchClient,
+  IndexRenderState,
+} from '../../types';
+import type {
+  AlgoliaSearchHelper as Helper,
+  DerivedHelper,
+  PlainSearchParameters,
+  SearchParameters,
+  SearchResults,
+  AlgoliaSearchHelper,
+} from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'index-widget',

--- a/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
+++ b/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
@@ -2,22 +2,23 @@
  * @jest-environment jsdom
  */
 
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
 import { getByText, waitFor, fireEvent } from '@testing-library/dom';
 
-import instantsearch from '../../../index.es';
 import { infiniteHits, configure } from '../..';
+import instantsearch from '../../../index.es';
 import { createInsightsMiddleware } from '../../../middlewares';
-import { wait } from '@instantsearch/testutils/wait';
-import type { PlainSearchParameters } from 'algoliasearch-helper';
+
 import type {
   InfiniteHitsCache,
   InfiniteHitsCachedHits,
 } from '../../../connectors/infinite-hits/connectInfiniteHits';
 import type { MockSearchClient } from '@instantsearch/mocks';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 
 describe('infiniteHits', () => {
   const createInstantSearch = ({ hitsPerPage = 2 } = {}) => {

--- a/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
+++ b/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits-test.ts
@@ -2,27 +2,29 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import type {
-  AlgoliaSearchHelper,
-  PlainSearchParameters,
-} from 'algoliasearch-helper';
+import { createSingleSearchResponse } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import algoliasearchHelper, {
   SearchParameters,
   SearchResults,
 } from 'algoliasearch-helper';
-import type { SearchClient } from '../../../types';
-import infiniteHits from '../infinite-hits';
-import type { InfiniteHitsProps } from '../../../components/InfiniteHits/InfiniteHits';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import { render as preactRender } from 'preact';
+
 import { createInstantSearch } from '../../../../test/createInstantSearch';
-import { createSingleSearchResponse } from '@instantsearch/mocks';
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import infiniteHits from '../infinite-hits';
+
+import type { InfiniteHitsProps } from '../../../components/InfiniteHits/InfiniteHits';
 import type { InfiniteHitsCache } from '../../../connectors/infinite-hits/connectInfiniteHits';
+import type { SearchClient } from '../../../types';
+import type {
+  AlgoliaSearchHelper,
+  PlainSearchParameters,
+} from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits.test.tsx
+++ b/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits.test.tsx
@@ -2,19 +2,20 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { Fragment, h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
-import infiniteHits from '../infinite-hits';
-import type { SearchResponse } from '../../../../src/types';
-import searchBox from '../../search-box/search-box';
 import { within, fireEvent } from '@testing-library/dom';
+import { Fragment, h } from 'preact';
+
+import instantsearch from '../../../index.es';
+import searchBox from '../../search-box/search-box';
+import infiniteHits from '../infinite-hits';
+
+import type { SearchResponse } from '../../../../src/types';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/infinite-hits/defaultTemplates.ts
+++ b/packages/instantsearch.js/src/widgets/infinite-hits/defaultTemplates.ts
@@ -1,4 +1,5 @@
 import { omit } from '../../lib/utils';
+
 import type { InfiniteHitsComponentTemplates } from '../../components/InfiniteHits/InfiniteHits';
 
 const defaultTemplates: InfiniteHitsComponentTemplates = {

--- a/packages/instantsearch.js/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/packages/instantsearch.js/src/widgets/infinite-hits/infinite-hits.tsx
@@ -1,27 +1,31 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
-import type { SearchResults } from 'algoliasearch-helper';
+import { h, render } from 'preact';
+
+import InfiniteHits from '../../components/InfiniteHits/InfiniteHits';
+import connectInfiniteHits from '../../connectors/infinite-hits/connectInfiniteHits';
+import { withInsights, withInsightsListener } from '../../lib/insights';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import defaultTemplates from './defaultTemplates';
+
 import type {
   InfiniteHitsComponentCSSClasses,
   InfiniteHitsComponentTemplates,
 } from '../../components/InfiniteHits/InfiniteHits';
-import InfiniteHits from '../../components/InfiniteHits/InfiniteHits';
 import type {
   InfiniteHitsConnectorParams,
   InfiniteHitsRenderState,
   InfiniteHitsCache,
   InfiniteHitsWidgetDescription,
 } from '../../connectors/infinite-hits/connectInfiniteHits';
-import connectInfiniteHits from '../../connectors/infinite-hits/connectInfiniteHits';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
-import { withInsights, withInsightsListener } from '../../lib/insights';
+import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   WidgetFactory,
   Template,
@@ -30,8 +34,7 @@ import type {
   InsightsClient,
   Renderer,
 } from '../../types';
-import defaultTemplates from './defaultTemplates';
-import type { PreparedTemplateProps } from '../../lib/templating';
+import type { SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'infinite-hits',

--- a/packages/instantsearch.js/src/widgets/menu-select/__tests__/menu-select-test.ts
+++ b/packages/instantsearch.js/src/widgets/menu-select/__tests__/menu-select-test.ts
@@ -2,18 +2,20 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
-import menuSelect from '../menu-select';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
+import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
+import instantsearch from '../../../index.es';
+import menuSelect from '../menu-select';
+
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/menu-select/__tests__/menu-select.test.tsx
+++ b/packages/instantsearch.js/src/widgets/menu-select/__tests__/menu-select.test.tsx
@@ -2,15 +2,15 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
 import menuSelect from '../menu-select';
 
 beforeEach(() => {

--- a/packages/instantsearch.js/src/widgets/menu-select/defaultTemplates.ts
+++ b/packages/instantsearch.js/src/widgets/menu-select/defaultTemplates.ts
@@ -1,5 +1,6 @@
-import type { MenuSelectComponentTemplates } from '../../components/MenuSelect/MenuSelect';
 import { formatNumber } from '../../lib/formatNumber';
+
+import type { MenuSelectComponentTemplates } from '../../components/MenuSelect/MenuSelect';
 
 const defaultTemplates: MenuSelectComponentTemplates = {
   item({ label, count }) {

--- a/packages/instantsearch.js/src/widgets/menu-select/menu-select.tsx
+++ b/packages/instantsearch.js/src/widgets/menu-select/menu-select.tsx
@@ -1,27 +1,30 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import MenuSelect from '../../components/MenuSelect/MenuSelect';
+import connectMenu from '../../connectors/menu/connectMenu';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import defaultTemplates from './defaultTemplates';
+
+import type {
+  MenuSelectComponentCSSClasses,
+  MenuSelectComponentTemplates,
+} from '../../components/MenuSelect/MenuSelect';
 import type {
   MenuConnectorParams,
   MenuRenderState,
   MenuWidgetDescription,
 } from '../../connectors/menu/connectMenu';
-import connectMenu from '../../connectors/menu/connectMenu';
-import type {
-  MenuSelectComponentCSSClasses,
-  MenuSelectComponentTemplates,
-} from '../../components/MenuSelect/MenuSelect';
-import MenuSelect from '../../components/MenuSelect/MenuSelect';
-import defaultTemplates from './defaultTemplates';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
-import type { RendererOptions, Template, WidgetFactory } from '../../types';
 import type { PreparedTemplateProps } from '../../lib/templating';
+import type { RendererOptions, Template, WidgetFactory } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'menu-select' });
 const suit = component('MenuSelect');

--- a/packages/instantsearch.js/src/widgets/menu/__tests__/menu-test.ts
+++ b/packages/instantsearch.js/src/widgets/menu/__tests__/menu-test.ts
@@ -2,22 +2,24 @@
  * @jest-environment jsdom
  */
 
-import jsHelper, {
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
 import {
   createSingleSearchResponse,
   createSearchClient,
 } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import jsHelper, {
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import menu from '../menu';
+
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/menu/__tests__/menu.test.tsx
+++ b/packages/instantsearch.js/src/widgets/menu/__tests__/menu.test.tsx
@@ -2,17 +2,17 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
-import menu from '../menu';
 import { fireEvent, within } from '@testing-library/dom';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
+import menu from '../menu';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/menu/defaultTemplates.tsx
+++ b/packages/instantsearch.js/src/widgets/menu/defaultTemplates.tsx
@@ -1,8 +1,8 @@
 /** @jsx h */
+import { cx } from '@algolia/ui-components-shared';
 import { h } from 'preact';
 
 import { formatNumber } from '../../lib/formatNumber';
-import { cx } from '@algolia/ui-components-shared';
 
 import type { MenuComponentTemplates } from './menu';
 

--- a/packages/instantsearch.js/src/widgets/menu/menu.tsx
+++ b/packages/instantsearch.js/src/widgets/menu/menu.tsx
@@ -1,28 +1,31 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
 import RefinementList from '../../components/RefinementList/RefinementList';
+import connectMenu from '../../connectors/menu/connectMenu';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import defaultTemplates from './defaultTemplates';
+
 import type {
   MenuConnectorParams,
   MenuRenderState,
   MenuWidgetDescription,
 } from '../../connectors/menu/connectMenu';
-import connectMenu from '../../connectors/menu/connectMenu';
-import defaultTemplates from './defaultTemplates';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
+import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   ComponentCSSClasses,
   RendererOptions,
   Template,
   WidgetFactory,
 } from '../../types';
-import type { PreparedTemplateProps } from '../../lib/templating';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'menu' });
 const suit = component('Menu');

--- a/packages/instantsearch.js/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
+++ b/packages/instantsearch.js/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
@@ -2,27 +2,28 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import type defaultTemplates from '../defaultTemplates';
-import numericMenu from '../numeric-menu';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper, {
-  SearchParameters,
-  SearchResults,
-} from 'algoliasearch-helper';
-
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
-import {
-  createRenderOptions,
-  createInitOptions,
-} from '../../../../test/createWidget';
 import {
   createSingleSearchResponse,
   createSearchClient,
 } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliasearchHelper, {
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
+import {
+  createRenderOptions,
+  createInitOptions,
+} from '../../../../test/createWidget';
+import numericMenu from '../numeric-menu';
+
 import type { RefinementListProps } from '../../../components/RefinementList/RefinementList';
 import type { NumericMenuConnectorParamsItem } from '../../../connectors/numeric-menu/connectNumericMenu';
+import type defaultTemplates from '../defaultTemplates';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/numeric-menu/__tests__/numeric-menu.test.tsx
+++ b/packages/instantsearch.js/src/widgets/numeric-menu/__tests__/numeric-menu.test.tsx
@@ -2,17 +2,17 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
-import numericMenu from '../numeric-menu';
 import { fireEvent, within } from '@testing-library/dom';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
+import numericMenu from '../numeric-menu';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/numeric-menu/numeric-menu.tsx
+++ b/packages/instantsearch.js/src/widgets/numeric-menu/numeric-menu.tsx
@@ -1,28 +1,31 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
 import RefinementList from '../../components/RefinementList/RefinementList';
+import connectNumericMenu from '../../connectors/numeric-menu/connectNumericMenu';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import defaultTemplates from './defaultTemplates';
+
 import type {
   NumericMenuConnectorParams,
   NumericMenuRenderState,
   NumericMenuWidgetDescription,
 } from '../../connectors/numeric-menu/connectNumericMenu';
-import connectNumericMenu from '../../connectors/numeric-menu/connectNumericMenu';
-import defaultTemplates from './defaultTemplates';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { component } from '../../lib/suit';
+import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   ComponentCSSClasses,
   Renderer,
   Template,
   WidgetFactory,
 } from '../../types';
-import { prepareTemplateProps } from '../../lib/templating';
-import type { PreparedTemplateProps } from '../../lib/templating';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'numeric-menu' });
 const suit = component('NumericMenu');

--- a/packages/instantsearch.js/src/widgets/pagination/__tests__/pagination-test.ts
+++ b/packages/instantsearch.js/src/widgets/pagination/__tests__/pagination-test.ts
@@ -2,27 +2,29 @@
  * @jest-environment jsdom
  */
 
-import { render as preactRender } from 'preact';
-import { getContainerNode as utilsGetContainerNode } from '../../../lib/utils/getContainerNode';
-import type {
-  PaginationCSSClasses,
-  PaginationWidgetParams,
-} from '../pagination';
-import pagination from '../pagination';
-import {
-  createInitOptions,
-  createRenderOptions,
-} from '../../../../test/createWidget';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper, {
-  SearchResults,
-  SearchParameters,
-} from 'algoliasearch-helper';
 import {
   createSingleSearchResponse,
   createSearchClient,
 } from '@instantsearch/mocks';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliasearchHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
+import {
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/createWidget';
+import { getContainerNode as utilsGetContainerNode } from '../../../lib/utils/getContainerNode';
+import pagination from '../pagination';
+
+import type {
+  PaginationCSSClasses,
+  PaginationWidgetParams,
+} from '../pagination';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/pagination/__tests__/pagination.test.tsx
+++ b/packages/instantsearch.js/src/widgets/pagination/__tests__/pagination.test.tsx
@@ -7,10 +7,12 @@ import {
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
-import pagination from '../pagination';
+
+import instantsearch from '../../../index.es';
 import configure from '../../configure/configure';
+import pagination from '../pagination';
+
 import type { SearchResponse } from '../../../../src/types';
 
 beforeEach(() => {

--- a/packages/instantsearch.js/src/widgets/pagination/pagination.tsx
+++ b/packages/instantsearch.js/src/widgets/pagination/pagination.tsx
@@ -1,23 +1,25 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import Pagination from '../../components/Pagination/Pagination';
+import connectPagination from '../../connectors/pagination/connectPagination';
+import { component } from '../../lib/suit';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
 import type {
   PaginationComponentCSSClasses,
   PaginationComponentTemplates,
 } from '../../components/Pagination/Pagination';
-import Pagination from '../../components/Pagination/Pagination';
 import type {
   PaginationConnectorParams,
   PaginationRenderState,
   PaginationWidgetDescription,
 } from '../../connectors/pagination/connectPagination';
-import connectPagination from '../../connectors/pagination/connectPagination';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { component } from '../../lib/suit';
 import type { Renderer, WidgetFactory } from '../../types';
 
 const suit = component('Pagination');

--- a/packages/instantsearch.js/src/widgets/panel/__tests__/panel-test.ts
+++ b/packages/instantsearch.js/src/widgets/panel/__tests__/panel-test.ts
@@ -2,18 +2,20 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
-import panel from '../panel';
-import type { PanelProps } from '../../../components/Panel/Panel';
+import algoliasearchHelper from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import {
   createInitOptions,
   createRenderOptions,
   createDisposeOptions,
 } from '../../../../test/createWidget';
-import algoliasearchHelper from 'algoliasearch-helper';
+import panel from '../panel';
+
+import type { PanelProps } from '../../../components/Panel/Panel';
 import type { Widget } from '../../../types';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/panel/__tests__/panel.test.tsx
+++ b/packages/instantsearch.js/src/widgets/panel/__tests__/panel.test.tsx
@@ -2,17 +2,17 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
-import panel from '../panel';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
 import stats from '../../stats/stats';
+import panel from '../panel';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/panel/panel.tsx
+++ b/packages/instantsearch.js/src/widgets/panel/panel.tsx
@@ -1,16 +1,18 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import Panel from '../../components/Panel/Panel';
+import { component } from '../../lib/suit';
 import {
   createDocumentationMessageGenerator,
   getContainerNode,
   getObjectType,
   warning,
 } from '../../lib/utils';
-import { component } from '../../lib/suit';
+
 import type { PanelComponentCSSClasses } from '../../components/Panel/Panel';
-import Panel from '../../components/Panel/Panel';
 import type {
   Template,
   RenderOptions,

--- a/packages/instantsearch.js/src/widgets/places/__tests__/places-test.ts
+++ b/packages/instantsearch.js/src/widgets/places/__tests__/places-test.ts
@@ -2,11 +2,13 @@
  * @jest-environment jsdom
  */
 
+import { createSearchClient } from '@instantsearch/mocks';
 import algoliasearchHelper, { SearchParameters } from 'algoliasearch-helper';
 import algoliaPlaces from 'places.js';
-import places from '../places';
-import { createSearchClient } from '@instantsearch/mocks';
+
 import { createInitOptions } from '../../../../test/createWidget';
+import places from '../places';
+
 import type { SearchClient } from '../../../types';
 
 jest.mock('places.js', () => {

--- a/packages/instantsearch.js/src/widgets/places/places.ts
+++ b/packages/instantsearch.js/src/widgets/places/places.ts
@@ -1,6 +1,6 @@
 /** @ts-ignore */
-import type * as Places from 'places.js';
 import type { WidgetFactory, WidgetRenderState } from '../../types';
+import type * as Places from 'places.js';
 
 // using the type like this requires only one ts-ignore
 type StaticOptions = Places.StaticOptions;

--- a/packages/instantsearch.js/src/widgets/powered-by/__tests__/powered-by-test.ts
+++ b/packages/instantsearch.js/src/widgets/powered-by/__tests__/powered-by-test.ts
@@ -2,18 +2,20 @@
  * @jest-environment jsdom
  */
 
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper from 'algoliasearch-helper';
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
 import { createSearchClient } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliasearchHelper from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
-import type { PoweredByProps } from '../../../components/PoweredBy/PoweredBy';
 import poweredBy from '../powered-by';
+
+import type { PoweredByProps } from '../../../components/PoweredBy/PoweredBy';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/powered-by/powered-by.tsx
+++ b/packages/instantsearch.js/src/widgets/powered-by/powered-by.tsx
@@ -1,20 +1,22 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
-import type { PoweredByComponentCSSClasses } from '../../components/PoweredBy/PoweredBy';
+import { h, render } from 'preact';
+
 import PoweredBy from '../../components/PoweredBy/PoweredBy';
+import connectPoweredBy from '../../connectors/powered-by/connectPoweredBy';
+import { component } from '../../lib/suit';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import type { PoweredByComponentCSSClasses } from '../../components/PoweredBy/PoweredBy';
 import type {
   PoweredByConnectorParams,
   PoweredByRenderState,
   PoweredByWidgetDescription,
 } from '../../connectors/powered-by/connectPoweredBy';
-import connectPoweredBy from '../../connectors/powered-by/connectPoweredBy';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { component } from '../../lib/suit';
 import type { Renderer, WidgetFactory } from '../../types';
 
 const suit = component('PoweredBy');

--- a/packages/instantsearch.js/src/widgets/query-rule-context/query-rule-context.tsx
+++ b/packages/instantsearch.js/src/widgets/query-rule-context/query-rule-context.tsx
@@ -1,12 +1,13 @@
-import type { WidgetFactory } from '../../types';
+import connectQueryRules from '../../connectors/query-rules/connectQueryRules';
 import { createDocumentationMessageGenerator, noop } from '../../lib/utils';
+
 import type {
   ParamTrackedFilters,
   ParamTransformRuleContexts,
   QueryRulesConnectorParams,
   QueryRulesWidgetDescription,
 } from '../../connectors/query-rules/connectQueryRules';
-import connectQueryRules from '../../connectors/query-rules/connectQueryRules';
+import type { WidgetFactory } from '../../types';
 
 export type QueryRuleContextWidgetParams = {
   trackedFilters: ParamTrackedFilters;

--- a/packages/instantsearch.js/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
+++ b/packages/instantsearch.js/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data-test.ts
@@ -2,18 +2,20 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import type { AlgoliaSearchHelper as Helper } from 'algoliasearch-helper';
-import algoliasearchHelper from 'algoliasearch-helper';
 import { createSearchClient } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliasearchHelper from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import {
   createDisposeOptions,
   createInitOptions,
 } from '../../../../test/createWidget';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import queryRuleCustomData from '../query-rule-custom-data';
+
 import type { QueryRuleCustomDataProps } from '../../../components/QueryRuleCustomData/QueryRuleCustomData';
+import type { AlgoliaSearchHelper as Helper } from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data.test.tsx
+++ b/packages/instantsearch.js/src/widgets/query-rule-custom-data/__tests__/query-rule-custom-data.test.tsx
@@ -2,15 +2,15 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
 import queryRuleCustomData from '../query-rule-custom-data';
 
 beforeEach(() => {

--- a/packages/instantsearch.js/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
+++ b/packages/instantsearch.js/src/widgets/query-rule-custom-data/query-rule-custom-data.tsx
@@ -1,25 +1,27 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import CustomData from '../../components/QueryRuleCustomData/QueryRuleCustomData';
+import connectQueryRules from '../../connectors/query-rules/connectQueryRules';
+import { component } from '../../lib/suit';
 import {
   getContainerNode,
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
-import { component } from '../../lib/suit';
-import type { WidgetFactory, Template } from '../../types';
+
+import type {
+  QueryRuleCustomDataComponentCSSClasses,
+  QueryRuleCustomDataComponentTemplates,
+} from '../../components/QueryRuleCustomData/QueryRuleCustomData';
 import type {
   QueryRulesConnectorParams,
   QueryRulesRenderState,
   QueryRulesWidgetDescription,
 } from '../../connectors/query-rules/connectQueryRules';
-import connectQueryRules from '../../connectors/query-rules/connectQueryRules';
-import type {
-  QueryRuleCustomDataComponentCSSClasses,
-  QueryRuleCustomDataComponentTemplates,
-} from '../../components/QueryRuleCustomData/QueryRuleCustomData';
-import CustomData from '../../components/QueryRuleCustomData/QueryRuleCustomData';
 import type { PreparedTemplateProps } from '../../lib/templating';
+import type { WidgetFactory, Template } from '../../types';
 
 export type QueryRuleCustomDataCSSClasses = Partial<{
   root: string | string[];

--- a/packages/instantsearch.js/src/widgets/range-input/__tests__/range-input-test.ts
+++ b/packages/instantsearch.js/src/widgets/range-input/__tests__/range-input-test.ts
@@ -3,21 +3,23 @@
  */
 /** @jsx h */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper from 'algoliasearch-helper';
-import rangeInput from '../range-input';
 import { createSearchClient } from '@instantsearch/mocks';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliasearchHelper from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
-import type { InstantSearch } from '../../../types';
+import rangeInput from '../range-input';
+
 import type { RangeInputProps } from '../../../components/RangeInput/RangeInput';
+import type { InstantSearch } from '../../../types';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/range-input/__tests__/range-input.test.tsx
+++ b/packages/instantsearch.js/src/widgets/range-input/__tests__/range-input.test.tsx
@@ -2,15 +2,15 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
 import rangeInput from '../range-input';
 
 beforeEach(() => {

--- a/packages/instantsearch.js/src/widgets/range-input/range-input.tsx
+++ b/packages/instantsearch.js/src/widgets/range-input/range-input.tsx
@@ -1,26 +1,28 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import RangeInput from '../../components/RangeInput/RangeInput';
+import connectRange from '../../connectors/range/connectRange';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
 import type {
   RangeInputComponentCSSClasses,
   RangeInputComponentTemplates,
 } from '../../components/RangeInput/RangeInput';
-import RangeInput from '../../components/RangeInput/RangeInput';
 import type {
   RangeConnectorParams,
   RangeRenderState,
   RangeWidgetDescription,
 } from '../../connectors/range/connectRange';
-import connectRange from '../../connectors/range/connectRange';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
-import type { Renderer, Template, WidgetFactory } from '../../types';
 import type { PreparedTemplateProps } from '../../lib/templating';
+import type { Renderer, Template, WidgetFactory } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'range-input' });
 const suit = component('RangeInput');

--- a/packages/instantsearch.js/src/widgets/range-slider/__tests__/range-slider-test.ts
+++ b/packages/instantsearch.js/src/widgets/range-slider/__tests__/range-slider-test.ts
@@ -2,25 +2,27 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import algoliasearchHelper, {
   SearchParameters,
   SearchResults,
 } from 'algoliasearch-helper';
-import rangeSlider from '../range-slider';
+import { render as preactRender } from 'preact';
+
 import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import rangeSlider from '../range-slider';
+
 import type { InstantSearch } from '../../../types';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/range-slider/range-slider.tsx
+++ b/packages/instantsearch.js/src/widgets/range-slider/range-slider.tsx
@@ -1,21 +1,23 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
-import type { RangeSliderComponentCSSClasses } from '../../components/Slider/Slider';
+import { h, render } from 'preact';
+
 import Slider from '../../components/Slider/Slider';
+import connectRange from '../../connectors/range/connectRange';
+import { component } from '../../lib/suit';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import type { RangeSliderComponentCSSClasses } from '../../components/Slider/Slider';
 import type {
   RangeBoundaries,
   RangeConnectorParams,
   RangeRenderState,
   RangeWidgetDescription,
 } from '../../connectors/range/connectRange';
-import connectRange from '../../connectors/range/connectRange';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { component } from '../../lib/suit';
 import type { Renderer, WidgetFactory } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'range-slider' });

--- a/packages/instantsearch.js/src/widgets/rating-menu/__tests__/rating-menu-integration-test.ts
+++ b/packages/instantsearch.js/src/widgets/rating-menu/__tests__/rating-menu-integration-test.ts
@@ -2,14 +2,15 @@
  * @jest-environment jsdom
  */
 
-import jsHelper, {
-  SearchResults,
-  SearchParameters,
-} from 'algoliasearch-helper';
 import {
   createSearchClient,
   createMultiSearchResponse,
 } from '@instantsearch/mocks';
+import jsHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+
 import {
   createInitOptions,
   createRenderOptions,

--- a/packages/instantsearch.js/src/widgets/rating-menu/__tests__/rating-menu-test.ts
+++ b/packages/instantsearch.js/src/widgets/rating-menu/__tests__/rating-menu-test.ts
@@ -2,23 +2,25 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import jsHelper, {
-  SearchResults,
-  SearchParameters,
-} from 'algoliasearch-helper';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import jsHelper, {
+  SearchResults,
+  SearchParameters,
+} from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { createInstantSearch } from '../../../../test/createInstantSearch';
 import ratingMenu from '../rating-menu';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/rating-menu/__tests__/rating-menu.test.tsx
+++ b/packages/instantsearch.js/src/widgets/rating-menu/__tests__/rating-menu.test.tsx
@@ -2,17 +2,17 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
+import { cx } from '@algolia/ui-components-shared';
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
 import ratingMenu from '../rating-menu';
-import { cx } from '@algolia/ui-components-shared';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/rating-menu/defaultTemplates.tsx
+++ b/packages/instantsearch.js/src/widgets/rating-menu/defaultTemplates.tsx
@@ -1,13 +1,14 @@
 /** @jsx h */
+import { cx } from '@algolia/ui-components-shared';
 import { h } from 'preact';
 
-import type { ComponentChild } from 'preact';
+import { formatNumber } from '../../lib/formatNumber';
+
 import type {
   RatingMenuComponentTemplates,
   RatingMenuCSSClasses,
 } from './rating-menu';
-import { formatNumber } from '../../lib/formatNumber';
-import { cx } from '@algolia/ui-components-shared';
+import type { ComponentChild } from 'preact';
 
 type ItemWrapperProps = { children: ComponentChild } & {
   value: string;

--- a/packages/instantsearch.js/src/widgets/rating-menu/rating-menu.tsx
+++ b/packages/instantsearch.js/src/widgets/rating-menu/rating-menu.tsx
@@ -1,28 +1,31 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
 import RefinementList from '../../components/RefinementList/RefinementList';
+import connectRatingMenu from '../../connectors/rating-menu/connectRatingMenu';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import defaultTemplates from './defaultTemplates';
+
 import type {
   RatingMenuWidgetDescription,
   RatingMenuConnectorParams,
   RatingMenuRenderState,
 } from '../../connectors/rating-menu/connectRatingMenu';
-import connectRatingMenu from '../../connectors/rating-menu/connectRatingMenu';
-import defaultTemplates from './defaultTemplates';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
+import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   ComponentCSSClasses,
   RendererOptions,
   Template,
   WidgetFactory,
 } from '../../types';
-import type { PreparedTemplateProps } from '../../lib/templating';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'rating-menu' });
 const suit = component('RatingMenu');

--- a/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list-test.ts
+++ b/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list-test.ts
@@ -2,18 +2,20 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as originalRender } from 'preact';
-import type { RefinementListTemplates } from '../refinement-list';
-import refinementList from '../refinement-list';
-import type { RefinementListProps } from '../../../components/RefinementList/RefinementList';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import { wait } from '@instantsearch/testutils/wait';
+import { render as originalRender } from 'preact';
+
+import instantsearch from '../../../index.es';
+import refinementList from '../refinement-list';
+
+import type { RefinementListProps } from '../../../components/RefinementList/RefinementList';
+import type { RefinementListTemplates } from '../refinement-list';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(originalRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
@@ -2,18 +2,18 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSFFVResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
-import refinementList from '../refinement-list';
 import { fireEvent, within } from '@testing-library/dom';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
+import refinementList from '../refinement-list';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/refinement-list/defaultTemplates.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/defaultTemplates.tsx
@@ -1,9 +1,10 @@
 /** @jsx h */
+import { cx } from '@algolia/ui-components-shared';
 import { h } from 'preact';
 
-import type { RefinementListComponentTemplates } from './refinement-list';
 import { formatNumber } from '../../lib/formatNumber';
-import { cx } from '@algolia/ui-components-shared';
+
+import type { RefinementListComponentTemplates } from './refinement-list';
 
 const defaultTemplates: RefinementListComponentTemplates = {
   item({ cssClasses, count, value, highlighted, isRefined, isFromSearch }) {

--- a/packages/instantsearch.js/src/widgets/refinement-list/refinement-list.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/refinement-list.tsx
@@ -1,27 +1,30 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
-import type { RefinementListComponentCSSClasses } from '../../components/RefinementList/RefinementList';
+import { h, render } from 'preact';
+
 import RefinementList from '../../components/RefinementList/RefinementList';
+import connectRefinementList from '../../connectors/refinement-list/connectRefinementList';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+import searchBoxDefaultTemplates from '../search-box/defaultTemplates';
+
+import defaultTemplates from './defaultTemplates';
+
+import type { RefinementListComponentCSSClasses } from '../../components/RefinementList/RefinementList';
+import type { SearchBoxComponentTemplates } from '../../components/SearchBox/SearchBox';
 import type {
   RefinementListRenderState,
   RefinementListConnectorParams,
   RefinementListWidgetDescription,
 } from '../../connectors/refinement-list/connectRefinementList';
-import connectRefinementList from '../../connectors/refinement-list/connectRefinementList';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
-import type { Template, WidgetFactory, Renderer } from '../../types';
 import type { PreparedTemplateProps } from '../../lib/templating';
-import searchBoxDefaultTemplates from '../search-box/defaultTemplates';
+import type { Template, WidgetFactory, Renderer } from '../../types';
 import type { SearchBoxTemplates } from '../search-box/search-box';
-import type { SearchBoxComponentTemplates } from '../../components/SearchBox/SearchBox';
-import defaultTemplates from './defaultTemplates';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'refinement-list',

--- a/packages/instantsearch.js/src/widgets/relevant-sort/__tests__/relevant-sort-test.ts
+++ b/packages/instantsearch.js/src/widgets/relevant-sort/__tests__/relevant-sort-test.ts
@@ -2,18 +2,20 @@
  * @jest-environment jsdom
  */
 
-import { render } from 'preact';
-import type { RelevantSortTemplates } from '../relevant-sort';
-import relevantSort from '../relevant-sort';
-import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+import { render } from 'preact';
+
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import relevantSort from '../relevant-sort';
+
+import type { RelevantSortTemplates } from '../relevant-sort';
 
 jest.mock('preact', () => {
   const module = jest.requireActual('preact');

--- a/packages/instantsearch.js/src/widgets/relevant-sort/__tests__/relevant-sort.test.tsx
+++ b/packages/instantsearch.js/src/widgets/relevant-sort/__tests__/relevant-sort.test.tsx
@@ -2,15 +2,15 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
 import relevantSort from '../relevant-sort';
 
 beforeEach(() => {

--- a/packages/instantsearch.js/src/widgets/relevant-sort/relevant-sort.tsx
+++ b/packages/instantsearch.js/src/widgets/relevant-sort/relevant-sort.tsx
@@ -1,26 +1,29 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import RelevantSort from '../../components/RelevantSort/RelevantSort';
+import connectRelevantSort from '../../connectors/relevant-sort/connectRelevantSort';
+import { component } from '../../lib/suit';
 import {
   getContainerNode,
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
-import { component } from '../../lib/suit';
-import type { WidgetFactory, Template } from '../../types';
+
+import defaultTemplates from './defaultTemplates';
+
+import type {
+  RelevantSortComponentCSSClasses,
+  RelevantSortComponentTemplates,
+} from '../../components/RelevantSort/RelevantSort';
 import type {
   RelevantSortConnectorParams,
   RelevantSortRenderState,
   RelevantSortWidgetDescription,
 } from '../../connectors/relevant-sort/connectRelevantSort';
-import connectRelevantSort from '../../connectors/relevant-sort/connectRelevantSort';
-import type {
-  RelevantSortComponentCSSClasses,
-  RelevantSortComponentTemplates,
-} from '../../components/RelevantSort/RelevantSort';
-import RelevantSort from '../../components/RelevantSort/RelevantSort';
-import defaultTemplates from './defaultTemplates';
 import type { PreparedTemplateProps } from '../../lib/templating';
+import type { WidgetFactory, Template } from '../../types';
 
 export type RelevantSortCSSClasses = Partial<{
   root: string;

--- a/packages/instantsearch.js/src/widgets/search-box/__tests__/search-box-test.ts
+++ b/packages/instantsearch.js/src/widgets/search-box/__tests__/search-box-test.ts
@@ -2,17 +2,19 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import searchBox from '../search-box';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliaSearchHelper from 'algoliasearch-helper';
 import { createSearchClient } from '@instantsearch/mocks';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliaSearchHelper from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
+import searchBox from '../search-box';
+
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 

--- a/packages/instantsearch.js/src/widgets/search-box/__tests__/search-box.test.tsx
+++ b/packages/instantsearch.js/src/widgets/search-box/__tests__/search-box.test.tsx
@@ -2,11 +2,11 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
 import { h } from 'preact';
 
-import { createSearchClient } from '@instantsearch/mocks';
 import instantsearch from '../../../index.es';
-import { wait } from '@instantsearch/testutils/wait';
 import searchBox from '../search-box';
 
 beforeEach(() => {

--- a/packages/instantsearch.js/src/widgets/search-box/search-box.tsx
+++ b/packages/instantsearch.js/src/widgets/search-box/search-box.tsx
@@ -1,25 +1,28 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import SearchBox from '../../components/SearchBox/SearchBox';
+import connectSearchBox from '../../connectors/search-box/connectSearchBox';
+import { component } from '../../lib/suit';
 import {
   getContainerNode,
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
-import { component } from '../../lib/suit';
-import type { WidgetFactory, Template, RendererOptions } from '../../types';
+
+import defaultTemplates from './defaultTemplates';
+
+import type {
+  SearchBoxComponentCSSClasses,
+  SearchBoxComponentTemplates,
+} from '../../components/SearchBox/SearchBox';
 import type {
   SearchBoxConnectorParams,
   SearchBoxRenderState,
   SearchBoxWidgetDescription,
 } from '../../connectors/search-box/connectSearchBox';
-import connectSearchBox from '../../connectors/search-box/connectSearchBox';
-import type {
-  SearchBoxComponentCSSClasses,
-  SearchBoxComponentTemplates,
-} from '../../components/SearchBox/SearchBox';
-import SearchBox from '../../components/SearchBox/SearchBox';
-import defaultTemplates from './defaultTemplates';
+import type { WidgetFactory, Template, RendererOptions } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'search-box' });
 const suit = component('SearchBox');

--- a/packages/instantsearch.js/src/widgets/sort-by/__tests__/sort-by-test.ts
+++ b/packages/instantsearch.js/src/widgets/sort-by/__tests__/sort-by-test.ts
@@ -2,21 +2,23 @@
  * @jest-environment jsdom
  */
 
-import { render as preactRender } from 'preact';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
-import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
-import type { SortByIndexDefinition } from '../sort-by';
-import sortBy from '../sort-by';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import sortBy from '../sort-by';
+
+import type { SortByIndexDefinition } from '../sort-by';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/sort-by/sort-by.tsx
+++ b/packages/instantsearch.js/src/widgets/sort-by/sort-by.tsx
@@ -1,21 +1,23 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
-import type { SelectorComponentCSSClasses } from '../../components/Selector/Selector';
+import { h, render } from 'preact';
+
 import Selector from '../../components/Selector/Selector';
+import connectSortBy from '../../connectors/sort-by/connectSortBy';
+import { component } from '../../lib/suit';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import type { SelectorComponentCSSClasses } from '../../components/Selector/Selector';
 import type {
   SortByConnectorParams,
   SortByItem,
   SortByRenderState,
   SortByWidgetDescription,
 } from '../../connectors/sort-by/connectSortBy';
-import connectSortBy from '../../connectors/sort-by/connectSortBy';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { component } from '../../lib/suit';
 import type { Renderer, TransformItems, WidgetFactory } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'sort-by' });

--- a/packages/instantsearch.js/src/widgets/stats/__tests__/stats-test.ts
+++ b/packages/instantsearch.js/src/widgets/stats/__tests__/stats-test.ts
@@ -2,15 +2,16 @@
  * @jest-environment jsdom
  */
 
-import { render as preactRender } from 'preact';
-import stats from '../stats';
+import { createSingleSearchResponse } from '@instantsearch/mocks';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import { SearchParameters, SearchResults } from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { SearchParameters, SearchResults } from 'algoliasearch-helper';
-import { createSingleSearchResponse } from '@instantsearch/mocks';
+import stats from '../stats';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/stats/__tests__/stats.test.tsx
+++ b/packages/instantsearch.js/src/widgets/stats/__tests__/stats.test.tsx
@@ -2,19 +2,20 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import { h } from 'preact';
-
 import {
   createSearchClient,
   createMultiSearchResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import instantsearch from '../../../index.es';
 import { wait } from '@instantsearch/testutils/wait';
-import stats from '../stats';
-import type { SearchResponse } from '../../../../src/types';
-import searchBox from '../../search-box/search-box';
 import { fireEvent, within } from '@testing-library/dom';
+import { h } from 'preact';
+
+import instantsearch from '../../../index.es';
+import searchBox from '../../search-box/search-box';
+import stats from '../stats';
+
+import type { SearchResponse } from '../../../../src/types';
 
 beforeEach(() => {
   document.body.innerHTML = '';

--- a/packages/instantsearch.js/src/widgets/stats/stats.tsx
+++ b/packages/instantsearch.js/src/widgets/stats/stats.tsx
@@ -1,27 +1,29 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import Stats from '../../components/Stats/Stats';
+import connectStats from '../../connectors/stats/connectStats';
+import { formatNumber } from '../../lib/formatNumber';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
 import type {
   StatsComponentCSSClasses,
   StatsComponentTemplates,
 } from '../../components/Stats/Stats';
-import Stats from '../../components/Stats/Stats';
 import type {
   StatsConnectorParams,
   StatsRenderState,
   StatsWidgetDescription,
 } from '../../connectors/stats/connectStats';
-import connectStats from '../../connectors/stats/connectStats';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import { component } from '../../lib/suit';
-import type { Renderer, Template, WidgetFactory } from '../../types';
 import type { PreparedTemplateProps } from '../../lib/templating';
-import { formatNumber } from '../../lib/formatNumber';
+import type { Renderer, Template, WidgetFactory } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'stats' });
 const suit = component('Stats');

--- a/packages/instantsearch.js/src/widgets/toggle-refinement/__tests__/toggle-refinement-test.ts
+++ b/packages/instantsearch.js/src/widgets/toggle-refinement/__tests__/toggle-refinement-test.ts
@@ -2,18 +2,20 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
-import toggleRefinement from '../toggle-refinement';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
-import { createRenderOptions } from '../../../../test/createWidget';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import { wait } from '@instantsearch/testutils/wait';
+import { render as preactRender } from 'preact';
+
 import instantsearch from '../../..';
+import { createRenderOptions } from '../../../../test/createWidget';
+import toggleRefinement from '../toggle-refinement';
+
 import type { ToggleRefinementProps } from '../../../components/ToggleRefinement/ToggleRefinement';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/toggle-refinement/__tests__/toggle-refinement.test.tsx
+++ b/packages/instantsearch.js/src/widgets/toggle-refinement/__tests__/toggle-refinement.test.tsx
@@ -2,11 +2,11 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
 import { h } from 'preact';
 
-import { createSearchClient } from '@instantsearch/mocks';
 import instantsearch from '../../../index.es';
-import { wait } from '@instantsearch/testutils/wait';
 import toggleRefinement from '../toggle-refinement';
 
 beforeEach(() => {

--- a/packages/instantsearch.js/src/widgets/toggle-refinement/toggle-refinement.tsx
+++ b/packages/instantsearch.js/src/widgets/toggle-refinement/toggle-refinement.tsx
@@ -1,28 +1,31 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
+import { h, render } from 'preact';
+
+import ToggleRefinement from '../../components/ToggleRefinement/ToggleRefinement';
+import connectToggleRefinement from '../../connectors/toggle-refinement/connectToggleRefinement';
+import { component } from '../../lib/suit';
+import { prepareTemplateProps } from '../../lib/templating';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import defaultTemplates from './defaultTemplates';
+
 import type {
   ToggleRefinementComponentCSSClasses,
   ToggleRefinementComponentTemplates,
 } from '../../components/ToggleRefinement/ToggleRefinement';
-import ToggleRefinement from '../../components/ToggleRefinement/ToggleRefinement';
 import type {
   ToggleRefinementConnectorParams,
   ToggleRefinementWidgetDescription,
   ToggleRefinementValue,
   ToggleRefinementRenderState,
 } from '../../connectors/toggle-refinement/connectToggleRefinement';
-import connectToggleRefinement from '../../connectors/toggle-refinement/connectToggleRefinement';
-import defaultTemplates from './defaultTemplates';
-import {
-  getContainerNode,
-  createDocumentationMessageGenerator,
-} from '../../lib/utils';
-import { prepareTemplateProps } from '../../lib/templating';
-import type { RendererOptions, Template, WidgetFactory } from '../../types';
-import { component } from '../../lib/suit';
 import type { PreparedTemplateProps } from '../../lib/templating';
+import type { RendererOptions, Template, WidgetFactory } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'toggle-refinement',

--- a/packages/instantsearch.js/src/widgets/voice-search/__tests__/voice-search-test.ts
+++ b/packages/instantsearch.js/src/widgets/voice-search/__tests__/voice-search-test.ts
@@ -2,25 +2,27 @@
  * @jest-environment jsdom
  */
 
-import type { VNode } from 'preact';
-import { render as preactRender } from 'preact';
+import { createSingleSearchResponse } from '@instantsearch/mocks';
+import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
 import algoliasearch from 'algoliasearch';
-import type { AlgoliaSearchHelper as Helper } from 'algoliasearch-helper';
 import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
 } from 'algoliasearch-helper';
+import { render as preactRender } from 'preact';
+
 import {
   createInitOptions,
   createRenderOptions,
 } from '../../../../test/createWidget';
-import { createSingleSearchResponse } from '@instantsearch/mocks';
-import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
+import voiceSearch from '../voice-search';
+
+import type { VoiceSearchProps } from '../../../components/VoiceSearch/VoiceSearch';
+import type { VoiceSearchHelper } from '../../../lib/voiceSearchHelper/types';
 import type { Widget } from '../../../types';
 import type { VoiceSearchWidgetParams } from '../voice-search';
-import voiceSearch from '../voice-search';
-import type { VoiceSearchHelper } from '../../../lib/voiceSearchHelper/types';
-import type { VoiceSearchProps } from '../../../components/VoiceSearch/VoiceSearch';
+import type { AlgoliaSearchHelper as Helper } from 'algoliasearch-helper';
+import type { VNode } from 'preact';
 
 const render = castToJestMock(preactRender);
 jest.mock('preact', () => {

--- a/packages/instantsearch.js/src/widgets/voice-search/__tests__/voice-search.test.tsx
+++ b/packages/instantsearch.js/src/widgets/voice-search/__tests__/voice-search.test.tsx
@@ -2,11 +2,11 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
 import { h } from 'preact';
 
-import { createSearchClient } from '@instantsearch/mocks';
 import instantsearch from '../../../index.es';
-import { wait } from '@instantsearch/testutils/wait';
 import voiceSearch from '../voice-search';
 
 beforeEach(() => {

--- a/packages/instantsearch.js/src/widgets/voice-search/voice-search.tsx
+++ b/packages/instantsearch.js/src/widgets/voice-search/voice-search.tsx
@@ -1,27 +1,30 @@
 /** @jsx h */
 
-import { h, render } from 'preact';
 import { cx } from '@algolia/ui-components-shared';
-import type { PlainSearchParameters } from 'algoliasearch-helper';
+import { h, render } from 'preact';
+
+import VoiceSearchComponent from '../../components/VoiceSearch/VoiceSearch';
+import connectVoiceSearch from '../../connectors/voice-search/connectVoiceSearch';
+import { component } from '../../lib/suit';
 import {
   getContainerNode,
   createDocumentationMessageGenerator,
 } from '../../lib/utils';
-import { component } from '../../lib/suit';
+
+import defaultTemplates from './defaultTemplates';
+
+import type {
+  VoiceSearchComponentCSSClasses,
+  VoiceSearchComponentTemplates,
+} from '../../components/VoiceSearch/VoiceSearch';
 import type {
   VoiceSearchConnectorParams,
   VoiceSearchRenderState,
   VoiceSearchWidgetDescription,
 } from '../../connectors/voice-search/connectVoiceSearch';
-import connectVoiceSearch from '../../connectors/voice-search/connectVoiceSearch';
-import type {
-  VoiceSearchComponentCSSClasses,
-  VoiceSearchComponentTemplates,
-} from '../../components/VoiceSearch/VoiceSearch';
-import VoiceSearchComponent from '../../components/VoiceSearch/VoiceSearch';
-import defaultTemplates from './defaultTemplates';
-import type { WidgetFactory, Template, Renderer } from '../../types';
 import type { CreateVoiceSearchHelper } from '../../lib/voiceSearchHelper/types';
+import type { WidgetFactory, Template, Renderer } from '../../types';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({ name: 'voice-search' });
 const suit = component('VoiceSearch');

--- a/packages/instantsearch.js/stories/analytics.stories.ts
+++ b/packages/instantsearch.js/stories/analytics.stories.ts
@@ -1,5 +1,6 @@
-import { storiesOf } from '@storybook/html';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Metadata/Analytics', module).add(

--- a/packages/instantsearch.js/stories/answers.stories.ts
+++ b/packages/instantsearch.js/stories/answers.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 import '../.storybook/static/answers.css';
 

--- a/packages/instantsearch.js/stories/autocomplete.stories.ts
+++ b/packages/instantsearch.js/stories/autocomplete.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Basics/Autocomplete', module).add(

--- a/packages/instantsearch.js/stories/breadcrumb.stories.ts
+++ b/packages/instantsearch.js/stories/breadcrumb.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits, withLifecycle } from '../.storybook/decorators';
 import { connectHierarchicalMenu } from '../src/connectors';
 import { noop } from '../src/lib/utils';

--- a/packages/instantsearch.js/stories/clear-refinements.stories.ts
+++ b/packages/instantsearch.js/stories/clear-refinements.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Refinements/ClearRefinements', module)

--- a/packages/instantsearch.js/stories/configure-related-items.stories.ts
+++ b/packages/instantsearch.js/stories/configure-related-items.stories.ts
@@ -1,7 +1,9 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
-import type { HitsWidgetParams } from '../src/widgets/hits/hits';
+
 import type { AlgoliaHit } from '../src/types';
+import type { HitsWidgetParams } from '../src/widgets/hits/hits';
 
 storiesOf('Basics/ConfigureRelatedItems', module).add(
   'default',

--- a/packages/instantsearch.js/stories/configure.stories.ts
+++ b/packages/instantsearch.js/stories/configure.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('Basics/Configure', module)

--- a/packages/instantsearch.js/stories/current-refinements.stories.ts
+++ b/packages/instantsearch.js/stories/current-refinements.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Refinements/CurrentRefinements', module)

--- a/packages/instantsearch.js/stories/dynamic-widgets.stories.ts
+++ b/packages/instantsearch.js/stories/dynamic-widgets.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Basics/DynamicWidgets', module)

--- a/packages/instantsearch.js/stories/geo-search.stories.ts
+++ b/packages/instantsearch.js/stories/geo-search.stories.ts
@@ -1,9 +1,10 @@
-import { storiesOf } from '@storybook/html';
 import { action } from '@storybook/addon-actions';
-import { withHits, withLifecycle } from '../.storybook/decorators';
-import createInfoBox from '../.storybook/utils/create-info-box';
+import { storiesOf } from '@storybook/html';
 import algoliaPlaces from 'places.js';
 import injectScript from 'scriptjs';
+
+import { withHits, withLifecycle } from '../.storybook/decorators';
+import createInfoBox from '../.storybook/utils/create-info-box';
 
 const API_KEY = 'AIzaSyBawL8VbstJDdU5397SUX7pEt9DslAwWgQ';
 

--- a/packages/instantsearch.js/stories/hierarchical-menu.stories.ts
+++ b/packages/instantsearch.js/stories/hierarchical-menu.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('Refinements/HierarchicalMenu', module)

--- a/packages/instantsearch.js/stories/hits-per-page.stories.ts
+++ b/packages/instantsearch.js/stories/hits-per-page.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('Pagination/HitsPerPage', module)

--- a/packages/instantsearch.js/stories/hits.stories.ts
+++ b/packages/instantsearch.js/stories/hits.stories.ts
@@ -1,6 +1,8 @@
-import { storiesOf } from '@storybook/html';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
+
 import type { InsightsClient } from '../src/types';
 
 const fakeInsightsClient: InsightsClient = (method, ...payloads) => {

--- a/packages/instantsearch.js/stories/index.stories.ts
+++ b/packages/instantsearch.js/stories/index.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits, withLifecycle } from '../.storybook/decorators';
 import { hitsItemTemplate } from '../.storybook/playgrounds/default';
 

--- a/packages/instantsearch.js/stories/infinite-hits.stories.ts
+++ b/packages/instantsearch.js/stories/infinite-hits.stories.ts
@@ -1,7 +1,9 @@
-import { storiesOf } from '@storybook/html';
 import { action } from '@storybook/addon-actions';
+import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 import { createInfiniteHitsSessionStorageCache } from '../src/lib/infiniteHitsCache';
+
 import type { InsightsClient } from '../src/types';
 
 const fakeInsightsClient: InsightsClient = (method, ...payloads) => {

--- a/packages/instantsearch.js/stories/instantsearch.stories.ts
+++ b/packages/instantsearch.js/stories/instantsearch.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Basics/InstantSearch', module)

--- a/packages/instantsearch.js/stories/menu-select.stories.ts
+++ b/packages/instantsearch.js/stories/menu-select.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('Refinements/MenuSelect', module)

--- a/packages/instantsearch.js/stories/menu.stories.ts
+++ b/packages/instantsearch.js/stories/menu.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('Refinements/Menu', module)

--- a/packages/instantsearch.js/stories/numeric-menu.stories.ts
+++ b/packages/instantsearch.js/stories/numeric-menu.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Refinements/NumericMenu', module)

--- a/packages/instantsearch.js/stories/pagination.stories.ts
+++ b/packages/instantsearch.js/stories/pagination.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Pagination/Pagination', module)

--- a/packages/instantsearch.js/stories/panel.stories.ts
+++ b/packages/instantsearch.js/stories/panel.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 import { connectHierarchicalMenu } from '../src/connectors';
 import { noop } from '../src/lib/utils';

--- a/packages/instantsearch.js/stories/powered-by.stories.ts
+++ b/packages/instantsearch.js/stories/powered-by.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Metadata/PoweredBy', module)

--- a/packages/instantsearch.js/stories/query-rule-context.stories.ts
+++ b/packages/instantsearch.js/stories/query-rule-context.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 import moviesPlayground from '../.storybook/playgrounds/movies';
 

--- a/packages/instantsearch.js/stories/query-rule-custom-data.stories.ts
+++ b/packages/instantsearch.js/stories/query-rule-custom-data.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 import moviesPlayground from '../.storybook/playgrounds/movies';
 

--- a/packages/instantsearch.js/stories/range-input.stories.ts
+++ b/packages/instantsearch.js/stories/range-input.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Refinements/RangeInput', module)

--- a/packages/instantsearch.js/stories/range-slider.stories.ts
+++ b/packages/instantsearch.js/stories/range-slider.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Refinements/RangeSlider', module)

--- a/packages/instantsearch.js/stories/rating-menu.stories.ts
+++ b/packages/instantsearch.js/stories/rating-menu.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Refinements/RatingMenu', module)

--- a/packages/instantsearch.js/stories/refinement-list.stories.ts
+++ b/packages/instantsearch.js/stories/refinement-list.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Refinements/RefinementList', module)

--- a/packages/instantsearch.js/stories/relevant-sort.stories.ts
+++ b/packages/instantsearch.js/stories/relevant-sort.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 const searchOptions = {

--- a/packages/instantsearch.js/stories/search-box.stories.ts
+++ b/packages/instantsearch.js/stories/search-box.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Basics/SearchBox', module)

--- a/packages/instantsearch.js/stories/sort-by.stories.ts
+++ b/packages/instantsearch.js/stories/sort-by.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('Sorting/SortBy', module)

--- a/packages/instantsearch.js/stories/stats.stories.ts
+++ b/packages/instantsearch.js/stories/stats.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Metadata/Stats', module)

--- a/packages/instantsearch.js/stories/toggle-refinement.stories.ts
+++ b/packages/instantsearch.js/stories/toggle-refinement.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits, withLifecycle } from '../.storybook/decorators';
 
 storiesOf('Refinements/ToggleRefinement', module)

--- a/packages/instantsearch.js/stories/voice-search.stories.ts
+++ b/packages/instantsearch.js/stories/voice-search.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/html';
+
 import { withHits } from '../.storybook/decorators';
 
 storiesOf('Basics/VoiceSearch', module)

--- a/packages/instantsearch.js/test/createInstantSearch.ts
+++ b/packages/instantsearch.js/test/createInstantSearch.ts
@@ -1,8 +1,10 @@
-import algoliasearchHelper from 'algoliasearch-helper';
-import index from '../src/widgets/index/index';
-import type { InstantSearch } from '../src/types';
 import { createSearchClient } from '@instantsearch/mocks';
+import algoliasearchHelper from 'algoliasearch-helper';
+
 import { defer } from '../src/lib/utils';
+import index from '../src/widgets/index/index';
+
+import type { InstantSearch } from '../src/types';
 
 export const createInstantSearch = (
   args: Partial<InstantSearch> = {}

--- a/packages/instantsearch.js/test/createWidget.ts
+++ b/packages/instantsearch.js/test/createWidget.ts
@@ -1,4 +1,8 @@
+import { createMultiSearchResponse } from '@instantsearch/mocks';
 import algoliasearchHelper from 'algoliasearch-helper';
+
+import { createInstantSearch } from './createInstantSearch';
+
 import type {
   InitOptions,
   RenderOptions,
@@ -6,8 +10,6 @@ import type {
   Widget,
 } from '../src/types';
 import type { IndexInitOptions } from '../src/widgets/index/index';
-import { createMultiSearchResponse } from '@instantsearch/mocks';
-import { createInstantSearch } from './createInstantSearch';
 
 export const createInitOptions = (
   args: Partial<InitOptions> = {}


### PR DESCRIPTION
This is with the same rules as were already present on react instantsearch hooks.

Doing this PR now as we don't have many pending PRs