### PR TITLE
fix(removeWidgets): defer search by a full tick

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -640,6 +640,15 @@ See ${createDocumentationLink({
     }
   });
 
+  public scheduleSearch2 = defer(
+    () => {
+      if (this.started) {
+        this.mainHelper!.search();
+      }
+    },
+    () => new Promise((resolve) => setTimeout(resolve, 0))
+  );
+
   public scheduleRender = defer((shouldResetStatus: boolean = true) => {
     if (!this.mainHelper?.hasPendingRequests()) {
       clearTimeout(this._searchStalledTimer);

--- a/packages/instantsearch.js/src/lib/utils/defer.ts
+++ b/packages/instantsearch.js/src/lib/utils/defer.ts
@@ -1,5 +1,3 @@
-const nextMicroTask = Promise.resolve();
-
 type Callback = (...args: any[]) => void;
 type Defer = {
   wait(): Promise<void>;
@@ -7,17 +5,19 @@ type Defer = {
 };
 
 export function defer<TCallback extends Callback>(
-  callback: TCallback
+  callback: TCallback,
+  nextTask?: () => Promise<void>
 ): TCallback & Defer {
   let progress: Promise<void> | null = null;
   let cancelled = false;
+  const nextTaskFn = nextTask || Promise.resolve.bind(Promise);
 
   const fn = ((...args: Parameters<TCallback>) => {
     if (progress !== null) {
       return;
     }
 
-    progress = nextMicroTask.then(() => {
+    progress = nextTaskFn().then(() => {
       progress = null;
 
       if (cancelled) {

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -404,7 +404,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         );
 
         if (localWidgets.length) {
-          localInstantSearchInstance.scheduleSearch();
+          localInstantSearchInstance.scheduleSearch2();
         }
       }
 

--- a/packages/react-instantsearch-hooks/src/__tests__/lifecycle.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/lifecycle.test.tsx
@@ -1,0 +1,53 @@
+/** @jest-environment jsdom */
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import { act, render } from '@testing-library/react';
+import React, { StrictMode } from 'react';
+
+import { InstantSearch, useSearchBox } from '..';
+
+function SearchBox() {
+  useSearchBox();
+  return null;
+}
+describe('mounting/unmounting', () => {
+  it('should search once when multiple widgets are removed', async () => {
+    const searchClient = createSearchClient();
+
+    function App({ children }: { children?: React.ReactNode }) {
+      return (
+        <StrictMode>
+          <InstantSearch indexName="instant_search" searchClient={searchClient}>
+            {children}
+          </InstantSearch>
+        </StrictMode>
+      );
+    }
+
+    const { rerender } = render(
+      <App>
+        <SearchBox />
+        <SearchBox />
+        <SearchBox />
+        <SearchBox />
+      </App>
+    );
+
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+
+    rerender(<App />);
+
+    await act(async () => {
+      await wait(0);
+      await wait(0);
+    });
+
+    // if the timing is wrong, the search will be called once for every removed widget
+    // except the final one (as there's no search if there are no widgets)
+    expect(searchClient.search).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
In React InstantSearch Hooks, the removeWidget cleanup is deferred by a timeout, as it ensures the widget doesn't get recreated in strict mode needlessly.

However, this meant that each one of the removeWidget calls happened in their own context, as the order was

timeout (remove)
promise (defer)
timeout (remove)
promise (defer)

and thus was never deduplicated.

Still to figure out in this PR whether the scheduleSearch using a timer is the way to go, or if `scheduleSearch` in index itself should be in a setTimeout (did not yet verify whether that would work too).

I'd also like to know if the order in which different timers are fired is consistent enough for this to work always. We may need to reimplement a queue ourselves.