### PR TITLE
fix(insights): pass credentials in payload

### DIFF
--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -799,6 +799,8 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
         index: 'my-index',
         eventName: 'My Hits Viewed',
         objectIDs: ['obj1'],
+        appId: 'myAppId',
+        apiKey: 'myApiKey',
       });
     });
 
@@ -831,6 +833,8 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           eventType: 'click',
           payload: {
             hello: 'world',
+            appId: 'myAppId',
+            apiKey: 'myApiKey',
           },
         },
         insightsClient

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -226,6 +226,10 @@ export function createInsightsMiddleware<
         });
 
         instantSearchInstance.sendEventToInsights = (event: InsightsEvent) => {
+          // Pass credentials in event payload, in case init was called with different credentials
+          event.payload.appId = event.payload.appId || appId;
+          event.payload.apiKey = event.payload.apiKey || apiKey;
+
           if (onEvent) {
             onEvent(event, _insightsClient as TInsightsClient);
           } else if (event.insightsMethod) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

If something else controls insights client too, it could be initialised with the wrong parameters. To ensure the right app is targeted, we pass appId and apiKey in the payload as well.

This requires https://github.com/algolia/search-insights.js/pull/398 or similar to have any effect though

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

appId/apiKey is in event payload
