### PR TITLE
fix(insights): send default click event when using auxiliary pointer button

### DIFF
--- a/packages/instantsearch.js/src/components/Hits/Hits.tsx
+++ b/packages/instantsearch.js/src/components/Hits/Hits.tsx
@@ -68,6 +68,10 @@ export default function Hits({
                 handleInsightsClick(event);
                 sendEvent('click:internal', hit, 'Hit Clicked');
               },
+              onAuxClick: (event: MouseEvent) => {
+                handleInsightsClick(event);
+                sendEvent('click:internal', hit, 'Hit Clicked');
+              },
             }}
             key={hit.objectID}
             data={{

--- a/packages/instantsearch.js/src/components/Hits/__tests__/__snapshots__/Hits-test.tsx.snap
+++ b/packages/instantsearch.js/src/components/Hits/__tests__/__snapshots__/Hits-test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Hits markup should render <Hits /> 1`] = `
           "__html": "item",
         }
       }
+      onAuxClick={[Function]}
       onClick={[Function]}
     />
     <li
@@ -23,6 +24,7 @@ exports[`Hits markup should render <Hits /> 1`] = `
           "__html": "item",
         }
       }
+      onAuxClick={[Function]}
       onClick={[Function]}
     />
   </ol>
@@ -45,6 +47,7 @@ exports[`Hits markup should render <Hits /> without highlight function 1`] = `
 </mark>,
         }
       }
+      onAuxClick={[Function]}
       onClick={[Function]}
     />
     <li
