### PR TITLE
test(DynamicWidgets): clearer assertions for widgets

### DIFF
--- a/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
@@ -445,25 +445,21 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current).toMatchInlineSnapshot(`
-      Widget(ais.index) {
-        $$widgetType: ais.index
-        indexId: indexName
-        widgets: [
-          Widget(ais.index) {
-            $$widgetType: ais.index
-            indexId: subIndexName
-            widgets: [
-              Widget(ais.refinementList) {
-                attribute: brand
-              }
-              Widget(ais.dynamicWidgets) {
-                $$widgetType: ais.dynamicWidgets
-              }
-            ]
-          }
-        ]
-      }
+    expect(indexContextRef.current!.getWidgets()).toMatchInlineSnapshot(`
+      [
+        Widget(ais.index) {
+          $$widgetType: ais.index
+          indexId: subIndexName
+          widgets: [
+            Widget(ais.refinementList) {
+              attribute: brand
+            }
+            Widget(ais.dynamicWidgets) {
+              $$widgetType: ais.dynamicWidgets
+            }
+          ]
+        },
+      ]
     `);
   });
 

--- a/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { createSearchClient } from '@instantsearch/mocks';
+import { widgetSnapshotSerializer } from '@instantsearch/testutils';
 import { act, render, waitFor } from '@testing-library/react';
 import React, { createRef } from 'react';
 
@@ -21,6 +22,8 @@ import type { UsePaginationProps } from '../../connectors/usePagination';
 import type { UseRefinementListProps } from '../../connectors/useRefinementList';
 import type { InstantSearchProps } from '../InstantSearch';
 import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
+
+expect.addSnapshotSerializer(widgetSnapshotSerializer);
 
 function Pagination(props: UsePaginationProps) {
   usePagination(props);
@@ -139,10 +142,16 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
-      'ais.refinementList',
-      'ais.dynamicWidgets',
-    ]);
+    expect(indexContextRef.current!.getWidgets()).toMatchInlineSnapshot(`
+      [
+        Widget(ais.refinementList) {
+          attribute: brand
+        },
+        Widget(ais.dynamicWidgets) {
+          $$widgetType: ais.dynamicWidgets
+        },
+      ]
+    `);
   });
 
   test('renders widgets in components', async () => {
@@ -179,10 +188,16 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
-      'ais.refinementList',
-      'ais.dynamicWidgets',
-    ]);
+    expect(indexContextRef.current!.getWidgets()).toMatchInlineSnapshot(`
+      [
+        Widget(ais.refinementList) {
+          attribute: brand
+        },
+        Widget(ais.dynamicWidgets) {
+          $$widgetType: ais.dynamicWidgets
+        },
+      ]
+    `);
   });
 
   test('throws when a nested component contains multiple children', () => {
@@ -284,10 +299,16 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
-      'ais.refinementList',
-      'ais.dynamicWidgets',
-    ]);
+    expect(indexContextRef.current!.getWidgets()).toMatchInlineSnapshot(`
+      [
+        Widget(ais.refinementList) {
+          attribute: brand
+        },
+        Widget(ais.dynamicWidgets) {
+          $$widgetType: ais.dynamicWidgets
+        },
+      ]
+    `);
   });
 
   test('renders attributes without widget with fallbackComponent', async () => {
@@ -321,12 +342,22 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
-      'ais.refinementList',
-      'ais.menu',
-      'ais.menu',
-      'ais.dynamicWidgets',
-    ]);
+    expect(indexContextRef.current!.getWidgets()).toMatchInlineSnapshot(`
+      [
+        Widget(ais.refinementList) {
+          attribute: brand
+        },
+        Widget(ais.menu) {
+          attribute: categories
+        },
+        Widget(ais.menu) {
+          attribute: hierarchicalCategories.lvl0
+        },
+        Widget(ais.dynamicWidgets) {
+          $$widgetType: ais.dynamicWidgets
+        },
+      ]
+    `);
   });
 
   test('renders attributes without widget with fallbackComponent (function form)', async () => {
@@ -414,18 +445,26 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    const index = indexContextRef
-      .current!.getWidgets()
-      .find<IndexWidget>(
-        (widget): widget is IndexWidget => widget.$$type === 'ais.index'
-      )!;
-    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
-      'ais.index',
-    ]);
-    expect(index.getWidgets().map((w) => w.$$type)).toEqual([
-      'ais.refinementList',
-      'ais.dynamicWidgets',
-    ]);
+    expect(indexContextRef.current).toMatchInlineSnapshot(`
+      Widget(ais.index) {
+        $$widgetType: ais.index
+        indexId: indexName
+        widgets: [
+          Widget(ais.index) {
+            $$widgetType: ais.index
+            indexId: subIndexName
+            widgets: [
+              Widget(ais.refinementList) {
+                attribute: brand
+              }
+              Widget(ais.dynamicWidgets) {
+                $$widgetType: ais.dynamicWidgets
+              }
+            ]
+          }
+        ]
+      }
+    `);
   });
 
   test('dynamically updates widgets when attributes change', async () => {
@@ -460,10 +499,16 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
-      'ais.refinementList',
-      'ais.dynamicWidgets',
-    ]);
+    expect(indexContextRef.current!.getWidgets()).toMatchInlineSnapshot(`
+      [
+        Widget(ais.refinementList) {
+          attribute: brand
+        },
+        Widget(ais.dynamicWidgets) {
+          $$widgetType: ais.dynamicWidgets
+        },
+      ]
+    `);
 
     act(() => {
       rerender(<App attributes={['brand', 'categories']} />);
@@ -480,11 +525,19 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
-      'ais.refinementList',
-      'ais.dynamicWidgets',
-      'ais.menu',
-    ]);
+    expect(indexContextRef.current!.getWidgets()).toMatchInlineSnapshot(`
+      [
+        Widget(ais.refinementList) {
+          attribute: brand
+        },
+        Widget(ais.dynamicWidgets) {
+          $$widgetType: ais.dynamicWidgets
+        },
+        Widget(ais.menu) {
+          attribute: categories
+        },
+      ]
+    `);
 
     act(() => {
       rerender(<App attributes={['brand']} />);
@@ -500,10 +553,16 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
-      'ais.refinementList',
-      'ais.dynamicWidgets',
-    ]);
+    expect(indexContextRef.current!.getWidgets()).toMatchInlineSnapshot(`
+      [
+        Widget(ais.refinementList) {
+          attribute: brand
+        },
+        Widget(ais.dynamicWidgets) {
+          $$widgetType: ais.dynamicWidgets
+        },
+      ]
+    `);
 
     consoleError.mockRestore();
   });

--- a/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/DynamicWidgets.test.tsx
@@ -139,9 +139,9 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets()).toEqual([
-      expect.objectContaining({ $$type: 'ais.refinementList' }),
-      expect.objectContaining({ $$type: 'ais.dynamicWidgets' }),
+    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
+      'ais.refinementList',
+      'ais.dynamicWidgets',
     ]);
   });
 
@@ -179,9 +179,9 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets()).toEqual([
-      expect.objectContaining({ $$type: 'ais.refinementList' }),
-      expect.objectContaining({ $$type: 'ais.dynamicWidgets' }),
+    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
+      'ais.refinementList',
+      'ais.dynamicWidgets',
     ]);
   });
 
@@ -284,9 +284,9 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets()).toEqual([
-      expect.objectContaining({ $$type: 'ais.refinementList' }),
-      expect.objectContaining({ $$type: 'ais.dynamicWidgets' }),
+    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
+      'ais.refinementList',
+      'ais.dynamicWidgets',
     ]);
   });
 
@@ -321,11 +321,11 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets()).toEqual([
-      expect.objectContaining({ $$type: 'ais.refinementList' }),
-      expect.objectContaining({ $$type: 'ais.menu' }),
-      expect.objectContaining({ $$type: 'ais.menu' }),
-      expect.objectContaining({ $$type: 'ais.dynamicWidgets' }),
+    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
+      'ais.refinementList',
+      'ais.menu',
+      'ais.menu',
+      'ais.dynamicWidgets',
     ]);
   });
 
@@ -419,12 +419,12 @@ describe('DynamicWidgets', () => {
       .find<IndexWidget>(
         (widget): widget is IndexWidget => widget.$$type === 'ais.index'
       )!;
-    expect(indexContextRef.current!.getWidgets()).toEqual([
-      expect.objectContaining({ $$type: 'ais.index' }),
+    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
+      'ais.index',
     ]);
-    expect(index.getWidgets()).toEqual([
-      expect.objectContaining({ $$type: 'ais.refinementList' }),
-      expect.objectContaining({ $$type: 'ais.dynamicWidgets' }),
+    expect(index.getWidgets().map((w) => w.$$type)).toEqual([
+      'ais.refinementList',
+      'ais.dynamicWidgets',
     ]);
   });
 
@@ -460,9 +460,9 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets()).toEqual([
-      expect.objectContaining({ $$type: 'ais.refinementList' }),
-      expect.objectContaining({ $$type: 'ais.dynamicWidgets' }),
+    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
+      'ais.refinementList',
+      'ais.dynamicWidgets',
     ]);
 
     act(() => {
@@ -480,10 +480,10 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets()).toEqual([
-      expect.objectContaining({ $$type: 'ais.refinementList' }),
-      expect.objectContaining({ $$type: 'ais.dynamicWidgets' }),
-      expect.objectContaining({ $$type: 'ais.menu' }),
+    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
+      'ais.refinementList',
+      'ais.dynamicWidgets',
+      'ais.menu',
     ]);
 
     act(() => {
@@ -500,9 +500,9 @@ describe('DynamicWidgets', () => {
       </div>
     `);
 
