### PR TITLE
feat(createInsightsMiddleware): always pass Algolia credentials locally

### DIFF
--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -529,7 +529,13 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
       expect(insightsClient).toHaveBeenCalledTimes(1);
       expect(insightsClient).toHaveBeenCalledWith(
         'clickedObjectIDsAfterSearch',
-        { eventName: 'Add to cart' }
+        { eventName: 'Add to cart' },
+        {
+          headers: {
+            'X-Algolia-API-Key': 'apiKey',
+            'X-Algolia-Application-Id': 'appId',
+          },
+        }
       );
     });
 

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -225,11 +225,27 @@ export function createInsightsMiddleware<
           immediate: true,
         });
 
+        // @ts-ignore
+        const insightsClientWithLocalCredentials = (method, payload) => {
+          return insightsClient(method, payload, {
+            headers: {
+              'X-Algolia-Application-Id': appId,
+              'X-Algolia-API-Key': apiKey,
+            },
+          });
+        };
+
         instantSearchInstance.sendEventToInsights = (event: InsightsEvent) => {
           if (onEvent) {
-            onEvent(event, _insightsClient as TInsightsClient);
+            onEvent(
+              event,
+              insightsClientWithLocalCredentials as TInsightsClient
+            );
           } else if (event.insightsMethod) {
-            insightsClient(event.insightsMethod, event.payload);
+            insightsClientWithLocalCredentials(
+              event.insightsMethod,
+              event.payload
+            );
 
             warning(
               Boolean((helper.state as PlainSearchParameters).userToken),

--- a/packages/instantsearch.js/src/widgets/hierarchical-menu/__tests__/hierarchical-menu.test.tsx
+++ b/packages/instantsearch.js/src/widgets/hierarchical-menu/__tests__/hierarchical-menu.test.tsx
@@ -370,7 +370,7 @@ describe('refinementList', () => {
           },
           widgetType: 'ais.hierarchicalMenu',
         },
-        null
+        expect.any(Function)
       );
 
       await wait(0);
@@ -393,7 +393,7 @@ describe('refinementList', () => {
           },
           widgetType: 'ais.hierarchicalMenu',
         },
-        null
+        expect.any(Function)
       );
     });
   });

--- a/packages/instantsearch.js/src/widgets/hits/__tests__/hits-integration-test.ts
+++ b/packages/instantsearch.js/src/widgets/hits/__tests__/hits-integration-test.ts
@@ -119,7 +119,7 @@ describe('hits', () => {
           },
           widgetType: 'ais.hits',
         },
-        null
+        expect.any(Function)
       );
     });
 
@@ -157,7 +157,7 @@ describe('hits', () => {
           },
           widgetType: 'ais.hits',
         },
-        null
+        expect.any(Function)
       );
     });
 

--- a/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
+++ b/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits-integration-test.ts
@@ -367,7 +367,7 @@ describe('infiniteHits', () => {
           },
           widgetType: 'ais.infiniteHits',
         },
-        null
+        expect.any(Function)
       );
     });
 
@@ -405,7 +405,7 @@ describe('infiniteHits', () => {
           },
           widgetType: 'ais.infiniteHits',
         },
-        null
+        expect.any(Function)
       );
     });
 

