### PR TITLE
feat(insights): load insights script for based on condition

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -228,7 +228,9 @@ Use \`InstantSearch.status === "stalled"\` instead.`
       numberLocale,
       initialUiState = {} as TUiState,
       routing = null,
-      insights = true,
+      insights = {
+        verifyEventPermission: true,
+      },
       searchFunction,
       stalledSearchDelay = 200,
       searchClient = null,


### PR DESCRIPTION
- if regular middleware: load it
- if default middleware: check the network response

This has as impact that the clickAnalytics is correctly set to true initially, but a userToken generated by search-insights of course wouldn't be taken in account (one stored in the cookie from a previous session will be).

FX-2293