### PR TITLE
fix(DynamicWidgets): prevent non-stable fallbackComponent

### DIFF
--- a/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
+++ b/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
@@ -5,8 +5,9 @@ import { invariant } from '../lib/invariant';
 
 import type { DynamicWidgetsConnectorParams } from 'instantsearch.js/es/connectors/dynamic-widgets/connectDynamicWidgets';
 import type { ReactElement, ComponentType, ReactNode } from 'react';
+import { warn } from '../lib/warn';
 
-function FallbackComponent() {
+function DefaultFallbackComponent() {
   return null;
 }
 
@@ -26,9 +27,16 @@ export type DynamicWidgetsProps = Omit<
 
 export function DynamicWidgets({
   children,
-  fallbackComponent: Fallback = FallbackComponent,
+  fallbackComponent: Fallback = DefaultFallbackComponent,
   ...props
 }: DynamicWidgetsProps) {
+  const FallbackComponent = React.useRef(Fallback);
+
+  warn(
+    Fallback === FallbackComponent.current,
+    'The `fallbackComponent` prop of `DynamicWidgets` changed between renders. Please provide a stable reference.'
+  );
+
   const { attributesToRender } = useDynamicWidgets(props, {
     $$widgetType: 'ais.dynamicWidgets',
   });
@@ -49,7 +57,9 @@ export function DynamicWidgets({
     <>
       {attributesToRender.map((attribute) => (
         <Fragment key={attribute}>
-          {widgets.get(attribute) || <Fallback attribute={attribute} />}
+          {widgets.get(attribute) || (
+            <FallbackComponent.current attribute={attribute} />
+          )}
         </Fragment>
       ))}
     </>

--- a/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
+++ b/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
@@ -34,7 +34,7 @@ export function DynamicWidgets({
 
   warn(
     Fallback === FallbackComponent.current,
-    'The `fallbackComponent` prop of `DynamicWidgets` changed between renders. Please provide a stable reference, as described in https://www.algolia.com/doc/api-reference/widgets/dynamic-facets/react-hooks/#widget-param-fallbackcomponent.'
+    'The `fallbackComponent` prop of `DynamicWidgets` changed between renders. Please provide a stable reference, as described in https://www.algolia.com/doc/api-reference/widgets/dynamic-facets/react-hooks/#widget-param-fallbackcomponent'
   );
 
   const { attributesToRender } = useDynamicWidgets(props, {

--- a/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
+++ b/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
@@ -2,10 +2,10 @@ import React, { Fragment } from 'react';
 
 import { useDynamicWidgets } from '../connectors/useDynamicWidgets';
 import { invariant } from '../lib/invariant';
+import { warn } from '../lib/warn';
 
 import type { DynamicWidgetsConnectorParams } from 'instantsearch.js/es/connectors/dynamic-widgets/connectDynamicWidgets';
 import type { ReactElement, ComponentType, ReactNode } from 'react';
-import { warn } from '../lib/warn';
 
 function DefaultFallbackComponent() {
   return null;

--- a/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
+++ b/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
@@ -34,7 +34,7 @@ export function DynamicWidgets({
 
   warn(
     Fallback === FallbackComponent.current,
-    'The `fallbackComponent` prop of `DynamicWidgets` changed between renders. Please provide a stable reference.'
+    'The `fallbackComponent` prop of `DynamicWidgets` changed between renders. Please provide a stable reference, as described in https://www.algolia.com/doc/api-reference/widgets/dynamic-facets/react-hooks/#widget-param-fallbackcomponent.'
   );
 
   const { attributesToRender } = useDynamicWidgets(props, {

--- a/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
@@ -374,7 +374,7 @@ describe('DynamicWidgets', () => {
     expect(() => {
       rerender(<App />);
     }).toWarnDev(
-      '[InstantSearch] The `fallbackComponent` prop of `DynamicWidgets` changed between renders. Please provide a stable reference.'
+      '[InstantSearch] The `fallbackComponent` prop of `DynamicWidgets` changed between renders. Please provide a stable reference, as described in https://www.algolia.com/doc/api-reference/widgets/dynamic-facets/react-hooks/#widget-param-fallbackcomponent'
     );
 
     await waitFor(() => {

--- a/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
@@ -332,23 +332,53 @@ describe('DynamicWidgets', () => {
   test('renders attributes without widget with fallbackComponent (function form)', async () => {
     const searchClient = createSearchClient({});
 
-    const { container } = render(
-      <InstantSearch indexName="indexName" searchClient={searchClient}>
-        <DynamicWidgets
-          fallbackComponent={({ attribute }) => <Menu attribute={attribute} />}
-          transformItems={() => [
-            'brand',
-            'categories',
-            'hierarchicalCategories.lvl0',
-          ]}
-        >
-          <RefinementList attribute="brand" />
-        </DynamicWidgets>
-      </InstantSearch>
+    let fallbackComponent = ({ attribute }: { attribute: string }) => (
+      <Menu attribute={attribute} />
     );
+
+    function App() {
+      return (
+        <InstantSearch indexName="indexName" searchClient={searchClient}>
+          <DynamicWidgets
+            fallbackComponent={fallbackComponent}
+            transformItems={() => [
+              'brand',
+              'categories',
+              'hierarchicalCategories.lvl0',
+            ]}
+          >
+            <RefinementList attribute="brand" />
+          </DynamicWidgets>
+        </InstantSearch>
+      );
+    }
+
+    const { container, rerender } = render(<App />);
 
     await waitFor(() => {
       expect(searchClient.search).toHaveBeenCalledTimes(1);
+    });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        RefinementList(brand)
+        Menu(categories)
+        Menu(hierarchicalCategories.lvl0)
+      </div>
+    `);
+
+    fallbackComponent = ({ attribute }: { attribute: string }) => (
+      <RefinementList attribute={attribute} />
+    );
+
+    expect(() => {
+      rerender(<App />);
+    }).toWarnDev(
+      '[InstantSearch] The `fallbackComponent` prop of `DynamicWidgets` changed between renders. Please provide a stable reference.'
+    );
+
+    await waitFor(() => {
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
     });
 
     expect(container).toMatchInlineSnapshot(`


### PR DESCRIPTION
All our documentation makes sure to use stable references, although it could also make sure to clarify that is a requirement as well.

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

When you re-render and use a fallbackComponent which isn't stable, this causes that widget to unmount and remount (as a different widget). We now prevent that by making sure (and warning when it isn't) that fallbackComponent is stable.

Note that this could be considered breaking if someone was _only_ rendering when the widget actually changed (some other state possibly), but I'd consider that code already broken personally, as a render happening when the widget doesn't change would erase the state.

fixes #5530

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->



- add a warning when the fallbackComponent isn't stable
- only ever use the first value of fallbackComponent
