### PR TITLE
feat(useInstantSearchApi): warn when an unstable search client is detected

### DIFF
--- a/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
@@ -606,7 +606,7 @@ describe('InstantSearch', () => {
     });
   });
 
-  test('warns when the `searchClient` changes', async () => {
+  test('warns when the `searchClient` changes', () => {
     function App() {
       // The client is re-created whenever the component re-renders
       const searchClient = createAlgoliaSearchClient({});
@@ -630,7 +630,7 @@ describe('InstantSearch', () => {
     );
   });
 
-  test('does not warn when the `searchClient` does not change', async () => {
+  test('does not warn when the `searchClient` does not change', () => {
     const searchClient = createAlgoliaSearchClient({});
 
     function App() {

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -93,6 +93,11 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
     }
 
     if (prevProps.searchClient !== props.searchClient) {
+      warn(
+        false,
+        'The `searchClient` prop of `<InstantSearch>` changed between renders, which may cause more search requests than necessary. If this is an unwanted behavior, please provide a stable reference: https://www.algolia.com/doc/api-reference/widgets/instantsearch/react-hooks/#widget-param-searchclient'
+      );
+
       addAlgoliaAgents(props.searchClient, [
         ...defaultUserAgents,
         serverContext && serverUserAgent,


### PR DESCRIPTION
One of the most common mistakes customers make is to provide a new instance of the search client at each re-render, often by instantiating the client inside their component. While this can sometimes be wanted (e.g., to update an ephemeral API key), this is more frequently an oversight which causes InstantSearch to dispatch more search requests than necessary.

This change adds a dev warning that lets you know of an unstable search client. I'll also update the linked docs to add a note on client stability.

If we're happy to move forward with this change, I'll do it for Vue InstantSearch as well.