### PR TITLE
chore(versions): ensure React InstantSearch Hooks version script runs in CommonJS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -319,7 +319,12 @@ const config = {
       files: ['packages/*/test/module/**/*.cjs'],
       rules: {
         'import/extensions': ['error', 'always'],
-        'import/no-commonjs': ['error', { allowRequire: true }],
+      },
+    },
+    {
+      files: ['*.cjs'],
+      rules: {
+        'import/no-commonjs': 'off',
       },
     },
     {

--- a/packages/react-instantsearch-hooks/package.json
+++ b/packages/react-instantsearch-hooks/package.json
@@ -45,7 +45,7 @@
     "build:umd": "BABEL_ENV=rollup rollup -c rollup.config.js",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
     "test:exports": "node ./test/module/is-es-module.mjs && node ./test/module/is-cjs-module.cjs",
-    "version": "./scripts/version.js"
+    "version": "./scripts/version.cjs"
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",

--- a/packages/react-instantsearch-hooks/scripts/version.cjs
+++ b/packages/react-instantsearch-hooks/scripts/version.cjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable import/no-commonjs */
 
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION




<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

It's written in CommonJS, as that way it's the same as the other packages in the project, but it has `type: module` in the package.json, so needs to be marked as cjs.

Also changed the lint to not need ignore comments in cjs files for using cjs

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

`yarn run version` in React InstantSearch Hooks works without error
