### PR TITLE
feat(insights): allow passing options to default middleware

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -20,7 +20,10 @@ import {
 } from './utils';
 import version from './version';
 
-import type { InsightsEvent } from '../middlewares/createInsightsMiddleware';
+import type {
+  InsightsEvent,
+  InsightsProps,
+} from '../middlewares/createInsightsMiddleware';
 import type { RouterProps } from '../middlewares/createRouterMiddleware';
 import type {
   InsightsClient as AlgoliaInsightsClient,
@@ -145,7 +148,7 @@ export type InstantSearchOptions<
    *
    * @default true
    */
-  insights?: boolean;
+  insights?: InsightsProps | boolean;
 
   /**
    * the instance of search-insights to use for sending insights events inside
@@ -325,7 +328,9 @@ See ${createDocumentationLink({
     // This is the default middleware,
     // any user-provided middleware will be added later and override this one.
     if (insights) {
-      this.use(createInsightsMiddleware({ $$internal: true }));
+      const insightsOptions = typeof insights === 'boolean' ? {} : insights;
+      insightsOptions.$$internal = true;
+      this.use(createInsightsMiddleware(insightsOptions));
     }
 
     if (isMetadataEnabled()) {

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -27,11 +27,10 @@ export type InsightsEvent = {
   attribute?: string;
 };
 
+type ProvidedInsightsClient = InsightsClient | null | undefined;
+
 export type InsightsProps<
-  TInsightsClient extends InsightsClient | null | undefined =
-    | InsightsClient
-    | null
-    | undefined
+  TInsightsClient extends ProvidedInsightsClient = ProvidedInsightsClient
 > = {
   insightsClient?: TInsightsClient;
   insightsInitParams?: {
@@ -53,7 +52,7 @@ const ALGOLIA_INSIGHTS_SRC =
 export type CreateInsightsMiddleware = typeof createInsightsMiddleware;
 
 export function createInsightsMiddleware<
-  TInsightsClient extends null | InsightsClient
+  TInsightsClient extends ProvidedInsightsClient
 >(props: InsightsProps<TInsightsClient> = {}): InternalMiddleware {
   const {
     insightsClient: _insightsClient,


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This allows passing all insights middleware options to the instantsearch constructor as well, simplifying the guide on "how to use insights", even if we choose to change the default of the insights option to `false`

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

`insights` option to InstantSearch accepts options for the insights middleware.