### PR TITLE
fix(lifecycle): prevent extra network requests when unmounting multiple widgets

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "packages/react-instantsearch-hooks/dist/umd/ReactInstantSearchHooks.min.js",
-      "maxSize": "42.00 kB"
+      "maxSize": "42.25 kB"
     },
     {
       "path": "packages/react-instantsearch-hooks-web/dist/umd/ReactInstantSearchHooksDOM.min.js",
-      "maxSize": "51.25 kB"
+      "maxSize": "51.50 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",

--- a/packages/react-instantsearch-hooks/src/components/InstantSearchSSRProvider.tsx
+++ b/packages/react-instantsearch-hooks/src/components/InstantSearchSSRProvider.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { InstantSearchSSRContext } from '../lib/InstantSearchSSRContext';
 
-import type { InitialResults, InstantSearch, UiState } from 'instantsearch.js';
+import type { InternalInstantSearch } from '../lib/useInstantSearchApi';
+import type { InitialResults, UiState } from 'instantsearch.js';
 import type { ReactNode } from 'react';
 
 export type InstantSearchServerState = {
@@ -24,9 +25,10 @@ export function InstantSearchSSRProvider<
 >({ children, ...props }: InstantSearchSSRProviderProps) {
   // This is used in `useInstantSearchApi()` to avoid creating and starting multiple instances of
   // `InstantSearch` on mount.
-  const ssrSearchRef = React.useRef<InstantSearch<UiState, TRouteState> | null>(
-    null
-  );
+  const ssrSearchRef = React.useRef<InternalInstantSearch<
+    UiState,
+    TRouteState
+  > | null>(null);
 
   // When <DynamicWidgets> is mounted, a second provider is used above the user-land
   // <InstantSearchSSRProvider> in `getServerState()`.

--- a/packages/react-instantsearch-hooks/src/lib/InstantSearchSSRContext.ts
+++ b/packages/react-instantsearch-hooks/src/lib/InstantSearchSSRContext.ts
@@ -1,14 +1,18 @@
 import { createContext } from 'react';
 
 import type { InstantSearchServerState } from '../components/InstantSearchSSRProvider';
-import type { UiState, InstantSearch } from 'instantsearch.js';
+import type { InternalInstantSearch } from './useInstantSearchApi';
+import type { UiState } from 'instantsearch.js';
 import type { MutableRefObject } from 'react';
 
 export type InstantSearchSSRContextApi<
   TUiState extends UiState,
   TRouteState = TUiState
 > = InstantSearchServerState & {
-  ssrSearchRef: MutableRefObject<InstantSearch<TUiState, TRouteState> | null>;
+  ssrSearchRef: MutableRefObject<InternalInstantSearch<
+    TUiState,
+    TRouteState
+  > | null>;
 };
 
 export const InstantSearchSSRContext = createContext<Partial<

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchContext.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchContext.ts
@@ -4,7 +4,8 @@ import { invariant } from '../lib/invariant';
 
 import { InstantSearchContext } from './InstantSearchContext';
 
-import type { InstantSearch, UiState } from 'instantsearch.js';
+import type { InternalInstantSearch } from './useInstantSearchApi';
+import type { UiState } from 'instantsearch.js';
 import type { Context } from 'react';
 
 export function useInstantSearchContext<
@@ -12,7 +13,10 @@ export function useInstantSearchContext<
   TRouteState = TUiState
 >() {
   const search = useContext(
-    InstantSearchContext as Context<InstantSearch<TUiState, TRouteState> | null>
+    InstantSearchContext as Context<InternalInstantSearch<
+      TUiState,
+      TRouteState
+    > | null>
   );
 
   invariant(


### PR DESCRIPTION



<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

When unmounting multiple widgets at once, but not the InstantSearch widget, multiple searches were triggered. This was because every timeout leaves a moment for microtasks to be processed, and thus did not deduplicate scheduleSearch.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->


This PR fixes that by adding a private timeout-based scheduler that ensures all removeWidgets calls get called synchronously.

CR-3255