### PR TITLE
fix(cisa): remove fixed isjs dependency from rish templates

### DIFF
--- a/packages/create-instantsearch-app/src/templates/React InstantSearch Hooks Native/package.json
+++ b/packages/create-instantsearch-app/src/templates/React InstantSearch Hooks Native/package.json
@@ -14,7 +14,6 @@
     "algoliasearch": "4.12.1",
     "expo": "~44.0.0",
     "expo-status-bar": "~1.2.0",
-    "instantsearch.js": "4.38.1",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-instantsearch-hooks": "{{libraryVersion}}",

--- a/packages/create-instantsearch-app/src/templates/React InstantSearch Hooks/package.json
+++ b/packages/create-instantsearch-app/src/templates/React InstantSearch Hooks/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "algoliasearch": "4",
-    "instantsearch.js": "4.43.1",
     "react": "18.1.0",
     "react-dom": "18.1.0",
     "react-instantsearch-hooks-web": "{{libraryVersion}}"


### PR DESCRIPTION
**Summary**

This PR removes the fixed declaration of `instantsearch.js` as a dependency from RISH templates in Create InstantSearch App. This can causes type and feature mismatch between React InstantSearch Hooks and InstantSearch.js if versions are not in sync.

Since `instantsearch.js` is already a dependency of `react-instantsearch-hooks`, this is not needed.

**Result**

In React InstantSearch Hooks templates, `instantsearch.js` will be downloaded as a dependency of `react-instantsearch-hooks` with the appropriate version.