### PR TITLE
feat(react): export `InstantSearchApi` type

### DIFF
--- a/packages/react-instantsearch-hooks/src/hooks/useInstantSearch.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useInstantSearch.ts
@@ -9,13 +9,14 @@ import type { SearchResultsApi } from '../lib/useSearchResults';
 import type { SearchStateApi } from '../lib/useSearchState';
 import type { InstantSearch, Middleware, UiState } from 'instantsearch.js';
 
-type InstantSearchApi<TUiState extends UiState> = SearchStateApi<TUiState> &
-  SearchResultsApi & {
-    use: (...middlewares: Middleware[]) => () => void;
-    refresh: InstantSearch['refresh'];
-    status: InstantSearch['status'];
-    error: InstantSearch['error'];
-  };
+export type InstantSearchApi<TUiState extends UiState = UiState> =
+  SearchStateApi<TUiState> &
+    SearchResultsApi & {
+      use: (...middlewares: Middleware[]) => () => void;
+      refresh: InstantSearch['refresh'];
+      status: InstantSearch['status'];
+      error: InstantSearch['error'];
+    };
 
 export type UseInstantSearchProps = {
   /**


### PR DESCRIPTION
As [discussed internally](https://algolia.slack.com/archives/C03QWAMAN6P/p1677684849444629), exporting the `InstantSearchApi` is handy in consumers app to make sure that types are fully consistent.

As an example, there are a few unintended bugs on the dashboard search because they use their own `SearchResults` type for `useInstantSearch().results`, and they assumed that it can be `null` when loading. But it doesn't, RISHooks always exposes a fallback results object.

Consumer apps will now be able to rely on things like `InstantSearchApi['results']` to minimize this kind of errors.

I also defaulted the generic to `UiState` so that it can be used just like `useInstantSearch()` which is already defaulted.