### PR TITLE
fix(server): error when multiple InstantSearch instances in getServerState

### DIFF
--- a/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
@@ -132,6 +132,29 @@ describe('getServerState', () => {
     );
   });
 
+  test('throws with multiple <InstantSearch> components', async () => {
+    function App({ serverState }: { serverState?: InstantSearchServerState }) {
+      return (
+        <InstantSearchSSRProvider {...serverState}>
+          <InstantSearch
+            searchClient={createSearchClient({})}
+            indexName="index"
+          />
+          <InstantSearch
+            searchClient={createSearchClient({})}
+            indexName="index"
+          />
+        </InstantSearchSSRProvider>
+      );
+    }
+
+    await expect(
+      getServerState(<App />)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"getServerState should be called with a single InstantSearchSSRProvider and a single InstantSearch component."`
+    );
+  });
+
   test('throws when the search client errors, async', async () => {
     const searchClient = createSearchClient({
       // Function is async to match the real search client.


### PR DESCRIPTION



<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

In server environments, the InstantSearch instance gets passed from InstantSearchSSRProvider to InstantSearch, meaning that all child InstantSearch components have the _same_ instance, which can cause many issues.

As this already is working badly, I don't think erroring would be a breaking change, but possibly people are already relying on the current behaviour?

I considered finding a place to have this error in useInstantSearch (as it's the real root cause), I couldn't find anything that still worked with strict mode only creating one InstantSearch instance for both renders.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

fixes https://github.com/algolia/instantsearch/issues/5585

An error gets thrown if there are multiple InstantSearch components in a single call to getWidgetState