--- a/tests/common/widgets/hits/insights.ts
+++ b/tests/common/widgets/hits/insights.ts
@@ -77,22 +77,40 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
       // View event called for each index once
       {
         expect(window.aa).toHaveBeenCalledTimes(2);
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'indexName',
-          objectIDs: Array.from(
-            { length: hitsPerPage },
-            (_, index) => `indexName-${index}`
-          ),
-        });
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'nested',
-          objectIDs: Array.from(
-            { length: hitsPerPage },
-            (_, index) => `nested-${index}`
-          ),
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'indexName',
+            objectIDs: Array.from(
+              { length: hitsPerPage },
+              (_, index) => `indexName-${index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'nested',
+            objectIDs: Array.from(
+              { length: hitsPerPage },
+              (_, index) => `nested-${index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
         window.aa.mockClear();
       }
 
@@ -170,39 +188,75 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
       // View event called for each index, batched in chunks of 20
       {
         expect(window.aa).toHaveBeenCalledTimes(4);
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'indexName',
-          objectIDs: Array.from(
-            { length: 20 },
-            (_, index) => `indexName-${index}`
-          ),
-        });
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'indexName',
-          objectIDs: Array.from(
-            { length: 5 },
-            (_, index) => `indexName-${20 + index}`
-          ),
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'indexName',
+            objectIDs: Array.from(
+              { length: 20 },
+              (_, index) => `indexName-${index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'indexName',
+            objectIDs: Array.from(
+              { length: 5 },
+              (_, index) => `indexName-${20 + index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
 
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'nested',
-          objectIDs: Array.from(
-            { length: 20 },
-            (_, index) => `nested-${index}`
-          ),
-        });
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'nested',
-          objectIDs: Array.from(
-            { length: 5 },
-            (_, index) => `nested-${20 + index}`
-          ),
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'nested',
+            objectIDs: Array.from(
+              { length: 20 },
+              (_, index) => `nested-${index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'nested',
+            objectIDs: Array.from(
+              { length: 5 },
+              (_, index) => `nested-${20 + index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
 
@@ -268,12 +322,21 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
         userEvent.click(screen.getByTestId('main-hits-top-level-1'));
 
         expect(window.aa).toHaveBeenCalledTimes(1);
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Hit Clicked',
-          index: 'indexName',
-          objectIDs: ['indexName-0'],
-          positions: [1],
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Hit Clicked',
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
 
@@ -343,12 +406,21 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
         userEvent.click(screen.getByTestId('main-hits-top-level-1'));
 
         expect(window.aa).toHaveBeenCalledTimes(2);
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Hit Clicked',
-          index: 'indexName',
-          objectIDs: ['indexName-0'],
-          positions: [1],
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Hit Clicked',
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
 
@@ -420,14 +492,29 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
             eventName: 'Converted',
             index: 'indexName',
             objectIDs: ['indexName-0'],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
           }
         );
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Hit Clicked',
-          index: 'indexName',
-          objectIDs: ['indexName-0'],
-          positions: [1],
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Hit Clicked',
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
 
@@ -493,12 +580,21 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
         userEvent.click(screen.getByTestId('main-hits-click-1'));
 
         expect(window.aa).toHaveBeenCalledTimes(1);
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Clicked',
-          index: 'indexName',
-          objectIDs: ['indexName-0'],
-          positions: [1],
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Clicked',
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
 
@@ -566,18 +662,36 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
         userEvent.click(screen.getByTestId('main-hits-top-level-1'));
 
         expect(window.aa).toHaveBeenCalledTimes(2);
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Clicked nested',
-          index: 'nested',
-          objectIDs: ['nested-0'],
-          positions: [1],
-        });
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Hit Clicked',
-          index: 'indexName',
-          objectIDs: ['indexName-0'],
-          positions: [1],
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Clicked nested',
+            index: 'nested',
+            objectIDs: ['nested-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Hit Clicked',
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
   });

