### PR TITLE
tests(algoliaAgent): ensure all algoliaAgents match expectation

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common.test.tsx
@@ -265,7 +265,14 @@ createRangeInputTests(({ instantSearchOptions, widgetParams }) => {
 });
 
 createInstantSearchTests(({ instantSearchOptions }) => {
-  instantsearch(instantSearchOptions).start();
+  instantsearch(instantSearchOptions)
+    .on('error', () => {
+      /*
+       * prevent rethrowing InstantSearch errors, so tests can be asserted.
+       * IRL this isn't needed, as the error doesn't stop execution.
+       */
+    })
+    .start();
 
   return {
     algoliaAgents: [

--- a/packages/instantsearch.js/src/__tests__/common.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common.test.tsx
@@ -10,6 +10,7 @@ import {
   createInfiniteHitsTests,
   createHitsTests,
   createRangeInputTests,
+  createInstantSearchTests,
 } from '@instantsearch/tests';
 
 import instantsearch from '../index.es';
@@ -261,4 +262,16 @@ createRangeInputTests(({ instantSearchOptions, widgetParams }) => {
        */
     })
     .start();
+});
+
+createInstantSearchTests(({ instantSearchOptions }) => {
+  instantsearch(instantSearchOptions).start();
+
+  return {
+    algoliaAgents: [
+      `instantsearch.js (${
+        require('../../../instantsearch.js/package.json').version
+      })`,
+    ],
+  };
 });

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common.test.tsx
@@ -10,6 +10,7 @@ import {
   createInfiniteHitsTests,
   createHitsTests,
   createRangeInputTests,
+  createInstantSearchTests,
 } from '@instantsearch/tests';
 import { act, render } from '@testing-library/react';
 import React from 'react';
@@ -214,4 +215,24 @@ createRangeInputTests(({ instantSearchOptions, widgetParams }) => {
       <GlobalErrorSwallower />
     </InstantSearch>
   );
+}, act);
+
+createInstantSearchTests(({ instantSearchOptions }) => {
+  render(
+    <InstantSearch {...instantSearchOptions}>
+      <GlobalErrorSwallower />
+    </InstantSearch>
+  );
+
+  return {
+    algoliaAgents: [
+      `instantsearch.js (${
+        require('../../../instantsearch.js/package.json').version
+      })`,
+      `react-instantsearch (${
+        require('../../../react-instantsearch-hooks/package.json').version
+      })`,
+      `react (${require('react').version})`,
+    ],
+  };
 }, act);

--- a/packages/vue-instantsearch/src/__tests__/common.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common.test.js
@@ -304,7 +304,9 @@ createInstantSearchTests(({ instantSearchOptions }) => {
   mountApp(
     {
       render: renderCompat((h) =>
-        h(AisInstantSearch, { props: instantSearchOptions })
+        h(AisInstantSearch, { props: instantSearchOptions }, [
+          h(GlobalErrorSwallower),
+        ])
       ),
     },
     document.body.appendChild(document.createElement('div'))

--- a/packages/vue-instantsearch/src/__tests__/common.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common.test.js
@@ -10,6 +10,7 @@ import {
   createInfiniteHitsTests,
   createHitsTests,
   createRangeInputTests,
+  createInstantSearchTests,
 } from '@instantsearch/tests';
 
 import { nextTick, mountApp } from '../../test/utils';
@@ -297,4 +298,27 @@ createRangeInputTests(async ({ instantSearchOptions, widgetParams }) => {
   );
 
   await nextTick();
+});
+
+createInstantSearchTests(({ instantSearchOptions }) => {
+  mountApp(
+    {
+      render: renderCompat((h) =>
+        h(AisInstantSearch, { props: instantSearchOptions })
+      ),
+    },
+    document.body.appendChild(document.createElement('div'))
+  );
+
+  return {
+    algoliaAgents: [
+      `instantsearch.js (${
+        require('../../../instantsearch.js/package.json').version
+      })`,
+      `Vue InstantSearch (${
+        require('../../../vue-instantsearch/package.json').version
+      })`,
+      `Vue (${require('../util/vue-compat').version})`,
+    ],
+  };
 });

--- a/tests/common/common.ts
+++ b/tests/common/common.ts
@@ -6,9 +6,9 @@ type TestSetupOptions = {
   instantSearchOptions: InstantSearchOptions;
 };
 
-export type TestSetup<TOptions = Record<string, unknown>> = (
+export type TestSetup<TOptions = Record<string, unknown>, TResult = void> = (
   options: TestSetupOptions & TOptions
-) => MaybePromise<void>;
+) => MaybePromise<TResult>;
 
 export interface Act {
   (callback: () => Promise<void>): Promise<undefined>;

--- a/tests/common/index.ts
+++ b/tests/common/index.ts
@@ -6,3 +6,4 @@ export * from './widgets/pagination';
 export * from './widgets/infinite-hits';
 export * from './widgets/hits';
 export * from './widgets/range-input';
+export * from './widgets/instantsearch';

--- a/tests/common/widgets/instantsearch/algolia-agent.ts
+++ b/tests/common/widgets/instantsearch/algolia-agent.ts
@@ -1,0 +1,28 @@
+import algoliasearch from 'algoliasearch';
+import type { InstantSearchSetup } from '.';
+import type { Act } from '../../common';
+
+export function createAlgoliaAgentTests(setup: InstantSearchSetup, _act: Act) {
+  describe('algolia agent', () => {
+    test('sets the correct algolia agents', async () => {
+      const searchClient = algoliasearch('appId', 'apiKey');
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {},
+      };
+
+      const { algoliaAgents } = await setup(options);
+
+      const algoliaAgent: string = searchClient.transporter
+        ? (searchClient as any).transporter.userAgent.value
+        : (searchClient as any)._ua;
+
+      expect(algoliaAgent.split(';').map((agent) => agent.trim())).toEqual(
+        expect.arrayContaining(algoliaAgents)
+      );
+    });
+  });
+}

--- a/tests/common/widgets/instantsearch/algolia-agent.ts
+++ b/tests/common/widgets/instantsearch/algolia-agent.ts
@@ -16,7 +16,7 @@ export function createAlgoliaAgentTests(setup: InstantSearchSetup, _act: Act) {
 
       const { algoliaAgents } = await setup(options);
 
-      const algoliaAgent: string = searchClient.transporter
+      const algoliaAgent: string = (searchClient as any).transporter
         ? (searchClient as any).transporter.userAgent.value
         : (searchClient as any)._ua;
 

--- a/tests/common/widgets/instantsearch/index.ts
+++ b/tests/common/widgets/instantsearch/index.ts
@@ -1,0 +1,23 @@
+import type { Act, TestSetup } from '../../common';
+import { fakeAct } from '../../common';
+import { createAlgoliaAgentTests } from './algolia-agent';
+
+export type InstantSearchSetup = TestSetup<
+  Record<string, unknown>,
+  {
+    algoliaAgents: string[];
+  }
+>;
+
+export function createInstantSearchTests(
+  setup: InstantSearchSetup,
+  act: Act = fakeAct
+) {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('InstantSearch common tests', () => {
+    createAlgoliaAgentTests(setup, act);
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

In follow-up of #5662 and #5655 (under FX-2385), a test is added to ensure agents added to algoliasearch stay in sync with the respective package.jsons.

This may somewhat be overkill, but at least we'll be extra sure.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

- a new suite in common test suites for instantsearch
- a method to pass specific assertions per flavour (return of setup function)
- assertions that all versions match the respective package.jsons

In those tests, the server-specific algolia agents aren't tested or asserted upon, as they're too conditional

I used relative imports to make sure Jest doesn't mess with them too much, and used require, as that's not static, but import could easily be used too.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
