### PR TITLE
feat(history): warn when `createURL` does not return an absolute URL

### DIFF
--- a/packages/instantsearch.js/src/lib/routers/__tests__/history.test.ts
+++ b/packages/instantsearch.js/src/lib/routers/__tests__/history.test.ts
@@ -6,7 +6,7 @@ import { createSearchClient } from '@instantsearch/mocks';
 
 import instantsearch from '../../..';
 import { simple } from '../../stateMappings';
-import { noop } from '../../utils';
+import { noop, warning } from '../../utils';
 import historyRouter from '../history';
 
 import type { UiState } from '../../../types';
@@ -259,6 +259,18 @@ describe('life cycle', () => {
       router.dispose();
 
       expect(dispose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('createURL', () => {
+    test('prints a warning when created URL is not valid', () => {
+      warning.cache = {};
+
+      const router = historyRouter<UiState>({ createURL: () => '/search' });
+
+      expect(() => router.createURL({ indexName: {} }))
+        .toWarnDev(`[InstantSearch.js]: The URL returned by the \`createURL\` function is invalid.
+Please make sure it returns an absolute URL to avoid issues, e.g: \`https://algolia.com/search?query=iphone\`.`);
     });
   });
 });

--- a/packages/instantsearch.js/src/lib/routers/history.ts
+++ b/packages/instantsearch.js/src/lib/routers/history.ts
@@ -213,16 +213,18 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
       location: this.getLocation(),
     });
 
-    try {
-      // We just want to check if the URL is valid.
-      // eslint-disable-next-line no-new
-      new URL(url);
-    } catch (e) {
-      warning(
-        false,
-        `The URL returned by the \`createURL\` function is invalid.
-Please make sure it returns an absolute URL to avoid issues, e.g: \`https://algolia.com/search?query=iphone\`.`
-      );
+    if (__DEV__) {
+      try {
+        // We just want to check if the URL is valid.
+        // eslint-disable-next-line no-new
+        new URL(url);
+      } catch (e) {
+        warning(
+          false,
+          `The URL returned by the \`createURL\` function is invalid.
+  Please make sure it returns an absolute URL to avoid issues, e.g: \`https://algolia.com/search?query=iphone\`.`
+        );
+      }
     }
 
     return url;

--- a/packages/instantsearch.js/src/lib/routers/history.ts
+++ b/packages/instantsearch.js/src/lib/routers/history.ts
@@ -222,7 +222,7 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
         warning(
           false,
           `The URL returned by the \`createURL\` function is invalid.
-  Please make sure it returns an absolute URL to avoid issues, e.g: \`https://algolia.com/search?query=iphone\`.`
+Please make sure it returns an absolute URL to avoid issues, e.g: \`https://algolia.com/search?query=iphone\`.`
         );
       }
     }

--- a/packages/instantsearch.js/src/lib/routers/history.ts
+++ b/packages/instantsearch.js/src/lib/routers/history.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 
-import { safelyRunOnBrowser } from '../utils';
+import { safelyRunOnBrowser, warning } from '../utils';
 
 import type { Router, UiState } from '../../types';
 
@@ -207,11 +207,25 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
    * See: https://github.com/algolia/instantsearch.js/issues/790
    */
   public createURL(routeState: TRouteState): string {
-    return this._createURL({
+    const url = this._createURL({
       qsModule: qs,
       routeState,
       location: this.getLocation(),
     });
+
+    try {
+      // We just want to check if the URL is valid.
+      // eslint-disable-next-line no-new
+      new URL(url);
+    } catch (e) {
+      warning(
+        false,
+        `The URL returned by the \`createURL\` function is invalid.
+Please make sure it returns an absolute URL to avoid issues, e.g: \`https://algolia.com/search?query=iphone\`.`
+      );
+    }
+
+    return url;
   }
 
   /**


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

There are two reasons we want users to create absolute URLs with `createURL` : 

- This issue which is actually mentioned in comments : #790 
- In [shouldWrite](https://github.com/algolia/instantsearch/blob/a8b5c1e5bbd6afac39fce523f7d7c2ec02f51153/packages/instantsearch.js/src/lib/routers/history.ts#L263) we expect it to match `window.location.href`.

At first I was thinking about ignoring what's before the `pathname` in `shouldWrite` but as there are other reasons we want URLs to be absolute, I think adding a warning might be what's best.

**Result**

Added a test to check that it's outputted.
