### PR TITLE
fix(routing): allow writing when InstantSearch restarts

### DIFF
--- a/packages/instantsearch.js/src/lib/__tests__/routing/spa-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/routing/spa-test.ts
@@ -21,6 +21,8 @@ describe('routing with third-party client-side router', () => {
     // 2. Refine: '/?indexName[query]=Apple'
     // 3. Navigate: '/about'
     // 4. Back: '/?indexName[query]=Apple'
+    // 5. Restart: '/?indexName[query]=Apple'
+    // 6. Refine: '/?indexName[query]=Samsung'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -75,6 +77,29 @@ describe('routing with third-party client-side router', () => {
       expect(window.location.search).toEqual(
         `?${encodeURI('indexName[query]=Apple')}`
       );
+    }
+
+    // 5. Restart InstantSearch
+    {
+      search.addWidgets([connectSearchBox(() => {})({})]);
+      search.start();
+
+      await wait(writeWait);
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    }
+
+    // 6. Refine: '/?indexName[query]=Samsung'
+    {
+      search.renderState.indexName.searchBox!.refine('Samsung');
+
+      await wait(writeWait);
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Samsung')}`
+      );
+      expect(pushState).toHaveBeenCalledTimes(3);
     }
   });
 });

--- a/packages/instantsearch.js/src/lib/routers/history.ts
+++ b/packages/instantsearch.js/src/lib/routers/history.ts
@@ -236,6 +236,10 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
     this.write({} as TRouteState);
   }
 
+  public start() {
+    this.isDisposed = false;
+  }
+
   private shouldWrite(url: string): boolean {
     return safelyRunOnBrowser(({ window }) => {
       // We do want to `pushState` if:

--- a/packages/instantsearch.js/src/middlewares/createRouterMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createRouterMiddleware.ts
@@ -87,7 +87,9 @@ export const createRouterMiddleware = <
         });
       },
 
-      started() {},
+      started() {
+        router.start?.();
+      },
 
       unsubscribe() {
         router.dispose();

--- a/packages/instantsearch.js/src/types/router.ts
+++ b/packages/instantsearch.js/src/types/router.ts
@@ -39,7 +39,7 @@ export type Router<TRouteState = UiState> = {
   /**
    * Called when InstantSearch is started.
    */
-  start(): void;
+  start?: () => void;
 };
 
 /**

--- a/packages/instantsearch.js/src/types/router.ts
+++ b/packages/instantsearch.js/src/types/router.ts
@@ -35,6 +35,11 @@ export type Router<TRouteState = UiState> = {
    * Called when InstantSearch is disposed. Used to remove subscriptions.
    */
   dispose(): void;
+
+  /**
+   * Called when InstantSearch is started.
+   */
+  start(): void;
 };
 
 /**


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
Previously this code considered that InstantSearch is started once, and then disposed, but if the instance is restarted (and its widgets remounted) like in React InstantSearch Hooks, routing should no longer be considered disposed

discovered in https://github.com/algolia/instantsearch/discussions/5519#discussioncomment-5226767
<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- routers can have a new method "start"
- in start we make sure router is no longer considered disposed
