### PR TITLE
fix(infiniteHits): correctly avoid writing to cache when dynamicWidgets has no facets in the results

### DIFF
--- a/packages/instantsearch.js/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -17,7 +17,6 @@ import {
   createRenderOptions,
 } from '../../../../test/createWidget';
 import instantsearch from '../../../index.es';
-import { createInfiniteHitsSessionStorageCache } from '../../../lib/infiniteHitsCache';
 import { TAG_PLACEHOLDER, deserializePayload } from '../../../lib/utils';
 import connectInfiniteHits from '../connectInfiniteHits';
 
@@ -868,120 +867,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
 
     expect((results.hits as unknown as EscapedHits).__escaped).toBe(true);
-  });
-
-  it('does not overwrite custom cache when dynamic widgets have no facets in state yet', () => {
-    const sessionStorageCache = createInfiniteHitsSessionStorageCache();
-
-    function getInstance() {
-      const renderFn = jest.fn();
-      const makeWidget = connectInfiniteHits(renderFn);
-      const widget = makeWidget({ cache: sessionStorageCache });
-
-      const helper = algoliasearchHelper({} as SearchClient, '', {});
-      helper.search = jest.fn();
-
-      const instantSearchInstance = createInstantSearch();
-      instantSearchInstance.mainIndex.addWidgets([
-        { $$type: 'ais.dynamicWidgets', init() {} },
-      ]);
-
-      const initOptions = createInitOptions({
-        state: helper.state,
-        helper,
-        instantSearchInstance,
-      });
-
-      widget.init!(initOptions);
-
-      const renderWidget = (
-        args: Partial<ReturnType<typeof createRenderOptions>>
-      ) => {
-        const renderOptions = createRenderOptions({
-          state: helper.state,
-          helper,
-          instantSearchInstance,
-          ...args,
-        });
-
-        widget.render!(renderOptions);
-      };
-      return { helper, renderFn, renderWidget };
-    }
-
-    const firstPageHits = [{ objectID: '1' }, { objectID: '2' }];
-    const secondPageHits = [{ objectID: '3' }, { objectID: '4' }];
-
-    // Load InstantSearch
-    {
-      const { helper, renderFn, renderWidget } = getInstance();
-
-      // Render: page 1
-      let searchResults = new SearchResults(helper.state, [
-        createSingleSearchResponse({ hits: firstPageHits }),
-      ]);
-      renderWidget({ results: searchResults });
-
-      // Simulate facets added to state by Dynamic Widgets
-      helper.setState(helper.state.addFacet('brand'));
-
-      // Rerender: page 1
-      searchResults = new SearchResults(helper.state, [
-        createSingleSearchResponse({
-          facets: { brand: { Apple: 100 } },
-          hits: firstPageHits,
-        }),
-      ]);
-      renderWidget({ results: searchResults });
-
-      let renderOptions = renderFn.mock.calls[2][0];
-      expect(renderOptions.hits).toEqual(firstPageHits);
-      expect(renderOptions.results).toEqual(searchResults);
-
-      // Search: page 2
-      renderOptions.showMore();
-      expect(helper.search).toHaveBeenCalledTimes(1);
-
-      // Render: page 2
-      searchResults = new SearchResults(helper.state, [
-        createSingleSearchResponse({
-          facets: { brand: { Apple: 100 } },
-          hits: secondPageHits,
-        }),
-      ]);
-      renderWidget({ results: searchResults });
-
-      renderOptions = renderFn.mock.calls[3][0];
-      expect(renderOptions.hits).toEqual([...firstPageHits, ...secondPageHits]);
-      expect(renderOptions.results).toEqual(searchResults);
-    }
-
-    // Refresh InstantSearch
-    {
-      const { helper, renderFn, renderWidget } = getInstance();
-
-      // Render: page 2
-      let searchResults = new SearchResults(helper.state, [
-        createSingleSearchResponse({ hits: secondPageHits }),
-      ]);
-      renderWidget({ results: searchResults });
-
-      // Simulate facets added to state by Dynamic Widgets
-      helper.setState(helper.state.addFacet('brand'));
-
-      // Rerender: page 2
-      searchResults = new SearchResults(helper.state, [
-        createSingleSearchResponse({
-          facets: { brand: { Apple: 100 } },
-          hits: secondPageHits,
-        }),
-      ]);
-      renderWidget({ results: searchResults });
-
-      const renderOptions = renderFn.mock.calls[2][0];
-      expect(renderOptions.hits).toEqual([...firstPageHits, ...secondPageHits]);
-      expect(renderOptions.results).toEqual(searchResults);
-    }
   });
 
   describe('dispose', () => {

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -9,6 +9,7 @@ import {
   noop,
   createSendEventForHits,
   createBindEventForHits,
+  walkIndex,
 } from '../../lib/utils';
 
 import type { SendEventForHits, BindEventForHits } from '../../lib/utils';
@@ -356,10 +357,31 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
             { results }
           );
 
+          /*
+            With dynamic widgets, facets are not included in the state before their relevant widgets are mounted. Until then, we need to bail out of writing this incomplete state representation in cache.
+          */
+          let hasDynamicWidgets = false;
+          walkIndex(instantSearchInstance.mainIndex, (indexWidget) => {
+            if (
+              !hasDynamicWidgets &&
+              indexWidget
+                .getWidgets()
+                .some(({ $$type }) => $$type === 'ais.dynamicWidgets')
+            ) {
+              hasDynamicWidgets = true;
+            }
+          });
+
+          const hasNoFacets =
+            !state.disjunctiveFacets?.length &&
+            !(state.facets || []).filter((f) => f !== '*').length &&
+            !state.hierarchicalFacets?.length;
+
           if (
             cachedHits[page] === undefined &&
             !results.__isArtificial &&
-            instantSearchInstance.status === 'idle'
+            instantSearchInstance.status === 'idle' &&
+            !(hasDynamicWidgets && hasNoFacets)
           ) {
             cachedHits[page] = transformedHits;
             cache.write({ state: normalizeState(state), hits: cachedHits });

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -9,7 +9,6 @@ import {
   noop,
   createSendEventForHits,
   createBindEventForHits,
-  walkIndex,
 } from '../../lib/utils';
 
 import type { SendEventForHits, BindEventForHits } from '../../lib/utils';
@@ -357,31 +356,10 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
             { results }
           );
 
-          /*
-            With dynamic widgets, facets are not included in the state before their relevant widgets are mounted. Until then, we need to bail out of writing this incomplete state representation in cache.
-          */
-          let hasDynamicWidgets = false;
-          walkIndex(instantSearchInstance.mainIndex, (indexWidget) => {
-            if (
-              !hasDynamicWidgets &&
-              indexWidget
-                .getWidgets()
-                .some(({ $$type }) => $$type === 'ais.dynamicWidgets')
-            ) {
-              hasDynamicWidgets = true;
-            }
-          });
-
-          const hasNoFacets =
-            !results.disjunctiveFacets?.length &&
-            !results.facets?.length &&
-            !results.hierarchicalFacets?.length;
-
           if (
             cachedHits[page] === undefined &&
             !results.__isArtificial &&
-            instantSearchInstance.status === 'idle' &&
-            !(hasDynamicWidgets && hasNoFacets)
+            instantSearchInstance.status === 'idle'
           ) {
             cachedHits[page] = transformedHits;
             cache.write({ state: normalizeState(state), hits: cachedHits });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

In #5620 we added a logic to ensure cache does not get written when we expect dynamic widgets to be mounted in the future. This check was too strict and prevented writing when they're _were_ widgets, but they had no results.

I have a couple questions still that maybe should be solved:
- is this check still too strict, what if no widgets get mounted? shouldn't we also write to the cache then?
- what if there are static refinement widgets mounted outside of dynamicWidgets? Does that break this check?

I believe both of these questions can be solved after this PR

**Result**

fixup upon https://github.com/algolia/instantsearch/pull/5620
replaces https://github.com/algolia/instantsearch/pull/5668
FX-2397

Read the condition for deciding if there's any widgets mounted from the state, not from the results.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