--- a/tests/common/widgets/infinite-hits/insights.ts
+++ b/tests/common/widgets/infinite-hits/insights.ts
@@ -77,22 +77,40 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
       // View event called for each index once
       {
         expect(window.aa).toHaveBeenCalledTimes(2);
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'indexName',
-          objectIDs: Array.from(
-            { length: hitsPerPage },
-            (_, index) => `indexName-${index}`
-          ),
-        });
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'nested',
-          objectIDs: Array.from(
-            { length: hitsPerPage },
-            (_, index) => `nested-${index}`
-          ),
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'indexName',
+            objectIDs: Array.from(
+              { length: hitsPerPage },
+              (_, index) => `indexName-${index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'nested',
+            objectIDs: Array.from(
+              { length: hitsPerPage },
+              (_, index) => `nested-${index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
         window.aa.mockClear();
       }
 
@@ -170,39 +188,75 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
       // View event called for each index, batched in chunks of 20
       {
         expect(window.aa).toHaveBeenCalledTimes(4);
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'indexName',
-          objectIDs: Array.from(
-            { length: 20 },
-            (_, index) => `indexName-${index}`
-          ),
-        });
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'indexName',
-          objectIDs: Array.from(
-            { length: 5 },
-            (_, index) => `indexName-${20 + index}`
-          ),
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'indexName',
+            objectIDs: Array.from(
+              { length: 20 },
+              (_, index) => `indexName-${index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'indexName',
+            objectIDs: Array.from(
+              { length: 5 },
+              (_, index) => `indexName-${20 + index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
 
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'nested',
-          objectIDs: Array.from(
-            { length: 20 },
-            (_, index) => `nested-${index}`
-          ),
-        });
-        expect(window.aa).toHaveBeenCalledWith('viewedObjectIDs', {
-          eventName: 'Hits Viewed',
-          index: 'nested',
-          objectIDs: Array.from(
-            { length: 5 },
-            (_, index) => `nested-${20 + index}`
-          ),
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'nested',
+            objectIDs: Array.from(
+              { length: 20 },
+              (_, index) => `nested-${index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
+        expect(window.aa).toHaveBeenCalledWith(
+          'viewedObjectIDs',
+          {
+            eventName: 'Hits Viewed',
+            index: 'nested',
+            objectIDs: Array.from(
+              { length: 5 },
+              (_, index) => `nested-${20 + index}`
+            ),
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
 
@@ -268,12 +322,21 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
         userEvent.click(screen.getByTestId('main-hits-top-level-1'));
 
         expect(window.aa).toHaveBeenCalledTimes(1);
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Hit Clicked',
-          index: 'indexName',
-          objectIDs: ['indexName-0'],
-          positions: [1],
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Hit Clicked',
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
 
@@ -343,12 +406,21 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
         userEvent.click(screen.getByTestId('main-hits-top-level-1'));
 
         expect(window.aa).toHaveBeenCalledTimes(2);
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Hit Clicked',
-          index: 'indexName',
-          objectIDs: ['indexName-0'],
-          positions: [1],
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Hit Clicked',
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
 
@@ -420,14 +492,29 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
             eventName: 'Converted',
             index: 'indexName',
             objectIDs: ['indexName-0'],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
           }
         );
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Hit Clicked',
-          index: 'indexName',
-          objectIDs: ['indexName-0'],
-          positions: [1],
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Hit Clicked',
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
 
@@ -493,12 +580,21 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
         userEvent.click(screen.getByTestId('main-hits-click-1'));
 
         expect(window.aa).toHaveBeenCalledTimes(1);
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Clicked',
-          index: 'indexName',
-          objectIDs: ['indexName-0'],
-          positions: [1],
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Clicked',
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
 
@@ -566,18 +662,36 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
         userEvent.click(screen.getByTestId('main-hits-top-level-1'));
 
         expect(window.aa).toHaveBeenCalledTimes(2);
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Clicked nested',
-          index: 'nested',
-          objectIDs: ['nested-0'],
-          positions: [1],
-        });
-        expect(window.aa).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
-          eventName: 'Hit Clicked',
-          index: 'indexName',
-          objectIDs: ['indexName-0'],
-          positions: [1],
-        });
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Clicked nested',
+            index: 'nested',
+            objectIDs: ['nested-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Hit Clicked',
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
       }
     });
   });


### PR DESCRIPTION
This attaches the Algolia credentials to each event we send, via `headers`.

The goal is to ensure events are always sent to the right app even when the Insights client is shared—for example, when using InstantSearch together with Autocomplete.

[FX-2278](https://algolia.atlassian.net/browse/FX-2278)

[FX-2278]: https://algolia.atlassian.net/browse/FX-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