-    expect(indexContextRef.current!.getWidgets()).toEqual([
-      expect.objectContaining({ $$type: 'ais.refinementList' }),
-      expect.objectContaining({ $$type: 'ais.dynamicWidgets' }),
+    expect(indexContextRef.current!.getWidgets().map((w) => w.$$type)).toEqual([
+      'ais.refinementList',
+      'ais.dynamicWidgets',
     ]);
 
     consoleError.mockRestore();

--- a/tests/utils/widgetSnapshotSerializer.ts
+++ b/tests/utils/widgetSnapshotSerializer.ts
@@ -1,6 +1,9 @@
 import type { InitOptions, Widget } from 'instantsearch.js';
 import type { IndexWidget } from 'instantsearch.js/es/widgets/index/index';
-import { getWidgetAttribute } from 'instantsearch.js/es/lib/utils';
+import {
+  getWidgetAttribute,
+  isIndexWidget,
+} from 'instantsearch.js/es/lib/utils';
 import { createInitOptions } from 'instantsearch.js/test/createWidget';
 
 function getAttribute(widget: Widget | IndexWidget) {
@@ -28,6 +31,20 @@ export const widgetSnapshotSerializer: jest.SnapshotSerializerPlugin = {
     const keys = {
       $$widgetType: widget.$$widgetType,
       attribute: getAttribute(widget),
+      widgets:
+        isIndexWidget(widget) &&
+        `[\n${indentation + indent + indent}${widget
+          .getWidgets()
+          .map((w) =>
+            (this as any).serialize(
+              w,
+              { indent },
+              indentation + indent + indent
+            )
+          )
+          .join(`\n${indentation + indent + indent}`)}\n${
+          indentation + indent
+        }]`,
     };
 
     const widgetName = `Widget(${widget.$$type || 'unknown'})`;

--- a/tests/utils/widgetSnapshotSerializer.ts
+++ b/tests/utils/widgetSnapshotSerializer.ts
@@ -31,6 +31,7 @@ export const widgetSnapshotSerializer: jest.SnapshotSerializerPlugin = {
     const keys = {
       $$widgetType: widget.$$widgetType,
       attribute: getAttribute(widget),
+      indexId: isIndexWidget(widget) && widget.getIndexId(),
       widgets:
         isIndexWidget(widget) &&
         `[\n${indentation + indent + indent}${widget


### PR DESCRIPTION
When the assertions for objectContaining fail, they give a whole lot of information that isn't actually useful, as we only want to know the type.

I therefore changed it to using the snapshot serialiser we have for widgets, and the diffs are much neater when there's the wrong widgets mounted.