### PR TITLE
feat(widgets): introduce parentIndexId

### DIFF
--- a/packages/instantsearch.js/.storybook/decorators/withHits.ts
+++ b/packages/instantsearch.js/.storybook/decorators/withHits.ts
@@ -95,14 +95,6 @@ export const withHits =
     rightPanelPlaygroundElement.classList.add('panel-right');
     playgroundElement.appendChild(rightPanelPlaygroundElement);
 
-    search.addWidgets([
-      instantsearch.widgets.configure({
-        hitsPerPage: 4,
-        attributesToSnippet: ['description:15'],
-        snippetEllipsisText: '[…]',
-      }),
-    ]);
-
     playground({
       search,
       instantsearch,

--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -33,7 +33,7 @@
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
     "@types/qs": "^6.5.3",
-    "algoliasearch-helper": "^3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "hogan.js": "^3.0.2",
     "htm": "^3.0.0",
     "preact": "^10.10.0",

--- a/packages/instantsearch.js/src/connectors/sort-by/__tests__/connectSortBy-test.ts
+++ b/packages/instantsearch.js/src/connectors/sort-by/__tests__/connectSortBy-test.ts
@@ -507,7 +507,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         const renderFn = jest.fn();
         const customSortBy = connectSortBy(renderFn);
         const instantSearchInstance = createInstantSearch({
-          indexName: '',
+          indexName: 'indexName',
         });
         const helper = algoliasearchHelper(
           createSearchClient(),
@@ -540,7 +540,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
         const renderFn = jest.fn();
         const customSortBy = connectSortBy(renderFn);
         const instantSearchInstance = createInstantSearch({
-          indexName: '',
+          indexName: 'indexName',
         });
         const helper = algoliasearchHelper(
           createSearchClient(),

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -17,6 +17,7 @@ import {
   noop,
   warning,
   setIndexHelperState,
+  isIndexWidget,
 } from './utils';
 import version from './version';
 
@@ -62,7 +63,7 @@ export type InstantSearchOptions<
   /**
    * The name of the main index
    */
-  indexName: string;
+  indexName?: string;
 
   /**
    * The search client to plug to InstantSearch.js
@@ -224,7 +225,7 @@ Use \`InstantSearch.status === "stalled"\` instead.`
     this.setMaxListeners(100);
 
     const {
-      indexName = null,
+      indexName = '',
       numberLocale,
       initialUiState = {} as TUiState,
       routing = null,
@@ -235,10 +236,6 @@ Use \`InstantSearch.status === "stalled"\` instead.`
       insightsClient = null,
       onStateChange = null,
     } = options;
-
-    if (indexName === null) {
-      throw new Error(withUsage('The `indexName` option is required.'));
-    }
 
     if (searchClient === null) {
       throw new Error(withUsage('The `searchClient` option is required.'));
@@ -516,6 +513,15 @@ See ${createDocumentationLink({
     mainHelper.search = () => {
       this.status = 'loading';
       this.scheduleRender(false);
+
+      if (__DEV__) {
+        const mainWidgets = this.mainIndex.getWidgets();
+        warning(
+          !this.indexName &&
+            (!mainWidgets.length || mainWidgets.some(isIndexWidget)),
+          'No indexName provided, nor an explicit index widget in the widgets tree. This is required to be able to display results.'
+        );
+      }
 
       // This solution allows us to keep the exact same API for the users but
       // under the hood, we have a different implementation. It should be

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -514,14 +514,11 @@ See ${createDocumentationLink({
       this.status = 'loading';
       this.scheduleRender(false);
 
-      if (__DEV__) {
-        const mainWidgets = this.mainIndex.getWidgets();
-        warning(
-          !this.indexName &&
-            (!mainWidgets.length || mainWidgets.some(isIndexWidget)),
-          'No indexName provided, nor an explicit index widget in the widgets tree. This is required to be able to display results.'
-        );
-      }
+      warning(
+        Boolean(this.indexName) ||
+          this.mainIndex.getWidgets().some(isIndexWidget),
+        'No indexName provided, nor an explicit index widget in the widgets tree. This is required to be able to display results.'
+      );
 
       // This solution allows us to keep the exact same API for the users but
       // under the hood, we have a different implementation. It should be

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -61,7 +61,7 @@ export type InstantSearchOptions<
   TRouteState = TUiState
 > = {
   /**
-   * The name of the main index
+   * The name of the main index. If no indexName is provided, you have to manually add an index widget.
    */
   indexName?: string;
 

--- a/packages/instantsearch.js/src/lib/utils/render-args.ts
+++ b/packages/instantsearch.js/src/lib/utils/render-args.ts
@@ -30,14 +30,15 @@ export function createRenderArgs(
   parent: IndexWidget
 ) {
   const results = parent.getResults()!;
+  const helper = parent.getHelper()!;
 
   return {
-    helper: parent.getHelper()!,
+    helper,
     parent,
     instantSearchInstance,
     results,
     scopedResults: parent.getScopedResults(),
-    state: results._state,
+    state: results ? results._state : helper.state,
     renderState: instantSearchInstance.renderState,
     templatesConfig: instantSearchInstance.templatesConfig,
     createURL: parent.createURL,

--- a/packages/instantsearch.js/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
+++ b/packages/instantsearch.js/src/widgets/dynamic-widgets/__tests__/dynamic-widgets-test.ts
@@ -219,7 +219,7 @@ describe('dynamicWidgets()', () => {
 
     it('renders the widgets returned by transformItems', async () => {
       const instantSearchInstance = instantsearch({
-        indexName: '',
+        indexName: 'indexName',
         searchClient: createSearchClient(),
       });
       const rootContainer = document.createElement('div');
@@ -291,7 +291,7 @@ describe('dynamicWidgets()', () => {
 
     it('updates the position of widgets returned by transformItems', async () => {
       const instantSearchInstance = instantsearch({
-        indexName: '',
+        indexName: 'indexName',
         searchClient: createSearchClient(),
       });
       instantSearchInstance.start();
@@ -491,7 +491,7 @@ describe('dynamicWidgets()', () => {
 
     it('removes dom on dispose', async () => {
       const instantSearchInstance = instantsearch({
-        indexName: '',
+        indexName: 'indexName',
         searchClient: createSearchClient(),
       });
       instantSearchInstance.start();

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -608,12 +608,19 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       // then would no longer be thrown for global handlers.
       if (
         instantSearchInstance.status === 'error' &&
-        !instantSearchInstance.mainHelper!.hasPendingRequests()
+        !instantSearchInstance.mainHelper!.hasPendingRequests() &&
+        lastValidSearchParameters
       ) {
-        helper!.setState(lastValidSearchParameters!);
+        helper!.setState(lastValidSearchParameters);
       }
 
-      localWidgets.forEach((widget) => {
+      // We only render index widgets if there are no results.
+      // This makes sure `render` is never called with `results` being `null`.
+      const widgetsToRender = this.getResults()
+        ? localWidgets
+        : localWidgets.filter(isIndexWidget);
+
+      widgetsToRender.forEach((widget) => {
         if (widget.getRenderState) {
           const renderState = widget.getRenderState(
             instantSearchInstance.renderState[this.getIndexId()] || {},
@@ -628,12 +635,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         }
       });
 
-      (this.getResults()
-        ? localWidgets
-        : // We only render index widgets if there are no results.
-          // This makes sure `render` is never called with `results` being `null`.
-          localWidgets.filter(isIndexWidget)
-      ).forEach((widget) => {
+      widgetsToRender.forEach((widget) => {
         // At this point, all the variables used below are set. Both `helper`
         // and `derivedHelper` have been created at the `init` step. The attribute
         // `lastResults` might be `null` though. It's possible that a stalled render

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -534,7 +534,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         // does not have access to lastResults, which it used to in pre-federated
         // search behavior.
         helper!.lastResults = results;
-        lastValidSearchParameters = results._state;
+        lastValidSearchParameters = results?._state;
       });
 
       // We compute the render state before calling `init` in a separate loop
@@ -604,10 +604,6 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
     },
 
     render({ instantSearchInstance }: IndexRenderOptions) {
-      if (!this.getResults()) {
-        return;
-      }
-
       // we can't attach a listener to the error event of search, as the error
       // then would no longer be thrown for global handlers.
       if (
@@ -632,7 +628,12 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         }
       });
 
-      localWidgets.forEach((widget) => {
+      (this.getResults()
+        ? localWidgets
+        : // We only render index widgets if there are no results.
+          // This makes sure `render` is never called with `results` being `null`.
+          localWidgets.filter(isIndexWidget)
+      ).forEach((widget) => {
         // At this point, all the variables used below are set. Both `helper`
         // and `derivedHelper` have been created at the `init` step. The attribute
         // `lastResults` might be `null` though. It's possible that a stalled render

--- a/packages/instantsearch.js/src/widgets/sort-by/__tests__/sort-by-test.ts
+++ b/packages/instantsearch.js/src/widgets/sort-by/__tests__/sort-by-test.ts
@@ -52,7 +52,7 @@ describe('sortBy()', () => {
     render.mockClear();
 
     const instantSearchInstance = createInstantSearch({
-      indexName: '',
+      indexName: 'indexName',
     });
 
     container = document.createElement('div');

--- a/packages/instantsearch.js/stories/instantsearch.stories.ts
+++ b/packages/instantsearch.js/stories/instantsearch.stories.ts
@@ -44,4 +44,92 @@ storiesOf('Basics/InstantSearch', module)
       container.appendChild(button);
       container.appendChild(searchBoxContainer);
     })
+  )
+  .add(
+    'Without a root indexName',
+    withHits(
+      ({ container, instantsearch, search }) => {
+        const index1Container = document.createElement('fieldset');
+        index1Container.appendChild(
+          document.createElement('legend')
+        ).innerText = 'Index 1';
+        container.appendChild(index1Container);
+
+        const index2Container = document.createElement('fieldset');
+        index2Container.appendChild(
+          document.createElement('legend')
+        ).innerText = 'Index 2';
+        container.appendChild(index2Container);
+
+        search.addWidgets([
+          instantsearch.widgets
+            .index({
+              indexName: 'instant_search_movies',
+            })
+            .addWidgets([
+              instantsearch.widgets.searchBox({
+                container: index1Container.appendChild(
+                  document.createElement('div')
+                ),
+              }),
+              instantsearch.widgets.hits({
+                container: index1Container.appendChild(
+                  document.createElement('div')
+                ),
+                templates: {
+                  item: (hit, { html, components }) => html`
+                    <div>
+                      <div>
+                        <strong>name</strong>:${' '}
+                        ${components.Highlight({ hit, attribute: 'title' })}
+                      </div>
+                    </div>
+                  `,
+                },
+              }),
+            ]),
+          instantsearch.widgets
+            .index({
+              indexName: 'instant_search',
+            })
+            .addWidgets([
+              instantsearch.widgets.searchBox({
+                container: index2Container.appendChild(
+                  document.createElement('div')
+                ),
+              }),
+              instantsearch.widgets.hits({
+                container: index2Container.appendChild(
+                  document.createElement('div')
+                ),
+                templates: {
+                  item: (hit, { html, components }) => html`
+                    <div>
+                      <div>
+                        <strong>name</strong>:${' '}
+                        ${components.Highlight({ hit, attribute: 'name' })}
+                      </div>
+                      <div>
+                        <strong>description</strong>:${' '}
+                        ${components.Snippet({ hit, attribute: 'description' })}
+                      </div>
+                    </div>
+                  `,
+                },
+              }),
+            ]),
+        ]);
+      },
+      {
+        // In a real application, you can skip the indexName, withHits just has default values set
+        indexName: '',
+        playground: ({ instantsearch, search, rightPanel }) => {
+          search.addWidgets([
+            instantsearch.widgets.hits({
+              container: rightPanel.appendChild(document.createElement('div')),
+            }),
+          ]);
+        },
+      }
+    )
   );

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0"
   },

--- a/packages/react-instantsearch-dom/package.json
+++ b/packages/react-instantsearch-dom/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.2",
     "react-fast-compare": "^3.0.0",

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "algoliasearch-helper": "^3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "instantsearch.js": "4.55.0",
     "use-sync-external-store": "^1.0.0"
   },

--- a/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
+++ b/packages/react-instantsearch-hooks/src/components/DynamicWidgets.tsx
@@ -1,10 +1,12 @@
 import React, { Fragment } from 'react';
 
 import { useDynamicWidgets } from '../connectors/useDynamicWidgets';
+import { IndexContext } from '../lib/IndexContext';
 import { invariant } from '../lib/invariant';
+import { useParentIndex } from '../lib/useParentIndex';
 import { warn } from '../lib/warn';
 
-import type { DynamicWidgetsConnectorParams } from 'instantsearch.js/es/connectors/dynamic-widgets/connectDynamicWidgets';
+import type { UseDynamicWidgetsProps } from '../connectors/useDynamicWidgets';
 import type { ReactElement, ComponentType, ReactNode } from 'react';
 
 function DefaultFallbackComponent() {
@@ -17,7 +19,7 @@ type AtLeastOne<
 > = Partial<TTarget> & TMapped[keyof TMapped];
 
 export type DynamicWidgetsProps = Omit<
-  DynamicWidgetsConnectorParams,
+  UseDynamicWidgetsProps,
   'widgets' | 'fallbackWidget'
 > &
   AtLeastOne<{
@@ -40,6 +42,7 @@ export function DynamicWidgets({
   const { attributesToRender } = useDynamicWidgets(props, {
     $$widgetType: 'ais.dynamicWidgets',
   });
+  const parentIndex = useParentIndex(props);
   const widgets: Map<string, ReactNode> = new Map();
 
   React.Children.forEach(children, (child) => {
@@ -54,7 +57,7 @@ export function DynamicWidgets({
   });
 
   return (
-    <>
+    <IndexContext.Provider value={parentIndex}>
       {attributesToRender.map((attribute) => (
         <Fragment key={attribute}>
           {widgets.get(attribute) || (
@@ -62,7 +65,7 @@ export function DynamicWidgets({
           )}
         </Fragment>
       ))}
-    </>
+    </IndexContext.Provider>
   );
 }
 

--- a/packages/react-instantsearch-hooks/src/connectors/useBreadcrumb.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useBreadcrumb.ts
@@ -3,12 +3,14 @@ import connectBreadcrumb from 'instantsearch.js/es/connectors/breadcrumb/connect
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   BreadcrumbConnectorParams,
   BreadcrumbWidgetDescription,
 } from 'instantsearch.js/es/connectors/breadcrumb/connectBreadcrumb';
 
-export type UseBreadcrumbProps = BreadcrumbConnectorParams;
+export type UseBreadcrumbProps = BreadcrumbConnectorParams &
+  UseParentIndexProps;
 
 export function useBreadcrumb(
   props: UseBreadcrumbProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useClearRefinements.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useClearRefinements.ts
@@ -3,12 +3,14 @@ import connectClearRefinements from 'instantsearch.js/es/connectors/clear-refine
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   ClearRefinementsConnectorParams,
   ClearRefinementsWidgetDescription,
 } from 'instantsearch.js/es/connectors/clear-refinements/connectClearRefinements';
 
-export type UseClearRefinementsProps = ClearRefinementsConnectorParams;
+export type UseClearRefinementsProps = ClearRefinementsConnectorParams &
+  UseParentIndexProps;
 
 export function useClearRefinements(
   props?: UseClearRefinementsProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useConfigure.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useConfigure.ts
@@ -3,12 +3,14 @@ import connectConfigure from 'instantsearch.js/es/connectors/configure/connectCo
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   ConfigureConnectorParams,
   ConfigureWidgetDescription,
 } from 'instantsearch.js/es/connectors/configure/connectConfigure';
 
-export type UseConfigureProps = ConfigureConnectorParams['searchParameters'];
+export type UseConfigureProps = ConfigureConnectorParams['searchParameters'] &
+  UseParentIndexProps;
 
 export function useConfigure(
   props: UseConfigureProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useCurrentRefinements.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useCurrentRefinements.ts
@@ -3,12 +3,14 @@ import connectCurrentRefinements from 'instantsearch.js/es/connectors/current-re
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   CurrentRefinementsConnectorParams,
   CurrentRefinementsWidgetDescription,
 } from 'instantsearch.js/es/connectors/current-refinements/connectCurrentRefinements';
 
-export type UseCurrentRefinementsProps = CurrentRefinementsConnectorParams;
+export type UseCurrentRefinementsProps = CurrentRefinementsConnectorParams &
+  UseParentIndexProps;
 
 export function useCurrentRefinements(
   props?: UseCurrentRefinementsProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useDynamicWidgets.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useDynamicWidgets.ts
@@ -3,6 +3,7 @@ import connectDynamicWidgets from 'instantsearch.js/es/connectors/dynamic-widget
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   DynamicWidgetsConnectorParams,
   DynamicWidgetsWidgetDescription,
@@ -11,7 +12,8 @@ import type {
 export type UseDynamicWidgetsProps = Omit<
   DynamicWidgetsConnectorParams,
   'widgets' | 'fallbackWidget'
->;
+> &
+  UseParentIndexProps;
 
 export function useDynamicWidgets(
   props?: UseDynamicWidgetsProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useHierarchicalMenu.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useHierarchicalMenu.ts
@@ -3,12 +3,14 @@ import connectHierarchicalMenu from 'instantsearch.js/es/connectors/hierarchical
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   HierarchicalMenuConnectorParams,
   HierarchicalMenuWidgetDescription,
 } from 'instantsearch.js/es/connectors/hierarchical-menu/connectHierarchicalMenu';
 
-export type UseHierarchicalMenuProps = HierarchicalMenuConnectorParams;
+export type UseHierarchicalMenuProps = HierarchicalMenuConnectorParams &
+  UseParentIndexProps;
 
 export function useHierarchicalMenu(
   props: UseHierarchicalMenuProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useHits.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useHits.ts
@@ -3,6 +3,7 @@ import connectHits from 'instantsearch.js/es/connectors/hits/connectHits';
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type { BaseHit } from 'instantsearch.js';
 import type {
   HitsConnectorParams,
@@ -11,7 +12,7 @@ import type {
 } from 'instantsearch.js/es/connectors/hits/connectHits';
 
 export type UseHitsProps<THit extends BaseHit = BaseHit> =
-  HitsConnectorParams<THit>;
+  HitsConnectorParams<THit> & UseParentIndexProps;
 
 export function useHits<THit extends BaseHit = BaseHit>(
   props?: UseHitsProps<THit>,

--- a/packages/react-instantsearch-hooks/src/connectors/useHitsPerPage.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useHitsPerPage.ts
@@ -3,12 +3,14 @@ import connectHitsPerPage from 'instantsearch.js/es/connectors/hits-per-page/con
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   HitsPerPageConnectorParams,
   HitsPerPageWidgetDescription,
 } from 'instantsearch.js/es/connectors/hits-per-page/connectHitsPerPage';
 
-export type UseHitsPerPageProps = HitsPerPageConnectorParams;
+export type UseHitsPerPageProps = HitsPerPageConnectorParams &
+  UseParentIndexProps;
 
 export function useHitsPerPage(
   props: UseHitsPerPageProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useInfiniteHits.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useInfiniteHits.ts
@@ -3,6 +3,7 @@ import connectInfiniteHits from 'instantsearch.js/es/connectors/infinite-hits/co
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type { BaseHit } from 'instantsearch.js';
 import type {
   InfiniteHitsConnectorParams,
@@ -11,7 +12,7 @@ import type {
 } from 'instantsearch.js/es/connectors/infinite-hits/connectInfiniteHits';
 
 export type UseInfiniteHitsProps<THit extends BaseHit = BaseHit> =
-  InfiniteHitsConnectorParams<THit>;
+  InfiniteHitsConnectorParams<THit> & UseParentIndexProps;
 
 export function useInfiniteHits<THit extends BaseHit = BaseHit>(
   props?: UseInfiniteHitsProps<THit>,

--- a/packages/react-instantsearch-hooks/src/connectors/useMenu.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useMenu.ts
@@ -3,12 +3,13 @@ import connectMenu from 'instantsearch.js/es/connectors/menu/connectMenu';
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   MenuConnectorParams,
   MenuWidgetDescription,
 } from 'instantsearch.js/es/connectors/menu/connectMenu';
 
-export type UseMenuProps = MenuConnectorParams;
+export type UseMenuProps = MenuConnectorParams & UseParentIndexProps;
 
 export function useMenu(
   props: UseMenuProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useNumericMenu.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useNumericMenu.ts
@@ -3,12 +3,14 @@ import connectNumericMenu from 'instantsearch.js/es/connectors/numeric-menu/conn
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   NumericMenuConnectorParams,
   NumericMenuWidgetDescription,
 } from 'instantsearch.js/es/connectors/numeric-menu/connectNumericMenu';
 
-export type UseNumericMenuProps = NumericMenuConnectorParams;
+export type UseNumericMenuProps = NumericMenuConnectorParams &
+  UseParentIndexProps;
 
 export function useNumericMenu(
   props: UseNumericMenuProps,

--- a/packages/react-instantsearch-hooks/src/connectors/usePagination.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/usePagination.ts
@@ -3,12 +3,14 @@ import connectPagination from 'instantsearch.js/es/connectors/pagination/connect
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   PaginationConnectorParams,
   PaginationWidgetDescription,
 } from 'instantsearch.js/es/connectors/pagination/connectPagination';
 
-export type UsePaginationProps = PaginationConnectorParams;
+export type UsePaginationProps = PaginationConnectorParams &
+  UseParentIndexProps;
 
 export function usePagination(
   props?: UsePaginationProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useQueryRules.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useQueryRules.ts
@@ -3,12 +3,14 @@ import connectQueryRules from 'instantsearch.js/es/connectors/query-rules/connec
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   QueryRulesConnectorParams,
   QueryRulesWidgetDescription,
 } from 'instantsearch.js/es/connectors/query-rules/connectQueryRules';
 
-export type UseQueryRulesProps = QueryRulesConnectorParams;
+export type UseQueryRulesProps = QueryRulesConnectorParams &
+  UseParentIndexProps;
 
 export function useQueryRules(
   props?: UseQueryRulesProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useRange.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useRange.ts
@@ -3,12 +3,13 @@ import connectRange from 'instantsearch.js/es/connectors/range/connectRange';
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   RangeConnectorParams,
   RangeWidgetDescription,
 } from 'instantsearch.js/es/connectors/range/connectRange';
 
-export type UseRangeProps = RangeConnectorParams;
+export type UseRangeProps = RangeConnectorParams & UseParentIndexProps;
 
 export function useRange(
   props: UseRangeProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useRefinementList.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useRefinementList.ts
@@ -3,12 +3,14 @@ import connectRefinementList from 'instantsearch.js/es/connectors/refinement-lis
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   RefinementListConnectorParams,
   RefinementListWidgetDescription,
 } from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
 
-export type UseRefinementListProps = RefinementListConnectorParams;
+export type UseRefinementListProps = RefinementListConnectorParams &
+  UseParentIndexProps;
 
 export function useRefinementList(
   props: UseRefinementListProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useSearchBox.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useSearchBox.ts
@@ -3,12 +3,13 @@ import connectSearchBox from 'instantsearch.js/es/connectors/search-box/connectS
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   SearchBoxConnectorParams,
   SearchBoxWidgetDescription,
 } from 'instantsearch.js/es/connectors/search-box/connectSearchBox';
 
-export type UseSearchBoxProps = SearchBoxConnectorParams;
+export type UseSearchBoxProps = SearchBoxConnectorParams & UseParentIndexProps;
 
 export function useSearchBox(
   props?: UseSearchBoxProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useSortBy.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useSortBy.ts
@@ -3,12 +3,13 @@ import connectSortBy from 'instantsearch.js/es/connectors/sort-by/connectSortBy'
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   SortByConnectorParams,
   SortByWidgetDescription,
 } from 'instantsearch.js/es/connectors/sort-by/connectSortBy';
 
-export type UseSortByProps = SortByConnectorParams;
+export type UseSortByProps = SortByConnectorParams & UseParentIndexProps;
 
 export function useSortBy(
   props: UseSortByProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useStats.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useStats.ts
@@ -3,12 +3,13 @@ import connectStats from 'instantsearch.js/es/connectors/stats/connectStats';
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   StatsConnectorParams,
   StatsWidgetDescription,
 } from 'instantsearch.js/es/connectors/stats/connectStats';
 
-export type UseStatsProps = StatsConnectorParams;
+export type UseStatsProps = StatsConnectorParams & UseParentIndexProps;
 
 export function useStats(
   props?: UseStatsProps,

--- a/packages/react-instantsearch-hooks/src/connectors/useToggleRefinement.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useToggleRefinement.ts
@@ -3,12 +3,14 @@ import connectToggleRefinement from 'instantsearch.js/es/connectors/toggle-refin
 import { useConnector } from '../hooks/useConnector';
 
 import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   ToggleRefinementConnectorParams,
   ToggleRefinementWidgetDescription,
 } from 'instantsearch.js/es/connectors/toggle-refinement/connectToggleRefinement';
 
-export type UseToggleRefinementProps = ToggleRefinementConnectorParams;
+export type UseToggleRefinementProps = ToggleRefinementConnectorParams &
+  UseParentIndexProps;
 
 export function useToggleRefinement(
   props: UseToggleRefinementProps,

--- a/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-hooks/src/hooks/useConnector.ts
@@ -2,12 +2,13 @@ import { useMemo, useRef, useState } from 'react';
 
 import { dequal } from '../lib/dequal';
 import { getIndexSearchResults } from '../lib/getIndexSearchResults';
-import { useIndexContext } from '../lib/useIndexContext';
 import { useInstantSearchContext } from '../lib/useInstantSearchContext';
 import { useInstantSearchServerContext } from '../lib/useInstantSearchServerContext';
+import { useParentIndex } from '../lib/useParentIndex';
 import { useStableValue } from '../lib/useStableValue';
 import { useWidget } from '../lib/useWidget';
 
+import type { UseParentIndexProps } from '../lib/useParentIndex';
 import type {
   Connector,
   UiState,
@@ -22,13 +23,13 @@ export function useConnector<
   TDescription extends WidgetDescription
 >(
   connector: Connector<TDescription, TProps>,
-  props: TProps = {} as TProps,
+  { parentIndexId, ...props }: TProps & UseParentIndexProps = {} as TProps,
   additionalWidgetProperties: AdditionalWidgetProperties = {}
 ): TDescription['renderState'] {
   const serverContext = useInstantSearchServerContext();
   const search = useInstantSearchContext();
-  const parentIndex = useIndexContext();
-  const stableProps = useStableValue(props);
+  const parentIndex = useParentIndex({ parentIndexId });
+  const stableProps = useStableValue(props as TProps);
   const stableAdditionalWidgetProperties = useStableValue(
     additionalWidgetProperties
   );

--- a/packages/react-instantsearch-hooks/src/lib/useIndex.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useIndex.ts
@@ -1,31 +1,18 @@
-import { walkIndex } from 'instantsearch.js/es/lib/utils';
 import index from 'instantsearch.js/es/widgets/index/index';
 import { useMemo } from 'react';
 
-import { useIndexContext } from '../lib/useIndexContext';
-
 import { useForceUpdate } from './useForceUpdate';
-import { useInstantSearchContext } from './useInstantSearchContext';
 import { useInstantSearchServerContext } from './useInstantSearchServerContext';
 import { useInstantSearchSSRContext } from './useInstantSearchSSRContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+import { useParentIndex } from './useParentIndex';
 import { useStableValue } from './useStableValue';
 import { useWidget } from './useWidget';
 
-import type {
-  IndexWidgetParams,
-  IndexWidget,
-} from 'instantsearch.js/es/widgets/index/index';
+import type { UseParentIndexProps } from './useParentIndex';
+import type { IndexWidgetParams } from 'instantsearch.js/es/widgets/index/index';
 
-type UseIndexOwnProps = {
-  /**
-   * Logically mount this index to a different parent.
-   * If `null`, the index is mounted to the main index.
-   */
-  parentIndexId?: string | null;
-};
-
-export type UseIndexProps = IndexWidgetParams & UseIndexOwnProps;
+export type UseIndexProps = IndexWidgetParams & UseParentIndexProps;
 
 export function useIndex(props: UseIndexProps) {
   const serverContext = useInstantSearchServerContext();
@@ -49,30 +36,4 @@ export function useIndex(props: UseIndexProps) {
   });
 
   return indexWidget;
-}
-
-function useParentIndex({ parentIndexId }: UseIndexOwnProps) {
-  const physicalParentIndex = useIndexContext();
-  const search = useInstantSearchContext();
-
-  if (parentIndexId === null) {
-    return search.mainIndex;
-  }
-
-  if (parentIndexId) {
-    let foundIndex: IndexWidget | null = null;
-    walkIndex(search.mainIndex, (currentIndex) => {
-      if (currentIndex.getIndexId() === parentIndexId) {
-        foundIndex = currentIndex;
-      }
-    });
-
-    if (!foundIndex) {
-      throw new Error(`Couldn't find index ${parentIndexId}`);
-    }
-
-    return foundIndex;
-  }
-
-  return physicalParentIndex;
 }

--- a/packages/react-instantsearch-hooks/src/lib/useIndex.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useIndex.ts
@@ -1,24 +1,37 @@
+import { walkIndex } from 'instantsearch.js/es/lib/utils';
 import index from 'instantsearch.js/es/widgets/index/index';
 import { useMemo } from 'react';
 
 import { useIndexContext } from '../lib/useIndexContext';
 
 import { useForceUpdate } from './useForceUpdate';
+import { useInstantSearchContext } from './useInstantSearchContext';
 import { useInstantSearchServerContext } from './useInstantSearchServerContext';
 import { useInstantSearchSSRContext } from './useInstantSearchSSRContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 import { useStableValue } from './useStableValue';
 import { useWidget } from './useWidget';
 
-import type { IndexWidgetParams } from 'instantsearch.js/es/widgets/index/index';
+import type {
+  IndexWidgetParams,
+  IndexWidget,
+} from 'instantsearch.js/es/widgets/index/index';
 
-export type UseIndexProps = IndexWidgetParams;
+type UseIndexOwnProps = {
+  /**
+   * Logically mount this index to a different parent.
+   * If `null`, the index is mounted to the main index.
+   */
+  parentIndexId?: string | null;
+};
+
+export type UseIndexProps = IndexWidgetParams & UseIndexOwnProps;
 
 export function useIndex(props: UseIndexProps) {
   const serverContext = useInstantSearchServerContext();
   const ssrContext = useInstantSearchSSRContext();
   const initialResults = ssrContext?.initialResults;
-  const parentIndex = useIndexContext();
+  const parentIndex = useParentIndex(props);
   const stableProps = useStableValue(props);
   const indexWidget = useMemo(() => index(stableProps), [stableProps]);
   const helper = indexWidget.getHelper();
@@ -36,4 +49,30 @@ export function useIndex(props: UseIndexProps) {
   });
 
   return indexWidget;
+}
+
+function useParentIndex({ parentIndexId }: UseIndexOwnProps) {
+  const physicalParentIndex = useIndexContext();
+  const search = useInstantSearchContext();
+
+  if (parentIndexId === null) {
+    return search.mainIndex;
+  }
+
+  if (parentIndexId) {
+    let foundIndex: IndexWidget | null = null;
+    walkIndex(search.mainIndex, (currentIndex) => {
+      if (currentIndex.getIndexId() === parentIndexId) {
+        foundIndex = currentIndex;
+      }
+    });
+
+    if (!foundIndex) {
+      throw new Error(`Couldn't find index ${parentIndexId}`);
+    }
+
+    return foundIndex;
+  }
+
+  return physicalParentIndex;
 }

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -127,7 +127,7 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
     const prevProps = prevPropsRef.current;
 
     if (prevProps.indexName !== props.indexName) {
-      search.helper!.setIndex(props.indexName).search();
+      search.helper!.setIndex(props.indexName || '').search();
       prevPropsRef.current = props;
     }
 

--- a/packages/react-instantsearch-hooks/src/lib/useParentIndex.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useParentIndex.ts
@@ -1,0 +1,40 @@
+import { walkIndex } from 'instantsearch.js/es/lib/utils';
+
+import { useIndexContext } from './useIndexContext';
+import { useInstantSearchContext } from './useInstantSearchContext';
+
+import type { IndexWidget } from 'instantsearch.js';
+
+export type UseParentIndexProps = {
+  /**
+   * Logically mount this index to a different parent.
+   * If `null`, the index is mounted to the main index.
+   */
+  parentIndexId?: string | null;
+};
+
+export function useParentIndex({ parentIndexId }: UseParentIndexProps) {
+  const physicalParentIndex = useIndexContext();
+  const search = useInstantSearchContext();
+
+  if (parentIndexId === null) {
+    return search.mainIndex;
+  }
+
+  if (parentIndexId) {
+    let foundIndex: IndexWidget | null = null;
+    walkIndex(search.mainIndex, (currentIndex) => {
+      if (currentIndex.getIndexId() === parentIndexId) {
+        foundIndex = currentIndex;
+      }
+    });
+
+    if (!foundIndex) {
+      throw new Error(`Couldn't find index ${parentIndexId}`);
+    }
+
+    return foundIndex;
+  }
+
+  return physicalParentIndex;
+}

--- a/packages/vue-instantsearch/package.json
+++ b/packages/vue-instantsearch/package.json
@@ -60,7 +60,7 @@
     "@vue/test-utils": "1.3.0",
     "@vue/test-utils2": "npm:@vue/test-utils@2.0.0-rc.11",
     "algoliasearch": "4.14.3",
-    "algoliasearch-helper": "3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "instantsearch.css": "8.0.0",
     "rollup": "1.32.1",
     "rollup-plugin-babel": "4.4.0",

--- a/packages/vue-instantsearch/src/components/Autocomplete.vue
+++ b/packages/vue-instantsearch/src/components/Autocomplete.vue
@@ -43,6 +43,11 @@ export default {
       required: false,
       default: true,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/Breadcrumb.vue
+++ b/packages/vue-instantsearch/src/components/Breadcrumb.vue
@@ -87,6 +87,11 @@ export default {
       type: Function,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/ClearRefinements.vue
+++ b/packages/vue-instantsearch/src/components/ClearRefinements.vue
@@ -50,6 +50,11 @@ export default {
       type: Function,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/ConfigureRelatedItems.js
+++ b/packages/vue-instantsearch/src/components/ConfigureRelatedItems.js
@@ -27,6 +27,11 @@ export default {
       type: Function,
       required: false,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/CurrentRefinements.vue
+++ b/packages/vue-instantsearch/src/components/CurrentRefinements.vue
@@ -85,6 +85,11 @@ export default {
       type: Function,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     noRefinement() {

--- a/packages/vue-instantsearch/src/components/DynamicWidgets.js
+++ b/packages/vue-instantsearch/src/components/DynamicWidgets.js
@@ -65,6 +65,13 @@ export default {
       type: Number,
       default: undefined,
     },
+    // TODO: this only adds the dynamic widgets to the parent index, not the
+    // widgets that it renders. The parentIndexId should be forwarded.
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   render: renderCompat(function (h) {
     const components = new Map();

--- a/packages/vue-instantsearch/src/components/DynamicWidgets.js
+++ b/packages/vue-instantsearch/src/components/DynamicWidgets.js
@@ -65,13 +65,18 @@ export default {
       type: Number,
       default: undefined,
     },
-    // TODO: this only adds the dynamic widgets to the parent index, not the
-    // widgets that it renders. The parentIndexId should be forwarded.
     parentIndexId: {
       type: String,
       required: false,
       default: undefined,
     },
+  },
+  provide() {
+    return {
+      // To ensure child widgets are registered in the correct parent.
+      // DynamicWidgets can only have widget children, so this doesn't get propagated further.
+      $_ais_getParentIndex: () => this.parentIndex,
+    };
   },
   render: renderCompat(function (h) {
     const components = new Map();

--- a/packages/vue-instantsearch/src/components/HierarchicalMenu.vue
+++ b/packages/vue-instantsearch/src/components/HierarchicalMenu.vue
@@ -99,6 +99,11 @@ export default {
       type: Function,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/Hits.vue
+++ b/packages/vue-instantsearch/src/components/Hits.vue
@@ -54,6 +54,11 @@ export default {
       type: Function,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     items() {

--- a/packages/vue-instantsearch/src/components/HitsPerPage.vue
+++ b/packages/vue-instantsearch/src/components/HitsPerPage.vue
@@ -53,6 +53,11 @@ export default {
       type: Function,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/Index.js
+++ b/packages/vue-instantsearch/src/components/Index.js
@@ -33,6 +33,11 @@ export default {
       type: String,
       required: false,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   render: renderCompat(function (h) {
     return h('div', {}, getDefaultSlot(this));

--- a/packages/vue-instantsearch/src/components/InfiniteHits.vue
+++ b/packages/vue-instantsearch/src/components/InfiniteHits.vue
@@ -105,6 +105,11 @@ export default {
       type: Object,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/Menu.vue
+++ b/packages/vue-instantsearch/src/components/Menu.vue
@@ -95,6 +95,11 @@ export default {
       type: Function,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/MenuSelect.vue
+++ b/packages/vue-instantsearch/src/components/MenuSelect.vue
@@ -70,6 +70,11 @@ export default {
         return items;
       },
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/NumericMenu.vue
+++ b/packages/vue-instantsearch/src/components/NumericMenu.vue
@@ -66,6 +66,11 @@ export default {
       type: Function,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/Pagination.vue
+++ b/packages/vue-instantsearch/src/components/Pagination.vue
@@ -207,6 +207,11 @@ export default {
       type: Boolean,
       default: true,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/QueryRuleContext.js
+++ b/packages/vue-instantsearch/src/components/QueryRuleContext.js
@@ -25,6 +25,11 @@ export default {
       required: false,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/QueryRuleCustomData.vue
+++ b/packages/vue-instantsearch/src/components/QueryRuleCustomData.vue
@@ -34,6 +34,11 @@ export default {
       required: false,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/RangeInput.vue
+++ b/packages/vue-instantsearch/src/components/RangeInput.vue
@@ -96,6 +96,11 @@ export default {
       required: false,
       default: 0,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   data() {
     return {

--- a/packages/vue-instantsearch/src/components/RatingMenu.vue
+++ b/packages/vue-instantsearch/src/components/RatingMenu.vue
@@ -96,6 +96,11 @@ export default {
       type: Number,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/RefinementList.vue
+++ b/packages/vue-instantsearch/src/components/RefinementList.vue
@@ -149,6 +149,11 @@ export default {
       required: false,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   data() {
     return {

--- a/packages/vue-instantsearch/src/components/SearchBox.vue
+++ b/packages/vue-instantsearch/src/components/SearchBox.vue
@@ -94,6 +94,11 @@ export default {
       type: Function,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   data() {
     return {

--- a/packages/vue-instantsearch/src/components/SearchInput.vue
+++ b/packages/vue-instantsearch/src/components/SearchInput.vue
@@ -158,6 +158,11 @@ export default {
       required: false,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   emits: ['input', 'update:modelValue', 'blur', 'focus', 'reset'],
   data() {

--- a/packages/vue-instantsearch/src/components/Snippet.vue
+++ b/packages/vue-instantsearch/src/components/Snippet.vue
@@ -31,6 +31,11 @@ export default {
       type: String,
       default: 'mark',
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
 };
 </script>

--- a/packages/vue-instantsearch/src/components/SortBy.vue
+++ b/packages/vue-instantsearch/src/components/SortBy.vue
@@ -53,6 +53,11 @@ export default {
       type: Function,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/StateResults.vue
+++ b/packages/vue-instantsearch/src/components/StateResults.vue
@@ -30,13 +30,18 @@ export default {
       type: Boolean,
       default: false,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   data() {
     return {
       renderFn: () => {
         const { status, error } = this.instantSearchInstance;
-        const results = this.getParentIndex().getResults();
-        const helper = this.getParentIndex().getHelper();
+        const results = this.parentIndex.getResults();
+        const helper = this.parentIndex.getHelper();
         const state = helper ? helper.state : null;
 
         // @MAJOR no longer spread this inside `results`

--- a/packages/vue-instantsearch/src/components/ToggleRefinement.vue
+++ b/packages/vue-instantsearch/src/components/ToggleRefinement.vue
@@ -67,6 +67,11 @@ export default {
       required: false,
       default: undefined,
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {

--- a/packages/vue-instantsearch/src/components/VoiceSearch.vue
+++ b/packages/vue-instantsearch/src/components/VoiceSearch.vue
@@ -78,6 +78,11 @@ export default {
       required: false,
       default: 'Search by voice (not supported on this browser)',
     },
+    parentIndexId: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   data() {
     return {

--- a/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
+++ b/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
@@ -70,23 +70,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 `);
     });
 
-    it('requires indexName', () => {
-      expect(() =>
-        createSSRApp({
-          mixins: [
-            createServerRootMixin({
-              searchClient: createFakeClient(),
-              indexName: undefined,
-            }),
-          ],
-        })
-      ).toThrowErrorMatchingInlineSnapshot(`
-"The \`indexName\` option is required.
-
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
-    });
-
     it('creates an instantsearch instance on "data"', () => {
       const App = {
         mixins: [

--- a/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
+++ b/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
@@ -23,7 +23,7 @@ export const createInstantSearchComponent = (component) =>
           this.instantSearchInstance.helper.setClient(searchClient).search();
         },
         indexName(indexName) {
-          this.instantSearchInstance.helper.setIndex(indexName).search();
+          this.instantSearchInstance.helper.setIndex(indexName || '').search();
         },
         stalledSearchDelay(stalledSearchDelay) {
           // private InstantSearch.js API:

--- a/tests/mocks/package.json
+++ b/tests/mocks/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.0",
   "private": true,
   "dependencies": {
-    "algoliasearch-helper": "3.11.3",
+    "algoliasearch-helper": "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper",
     "instantsearch.js": "4.55.0"
   }
 }

--- a/tests/utils/widgetSnapshotSerializer.ts
+++ b/tests/utils/widgetSnapshotSerializer.ts
@@ -37,6 +37,7 @@ export const widgetSnapshotSerializer: jest.SnapshotSerializerPlugin = {
       indexId: isIndexWidget(widget) && widget.getIndexId(),
       widgets:
         isIndexWidget(widget) &&
+        widget.getWidgets().length > 0 &&
         `[\n${indentation + indent + indent}${widget
           .getWidgets()
           .map((w) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8521,10 +8521,10 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-algoliasearch-helper@3.11.3, algoliasearch-helper@^3.11.3:
-  version "3.11.3"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.11.3.tgz#6e7af8afe6f9a9e55186abffb7b6cf7ca8de3301"
-  integrity sha512-TbaEvLwiuGygHQIB8y+OsJKQQ40+JKUua5B91X66tMUHyyhbNHvqyr0lqd3wCoyKx7WybyQrC0WJvzoIeh24Aw==
+"algoliasearch-helper@https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper":
+  version "3.12.0"
+  uid e4bc32a93a30775c72a2f5cef98748fd76f0a03c
+  resolved "https://pkg.csb.dev/algolia/algoliasearch-helper-js/commit/6ca09d86/algoliasearch-helper#e4bc32a93a30775c72a2f5cef98748fd76f0a03c"
   dependencies:
     "@algolia/events" "^4.0.1"
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This allows you to pop out of the index hierarchy, to create more advanced nesting, for example for "no results" pages which query again, or for query suggestions.

This is not needed for vanilla InstantSearch, as the widget isn't in charge of being added, addWidgets is called by the user.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Now the parentIndexId logic is added to useWidget/widgetMixin, meaning it's valid for all widgets.

DynamicWidgets needs to expose index context/provider again to pretend to the child widgets they are part of the parentIndex as requested.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

parentIndexId as a prop to the React InstantSearch Hooks Index widget.

This enables the following UI/index combination

```jsx
const App = () => (
  <InstantSearch>
    <Index indexName="index1">
      <Index indexName="index2" parentIndexId={null}>
        <Index indexName="index3" />
      </Index>
      <Index indexName="index4" />
    </Index>
  </InstantSearch>
);

// output:
const mainIndex = {
  id: '',
  widgets: [
    {
      id: 'index1',
      widgets: [{ id: 'index4' }],
    },
    {
      id: 'index2',
      widgets: [{ id: 'index3' }],
    },
  ],
};
```
