### PR TITLE
fix(insights): keep track of script loading in global

### DIFF
--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -185,6 +185,49 @@ describe('insights', () => {
       expect((window as any).aa).toEqual(expect.any(Function));
     });
 
+    it('loads script, even when globals are set up by a different instance', () => {
+      const { instantSearchInstance: instantSearchInstance1 } =
+        createTestEnvironment({
+          started: false,
+        });
+      const { instantSearchInstance: instantSearchInstance2 } =
+        createTestEnvironment({
+          started: false,
+        });
+
+      expect((window as any).AlgoliaAnalyticsObject).toBe(undefined);
+
+      // middleware is added to first instance
+      instantSearchInstance1.use(createInsightsMiddleware());
+
+      // it sets up globals
+      expect(document.body).toMatchInlineSnapshot(`<body />`);
+      expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
+      expect((window as any).aa).toEqual(expect.any(Function));
+
+      // middleware is set up on second instance
+      instantSearchInstance2.use(createInsightsMiddleware());
+
+      // globals stay as-is
+      expect(document.body).toMatchInlineSnapshot(`<body />`);
+      expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
+      expect((window as any).aa).toEqual(expect.any(Function));
+
+      // only second instance starts
+      instantSearchInstance2.start();
+
+      // which finally loads search-insights
+      expect(document.body).toMatchInlineSnapshot(`
+        <body>
+          <script
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.3.0/dist/search-insights.min.js"
+          />
+        </body>
+      `);
+      expect((window as any).AlgoliaAnalyticsObject).toBe('aa');
+      expect((window as any).aa).toEqual(expect.any(Function));
+    });
+
     it('notifies when the script fails to be added', () => {
       const { instantSearchInstance } = createTestEnvironment();
       const createElement = document.createElement;


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This is needed for example in StrictMode with React InstantSearch Hooks, where there are two InstantSearch instances, but the first one never gets started.

Before this PR, the "should load script" was linked to "should add window.aa", but that doesn't necessarily correspond if `start` is never called on that instance.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

insights client loads in strict mode