### PR TITLE
docs(react-instantsearch-hooks-router-nextjs): add a warning about static rendering

### DIFF
--- a/packages/react-instantsearch-hooks-router-nextjs/README.md
+++ b/packages/react-instantsearch-hooks-router-nextjs/README.md
@@ -16,6 +16,8 @@
 
 This package is a router for [React InstantSearch Hooks](https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react-hooks/) that is compatible with [Next.js](https://nextjs.org/) routing.
 
+> :warning: **This function cannot be used in conjunction with [`getStaticProps()`](https://nextjs.org/docs/api-reference/data-fetching/get-static-props). Use `getServerSideProps()` or client-side rendering instead.**
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
**Summary**

This PR adds a warning about the Next.js function `getStaticProps()` incompatibility with the `createInstantSearchRouterNext()` function using RISH.

This is related to this issue: https://github.com/algolia/instantsearch/issues/5617
