### PR TITLE
chore(examples): set explicit typescript dev dependency for rish examples

### DIFF
--- a/examples/react-hooks/default-theme/package.json
+++ b/examples/react-hooks/default-theme/package.json
@@ -17,6 +17,7 @@
     "@parcel/core": "2.8.0",
     "@parcel/packager-raw-url": "2.8.0",
     "@parcel/transformer-webmanifest": "2.8.0",
-    "parcel": "2.8.0"
+    "parcel": "2.8.0",
+    "typescript": "4.9.4"
   }
 }

--- a/examples/react-hooks/e-commerce/package.json
+++ b/examples/react-hooks/e-commerce/package.json
@@ -20,6 +20,7 @@
     "@parcel/core": "2.8.0",
     "@parcel/packager-raw-url": "2.8.0",
     "@parcel/transformer-webmanifest": "2.8.0",
-    "parcel": "2.8.0"
+    "parcel": "2.8.0",
+    "typescript": "4.9.4"
   }
 }

--- a/examples/react-hooks/getting-started/package.json
+++ b/examples/react-hooks/getting-started/package.json
@@ -17,6 +17,7 @@
     "@parcel/core": "2.8.0",
     "@parcel/packager-raw-url": "2.8.0",
     "@parcel/transformer-webmanifest": "2.8.0",
-    "parcel": "2.8.0"
+    "parcel": "2.8.0",
+    "typescript": "4.9.4"
   }
 }


### PR DESCRIPTION
**Summary**

This is a quick QOL change that prevents issues on CodeSandbox that could be related to an unsupported TypeScript version.

**Result**

Now users can copy/paste code from our doc to some of our sandboxes without having issues that could be related to the default TypeScript version available in CodeSandbox.