### PR TITLE
fix(instantsearch): allow dispose before start

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -124,6 +124,16 @@ const config = {
         // these sorts of errors anyway.
         // See: https://github.com/typescript-eslint/typescript-eslint/issues/342
         'no-undef': 'off',
+        // This rule only supports ?. with the TypeScript parser.
+        'no-unused-expressions': 'off',
+        '@typescript-eslint/no-unused-expressions': [
+          'error',
+          {
+            allowShortCircuit: true,
+            allowTernary: true,
+            allowTaggedTemplates: true,
+          },
+        ],
       },
     },
     {

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -625,7 +625,7 @@ See ${createDocumentationLink({
     // The helper needs to be reset to perform the next search from a fresh state.
     // If not reset, it would use the state stored before calling `dispose()`.
     this.removeAllListeners();
-    this.mainHelper!.removeAllListeners();
+    this.mainHelper?.removeAllListeners();
     this.mainHelper = null;
     this.helper = null;
 

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -1177,6 +1177,15 @@ describe('dispose', () => {
     expect(search.mainHelper).not.toBe(null);
     expect(search.helper).not.toBe(null);
   });
+
+  it("doesn't throw without starting", () => {
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+    });
+
+    expect(() => search.dispose()).not.toThrow();
+  });
 });
 
 describe('scheduleSearch', () => {

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -665,10 +665,10 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
 
       localInstantSearchInstance = null;
       localParent = null;
-      helper!.removeAllListeners();
+      helper?.removeAllListeners();
       helper = null;
 
-      derivedHelper!.detach();
+      derivedHelper?.detach();
       derivedHelper = null;
     },
 


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

We were using non-null assertions in `dispose` of InstantSearch and index widget as we were assuming start/init comes first, but that's not necessarily the case.


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

No errors when disposing without calling start