### PR TITLE
feat(instantsearch): make root indexName optional

### DIFF
--- a/packages/instantsearch.js/.storybook/decorators/withHits.ts
+++ b/packages/instantsearch.js/.storybook/decorators/withHits.ts
@@ -95,14 +95,6 @@ export const withHits =
     rightPanelPlaygroundElement.classList.add('panel-right');
     playgroundElement.appendChild(rightPanelPlaygroundElement);
 
-    search.addWidgets([
-      instantsearch.widgets.configure({
-        hitsPerPage: 4,
-        attributesToSnippet: ['description:15'],
-        snippetEllipsisText: '[…]',
-      }),
-    ]);
-
     playground({
       search,
       instantsearch,

--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -33,7 +33,7 @@
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
     "@types/qs": "^6.5.3",
-    "algoliasearch-helper": "^3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "hogan.js": "^3.0.2",
     "htm": "^3.0.0",
     "preact": "^10.10.0",

--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -33,7 +33,7 @@
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
     "@types/qs": "^6.5.3",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
+    "algoliasearch-helper": "^3.13.0",
     "hogan.js": "^3.0.2",
     "htm": "^3.0.0",
     "preact": "^10.10.0",

--- a/packages/instantsearch.js/src/connectors/sort-by/__tests__/connectSortBy-test.ts
+++ b/packages/instantsearch.js/src/connectors/sort-by/__tests__/connectSortBy-test.ts
@@ -507,7 +507,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         const renderFn = jest.fn();
         const customSortBy = connectSortBy(renderFn);
         const instantSearchInstance = createInstantSearch({
-          indexName: '',
+          indexName: 'indexName',
         });
         const helper = algoliasearchHelper(
           createSearchClient(),
@@ -540,7 +540,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         const renderFn = jest.fn();
         const customSortBy = connectSortBy(renderFn);
         const instantSearchInstance = createInstantSearch({
-          indexName: '',
+          indexName: 'indexName',
         });
         const helper = algoliasearchHelper(
           createSearchClient(),

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -17,6 +17,7 @@ import {
   noop,
   warning,
   setIndexHelperState,
+  isIndexWidget,
 } from './utils';
 import version from './version';
 
@@ -62,7 +63,7 @@ export type InstantSearchOptions<
   /**
    * The name of the main index
    */
-  indexName: string;
+  indexName?: string;
 
   /**
    * The search client to plug to InstantSearch.js
@@ -224,7 +225,7 @@ Use \`InstantSearch.status === "stalled"\` instead.`
     this.setMaxListeners(100);
 
     const {
-      indexName = null,
+      indexName = '',
       numberLocale,
       initialUiState = {} as TUiState,
       routing = null,
@@ -235,10 +236,6 @@ Use \`InstantSearch.status === "stalled"\` instead.`
       insightsClient = null,
       onStateChange = null,
     } = options;
-
-    if (indexName === null) {
-      throw new Error(withUsage('The `indexName` option is required.'));
-    }
 
     if (searchClient === null) {
       throw new Error(withUsage('The `searchClient` option is required.'));
@@ -516,6 +513,15 @@ See ${createDocumentationLink({
     mainHelper.search = () => {
       this.status = 'loading';
       this.scheduleRender(false);
+
+      if (__DEV__) {
+        const mainWidgets = this.mainIndex.getWidgets();
+        warning(
+          !this.indexName &&
+            (!mainWidgets.length || mainWidgets.some(isIndexWidget)),
+          'No indexName provided, nor an explicit index widget in the widgets tree. This is required to be able to display results.'
+        );
+      }
 
       // This solution allows us to keep the exact same API for the users but
       // under the hood, we have a different implementation. It should be

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -514,14 +514,11 @@ See ${createDocumentationLink({
       this.status = 'loading';
       this.scheduleRender(false);
 
-      if (__DEV__) {
-        const mainWidgets = this.mainIndex.getWidgets();
-        warning(
-          !this.indexName &&
-            (!mainWidgets.length || mainWidgets.some(isIndexWidget)),
-          'No indexName provided, nor an explicit index widget in the widgets tree. This is required to be able to display results.'
-        );
-      }
+      warning(
+        Boolean(this.indexName) ||
+          this.mainIndex.getWidgets().some(isIndexWidget),
+        'No indexName provided, nor an explicit index widget in the widgets tree. This is required to be able to display results.'
+      );
 
       // This solution allows us to keep the exact same API for the users but
       // under the hood, we have a different implementation. It should be

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -61,7 +61,7 @@ export type InstantSearchOptions<
   TRouteState = TUiState
 > = {
   /**
-   * The name of the main index
+   * The name of the main index. If no indexName is provided, you have to manually add an index widget.
    */
   indexName?: string;
 

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -1166,7 +1166,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     expect(instance.mainHelper).toBe(helper);
   });
 
-  it('empty query for root if indexName is not given', async () => {
+  it('no query for root if indexName is not given', async () => {
     const searchClient = createSearchClient();
     const search = new InstantSearch({
       searchClient,
@@ -1176,13 +1176,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     search.start();
     await wait(0);
 
-    expect(searchClient.search).toHaveBeenCalledTimes(1);
-    expect(searchClient.search).toHaveBeenCalledWith([]);
+    expect(searchClient.search).toHaveBeenCalledTimes(0);
 
     search.addWidgets([index({ indexName: 'indexName' })]);
     await wait(0);
 
-    expect(searchClient.search).toHaveBeenCalledTimes(2);
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
     expect(searchClient.search).toHaveBeenCalledWith([
       {
         indexName: 'indexName',

--- a/packages/instantsearch.js/src/lib/utils/render-args.ts
+++ b/packages/instantsearch.js/src/lib/utils/render-args.ts
@@ -30,14 +30,15 @@ export function createRenderArgs(
   parent: IndexWidget
 ) {
   const results = parent.getResults()!;
+  const helper = parent.getHelper()!;
 
   return {
-    helper: parent.getHelper()!,
+    helper,
     parent,
     instantSearchInstance,
     results,
     scopedResults: parent.getScopedResults(),
-    state: results._state,
+    state: results ? results._state : helper.state,
     renderState: instantSearchInstance.renderState,
     templatesConfig: instantSearchInstance.templatesConfig,
     createURL: parent.createURL,

--- a/packages/instantsearch.js/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
+++ b/packages/instantsearch.js/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
@@ -219,7 +219,7 @@ describe('dynamicWidgets()', () => {
 
     it('renders the widgets returned by transformItems', async () => {
       const instantSearchInstance = instantsearch({
-        indexName: '',
+        indexName: 'indexName',
         searchClient: createSearchClient(),
       });
       const rootContainer = document.createElement('div');
@@ -291,7 +291,7 @@ describe('dynamicWidgets()', () => {
 
     it('updates the position of widgets returned by transformItems', async () => {
       const instantSearchInstance = instantsearch({
-        indexName: '',
+        indexName: 'indexName',
         searchClient: createSearchClient(),
       });
       instantSearchInstance.start();
@@ -491,7 +491,7 @@ describe('dynamicWidgets()', () => {
 
     it('removes dom on dispose', async () => {
       const instantSearchInstance = instantsearch({
-        indexName: '',
+        indexName: 'indexName',
         searchClient: createSearchClient(),
       });
       instantSearchInstance.start();

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -608,12 +608,19 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       // then would no longer be thrown for global handlers.
       if (
         instantSearchInstance.status === 'error' &&
-        !instantSearchInstance.mainHelper!.hasPendingRequests()
+        !instantSearchInstance.mainHelper!.hasPendingRequests() &&
+        lastValidSearchParameters
       ) {
-        helper!.setState(lastValidSearchParameters!);
+        helper!.setState(lastValidSearchParameters);
       }
 
-      localWidgets.forEach((widget) => {
+      // We only render index widgets if there are no results.
+      // This makes sure `render` is never called with `results` being `null`.
+      const widgetsToRender = this.getResults()
+        ? localWidgets
+        : localWidgets.filter(isIndexWidget);
+
+      widgetsToRender.forEach((widget) => {
         if (widget.getRenderState) {
           const renderState = widget.getRenderState(
             instantSearchInstance.renderState[this.getIndexId()] || {},
@@ -628,12 +635,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         }
       });
 
-      (this.getResults()
-        ? localWidgets
-        : // We only render index widgets if there are no results.
-          // This makes sure `render` is never called with `results` being `null`.
-          localWidgets.filter(isIndexWidget)
-      ).forEach((widget) => {
+      widgetsToRender.forEach((widget) => {
         // At this point, all the variables used below are set. Both `helper`
         // and `derivedHelper` have been created at the `init` step. The attribute
         // `lastResults` might be `null` though. It's possible that a stalled render

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -534,7 +534,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         // does not have access to lastResults, which it used to in pre-federated
         // search behavior.
         helper!.lastResults = results;
-        lastValidSearchParameters = results._state;
+        lastValidSearchParameters = results?._state;
       });
 
       // We compute the render state before calling `init` in a separate loop
@@ -604,10 +604,6 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
     },
 
     render({ instantSearchInstance }: IndexRenderOptions) {
-      if (!this.getResults()) {
-        return;
-      }
-
       // we can't attach a listener to the error event of search, as the error
       // then would no longer be thrown for global handlers.
       if (
@@ -632,7 +628,12 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         }
       });
 
-      localWidgets.forEach((widget) => {
+      (this.getResults()
+        ? localWidgets
+        : // We only render index widgets if there are no results.
+          // This makes sure `render` is never called with `results` being `null`.
+          localWidgets.filter(isIndexWidget)
+      ).forEach((widget) => {
         // At this point, all the variables used below are set. Both `helper`
         // and `derivedHelper` have been created at the `init` step. The attribute
         // `lastResults` might be `null` though. It's possible that a stalled render

--- a/packages/instantsearch.js/src/widgets/sort-by/__tests__/sort-by-test.ts
+++ b/packages/instantsearch.js/src/widgets/sort-by/__tests__/sort-by-test.ts
@@ -52,7 +52,7 @@ describe('sortBy()', () => {
     render.mockClear();
 
     const instantSearchInstance = createInstantSearch({
-      indexName: '',
+      indexName: 'indexName',
     });
 
     container = document.createElement('div');

--- a/packages/instantsearch.js/stories/instantsearch.stories.ts
+++ b/packages/instantsearch.js/stories/instantsearch.stories.ts
@@ -44,4 +44,92 @@ storiesOf('Basics/InstantSearch', module)
       container.appendChild(button);
       container.appendChild(searchBoxContainer);
     })
+  )
+  .add(
+    'Without a root indexName',
+    withHits(
+      ({ container, instantsearch, search }) => {
+        const index1Container = document.createElement('fieldset');
+        index1Container.appendChild(
+          document.createElement('legend')
+        ).innerText = 'Index 1';
+        container.appendChild(index1Container);
+
+        const index2Container = document.createElement('fieldset');
+        index2Container.appendChild(
+          document.createElement('legend')
+        ).innerText = 'Index 2';
+        container.appendChild(index2Container);
+
+        search.addWidgets([
+          instantsearch.widgets
+            .index({
+              indexName: 'instant_search_movies',
+            })
+            .addWidgets([
+              instantsearch.widgets.searchBox({
+                container: index1Container.appendChild(
+                  document.createElement('div')
+                ),
+              }),
+              instantsearch.widgets.hits({
+                container: index1Container.appendChild(
+                  document.createElement('div')
+                ),
+                templates: {
+                  item: (hit, { html, components }) => html`
+                    <div>
+                      <div>
+                        <strong>name</strong>:${' '}
+                        ${components.Highlight({ hit, attribute: 'title' })}
+                      </div>
+                    </div>
+                  `,
+                },
+              }),
+            ]),
+          instantsearch.widgets
+            .index({
+              indexName: 'instant_search',
+            })
+            .addWidgets([
+              instantsearch.widgets.searchBox({
+                container: index2Container.appendChild(
+                  document.createElement('div')
+                ),
+              }),
+              instantsearch.widgets.hits({
+                container: index2Container.appendChild(
+                  document.createElement('div')
+                ),
+                templates: {
+                  item: (hit, { html, components }) => html`
+                    <div>
+                      <div>
+                        <strong>name</strong>:${' '}
+                        ${components.Highlight({ hit, attribute: 'name' })}
+                      </div>
+                      <div>
+                        <strong>description</strong>:${' '}
+                        ${components.Snippet({ hit, attribute: 'description' })}
+                      </div>
+                    </div>
+                  `,
+                },
+              }),
+            ]),
+        ]);
+      },
+      {
+        // In a real application, you can skip the indexName, withHits just has default values set
+        indexName: '',
+        playground: ({ instantsearch, search, rightPanel }) => {
+          search.addWidgets([
+            instantsearch.widgets.hits({
+              container: rightPanel.appendChild(document.createElement('div')),
+            }),
+          ]);
+        },
+      }
+    )
   );

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
+    "algoliasearch-helper": "^3.13.0",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0"
   },

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0"
   },

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0",

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
+    "algoliasearch-helper": "^3.13.0",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0",

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
+    "algoliasearch-helper": "^3.13.0",
     "instantsearch.js": "4.55.0",
     "use-sync-external-store": "^1.0.0"
   },

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "instantsearch.js": "4.55.0",
     "use-sync-external-store": "^1.0.0"
   },

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -127,7 +127,7 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
     const prevProps = prevPropsRef.current;
 
     if (prevProps.indexName !== props.indexName) {
-      search.helper!.setIndex(props.indexName).search();
+      search.helper!.setIndex(props.indexName || '').search();
       prevPropsRef.current = props;
     }
 

--- a/packages/vue-instantsearch/package.json
+++ b/packages/vue-instantsearch/package.json
@@ -60,7 +60,7 @@
     "@vue/test-utils": "1.3.0",
     "@vue/test-utils2": "npm:@vue/test-utils@2.0.0-rc.11",
     "algoliasearch": "4.14.3",
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
+    "algoliasearch-helper": "3.13.0",
     "instantsearch.css": "8.0.0",
     "rollup": "1.32.1",
     "rollup-plugin-babel": "4.4.0",

--- a/packages/vue-instantsearch/package.json
+++ b/packages/vue-instantsearch/package.json
@@ -60,7 +60,7 @@
     "@vue/test-utils": "1.3.0",
     "@vue/test-utils2": "npm:@vue/test-utils@2.0.0-rc.11",
     "algoliasearch": "4.14.3",
-    "algoliasearch-helper": "3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "instantsearch.css": "8.0.0",
     "rollup": "1.32.1",
     "rollup-plugin-babel": "4.4.0",

--- a/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
+++ b/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
@@ -70,23 +70,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 `);
     });
 
-    it('requires indexName', () => {
-      expect(() =>
-        createSSRApp({
-          mixins: [
-            createServerRootMixin({
-              searchClient: createFakeClient(),
-              indexName: undefined,
-            }),
-          ],
-        })
-      ).toThrowErrorMatchingInlineSnapshot(`
-"The \`indexName\` option is required.
-
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
-    });
-
     it('creates an instantsearch instance on "data"', () => {
       const App = {
         mixins: [

--- a/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
+++ b/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
@@ -23,7 +23,7 @@ export const createInstantSearchComponent = (component) =>
           this.instantSearchInstance.helper.setClient(searchClient).search();
         },
         indexName(indexName) {
-          this.instantSearchInstance.helper.setIndex(indexName).search();
+          this.instantSearchInstance.helper.setIndex(indexName || '').search();
         },
         stalledSearchDelay(stalledSearchDelay) {
           // private InstantSearch.js API:

--- a/tests/mocks/package.json
+++ b/tests/mocks/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.0",
   "private": true,
   "dependencies": {
-    "algoliasearch-helper": "3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "instantsearch.js": "4.55.0"
   }
 }

--- a/tests/mocks/package.json
+++ b/tests/mocks/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.0",
   "private": true,
   "dependencies": {
-    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
+    "algoliasearch-helper": "3.13.0",
     "instantsearch.js": "4.55.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8521,10 +8521,10 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-algoliasearch-helper@3.11.3, algoliasearch-helper@^3.11.3:
-  version "3.11.3"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.11.3.tgz#6e7af8afe6f9a9e55186abffb7b6cf7ca8de3301"
-  integrity sha512-TbaEvLwiuGygHQIB8y+OsJKQQ40+JKUua5B91X66tMUHyyhbNHvqyr0lqd3wCoyKx7WybyQrC0WJvzoIeh24Aw==
+"algoliasearch-helper@https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper":
+  version "3.12.0"
+  uid e4bc32a93a30775c72a2f5cef98748fd76f0a03c
+  resolved "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper#e4bc32a93a30775c72a2f5cef98748fd76f0a03c"
   dependencies:
     "@algolia/events" "^4.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8521,10 +8521,10 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-"algoliasearch-helper@https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper":
-  version "3.12.0"
-  uid e4bc32a93a30775c72a2f5cef98748fd76f0a03c
-  resolved "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper#e4bc32a93a30775c72a2f5cef98748fd76f0a03c"
+algoliasearch-helper@3.13.0, algoliasearch-helper@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.13.0.tgz#1ccca7056fd27c2b0b5c92dd5c0abf4314bec3b8"
+  integrity sha512-kV3c1jMQCvkARtGsSDvAwuht4PAMSsQILqPiH4WFiARoa3jXJ/r1TQoBWAjWyWF48rsNYCv7kzxgB4LTxrvvuw==
   dependencies:
     "@algolia/events" "^4.0.1"
 


### PR DESCRIPTION
requires https://github.com/algolia/algoliasearch-helper-js/pull/938

Essentially this allows us to create neat non-inheriting indices like this with only three queries sent:

```jsx
const App = (
  <InstantSearch>
    <Index indexName="1" indexId="1a" />
    <Index indexName="1" indexId="1b" />
    <Index indexName="2" />
  </InstantSearch>
);
```



Combined with https://github.com/algolia/react-instantsearch/pull/3690 again, you could also create

```jsx
// 🚨 this isn't possible yet
const App = (
  <InstantSearch>
    <Index indexName="1">
      {/* other widgets, causing no results */}
      <NoResults>
        <Index indexName="1" parentIndexId={null}>
          {/* display stuff from a separate query,
        without interference of inheritance */}
        </Index>
      </NoResults>
    </Index>
  </InstantSearch>
);
```

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Allow for more flexible use cases to avoid inheritance of indices, like https://github.com/algolia/instantsearch/issues/5585#issuecomment-1502860567, without custom code skipping the root index.

This does mean that if you forget the indexName, there's a new warning, and no rendering.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- IndexName of InstantSearch is optional
- No query gets done for the root index if indexName isn't given