### PR TITLE
feat(ais-instant-search): warn when an unstable search client is detected

### DIFF
--- a/packages/vue-instantsearch/src/components/__tests__/InstantSearch.js
+++ b/packages/vue-instantsearch/src/components/__tests__/InstantSearch.js
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { createAlgoliaSearchClient } from '@instantsearch/mocks';
 import { isVue3, version as vueVersion } from '../../util/vue-compat';
 import { mount, nextTick } from '../../../test/utils';
 import instantsearch from 'instantsearch.js/es';
@@ -175,6 +176,37 @@ it('Allows a change in `search-client`', async () => {
   expect(helper.setClient).toHaveBeenCalledTimes(1);
   expect(helper.setClient).toHaveBeenCalledWith(newClient);
   expect(helper.search).toHaveBeenCalledTimes(1);
+});
+
+it('warns when the `search-client` changes', async () => {
+  const wrapper = mount(InstantSearch, {
+    propsData: {
+      searchClient: createAlgoliaSearchClient({}),
+      indexName: 'indexName',
+    },
+  });
+
+  const newClient = createAlgoliaSearchClient({});
+
+  await wrapper.setProps({ searchClient: newClient });
+
+  expect(warn).toHaveBeenCalledWith(
+    false,
+    'The `search-client` prop of `<ais-instant-search>` changed between renders, which may cause more search requests than necessary. If this is an unwanted behavior, please provide a stable reference: https://www.algolia.com/doc/api-reference/widgets/instantsearch/vue/#widget-param-search-client'
+  );
+});
+
+it('does not warn when the `search-client` does not change', async () => {
+  const wrapper = mount(InstantSearch, {
+    propsData: {
+      searchClient: createAlgoliaSearchClient({}),
+      indexName: 'indexName',
+    },
+  });
+
+  await wrapper.setProps({ indexName: 'indexName2' });
+
+  expect(warn).not.toHaveBeenCalled();
 });
 
 it('Allows a change in `search-function`', async () => {

--- a/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
+++ b/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
@@ -2,6 +2,7 @@ import { createSuitMixin } from '../mixins/suit';
 import { version } from '../../package.json'; // rollup does pick only what needed from json
 import { _objectSpread } from './polyfills';
 import { isVue3, version as vueVersion } from './vue-compat';
+import { warn } from './warn';
 
 export const createInstantSearchComponent = (component) =>
   _objectSpread(
@@ -14,6 +15,11 @@ export const createInstantSearchComponent = (component) =>
       },
       watch: {
         searchClient(searchClient) {
+          warn(
+            false,
+            'The `search-client` prop of `<ais-instant-search>` changed between renders, which may cause more search requests than necessary. If this is an unwanted behavior, please provide a stable reference: https://www.algolia.com/doc/api-reference/widgets/instantsearch/vue/#widget-param-search-client'
+          );
+
           this.instantSearchInstance.helper.setClient(searchClient).search();
         },
         indexName(indexName) {


### PR DESCRIPTION
This ports the change made in https://github.com/algolia/instantsearch/pull/5563 in Vue InstantSearch.

I'm still unsure this is necessary in Vue InstantSearch, as Vue keeps track of object references between updates. Happy to drop it if we think it doesn't apply here.