### PR TITLE
feat(current-refinements): provide indexId of refinements in transformItems

### DIFF
--- a/packages/instantsearch.js/src/components/CurrentRefinements/__tests__/CurrentRefinements-test.tsx
+++ b/packages/instantsearch.js/src/components/CurrentRefinements/__tests__/CurrentRefinements-test.tsx
@@ -27,6 +27,7 @@ describe('CurrentRefinements', () => {
       items: [
         {
           indexName: 'indexName',
+          indexId: 'indexName',
           attribute: 'facet',
           label: 'facet',
           refine: () => {},
@@ -47,6 +48,7 @@ describe('CurrentRefinements', () => {
         },
         {
           indexName: 'indexName',
+          indexId: 'indexName',
           attribute: 'facetExclude',
           label: 'facetExclude',
           refine: () => {},
@@ -62,6 +64,7 @@ describe('CurrentRefinements', () => {
         },
         {
           indexName: 'indexName',
+          indexId: 'indexName',
           attribute: 'disjunctive',
           label: 'disjunctive',
           refine: () => {},
@@ -76,6 +79,7 @@ describe('CurrentRefinements', () => {
         },
         {
           indexName: 'indexName',
+          indexId: 'indexName',
           attribute: 'hierarchical',
           label: 'hierarchical',
           refine: () => {},
@@ -90,6 +94,7 @@ describe('CurrentRefinements', () => {
         },
         {
           indexName: 'indexName',
+          indexId: 'indexName',
           attribute: 'numeric',
           label: 'numeric',
           refine: () => {},
@@ -105,6 +110,7 @@ describe('CurrentRefinements', () => {
         },
         {
           indexName: 'indexName',
+          indexId: 'indexName',
           attribute: 'tag',
           label: 'tag',
           refine: () => {},
@@ -147,6 +153,7 @@ describe('CurrentRefinements', () => {
         items: [
           {
             indexName: 'indexName',
+            indexId: 'indexName',
             attribute: 'customFacet',
             label: 'customFacet',
             refine: () => {},
@@ -174,6 +181,7 @@ describe('CurrentRefinements', () => {
         items: [
           {
             indexName: 'indexName',
+            indexId: 'indexName',
             attribute: 'customExcludeFacet',
             label: 'customExcludeFacet',
             refine: () => {},
@@ -202,6 +210,7 @@ describe('CurrentRefinements', () => {
         items: [
           {
             indexName: 'indexName',
+            indexId: 'indexName',
             attribute: 'customDisjunctiveFacet',
             label: 'customDisjunctiveFacet',
             refine: () => {},
@@ -229,6 +238,7 @@ describe('CurrentRefinements', () => {
         items: [
           {
             indexName: 'indexName',
+            indexId: 'indexName',
             attribute: 'customHierarchicalFacet',
             label: 'customHierarchicalFacet',
             refine: () => {},
@@ -256,6 +266,7 @@ describe('CurrentRefinements', () => {
         items: [
           {
             indexName: 'indexName',
+            indexId: 'indexName',
             attribute: 'customNumericFilter',
             label: 'customNumericFilter',
             refine: () => {},
@@ -271,6 +282,7 @@ describe('CurrentRefinements', () => {
           },
           {
             indexName: 'indexName',
+            indexId: 'indexName',
             attribute: 'customNumericFilter',
             label: 'customNumericFilter',
             refine: () => {},
@@ -286,6 +298,7 @@ describe('CurrentRefinements', () => {
           },
           {
             indexName: 'indexName',
+            indexId: 'indexName',
             attribute: 'customNumericFilter',
             label: 'customNumericFilter',
             refine: () => {},
@@ -314,6 +327,7 @@ describe('CurrentRefinements', () => {
         items: [
           {
             indexName: 'indexName',
+            indexId: 'indexName',
             attribute: '_tags',
             label: '_tags',
             refine: () => {},
@@ -341,6 +355,7 @@ describe('CurrentRefinements', () => {
         items: [
           {
             indexName: 'indexName',
+            indexId: 'indexName',
             attribute: 'query',
             label: 'query',
             refine: () => {},

--- a/packages/instantsearch.js/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
+++ b/packages/instantsearch.js/src/connectors/current-refinements/__tests__/connectCurrentRefinements-test.ts
@@ -211,6 +211,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
             {
               attribute: 'category',
               indexName: 'indexName',
+              indexId: 'indexName',
               label: 'category',
               refine: expect.any(Function),
               refinements: [
@@ -317,6 +318,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
           {
             attribute: 'category',
             indexName: 'indexName',
+            indexId: 'indexName',
             label: 'category',
             refine: expect.any(Function),
             refinements: [
@@ -736,6 +738,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       expect(firstRenderingOptions.items).toEqual([
         {
           indexName: 'indexName',
+          indexId: 'indexName',
           attribute: 'facet1',
           label: 'facet1',
           refinements: [
@@ -780,6 +783,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       expect(items).toEqual([
         {
           indexName: 'indexName',
+          indexId: 'firstIndex',
           attribute: 'facet1',
           label: 'facet1',
           refinements: [
@@ -794,6 +798,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
         },
         {
           indexName: 'indexName',
+          indexId: 'firstIndex',
           attribute: 'facet2',
           label: 'facet2',
           refinements: [
@@ -833,6 +838,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
     });
 
     it('provides the items from multiple scoped results', () => {
+      const indexHelper = algoliasearchHelper({} as any, 'indexName', {
+        facets: ['facet3', 'facet4'],
+      });
+
       const rendering = jest.fn();
       const customCurrentRefinements = connectCurrentRefinements(rendering);
       const widget = customCurrentRefinements({});
@@ -850,6 +859,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
         .addFacetRefinement('facet1', 'facetValue')
         .addFacetRefinement('facet2', 'facetValue');
 
+      indexHelper
+        .addFacetRefinement('facet3', 'facetValue')
+        .addFacetRefinement('facet4', 'facetValue');
+
       widget.render!(
         createRenderOptions({
           scopedResults: [
@@ -858,16 +871,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
               helper,
               results: new SearchResults(helper.state, [
                 createSingleSearchResponse({
-                  index: 'firstIndex',
+                  index: 'indexName',
                 }),
               ]),
             },
             {
               indexId: 'secondIndex',
-              helper,
-              results: new SearchResults(helper.state, [
+              helper: indexHelper,
+              results: new SearchResults(indexHelper.state, [
                 createSingleSearchResponse({
-                  index: 'secondIndex',
+                  index: 'indexName',
                 }),
               ]),
             },
@@ -884,6 +897,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
       expect(items).toEqual([
         {
           indexName: 'indexName',
+          indexId: 'firstIndex',
           attribute: 'facet1',
           label: 'facet1',
           refinements: [
@@ -898,6 +912,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
         },
         {
           indexName: 'indexName',
+          indexId: 'firstIndex',
           attribute: 'facet2',
           label: 'facet2',
           refinements: [
@@ -912,11 +927,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
         },
         {
           indexName: 'indexName',
-          attribute: 'facet1',
-          label: 'facet1',
+          indexId: 'secondIndex',
+          attribute: 'facet3',
+          label: 'facet3',
           refinements: [
             {
-              attribute: 'facet1',
+              attribute: 'facet3',
               label: 'facetValue',
               type: 'facet',
               value: 'facetValue',
@@ -926,11 +942,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/current-ref
         },
         {
           indexName: 'indexName',
-          attribute: 'facet2',
-          label: 'facet2',
+          indexId: 'secondIndex',
+          attribute: 'facet4',
+          label: 'facet4',
           refinements: [
             {
-              attribute: 'facet2',
+              attribute: 'facet4',
               label: 'facetValue',
               type: 'facet',
               value: 'facetValue',

--- a/packages/instantsearch.js/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/packages/instantsearch.js/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -74,6 +74,11 @@ export type CurrentRefinementsConnectorParamsItem = {
   indexName: string;
 
   /**
+   * The index id as provided to the index widget.
+   */
+  indexId: string;
+
+  /**
    * The attribute on which the refinement is applied.
    */
   attribute: string;
@@ -229,6 +234,7 @@ const connectCurrentRefinements: CurrentRefinementsConnector =
                 getRefinementsItems({
                   results: {},
                   helper,
+                  indexId: helper.state.index,
                   includedAttributes,
                   excludedAttributes,
                 }),
@@ -244,6 +250,7 @@ const connectCurrentRefinements: CurrentRefinementsConnector =
                   getRefinementsItems({
                     results: scopedResult.results,
                     helper: scopedResult.helper,
+                    indexId: scopedResult.indexId,
                     includedAttributes,
                     excludedAttributes,
                   }),
@@ -271,11 +278,13 @@ const connectCurrentRefinements: CurrentRefinementsConnector =
 function getRefinementsItems({
   results,
   helper,
+  indexId,
   includedAttributes,
   excludedAttributes,
 }: {
   results: SearchResults | Record<string, never>;
   helper: AlgoliaSearchHelper;
+  indexId: string;
   includedAttributes: CurrentRefinementsConnectorParams['includedAttributes'];
   excludedAttributes: CurrentRefinementsConnectorParams['excludedAttributes'];
 }): CurrentRefinementsConnectorParamsItem[] {
@@ -298,6 +307,7 @@ function getRefinementsItems({
       ...allItems.filter((item) => item.attribute !== currentItem.attribute),
       {
         indexName: helper.state.index,
+        indexId,
         attribute: currentItem.attribute,
         label: currentItem.attribute,
         refinements: items

--- a/packages/instantsearch.js/src/widgets/current-refinements/__tests__/__snapshots__/current-refinements-test.ts.snap
+++ b/packages/instantsearch.js/src/widgets/current-refinements/__tests__/__snapshots__/current-refinements-test.ts.snap
@@ -16,6 +16,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
   "items": [
     {
       "attribute": "facet",
+      "indexId": "index_name",
       "indexName": "indexName",
       "label": "facet",
       "refine": [Function],
@@ -30,6 +31,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
     },
     {
       "attribute": "facetExclude",
+      "indexId": "index_name",
       "indexName": "indexName",
       "label": "facetExclude",
       "refine": [Function],
@@ -44,6 +46,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
     },
     {
       "attribute": "rating",
+      "indexId": "index_name",
       "indexName": "indexName",
       "label": "rating",
       "refine": [Function],
@@ -64,6 +67,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
     },
     {
       "attribute": "brand",
+      "indexId": "index_name",
       "indexName": "indexName",
       "label": "brand",
       "refine": [Function],
@@ -84,6 +88,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
     },
     {
       "attribute": "hierarchicalCategories.lvl0",
+      "indexId": "index_name",
       "indexName": "indexName",
       "label": "hierarchicalCategories.lvl0",
       "refine": [Function],
@@ -100,6 +105,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
     },
     {
       "attribute": "price",
+      "indexId": "index_name",
       "indexName": "indexName",
       "label": "price",
       "refine": [Function],
@@ -122,6 +128,7 @@ exports[`currentRefinements() render() DOM output renders correctly 1`] = `
     },
     {
       "attribute": "_tags",
+      "indexId": "index_name",
       "indexName": "indexName",
       "label": "_tags",
       "refine": [Function],
@@ -177,6 +184,7 @@ exports[`currentRefinements() render() should render twice <CurrentRefinements .
   "items": [
     {
       "attribute": "facet",
+      "indexId": "index_name",
       "indexName": "index_name",
       "label": "facet",
       "refine": [Function],
@@ -211,6 +219,7 @@ exports[`currentRefinements() render() should render twice <CurrentRefinements .
   "items": [
     {
       "attribute": "facet",
+      "indexId": "index_name",
       "indexName": "index_name",
       "label": "facet",
       "refine": [Function],

--- a/packages/react-instantsearch-hooks/src/connectors/__tests__/useCurrentRefinements.test.tsx
+++ b/packages/react-instantsearch-hooks/src/connectors/__tests__/useCurrentRefinements.test.tsx
@@ -68,6 +68,7 @@ describe('useCurrentRefinements', () => {
         {
           attribute: 'brand',
           indexName: 'indexName',
+          indexId: 'indexName',
           label: 'brand',
           refine: expect.any(Function),
           refinements: [
@@ -93,6 +94,7 @@ describe('useCurrentRefinements', () => {
         {
           attribute: 'brand',
           indexName: 'indexName',
+          indexId: 'indexName',
           label: 'brand',
           refine: expect.any(Function),
           refinements: [


### PR DESCRIPTION
**Summary**

The `currentRefinements` widget provides a way to transform/filter refined items to be returned, which is useful in multi-indices context, to potentially remove refinements from another index.

This works well when indices are different, but in the context of multi-indices targeting the same index with different configuration, it is impossible to easily determine which refinements are from where. 

This PR adds a `indexId` parameter to the items provided in `transformItems`, which solves this issue.