### PR TITLE
feat(insights): only send automatic events based on condition

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -228,7 +228,9 @@ Use \`InstantSearch.status === "stalled"\` instead.`
       numberLocale,
       initialUiState = {} as TUiState,
       routing = null,
-      insights = true,
+      insights = {
+        verifyEventPermission: true,
+      },
       searchFunction,
       stalledSearchDelay = 200,
       searchClient = null,

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -238,6 +238,17 @@ export function createInsightsMiddleware<
         };
 
         instantSearchInstance.sendEventToInsights = (event: InsightsEvent) => {
+          // @TODO: find out the exact key of the result to determine if analytics is disabled.
+          // if ($$internal && Boolean(helper.lastResults?.renderingContent?.analytics) === false) {
+          if ($$internal && !helper.lastResults?.queryID) {
+            warning(
+              false,
+              'Cannot send event to Algolia Insights because it is disabled through the dashboard.'
+            );
+
+            return;
+          }
+
           if (onEvent) {
             onEvent(
               event,


### PR DESCRIPTION
FX-2294

still WIP, as i didn't update any test, and we don't know the exact key, but this should be fine


In this solution, we are assuming it is ok:

- to load search-insights
- to set clickAnalytics: true
- to load the insights middleware automatically
- not remove insights middleware when it "becomes useless"

but it's not ok: 
- to send events without agreement of the developer

This introduces a hypothetical `renderingContent.analytics` boolean set on the dashboard, which we only honor if `insights` is not touched by the developer (aka left to undefined).