### PR TITLE
refactor: centralise code for SSR in InstantSearch.js

### DIFF
--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -1,0 +1,197 @@
+import {
+  createControlledSearchClient,
+  createSearchClient,
+} from '@instantsearch/mocks';
+
+import { connectSearchBox } from '../../connectors';
+import instantsearch from '../../index.es';
+import { index } from '../../widgets';
+import { getInitialResults, waitForResults } from '../server';
+
+describe('waitForResults', () => {
+  test('waits for the results from the search instance', async () => {
+    const { searchClient, searches } = createControlledSearchClient();
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient,
+    }).addWidgets([
+      index({ indexName: 'indexName2' }),
+      connectSearchBox(() => {})({}),
+    ]);
+
+    search.start();
+
+    const output = waitForResults(search);
+
+    searches[0].resolver();
+
+    await expect(output).resolves.toBeUndefined();
+  });
+
+  test('throws on a search client error', async () => {
+    const { searchClient, searches } = createControlledSearchClient();
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient,
+    }).addWidgets([
+      index({ indexName: 'indexName2' }),
+      connectSearchBox(() => {})({}),
+    ]);
+
+    search.start();
+
+    const output = waitForResults(search);
+
+    searches[0].rejecter({ message: 'Search error' });
+
+    await expect(output).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Search error"`
+    );
+  });
+
+  test('throws on an InstantSearch error', async () => {
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+    }).addWidgets([
+      index({ indexName: 'indexName2' }),
+      connectSearchBox(() => {})({}),
+    ]);
+
+    search.start();
+
+    const output = waitForResults(search);
+
+    search.on('error', () => {});
+    search.emit('error', new Error('Search error'));
+
+    await expect(output).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Search error"`
+    );
+  });
+});
+
+describe('getInitialResults', () => {
+  test('errors if results are not available', () => {
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+    });
+
+    expect(() => getInitialResults(search.mainIndex)).toThrow();
+  });
+
+  test('returns the current results from one index', async () => {
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+    });
+
+    search.start();
+
+    await waitForResults(search);
+
+    expect(getInitialResults(search.mainIndex)).toEqual({
+      indexName: {
+        state: {
+          disjunctiveFacets: [],
+          disjunctiveFacetsRefinements: {},
+          facets: [],
+          facetsExcludes: {},
+          facetsRefinements: {},
+          hierarchicalFacets: [],
+          hierarchicalFacetsRefinements: {},
+          index: 'indexName',
+          numericRefinements: {},
+          tagRefinements: [],
+        },
+        results: [
+          {
+            exhaustiveFacetsCount: true,
+            exhaustiveNbHits: true,
+            hits: [],
+            hitsPerPage: 20,
+            nbHits: 0,
+            nbPages: 0,
+            page: 0,
+            params: '',
+            processingTimeMS: 0,
+            query: '',
+          },
+        ],
+      },
+    });
+  });
+
+  test('returns the current results from multiple indices', async () => {
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+    });
+
+    search.addWidgets([index({ indexName: 'indexName2' })]);
+
+    search.start();
+
+    await waitForResults(search);
+
+    expect(getInitialResults(search.mainIndex)).toEqual({
+      indexName: {
+        state: {
+          disjunctiveFacets: [],
+          disjunctiveFacetsRefinements: {},
+          facets: [],
+          facetsExcludes: {},
+          facetsRefinements: {},
+          hierarchicalFacets: [],
+          hierarchicalFacetsRefinements: {},
+          index: 'indexName',
+          numericRefinements: {},
+          tagRefinements: [],
+        },
+        results: [
+          {
+            exhaustiveFacetsCount: true,
+            exhaustiveNbHits: true,
+            hits: [],
+            hitsPerPage: 20,
+            nbHits: 0,
+            nbPages: 0,
+            page: 0,
+            params: '',
+            processingTimeMS: 0,
+            query: '',
+          },
+        ],
+      },
+      indexName2: {
+        state: {
+          disjunctiveFacets: [],
+          disjunctiveFacetsRefinements: {},
+          facets: [],
+          facetsExcludes: {},
+          facetsRefinements: {},
+          hierarchicalFacets: [],
+          hierarchicalFacetsRefinements: {},
+          index: 'indexName2',
+          numericRefinements: {},
+          tagRefinements: [],
+        },
+        results: [
+          {
+            exhaustiveFacetsCount: true,
+            exhaustiveNbHits: true,
+            hits: [],
+            hitsPerPage: 20,
+            nbHits: 0,
+            nbPages: 0,
+            page: 0,
+            params: '',
+            processingTimeMS: 0,
+            query: '',
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -1,0 +1,54 @@
+import { walkIndex } from './utils';
+
+import type { IndexWidget, InitialResults, InstantSearch } from '../types';
+
+/**
+ * Waits for the results from the search instance to coordinate the next steps
+ * in `getServerState()`.
+ */
+export function waitForResults(search: InstantSearch): Promise<void> {
+  const helper = search.mainHelper!;
+
+  helper.searchOnlyWithDerivedHelpers();
+
+  return new Promise((resolve, reject) => {
+    // All derived helpers resolve in the same tick so we're safe only relying
+    // on the first one.
+    helper.derivedHelpers[0].on('result', () => {
+      resolve();
+    });
+
+    // However, we listen to errors that can happen on any derived helper because
+    // any error is critical.
+    helper.on('error', (error) => {
+      reject(error);
+    });
+    search.on('error', (error) => {
+      reject(error);
+    });
+    helper.derivedHelpers.forEach((derivedHelper) =>
+      derivedHelper.on('error', (error) => {
+        reject(error);
+      })
+    );
+  });
+}
+
+/**
+ * Walks the InstantSearch root index to construct the initial results.
+ */
+export function getInitialResults(rootIndex: IndexWidget): InitialResults {
+  const initialResults: InitialResults = {};
+
+  walkIndex(rootIndex, (widget) => {
+    const searchResults = widget.getResults()!;
+    initialResults[widget.getIndexId()] = {
+      // We convert the Helper state to a plain object to pass parsable data
+      // structures from server to client.
+      state: { ...searchResults._state },
+      results: searchResults._rawResults,
+    };
+  });
+
+  return initialResults;
+}

--- a/packages/instantsearch.js/src/lib/utils/__tests__/walkIndex.test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/walkIndex.test.ts
@@ -1,0 +1,26 @@
+import { walkIndex } from '..';
+import { index } from '../../../widgets';
+
+describe('walkIndex', () => {
+  test('calls the callback once for each widget', () => {
+    const callback = jest.fn();
+
+    walkIndex(
+      index({ indexName: '1', indexId: '1' }).addWidgets([
+        index({ indexName: '2', indexId: '2' }).addWidgets([
+          index({ indexName: '3', indexId: '3' }),
+        ]),
+        index({ indexName: '4', indexId: '4' }),
+      ]),
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledTimes(4);
+    expect(callback.mock.calls.map((call) => call[0].getIndexId())).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+    ]);
+  });
+});

--- a/packages/instantsearch.js/src/lib/utils/index.ts
+++ b/packages/instantsearch.js/src/lib/utils/index.ts
@@ -33,6 +33,7 @@ export * from './isFacetRefined';
 export * from './isFiniteNumber';
 export * from './isPlainObject';
 export * from './isSpecialClick';
+export * from './walkIndex';
 export * from './logger';
 export * from './mergeSearchParameters';
 export * from './omit';

--- a/packages/instantsearch.js/src/lib/utils/walkIndex.ts
+++ b/packages/instantsearch.js/src/lib/utils/walkIndex.ts
@@ -1,0 +1,19 @@
+import { isIndexWidget } from './isIndexWidget';
+
+import type { IndexWidget } from '../../types';
+
+/**
+ * Recurse over all child indices
+ */
+export function walkIndex(
+  indexWidget: IndexWidget,
+  callback: (widget: IndexWidget) => void
+) {
+  callback(indexWidget);
+
+  indexWidget.getWidgets().forEach((widget) => {
+    if (isIndexWidget(widget)) {
+      walkIndex(widget, callback);
+    }
+  });
+}

--- a/packages/react-instantsearch-hooks-server/src/getServerState.tsx
+++ b/packages/react-instantsearch-hooks-server/src/getServerState.tsx
@@ -1,12 +1,15 @@
-import { isIndexWidget } from 'instantsearch.js/es/lib/utils/index';
+import {
+  getInitialResults,
+  waitForResults,
+} from 'instantsearch.js/es/lib/server';
+import { walkIndex } from 'instantsearch.js/es/lib/utils';
 import React from 'react';
 import {
   InstantSearchServerContext,
   InstantSearchSSRProvider,
 } from 'react-instantsearch-hooks';
 
-import type { InitialResults, InstantSearch, UiState } from 'instantsearch.js';
-import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
+import type { InstantSearch, UiState } from 'instantsearch.js';
 import type { ReactNode } from 'react';
 import type {
   InstantSearchServerContextApi,
@@ -116,78 +119,10 @@ function execute({
       return waitForResults(searchRef.current);
     })
     .then(() => {
-      const initialResults = getInitialResults(searchRef.current!.mainIndex);
-
       return {
-        initialResults,
+        initialResults: getInitialResults(searchRef.current!.mainIndex),
       };
     });
-}
-
-/**
- * Waits for the results from the search instance to coordinate the next steps
- * in `getServerState()`.
- */
-function waitForResults(search: InstantSearch) {
-  const helper = search.mainHelper!;
-
-  helper.searchOnlyWithDerivedHelpers();
-
-  return new Promise<void>((resolve, reject) => {
-    // All derived helpers resolve in the same tick so we're safe only relying
-    // on the first one.
-    helper.derivedHelpers[0].on('result', () => {
-      resolve();
-    });
-
-    // However, we listen to errors that can happen on any derived helper because
-    // any error is critical.
-    helper.on('error', (error) => reject(error));
-    search.on('error', (error) => reject(error));
-    helper.derivedHelpers.forEach((derivedHelper) =>
-      derivedHelper.on('error', (error) => {
-        reject(error);
-      })
-    );
-  });
-}
-
-/**
- * Recurse over all child indices
- */
-function walkIndex(
-  indexWidget: IndexWidget,
-  callback: (widget: IndexWidget) => void
-) {
-  callback(indexWidget);
-
-  return indexWidget.getWidgets().forEach((widget) => {
-    if (!isIndexWidget(widget)) {
-      return;
-    }
-
-    callback(widget);
-    walkIndex(widget, callback);
-  });
-}
-
-/**
- * Walks the InstantSearch root index to construct the initial results.
- */
-function getInitialResults(rootIndex: IndexWidget): InitialResults {
-  const initialResults: InitialResults = {};
-
-  walkIndex(rootIndex, (widget) => {
-    const searchResults = widget.getResults()!;
-    initialResults[widget.getIndexId()] = {
-      // We convert the Helper state to a plain object to pass parsable data
-      // structures from server to client.
-      state: { ...searchResults._state },
-      results: searchResults._rawResults,
-    };
-  });
-
-  return initialResults;
 }
 
 function importRenderToString(

--- a/tests/mocks/createSearchClient.ts
+++ b/tests/mocks/createSearchClient.ts
@@ -25,6 +25,7 @@ type ControlledClient = {
   searches: Array<{
     promise: Promise<SearchResponses<any>>;
     resolver: () => void;
+    rejecter: (value: any) => void;
   }>;
 };
 
@@ -39,14 +40,20 @@ export const createControlledSearchClient = (
   const searchClient = createSearchClient({
     search: jest.fn((...params) => {
       let resolver: () => void;
-      const promise: Promise<SearchResponses<any>> = new Promise((resolve) => {
-        resolver = () => resolve(createResponse(...params));
-      });
+      let rejecter: (value: any) => void;
+      const promise: Promise<SearchResponses<any>> = new Promise(
+        (resolve, reject) => {
+          resolver = () => resolve(createResponse(...params));
+          rejecter = (value) => reject(value);
+        }
+      );
 
       searches.push({
         promise,
-        // @ts-expect-error
+        // @ts-expect-error actually being assigned in the promise constructor
         resolver,
+        // @ts-expect-error actually being assigned in the promise constructor
+        rejecter,
       });
 
       return promise;


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

A couple utilities were rewritten in Vue and React Hooks, to be able to make SSR. Moving these utilities into InstantSearch.js makes it so they don't need to be rewritten when we add SSR to JS or another flavor.

Note a little fix to `walkIndex` as well, it used to call every index (except the first one) two times.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- walkIndex in InstantSearch utils
- waitForResults in InstantSearch server file
- getInitialResults in InstantSearch server file
