### PR TITLE
docs(examples): avoid usage of html-as-a-string

### DIFF
--- a/examples/js/calendar-widget/app.js
+++ b/examples/js/calendar-widget/app.js
@@ -22,12 +22,12 @@ search.addWidgets([
   hits({
     container: '#hits',
     templates: {
-      item: (hit) => `
+      item: (hit, { html, components }) => html`
         <li class="hit">
           <h3>
-            ${instantsearch.highlight({ attribute: 'name', hit })}
+            ${components.Highlight({ attribute: 'name', hit })}
             <small>
-              ${instantsearch.highlight({ attribute: 'location', hit })}
+              ${components.Highlight({ attribute: 'location', hit })}
             </small>
           </h3>
           <small>

--- a/packages/instantsearch.js/stories/answers.stories.ts
+++ b/packages/instantsearch.js/stories/answers.stories.ts
@@ -25,9 +25,7 @@ storiesOf('Results/Answers', module)
           queryLanguages: ['en'],
           attributesForPrediction: ['description'],
           templates: {
-            item: (hit) => {
-              return `<p>${hit._answer.extract}</p>`;
-            },
+            item: (hit, { html }) => html`<p>${hit._answer.extract}</p>`,
           },
         }),
       ]);
@@ -51,9 +49,7 @@ storiesOf('Results/Answers', module)
             header: ({ hits }) => {
               return hits.length === 0 ? '' : `<p>Answers</p>`;
             },
-            item: (hit) => {
-              return `<p>${hit._answer.extract}</p>`;
-            },
+            item: (hit, { html }) => html`<p>${hit._answer.extract}</p>`,
           },
         }),
       ]);

--- a/packages/instantsearch.js/stories/infinite-hits.stories.ts
+++ b/packages/instantsearch.js/stories/infinite-hits.stories.ts
@@ -127,7 +127,7 @@ storiesOf('Results/InfiniteHits', module)
         instantsearch.widgets.infiniteHits({
           container,
           templates: {
-            item: (hit) => `
+            item: (hit, { html }) => html`
               <p>#${hit.__position} ${hit.name}</p>
               <a href="https://google.com">Details</a>
             `,


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Find all usages of hit templates that aren't using the html tagged template, to encourage its usage further


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

No usages for `(hit) => `, all replaced with `(hit, {html}) =>` (except in tests)