### PR TITLE
feat(insights): remove useCookie from default parameters

### DIFF
--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -38,7 +38,7 @@
     "htm": "^3.0.0",
     "preact": "^10.10.0",
     "qs": "^6.5.1 < 6.10",
-    "search-insights": "^2.5.0"
+    "search-insights": "^2.6.0"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.1 < 6"

--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -38,7 +38,7 @@
     "htm": "^3.0.0",
     "preact": "^10.10.0",
     "qs": "^6.5.1 < 6.10",
-    "search-insights": "^2.4.0"
+    "search-insights": "^2.5.0"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.1 < 6"

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -488,7 +488,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
     });
 
     test('insights: options passes options to middleware', () => {
-      const insightsClient = Object.assign(jest.fn(), { version: '2.4.0' });
+      const insightsClient = Object.assign(jest.fn(), { version: '2.6.0' });
       const search = new InstantSearch({
         searchClient: createSearchClient(),
         indexName: 'test',

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -177,7 +177,7 @@ describe('insights', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.4.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.min.js"
           />
         </body>
       `);
@@ -220,7 +220,7 @@ describe('insights', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.4.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.min.js"
           />
         </body>
       `);
@@ -240,7 +240,7 @@ describe('insights', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.4.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.min.js"
           />
         </body>
       `);
@@ -435,7 +435,10 @@ describe('insights', () => {
       instantSearchInstance.use(
         createInsightsMiddleware({
           insightsClient,
-          insightsInitParams: { useCookie: false },
+          insightsInitParams: {
+            useCookie: false,
+            anonymousUserToken: false,
+          },
         })
       );
 

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -41,7 +41,7 @@ export type InsightsProps<
   $$internal?: boolean;
 };
 
-const ALGOLIA_INSIGHTS_VERSION = '2.4.0';
+const ALGOLIA_INSIGHTS_VERSION = '2.5.0';
 const ALGOLIA_INSIGHTS_SRC = `https://cdn.jsdelivr.net/npm/search-insights@${ALGOLIA_INSIGHTS_VERSION}/dist/search-insights.min.js`;
 
 export type InsightsClientWithGlobals = InsightsClient & {
@@ -146,7 +146,6 @@ export function createInsightsMiddleware<
       insightsClient('init', {
         appId,
         apiKey,
-        useCookie: true,
         partial: true,
         ...insightsInitParams,
       });
@@ -322,9 +321,9 @@ function isModernInsightsClient(client: InsightsClientWithGlobals): boolean {
 
   /* eslint-disable @typescript-eslint/naming-convention */
   const v3 = major >= 3;
-  const v2_4 = major === 2 && minor >= 4;
+  const v2_5 = major === 2 && minor >= 5;
   const v1_10 = major === 1 && minor >= 10;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  return v3 || v2_4 || v1_10;
+  return v3 || v2_5 || v1_10;
 }

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -42,7 +42,7 @@ export type InsightsProps<
   $$internal?: boolean;
 };
 
-const ALGOLIA_INSIGHTS_VERSION = '2.5.0';
+const ALGOLIA_INSIGHTS_VERSION = '2.6.0';
 const ALGOLIA_INSIGHTS_SRC = `https://cdn.jsdelivr.net/npm/search-insights@${ALGOLIA_INSIGHTS_VERSION}/dist/search-insights.min.js`;
 
 export type InsightsClientWithGlobals = InsightsClient & {

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -31,6 +31,7 @@ export type InsightsProps<
   insightsInitParams?: {
     userHasOptedOut?: boolean;
     useCookie?: boolean;
+    anonymousUserToken?: boolean;
     cookieDuration?: number;
     region?: 'de' | 'us';
   };
@@ -321,9 +322,9 @@ function isModernInsightsClient(client: InsightsClientWithGlobals): boolean {
 
   /* eslint-disable @typescript-eslint/naming-convention */
   const v3 = major >= 3;
-  const v2_5 = major === 2 && minor >= 5;
+  const v2_6 = major === 2 && minor >= 6;
   const v1_10 = major === 1 && minor >= 10;
   /* eslint-enable @typescript-eslint/naming-convention */
 
-  return v3 || v2_5 || v1_10;
+  return v3 || v2_6 || v1_10;
 }

--- a/packages/react-instantsearch-hooks/src/__tests__/insights.test.tsx
+++ b/packages/react-instantsearch-hooks/src/__tests__/insights.test.tsx
@@ -29,7 +29,7 @@ describe('insights', () => {
       <body>
         <div />
         <script
-          src="https://cdn.jsdelivr.net/npm/search-insights@2.4.0/dist/search-insights.min.js"
+          src="https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.min.js"
         />
       </body>
     `);

--- a/tests/common/widgets/hits/insights.ts
+++ b/tests/common/widgets/hits/insights.ts
@@ -22,7 +22,7 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -136,7 +136,7 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 25;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -272,7 +272,7 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -354,7 +354,7 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -440,7 +440,7 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -537,7 +537,7 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -619,7 +619,7 @@ export function createInsightsTests(setup: HitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',

--- a/tests/common/widgets/infinite-hits/insights.ts
+++ b/tests/common/widgets/infinite-hits/insights.ts
@@ -22,7 +22,7 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -136,7 +136,7 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 25;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -272,7 +272,7 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -354,7 +354,7 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -440,7 +440,7 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -537,7 +537,7 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -619,7 +619,7 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.4.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',

--- a/tests/mocks/createInsightsClient.ts
+++ b/tests/mocks/createInsightsClient.ts
@@ -15,8 +15,8 @@ try {
   delete window.AlgoliaAnalyticsObject;
 } catch (error) {} // eslint-disable-line no-empty
 
-export function createInsights<TVersion extends string | undefined = '2.4.0'>({
-  forceVersion = '2.4.0',
+export function createInsights<TVersion extends string | undefined = '2.6.0'>({
+  forceVersion = '2.6.0',
 }: {
   forceVersion?: TVersion;
 } = {}) {
@@ -45,10 +45,13 @@ export function createInsights<TVersion extends string | undefined = '2.4.0'>({
 }
 
 export function createInsightsUmdVersion() {
-  const globalObject: { AlgoliaAnalyticsObject: string; aa?: InsightsClient } =
-    {
-      AlgoliaAnalyticsObject: 'aa',
-    };
+  const globalObject: {
+    AlgoliaAnalyticsObject: 'aa';
+    aa?: InsightsClient;
+  } = {
+    AlgoliaAnalyticsObject: 'aa',
+  };
+
   globalObject.aa = (methodName, ...args) => {
     globalObject.aa!.queue = globalObject.aa!.queue || [];
     // @ts-expect-error TypeScript loses track of the exact tuple type when the array gets recreated

--- a/yarn.lock
+++ b/yarn.lock
@@ -8521,7 +8521,7 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-algoliasearch-helper@3.11.3, algoliasearch-helper@^3.11.2, algoliasearch-helper@^3.11.3:
+algoliasearch-helper@3.11.3, algoliasearch-helper@^3.11.3:
   version "3.11.3"
   resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.11.3.tgz#6e7af8afe6f9a9e55186abffb7b6cf7ca8de3301"
   integrity sha512-TbaEvLwiuGygHQIB8y+OsJKQQ40+JKUua5B91X66tMUHyyhbNHvqyr0lqd3wCoyKx7WybyQrC0WJvzoIeh24Aw==
@@ -28436,16 +28436,6 @@ react-inspector@^4.0.0:
     prop-types "^15.6.1"
     storybook-chromatic "^2.2.2"
 
-react-instantsearch-hooks@6.38.3:
-  version "6.38.3"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-hooks/-/react-instantsearch-hooks-6.38.3.tgz#07757be19871d5d088038d96674b574660c540c7"
-  integrity sha512-Sgdh9LripR/Xx3qeIsL+BA6hy0gBm+jgFPSi5leB4ypwUtijxDV24fEnZsRZJqIuYuA+n+KCxQEaDJKOWPymrg==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    algoliasearch-helper "^3.11.2"
-    instantsearch.js "^4.49.4"
-    use-sync-external-store "^1.0.0"
-
 react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -30442,10 +30432,10 @@ scule@^0.2.1:
   resolved "https://registry.yarnpkg.com/scule/-/scule-0.2.1.tgz#0c1dc847b18e07219ae9a3832f2f83224e2079dc"
   integrity sha512-M9gnWtn3J0W+UhJOHmBxBTwv8mZCan5i1Himp60t6vvZcor0wr+IM0URKmIglsWJ7bRujNAVVN77fp+uZaWoKg==
 
-search-insights@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.4.0.tgz#7b6b19527dd186b459f6e2dd7e01f7a3de96ffe7"
-  integrity sha512-AqXxWFEIZTfOf0brQLvoAZcotrVX0xR/VoPCzBxsTZF/yO+izIH1eFCtKizR/dGI8NCMOTdc7l90hAOI68dBbg==
+search-insights@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.6.0.tgz#bb8771a73b83c4a0f1f207c2f64fea01acd3e7d0"
+  integrity sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw==
 
 section-iterator@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Thanks to http://github.com/algolia/search-insights.js/pull/441 token can be set automatically, so useCookie isn't needed anymore.

Because of this, the minimum modern version of search-insights is 2.6.0

FX-2304