### PR TITLE
chore(create-instantsearch-app): update links to monorepo

### DIFF
--- a/packages/create-instantsearch-app/README.md
+++ b/packages/create-instantsearch-app/README.md
@@ -173,7 +173,7 @@ To start contributing to the code, you need to:
 1.  [Clone the repository](https://help.github.com/articles/cloning-a-repository/)
 1.  Install the dependencies: `yarn`
 
-Please read [our contribution process](https://github.com/algolia/instantsearch.js/blob/master/CONTRIBUTING.md) to learn more.
+Please read [our contribution process](https://github.com/algolia/instantsearch/blob/master/CONTRIBUTING.md) to learn more.
 
 ## License
 

--- a/packages/create-instantsearch-app/README.md
+++ b/packages/create-instantsearch-app/README.md
@@ -4,7 +4,7 @@
 
 [![Version][version-svg]][package-url] [![License][license-image]][license-url] [![Build Status][ci-svg]][ci-url]
 
-`create-instantsearch-app` is a command line utility that helps you quick start your InstantSearch app using any [Algolia][algolia-website] InstantSearch flavor ([InstantSearch.js][instantsearchjs-github], [React InstantSearch][react-instantsearch-github], [Vue InstantSearch][vue-instantsearch-github], [Angular InstantSearch][angular-instantsearch-github], [InstantSearch iOS][instantsearch-ios-github] and [InstantSearch Android][instantsearch-android-github]).
+`create-instantsearch-app` is a command line utility that helps you quick start your InstantSearch app using any [Algolia][algolia-website] InstantSearch flavor ([InstantSearch.js][instantsearchjs-github], [React InstantSearch Hooks][react-instantsearch-hooks-github], [Vue InstantSearch][vue-instantsearch-github], [Angular InstantSearch][angular-instantsearch-github], [InstantSearch iOS][instantsearch-ios-github] and [InstantSearch Android][instantsearch-android-github]).
 
 <p align="center">
   <img src="preview.png" width="800" alt="Preview">
@@ -17,13 +17,16 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [Get started](#get-started)
-- [Usage](#usage)
-- [API](#api)
-- [Tutorials](#tutorials)
-- [Previews](#previews)
-- [Contributing](#contributing)
-- [License](#license)
+- [Create InstantSearch App](#create-instantsearch-app)
+  - [Get started](#get-started)
+  - [Usage](#usage)
+      - [`--template`](#--template)
+      - [`--config`](#--config)
+  - [API](#api)
+  - [Tutorials](#tutorials)
+  - [Previews](#previews)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -147,14 +150,14 @@ app.create().then(() => console.log('App generated!'));
 
 You can use the web templates on CodeSandbox:
 
-- [InstantSearch.js 3](https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/instantsearch.js)
-- [InstantSearch.js 2](https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/instantsearch.js-2.x)
-- [React InstantSearch](https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/react-instantsearch)
-- [Vue InstantSearch](https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/vue-instantsearch)
-- [Angular InstantSearch](https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/angular-instantsearch)
-- [Autocomplete.js](https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/autocomplete.js)
-- [JavaScript Client](https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/javascript-client)
-- [JavaScript Helper](https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/javascript-helper)
+- [InstantSearch.js 3](https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/instantsearch.js)
+- [InstantSearch.js 2](https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/instantsearch.js-2.x)
+- [React InstantSearch Hooks](https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/react-instantsearch-hooks)
+- [Vue InstantSearch](https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/vue-instantsearch)
+- [Angular InstantSearch](https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/angular-instantsearch)
+- [Autocomplete.js](https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/autocomplete.js)
+- [JavaScript Client](https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/javascript-client)
+- [JavaScript Helper](https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/javascript-helper)
 
 ## Contributing
 
@@ -188,14 +191,14 @@ Create InstantSearch App is [MIT licensed](LICENSE).
 <!-- Links -->
 
 [algolia-website]: https://www.algolia.com/?utm_medium=social-owned&utm_source=GitHub&utm_campaign=create-instantsearch-app%20repository
-[instantsearchjs-github]: https://github.com/algolia/instantsearch.js
-[react-instantsearch-github]: https://github.com/algolia/instantsearch.js
-[vue-instantsearch-github]: https://github.com/algolia/vue-instantsearch
+[instantsearchjs-github]: https://github.com/algolia/instantsearch/tree/master/packages/instantsearch.js
+[react-instantsearch-hooks-github]: https://github.com/algolia/instantsearch/tree/master/packages/react-instantsearch-hooks-web
+[vue-instantsearch-github]: https://github.com/algolia/instantsearch/tree/master/packages/vue-instantsearch
 [angular-instantsearch-github]: https://github.com/algolia/angular-instantsearch
 [instantsearch-ios-github]: https://github.com/algolia/instantsearch-ios
 [instantsearch-android-github]: https://github.com/algolia/instantsearch-android
-[contributing-bugreport]: https://github.com/algolia/instantsearch.js/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20Create+InstantSearch+App
-[contributing-featurerequest]: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage,Library%3A%20Create+InstantSearch+App&title=Feature%20request%3A%20
-[contributing-label-easy]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20Create+InstantSearch+App%22
-[contributing-label-bug]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20Create+InstantSearch+App%22
-[contributing-label-chore]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20Create+InstantSearch+App%22
+[contributing-bugreport]: https://github.com/algolia/instantsearch/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20Create+InstantSearch+App
+[contributing-featurerequest]: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage,Library%3A%20Create+InstantSearch+App&title=Feature%20request%3A%20
+[contributing-label-easy]: https://github.com/algolia/instantsearch/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20Create+InstantSearch+App%22
+[contributing-label-bug]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20Create+InstantSearch+App%22
+[contributing-label-chore]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20Create+InstantSearch+App%22

--- a/packages/create-instantsearch-app/e2e/__snapshots__/templates.test.js.snap
+++ b/packages/create-instantsearch-app/e2e/__snapshots__/templates.test.js.snap
@@ -2771,7 +2771,7 @@ exports[`Templates InstantSearch.js 2 File content: index.html 1`] = `
     </h1>
     <p class=\\"header-subtitle\\">
       using
-      <a href=\\"https://github.com/algolia/instantsearch/tree/master/packages/instantsearch.js\\">
+      <a href=\\"https://github.com/algolia/instantsearch/tree/v2.10.5\\">
         InstantSearch.js
       </a>
     </p>

--- a/packages/create-instantsearch-app/e2e/__snapshots__/templates.test.js.snap
+++ b/packages/create-instantsearch-app/e2e/__snapshots__/templates.test.js.snap
@@ -50,7 +50,7 @@ dist/"
 exports[`Templates Angular InstantSearch File content: README.md 1`] = `
 "# angular-instantsearch-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -764,7 +764,7 @@ exports[`Templates Autocomplete File content: .prettierrc 1`] = `
 exports[`Templates Autocomplete File content: README.md 1`] = `
 "# autocomplete-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -1002,7 +1002,7 @@ exports[`Templates Autocomplete.js 0 File content: .prettierrc 1`] = `
 exports[`Templates Autocomplete.js 0 File content: README.md 1`] = `
 "# autocomplete.js-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -2723,7 +2723,7 @@ exports[`Templates InstantSearch.js 2 File content: .prettierrc 1`] = `
 exports[`Templates InstantSearch.js 2 File content: README.md 1`] = `
 "# instantsearch.js-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -2771,7 +2771,7 @@ exports[`Templates InstantSearch.js 2 File content: index.html 1`] = `
     </h1>
     <p class=\\"header-subtitle\\">
       using
-      <a href=\\"https://github.com/algolia/instantsearch.js\\">
+      <a href=\\"https://github.com/algolia/instantsearch/tree/master/packages/instantsearch.js\\">
         InstantSearch.js
       </a>
     </p>
@@ -3057,7 +3057,7 @@ exports[`Templates InstantSearch.js File content: .prettierrc 1`] = `
 exports[`Templates InstantSearch.js File content: README.md 1`] = `
 "# instantsearch.js-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -3103,7 +3103,7 @@ exports[`Templates InstantSearch.js File content: index.html 1`] = `
     </h1>
     <p class=\\"header-subtitle\\">
       using
-      <a href=\\"https://github.com/algolia/instantsearch.js\\">
+      <a href=\\"https://github.com/algolia/instantsearch/tree/master/packages/instantsearch.js\\">
         InstantSearch.js
       </a>
     </p>
@@ -3632,7 +3632,7 @@ Please read [our contribution process](./CONTRIBUTING.md) to learn more.
 
 ---
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._"
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._"
 `;
 
 exports[`Templates InstantSearch.js widget File content: babel.config.cjs 1`] = `
@@ -4631,7 +4631,7 @@ exports[`Templates JavaScript Client File content: .prettierrc 1`] = `
 exports[`Templates JavaScript Client File content: README.md 1`] = `
 "# javascript-client-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -4944,7 +4944,7 @@ exports[`Templates JavaScript Helper 2 File content: .prettierrc 1`] = `
 exports[`Templates JavaScript Helper 2 File content: README.md 1`] = `
 "# javascript-helper-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -5251,7 +5251,7 @@ exports[`Templates JavaScript Helper File content: .prettierrc 1`] = `
 exports[`Templates JavaScript Helper File content: README.md 1`] = `
 "# javascript-helper-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -5551,7 +5551,7 @@ exports[`Templates React InstantSearch File content: .prettierrc 1`] = `
 exports[`Templates React InstantSearch File content: README.md 1`] = `
 "# react-instantsearch-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -5736,7 +5736,7 @@ function App() {
         </h1>
         <p className=\\"header-subtitle\\">
           using{' '}
-          <a href=\\"https://github.com/algolia/react-instantsearch\\">
+          <a href=\\"https://github.com/algolia/instantsearch/tree/master/packages/react-instantsearch\\">
             React InstantSearch
           </a>
         </p>
@@ -5885,7 +5885,7 @@ exports[`Templates React InstantSearch Hooks File content: .prettierrc 1`] = `
 exports[`Templates React InstantSearch Hooks File content: README.md 1`] = `
 "# react-instantsearch-hooks-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -6058,7 +6058,7 @@ export function App() {
         </h1>
         <p className=\\"header-subtitle\\">
           using{' '}
-          <a href=\\"https://github.com/algolia/react-instantsearch\\">
+          <a href=\\"https://github.com/algolia/instantsearch/tree/master/packages/react-instantsearch-hooks-web\\">
             React InstantSearch Hooks
           </a>
         </p>
@@ -6253,7 +6253,7 @@ const styles = StyleSheet.create({
 exports[`Templates React InstantSearch Hooks Native File content: README.md 1`] = `
 "# react-instantsearch-hooks-native-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -6703,7 +6703,7 @@ export default App;"
 exports[`Templates React InstantSearch Native File content: README.md 1`] = `
 "# react-instantsearch-native-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -7108,7 +7108,7 @@ Please read [our contribution process](./CONTRIBUTING.md) to learn more.
 
 ---
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._"
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._"
 `;
 
 exports[`Templates React InstantSearch widget File content: babel.config.cjs 1`] = `
@@ -7501,7 +7501,7 @@ exports[`Templates Vue InstantSearch 1 File content: .prettierrc 1`] = `
 exports[`Templates Vue InstantSearch 1 File content: README.md 1`] = `
 "# vue-instantsearch-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -7584,7 +7584,9 @@ exports[`Templates Vue InstantSearch 1 File content: src/App.vue 1`] = `
       </h1>
       <p class=\\"header-subtitle\\">
         using
-        <a href=\\"https://github.com/algolia/vue-instantsearch\\">
+        <a
+          href=\\"https://github.com/algolia/instantsearch/tree/master/packages/vue-instantsearch\\"
+        >
           Vue InstantSearch
         </a>
       </p>
@@ -7823,7 +7825,7 @@ exports[`Templates Vue InstantSearch 2 File content: .prettierrc 1`] = `
 exports[`Templates Vue InstantSearch 2 File content: README.md 1`] = `
 "# vue-instantsearch-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -7906,7 +7908,9 @@ exports[`Templates Vue InstantSearch 2 File content: src/App.vue 1`] = `
       </h1>
       <p class=\\"header-subtitle\\">
         using
-        <a href=\\"https://github.com/algolia/vue-instantsearch\\">
+        <a
+          href=\\"https://github.com/algolia/instantsearch/tree/master/packages/vue-instantsearch\\"
+        >
           Vue InstantSearch
         </a>
       </p>
@@ -8123,7 +8127,7 @@ exports[`Templates Vue InstantSearch File content: .prettierrc 1`] = `
 exports[`Templates Vue InstantSearch File content: README.md 1`] = `
 "# vue-instantsearch-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -8206,7 +8210,9 @@ exports[`Templates Vue InstantSearch File content: src/App.vue 1`] = `
       </h1>
       <p class=\\"header-subtitle\\">
         using
-        <a href=\\"https://github.com/algolia/vue-instantsearch\\">
+        <a
+          href=\\"https://github.com/algolia/instantsearch/tree/master/packages/vue-instantsearch\\"
+        >
           Vue InstantSearch
         </a>
       </p>
@@ -8422,7 +8428,7 @@ exports[`Templates Vue InstantSearch with Vue 3 File content: .prettierrc 1`] = 
 exports[`Templates Vue InstantSearch with Vue 3 File content: README.md 1`] = `
 "# vue-instantsearch-app
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 
@@ -8491,7 +8497,9 @@ exports[`Templates Vue InstantSearch with Vue 3 File content: src/App.vue 1`] = 
       </h1>
       <p class=\\"header-subtitle\\">
         using
-        <a href=\\"https://github.com/algolia/vue-instantsearch\\">
+        <a
+          href=\\"https://github.com/algolia/instantsearch/tree/master/packages/vue-instantsearch\\"
+        >
           Vue InstantSearch
         </a>
       </p>

--- a/packages/create-instantsearch-app/package.json
+++ b/packages/create-instantsearch-app/package.json
@@ -7,7 +7,7 @@
     "algolia",
     "instantsearch"
   ],
-  "repository": "algolia/instantsearch.js",
+  "repository": "algolia/instantsearch",
   "author": "Algolia <support@algolia.com>",
   "main": "index.js",
   "bin": {

--- a/packages/create-instantsearch-app/scripts/release-templates.js
+++ b/packages/create-instantsearch-app/scripts/release-templates.js
@@ -3,7 +3,7 @@
 /*
  * This script releases compiled templates to the branch `templates`.
  * This branch is used for CodeSandbox.
- * Example: https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/instantsearch.js
+ * Example: https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/instantsearch.js
  *
  * If this is the first time running this script, you need to create a new orphan branch:
  *   $ git checkout --orphan templates
@@ -17,7 +17,7 @@ const chalk = require('chalk');
 const { getLatestLibraryVersion } = require('../src/utils');
 const createInstantSearchApp = require('../');
 
-const GITHUB_REPOSITORY = 'https://github.com/algolia/instantsearch.js.git';
+const GITHUB_REPOSITORY = 'https://github.com/algolia/instantsearch.git';
 const TEMPLATES_BRANCH = 'templates';
 const BUILD_FOLDER = 'build';
 

--- a/packages/create-instantsearch-app/src/templates/Angular InstantSearch/README.md
+++ b/packages/create-instantsearch-app/src/templates/Angular InstantSearch/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/Autocomplete.js 0/README.md
+++ b/packages/create-instantsearch-app/src/templates/Autocomplete.js 0/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/Autocomplete/README.md
+++ b/packages/create-instantsearch-app/src/templates/Autocomplete/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/InstantSearch.js 2/README.md
+++ b/packages/create-instantsearch-app/src/templates/InstantSearch.js 2/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/InstantSearch.js 2/index.html.hbs
+++ b/packages/create-instantsearch-app/src/templates/InstantSearch.js 2/index.html.hbs
@@ -24,7 +24,7 @@
     </h1>
     <p class="header-subtitle">
       using
-      <a href="https://github.com/algolia/instantsearch/tree/master/packages/instantsearch.js">
+      <a href="https://github.com/algolia/instantsearch/tree/v2.10.5">
         InstantSearch.js
       </a>
     </p>

--- a/packages/create-instantsearch-app/src/templates/InstantSearch.js 2/index.html.hbs
+++ b/packages/create-instantsearch-app/src/templates/InstantSearch.js 2/index.html.hbs
@@ -24,7 +24,7 @@
     </h1>
     <p class="header-subtitle">
       using
-      <a href="https://github.com/algolia/instantsearch.js">
+      <a href="https://github.com/algolia/instantsearch/tree/master/packages/instantsearch.js">
         InstantSearch.js
       </a>
     </p>

--- a/packages/create-instantsearch-app/src/templates/InstantSearch.js widget/README.md
+++ b/packages/create-instantsearch-app/src/templates/InstantSearch.js widget/README.md
@@ -169,4 +169,4 @@ Please read [our contribution process](./CONTRIBUTING.md) to learn more.
 
 ---
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._

--- a/packages/create-instantsearch-app/src/templates/InstantSearch.js/README.md
+++ b/packages/create-instantsearch-app/src/templates/InstantSearch.js/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/InstantSearch.js/index.html.hbs
+++ b/packages/create-instantsearch-app/src/templates/InstantSearch.js/index.html.hbs
@@ -22,7 +22,7 @@
     </h1>
     <p class="header-subtitle">
       using
-      <a href="https://github.com/algolia/instantsearch.js">
+      <a href="https://github.com/algolia/instantsearch/tree/master/packages/instantsearch.js">
         InstantSearch.js
       </a>
     </p>

--- a/packages/create-instantsearch-app/src/templates/JavaScript Client/README.md
+++ b/packages/create-instantsearch-app/src/templates/JavaScript Client/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/JavaScript Helper 2/README.md
+++ b/packages/create-instantsearch-app/src/templates/JavaScript Helper 2/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/JavaScript Helper/README.md
+++ b/packages/create-instantsearch-app/src/templates/JavaScript Helper/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/React InstantSearch Hooks Native/README.md
+++ b/packages/create-instantsearch-app/src/templates/React InstantSearch Hooks Native/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/React InstantSearch Hooks/README.md
+++ b/packages/create-instantsearch-app/src/templates/React InstantSearch Hooks/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/React InstantSearch Hooks/src/App.tsx.hbs
+++ b/packages/create-instantsearch-app/src/templates/React InstantSearch Hooks/src/App.tsx.hbs
@@ -40,7 +40,7 @@ export function App() {
         </h1>
         <p className="header-subtitle">
           using{' '}
-          <a href="https://github.com/algolia/react-instantsearch">
+          <a href="https://github.com/algolia/instantsearch/tree/master/packages/react-instantsearch-hooks-web">
             React InstantSearch Hooks
           </a>
         </p>

--- a/packages/create-instantsearch-app/src/templates/React InstantSearch Native/README.md
+++ b/packages/create-instantsearch-app/src/templates/React InstantSearch Native/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/React InstantSearch widget/README.md
+++ b/packages/create-instantsearch-app/src/templates/React InstantSearch widget/README.md
@@ -82,4 +82,4 @@ Please read [our contribution process](./CONTRIBUTING.md) to learn more.
 
 ---
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._

--- a/packages/create-instantsearch-app/src/templates/React InstantSearch/README.md
+++ b/packages/create-instantsearch-app/src/templates/React InstantSearch/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/React InstantSearch/src/App.js.hbs
+++ b/packages/create-instantsearch-app/src/templates/React InstantSearch/src/App.js.hbs
@@ -34,7 +34,7 @@ function App() {
         </h1>
         <p className="header-subtitle">
           using{' '}
-          <a href="https://github.com/algolia/react-instantsearch">
+          <a href="https://github.com/algolia/instantsearch/tree/master/packages/react-instantsearch">
             React InstantSearch
           </a>
         </p>

--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch 1/README.md
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch 1/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch 1/src/App.vue
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch 1/src/App.vue
@@ -6,7 +6,7 @@
       </h1>
       <p class="header-subtitle">
         using
-        <a href="https://github.com/algolia/vue-instantsearch">
+        <a href="https://github.com/algolia/instantsearch/tree/master/packages/vue-instantsearch">
           Vue InstantSearch
         </a>
       </p>

--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch 2/README.md
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch 2/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch 2/src/App.vue
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch 2/src/App.vue
@@ -8,7 +8,7 @@
       </h1>
       <p class="header-subtitle">
         using
-        <a href="https://github.com/algolia/vue-instantsearch">
+        <a href="https://github.com/algolia/instantsearch/tree/master/packages/vue-instantsearch">
           Vue InstantSearch
         </a>
       </p>

--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch with Vue 3/README.md
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch with Vue 3/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch with Vue 3/src/App.vue
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch with Vue 3/src/App.vue
@@ -6,7 +6,7 @@
       </h1>
       <p class="header-subtitle">
         using
-        <a href="https://github.com/algolia/vue-instantsearch">
+        <a href="https://github.com/algolia/instantsearch/tree/master/packages/vue-instantsearch">
           Vue InstantSearch
         </a>
       </p>

--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch/README.md
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch/README.md
@@ -1,6 +1,6 @@
 # {{name}}
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch/src/App.vue
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch/src/App.vue
@@ -8,7 +8,7 @@
       </h1>
       <p class="header-subtitle">
         using
-        <a href="https://github.com/algolia/vue-instantsearch">
+        <a href="https://github.com/algolia/instantsearch/tree/master/packages/vue-instantsearch">
           Vue InstantSearch
         </a>
       </p>


### PR DESCRIPTION
**Summary**

This PR updates the links pointing to the monorepo for the `create-instantsearch-app` package.

**Result**

Links to the old `algolia/instantsearch.js` repo are now pointing to the `algolia/instantsearch` monorepo.
e2e test snapshots have been updated as well.
