### PR TITLE
feat(refinementList): show more count

### DIFF
--- a/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
@@ -68,6 +68,7 @@ export type RefinementListProps<TTemplates extends Templates> = {
   showMore?: boolean;
   toggleShowMore?: () => void;
   isShowingMore?: boolean;
+  showMoreCount?: number;
   hasExhaustiveItems?: boolean;
   canToggleShowMore?: boolean;
   className?: string;
@@ -307,6 +308,7 @@ class RefinementList<TTemplates extends Templates> extends Component<
         }}
         data={{
           isShowingMore: this.props.isShowingMore,
+          showMoreCount: this.props.showMoreCount,
         }}
       />
     );

--- a/packages/instantsearch.js/src/connectors/refinement-list/connectRefinementList.ts
+++ b/packages/instantsearch.js/src/connectors/refinement-list/connectRefinementList.ts
@@ -136,6 +136,10 @@ export type RefinementListRenderState = {
    */
   isShowingMore: boolean;
   /**
+   * Total number of facets that can be displayed for 'show more'.
+   */
+  showMoreCount: number;
+  /**
    * Toggles the number of values displayed between `limit` and `showMoreLimit`.
    */
   toggleShowMore(): void;
@@ -234,6 +238,7 @@ const connectRefinementList: RefinementListConnector =
       let sendEvent: RefinementListRenderState['sendEvent'] | undefined;
 
       let isShowingMore = false;
+      let showMoreCount = 0;
       // Provide the same function to the `renderFn` so that way the user
       // has to only bind it once when `isFirstRendering` for instance
       let toggleShowMore = () => {};
@@ -321,6 +326,7 @@ const connectRefinementList: RefinementListConnector =
                       }),
                       items: normalizedFacetValues,
                       canToggleShowMore: false,
+                      showMoreCount,
                       canRefine: true,
                       isFromSearch: true,
                       instantSearchInstance,
@@ -370,6 +376,7 @@ const connectRefinementList: RefinementListConnector =
             renderOptions;
           let items: RefinementListItem[] = [];
           let facetValues: SearchResults.FacetValue[] | FacetHit[] = [];
+          showMoreCount = 0;
 
           if (!sendEvent || !triggerRefine || !searchForFacetValues) {
             sendEvent = createSendEventForFacet({
@@ -414,6 +421,10 @@ const connectRefinementList: RefinementListConnector =
             lastResultsFromMainSearch = results;
             lastItemsFromMainSearch = items;
 
+            if (facetValues.length > 0 && facetValues.length > currentLimit) {
+              showMoreCount = Object.keys(facetValues).length - currentLimit;
+            }
+
             if (renderOptions.results) {
               toggleShowMore = createToggleShowMore(renderOptions, this);
             }
@@ -442,6 +453,7 @@ const connectRefinementList: RefinementListConnector =
             canRefine: items.length > 0,
             widgetParams,
             isShowingMore,
+            showMoreCount,
             canToggleShowMore,
             toggleShowMore: cachedToggleShowMore,
             sendEvent,

--- a/packages/instantsearch.js/src/widgets/refinement-list/refinement-list.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/refinement-list.tsx
@@ -243,6 +243,7 @@ const renderer =
       instantSearchInstance,
       toggleShowMore,
       isShowingMore,
+      showMoreCount,
       hasExhaustiveItems,
       canToggleShowMore,
     },
@@ -277,6 +278,7 @@ const renderer =
         showMore={showMore && !isFromSearch && items.length > 0}
         toggleShowMore={toggleShowMore}
         isShowingMore={isShowingMore}
+        showMoreCount={showMoreCount}
         hasExhaustiveItems={hasExhaustiveItems}
         canToggleShowMore={canToggleShowMore}
       />,


### PR DESCRIPTION
**Summary**

Currently the 'show more' button doesn't provide any information about how many more facet values are available when clicking the 'show more' button.

This behaviour has been asked for several times by customers and raised on this [Stackoverflow issue](https://stackoverflowteams.com/c/algolia/questions/2496).

**Result**

Based upon the POC that I did for this Stackoverflow issue using a custom refinementList connector, I have applied this to the standard refinementList connector. This also adds an additional param that is passed to the `showMoreText` template function so that it can be used within the templating of these buttons.

An example of how this can be used is:
```js
  instantsearch.widgets.refinementList({
    container: '#brand',
    attribute: 'brand',
    limit: 5,
    showMoreLimit: 30,
    showMore: true,
    templates: {
      showMoreText(args) {
        return args.isShowingMore
          ? `Show top 5 items`
          : `Show ${args.showMoreCount} more`;
      },
    },
  }),
```