@@ -56,6 +59,7 @@ exports[`Hits markup should render <Hits /> without highlight function 1`] = `
 </mark>,
         }
       }
+      onAuxClick={[Function]}
       onClick={[Function]}
     />
   </ol>

--- a/packages/instantsearch.js/src/components/InfiniteHits/InfiniteHits.tsx
+++ b/packages/instantsearch.js/src/components/InfiniteHits/InfiniteHits.tsx
@@ -100,6 +100,10 @@ const InfiniteHits = ({
                 handleInsightsClick(event);
                 sendEvent('click:internal', hit, 'Hit Clicked');
               },
+              onAuxClick: (event: MouseEvent) => {
+                handleInsightsClick(event);
+                sendEvent('click:internal', hit, 'Hit Clicked');
+              },
             }}
             key={hit.objectID}
             data={{

--- a/packages/react-instantsearch-hooks-web/src/ui/Hits.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/Hits.tsx
@@ -67,6 +67,9 @@ export function Hits<THit extends Hit>({
             onClick={() => {
               sendEvent('click:internal', hit, 'Hit Clicked');
             }}
+            onAuxClick={() => {
+              sendEvent('click:internal', hit, 'Hit Clicked');
+            }}
           >
             <HitComponent hit={hit} sendEvent={sendEvent} />
           </li>

--- a/packages/react-instantsearch-hooks-web/src/ui/InfiniteHits.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/InfiniteHits.tsx
@@ -116,6 +116,9 @@ export function InfiniteHits<THit extends Hit>({
             onClick={() => {
               sendEvent('click:internal', hit, 'Hit Clicked');
             }}
+            onAuxClick={() => {
+              sendEvent('click:internal', hit, 'Hit Clicked');
+            }}
           >
             <HitComponent hit={hit} sendEvent={sendEvent} />
           </li>

--- a/packages/vue-instantsearch/src/components/Hits.vue
+++ b/packages/vue-instantsearch/src/components/Hits.vue
@@ -11,6 +11,7 @@
           :key="item.objectID"
           :class="suit('item')"
           @click="state.sendEvent('click:internal', item, 'Hit Clicked')"
+          @auxclick="state.sendEvent('click:internal', item, 'Hit Clicked')"
         >
           <slot
             name="item"

--- a/packages/vue-instantsearch/src/components/InfiniteHits.vue
+++ b/packages/vue-instantsearch/src/components/InfiniteHits.vue
@@ -35,6 +35,7 @@
           :class="suit('item')"
           :key="item.objectID"
           @click="state.sendEvent('click:internal', item, 'Hit Clicked')"
+          @auxclick="state.sendEvent('click:internal', item, 'Hit Clicked')"
         >
           <slot
             name="item"

--- a/tests/common/widgets/infinite-hits/insights.ts
+++ b/tests/common/widgets/infinite-hits/insights.ts
@@ -1,5 +1,5 @@
 import { wait } from '@instantsearch/testutils';
-import { screen } from '@testing-library/dom';
+import { fireEvent, screen } from '@testing-library/dom';
 import type { MockSearchClient } from '@instantsearch/mocks';
 import {
   createSearchClient,
@@ -329,6 +329,95 @@ export function createInsightsTests(setup: InfiniteHitsSetup, act: Act) {
       {
         window.aa.mockClear();
         userEvent.click(screen.getByTestId('main-hits-top-level-1'));
+
+        expect(window.aa).toHaveBeenCalledTimes(1);
+        expect(window.aa).toHaveBeenCalledWith(
+          'clickedObjectIDsAfterSearch',
+          {
+            eventName: 'Hit Clicked',
+            algoliaSource: ['instantsearch', 'instantsearch-internal'],
+            index: 'indexName',
+            objectIDs: ['indexName-0'],
+            positions: [1],
+          },
+          {
+            headers: {
+              'X-Algolia-API-Key': 'apiKey',
+              'X-Algolia-Application-Id': 'appId',
+            },
+          }
+        );
+      }
+    });
+
+    test('sends a default click event with a middle mouse button click', async () => {
+      const delay = 100;
+      const margin = 10;
+      const hitsPerPage = 2;
+      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          insights: true,
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(
+                  ({
+                    indexName,
+                    params: { page = 0, query } = {},
+                  }: Parameters<SearchClient['search']>[0][number]) =>
+                    createSingleSearchResponse({
+                      hits: Array.from({ length: hitsPerPage }).map(
+                        (_, index) => ({
+                          objectID: `${indexName}-${
+                            page * hitsPerPage + index
+                          }`,
+                        })
+                      ),
+                      query,
+                      page,
+                      nbPages: 20,
+                    })
+                )
+              );
+            }) as MockSearchClient['search'],
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+      window.aa.mockClear();
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      // Initial state, before interaction
+      {
+        expect(
+          document.querySelectorAll('#main-hits .ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+        expect(
+          document.querySelectorAll('#nested-hits .ais-InfiniteHits-item')
+        ).toHaveLength(hitsPerPage);
+      }
+
+      // Click on the first item of the first index with the middle mouse button
+      {
+        window.aa.mockClear();
+        fireEvent(
+          screen.getByTestId('main-hits-top-level-1'),
+          new MouseEvent('auxclick', {
+            bubbles: true,
+            cancelable: true,
+            button: 1,
+          })
+        );
 
         expect(window.aa).toHaveBeenCalledTimes(1);
         expect(window.aa).toHaveBeenCalledWith(


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

From [StackOverflow](https://stackoverflowteams.com/c/algolia/questions/3359).

When insights are enabled, default click events on hits / infinite hits are not sent if a user clicks with their pointer's auxiliary button (usually the mousewheel button). The main use case is opening a product detail page on a new browser tab.

This is because our default handler is set on a `click` event, which is only triggered by actions using the pointer's primary button. Here are more information on how and when this has been implemented by browsers:
- https://developer.chrome.com/blog/auxclick/
- https://bugzilla.mozilla.org/show_bug.cgi?id=1304044

To solve this, hits and infinite hits now also handle the `auxclick` event, triggered by actions using the pointer's auxiliary buttons.

> **Alternative considered**
> 
> Instead of adding another event handler, replacing `click` with `mousedown/mouseup` has been considered, but it breaks our deduplicating behavior, which relies on event bubbling. So users who would still use `click` events on their hit components would not prevent the default click event from being sent.

**Result**

Default click events are now sent when users click with their auxiliary button.
