### PR TITLE
fix(breadcrumb): align component with specs

### DIFF
--- a/packages/vue-instantsearch/src/components/Breadcrumb.vue
+++ b/packages/vue-instantsearch/src/components/Breadcrumb.vue
@@ -24,26 +24,32 @@
           >
             <slot name="rootLabel">Home</slot>
           </a>
-          <span v-else>
+          <a
+            v-else
+            :href="state.createURL(null)"
+            :class="suit('link')"
+            @click.prevent="state.refine(null)"
+          >
             <slot name="rootLabel">Home</slot>
-          </span>
-        </li>
-        <li
+          </a>
+          <!-- eslint-disable prettier/prettier -->
+        </li><!--
+        --><li
           v-for="(item, index) in state.items"
           :key="item.label"
           :class="[suit('item'), isLastItem(index) && suit('item', 'selected')]"
         >
+          <!-- eslint-enable prettier/prettier -->
           <span :class="suit('separator')" aria-hidden="true">
-            <slot name="separator">></slot>
-          </span>
-          <a
+            <slot name="separator">></slot> </span
+          ><a
             v-if="!isLastItem(index)"
             :href="state.createURL(item.value)"
             :class="suit('link')"
             @click.prevent="state.refine(item.value)"
             >{{ item.label }}</a
           >
-          <span v-else>{{ item.label }}</span>
+          <template v-else>{{ item.label }}</template>
         </li>
       </ul>
     </slot>

--- a/packages/vue-instantsearch/src/components/__tests__/__snapshots__/Breadcrumb.js.snap
+++ b/packages/vue-instantsearch/src/components/__tests__/__snapshots__/Breadcrumb.js.snap
@@ -65,9 +65,7 @@ exports[`custom rootLabel render renders correctly 1`] = `
       >
         &gt;
       </span>
-      <span>
-        Streaming Media Players
-      </span>
+      Streaming Media Players
     </li>
   </ul>
 </div>
@@ -77,9 +75,9 @@ exports[`custom rootLabel render renders correctly without refinement 1`] = `
 <div class="ais-Breadcrumb ais-Breadcrumb--noRefinement">
   <ul class="ais-Breadcrumb-list">
     <li class="ais-Breadcrumb-item ais-Breadcrumb-item--selected">
-      <span>
+      <a class="ais-Breadcrumb-link">
         Home page
-      </span>
+      </a>
     </li>
   </ul>
 </div>
@@ -109,9 +107,7 @@ exports[`custom separator render renders correctly 1`] = `
       >
         ~~
       </span>
-      <span>
-        Streaming Media Players
-      </span>
+      Streaming Media Players
     </li>
   </ul>
 </div>
@@ -141,9 +137,7 @@ exports[`default render renders correctly 1`] = `
       >
         &gt;
       </span>
-      <span>
-        Streaming Media Players
-      </span>
+      Streaming Media Players
     </li>
   </ul>
 </div>
@@ -173,9 +167,7 @@ exports[`default render renders correctly with a selected item 1`] = `
       >
         &gt;
       </span>
-      <span>
-        Streaming Media Players
-      </span>
+      Streaming Media Players
     </li>
   </ul>
 </div>
@@ -209,9 +201,7 @@ exports[`default render renders correctly with an URL for the href 1`] = `
       >
         &gt;
       </span>
-      <span>
-        Streaming Media Players
-      </span>
+      Streaming Media Players
     </li>
   </ul>
 </div>
@@ -221,9 +211,9 @@ exports[`default render renders correctly without refinement 1`] = `
 <div class="ais-Breadcrumb ais-Breadcrumb--noRefinement">
   <ul class="ais-Breadcrumb-list">
     <li class="ais-Breadcrumb-item ais-Breadcrumb-item--selected">
-      <span>
+      <a class="ais-Breadcrumb-link">
         Home
-      </span>
+      </a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

This PR updates the `<ais-breadcrumb>` widget from Vue InstantSearch to render in the same way it's [specified in the specs](https://instantsearchjs.netlify.app/specs/widgets/breadcrumb/).

This is a required step before moving some of the unit tests in a common test suite.

**Result**

The `<ais-breadcrumb>` widget root element is always an `<a>` link and the selected item label is not wrapped in a `<span>` anymore.
