### PR TITLE
ci: run e2e in a scheduled pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  slack: circleci/slack@4.12.1
+
 references:
   workspace_root: &workspace_root ~/instantsearch
   attach_workspace: &attach_workspace
@@ -240,6 +243,12 @@ jobs:
           command: yarn run test:e2e:saucelabs
       - store_test_results:
           path: junit/wdio/
+      - slack/notify:
+          channel: $SLACK_E2E_NOTIF_CHANNEL
+          event: fail
+          # See: https://app.slack.com/block-kit-builder/
+          custom: |
+            {"blocks":[{"type":"header","text":{"type":"plain_text","text":":warning: End-to-end tests failed","emoji":true}},{"type":"section","fields":[{"type":"mrkdwn","text":"*Project*: $CIRCLE_PROJECT_REPONAME"}]},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"CircleCI"},"url":"$CIRCLE_BUILD_URL"},{"type":"button","text":{"type":"plain_text","text":"SauceLabs"},"url":"https://app.saucelabs.com/dashboard/tests/vdc"}]}]}
 
   release if needed:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 references:
   workspace_root: &workspace_root ~/instantsearch
@@ -35,6 +35,9 @@ defaults: &defaults
 workflows:
   version: 2
   ci:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - build:
           context: fx-libraries
@@ -51,6 +54,37 @@ workflows:
       - vue v3:
           requires:
             - build
+      - release if needed:
+          context: fx-libraries
+          requires:
+            - build
+            - lint
+            - unit tests
+            - legacy algoliasearch
+          filters:
+            branches:
+              only:
+                - master
+  scheduled release:
+    # This workflow is triggered by a schedule pipeline.
+    # See: https://app.circleci.com/settings/project/github/algolia/instantsearch/triggers
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ scheduled_release, << pipeline.schedule.name >> ]
+    jobs:
+      - prepare release:
+          context: fx-libraries
+  scheduled e2e:
+    # This workflow is triggered by a schedule pipeline.
+    # See: https://app.circleci.com/settings/project/github/algolia/instantsearch/triggers
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ scheduled_e2e, << pipeline.schedule.name >> ]
+    jobs:
+      - build:
+          context: fx-libraries
       - examples:
           requires:
             - build
@@ -58,30 +92,6 @@ workflows:
           context: fx-libraries
           requires:
             - examples
-      - release if needed:
-          context: fx-libraries
-          requires:
-            - build
-            - lint
-            - unit tests
-            - examples
-            - legacy algoliasearch
-            - e2e tests
-          filters:
-            branches:
-              only:
-                - master
-  scheduled release:
-    triggers:
-      - schedule:
-          cron: '0 9 * * 2'
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - prepare release:
-          context: fx-libraries
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,13 +57,30 @@ workflows:
       - vue v3:
           requires:
             - build
+      - examples:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+      - e2e tests:
+          context: fx-libraries
+          requires:
+            - examples
+          filters:
+            branches:
+              only:
+                - master
       - release if needed:
           context: fx-libraries
           requires:
             - build
             - lint
             - unit tests
+            - examples
             - legacy algoliasearch
+            - e2e tests
           filters:
             branches:
               only:
@@ -248,7 +265,48 @@ jobs:
           event: fail
           # See: https://app.slack.com/block-kit-builder/
           custom: |
-            {"blocks":[{"type":"header","text":{"type":"plain_text","text":":warning: End-to-end tests failed","emoji":true}},{"type":"section","fields":[{"type":"mrkdwn","text":"*Project*: $CIRCLE_PROJECT_REPONAME"}]},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"CircleCI"},"url":"$CIRCLE_BUILD_URL"},{"type":"button","text":{"type":"plain_text","text":"SauceLabs"},"url":"https://app.saucelabs.com/dashboard/tests/vdc"}]}]}
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":warning: End-to-end tests failed",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project*: $CIRCLE_PROJECT_REPONAME"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "CircleCI"
+                      },
+                      "url": "$CIRCLE_BUILD_URL"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "SauceLabs"
+                      },
+                      "url": "https://app.saucelabs.com/dashboard/tests/vdc"
+                    }
+                  ]
+                }
+              ]
+            }
 
   release if needed:
     <<: *defaults


### PR DESCRIPTION
**Summary**

This PR stops running e2e tests on every branch and instead moves the job into a scheduled pipeline. It's currently set to run daily at 9PM CET. In case of failure a notification is sent to Slack.

It also moves the existing weekly release scheduled workflow to a scheduled pipeline as well, managed through Circle CI.

**Result**

CI pipelines are now completed in less time.