### PR TITLE
refactor(deps): replace latest-semver with semver

### DIFF
--- a/packages/create-instantsearch-app/package.json
+++ b/packages/create-instantsearch-app/package.json
@@ -38,7 +38,6 @@
     "commander": "4.1.1",
     "inquirer": "8.0.0",
     "jstransformer-handlebars": "1.1.0",
-    "latest-semver": "2.0.0",
     "load-json-file": "6.2.0",
     "lodash.camelcase": "4.3.0",
     "metalsmith": "2.3.0",

--- a/packages/create-instantsearch-app/src/cli/index.js
+++ b/packages/create-instantsearch-app/src/cli/index.js
@@ -5,7 +5,6 @@ const os = require('os');
 const program = require('commander');
 const inquirer = require('inquirer');
 const chalk = require('chalk');
-const latestSemver = require('latest-semver');
 const semver = require('semver');
 
 const createInstantSearchApp = require('../api');
@@ -75,7 +74,9 @@ const getQuestions = ({ appName }) => ({
 
         try {
           const versions = await fetchLibraryVersions(libraryName);
-          const latestStableVersion = latestSemver(versions);
+          const latestStableVersion = semver.maxSatisfying(versions, '*', {
+            includePrerelease: false,
+          });
 
           if (!latestStableVersion) {
             return versions;

--- a/packages/create-instantsearch-app/src/cli/postProcessAnswers.js
+++ b/packages/create-instantsearch-app/src/cli/postProcessAnswers.js
@@ -1,5 +1,5 @@
 const camelCase = require('lodash.camelcase');
-const latestSemver = require('latest-semver');
+const semver = require('semver');
 
 const { fetchLibraryVersions } = require('../utils');
 
@@ -24,10 +24,13 @@ async function getLibraryVersion(config, templateConfig) {
 
   if (libraryName && !libraryVersion) {
     const versions = await fetchLibraryVersions(libraryName);
+    const latestStableVersion = semver.maxSatisfying(versions, '*', {
+      includePrerelease: false,
+    });
 
     // Return the latest available version when
     // the stable version is not available
-    return latestSemver(versions) || versions[0];
+    return latestStableVersion || versions[0];
   }
 
   return libraryVersion;

--- a/yarn.lock
+++ b/yarn.lock
@@ -21232,13 +21232,6 @@ last-call-webpack-plugin@^3.0.0:
     lodash "^4.17.5"
     webpack-sources "^1.1.0"
 
-latest-semver@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/latest-semver/-/latest-semver-2.0.0.tgz#7208731deb29f1e109f269cff580fb61a792bb17"
-  integrity sha512-l8sU7ghgSK6fnaMMsmSkuLz8VWaHFhWFws6Iw6zIJdxTPC9mBsEZ+XW5nNTfNKWZmO4JMbfKIHXtQQjEO9o5Jw==
-  dependencies:
-    to-semver "^2.0.0"
-
 latest-version@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
@@ -32881,13 +32874,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-to-semver@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/to-semver/-/to-semver-2.0.0.tgz#56eba7579694ff656f526b5c9cb4f62e9776fea8"
-  integrity sha512-ZQbSDYCfuF4weayoQBoLOiLPMNiD/v1VTK05DQKelpWTBa2gYEIVQnLvPQLnC+/TzKqasuE90ma6jSoLry9BDA==
-  dependencies:
-    semver "^6.0.0"
 
 toggle-selection@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

We use both semver and latest-server, and the usage of latest-semver is actually not much simpler than semver directly.


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

no more usage and dependency on latest-semver

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
