### PR TITLE
feat(algoliaAgent): track Next.js version as Algolia agent

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "packages/react-instantsearch-hooks-web/dist/umd/ReactInstantSearchHooksDOM.min.js",
-      "maxSize": "53.50 kB"
+      "maxSize": "54 kB"
     },
     {
       "path": "packages/react-instantsearch-dom/dist/umd/ReactInstantSearchDOM.min.js",

--- a/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
@@ -189,8 +189,8 @@ describe('getServerState', () => {
   });
 
   test('adds the server user agents', async () => {
-    const nextVersion = '11.1.4';
-    process.env.npm_package_dependencies_next = nextVersion;
+    const nextRuntime = 'nodejs';
+    process.env.NEXT_RUNTIME = nextRuntime;
 
     const searchClient = createAlgoliaSearchClient({});
     const { App } = createTestEnvironment({ searchClient });
@@ -210,7 +210,7 @@ describe('getServerState', () => {
       `react-instantsearch-server (${version})`
     );
     expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
-      `next.js (${nextVersion})`
+      `next.js (${nextRuntime})`
     );
   });
 

--- a/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/getServerState.test.tsx
@@ -189,6 +189,9 @@ describe('getServerState', () => {
   });
 
   test('adds the server user agents', async () => {
+    const nextVersion = '11.1.4';
+    process.env.npm_package_dependencies_next = nextVersion;
+
     const searchClient = createAlgoliaSearchClient({});
     const { App } = createTestEnvironment({ searchClient });
 
@@ -205,6 +208,9 @@ describe('getServerState', () => {
     );
     expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
       `react-instantsearch-server (${version})`
+    );
+    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
+      `next.js (${nextVersion})`
     );
   });
 

--- a/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
@@ -90,6 +90,9 @@ describe('InstantSearch', () => {
   });
 
   test('attaches users agents', () => {
+    const nextVersion = '11.1.4';
+    (window as any).next = { version: nextVersion };
+
     const searchClient = createAlgoliaSearchClient({});
 
     render(
@@ -107,6 +110,9 @@ describe('InstantSearch', () => {
     expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
       `react-instantsearch-hooks (${version})`
     );
+    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
+      `next.js (${nextVersion})`
+    );
   });
 
   test('starts the search on mount', async () => {
@@ -119,7 +125,7 @@ describe('InstantSearch', () => {
       </StrictMode>
     );
 
-    expect(searchContext.current!.started).toEqual(true);
+    expect(searchContext.current?.started).toEqual(true);
 
     await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(0));
   });
@@ -136,7 +142,7 @@ describe('InstantSearch', () => {
       </StrictMode>
     );
 
-    expect(searchContext.current!.started).toEqual(true);
+    expect(searchContext.current?.started).toEqual(true);
 
     await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
   });
@@ -153,15 +159,15 @@ describe('InstantSearch', () => {
       </StrictMode>
     );
 
-    expect(searchContext.current!.started).toEqual(true);
+    expect(searchContext.current?.started).toEqual(true);
 
     await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     unmount();
     await waitFor(() => {
-      expect(searchContext.current!.dispose).toHaveBeenCalledTimes(1);
-      expect(searchContext.current!.started).toEqual(false);
-      expect(searchContext.current!.mainIndex.getWidgets()).toEqual([]);
+      expect(searchContext.current?.dispose).toHaveBeenCalledTimes(1);
+      expect(searchContext.current?.started).toEqual(false);
+      expect(searchContext.current?.mainIndex.getWidgets()).toEqual([]);
     });
   });
 

--- a/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/components/__tests__/InstantSearch.test.tsx
@@ -125,7 +125,7 @@ describe('InstantSearch', () => {
       </StrictMode>
     );
 
-    expect(searchContext.current?.started).toEqual(true);
+    expect(searchContext.current!.started).toEqual(true);
 
     await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(0));
   });
@@ -142,7 +142,7 @@ describe('InstantSearch', () => {
       </StrictMode>
     );
 
-    expect(searchContext.current?.started).toEqual(true);
+    expect(searchContext.current!.started).toEqual(true);
 
     await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
   });
@@ -159,15 +159,15 @@ describe('InstantSearch', () => {
       </StrictMode>
     );
 
-    expect(searchContext.current?.started).toEqual(true);
+    expect(searchContext.current!.started).toEqual(true);
 
     await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
 
     unmount();
     await waitFor(() => {
-      expect(searchContext.current?.dispose).toHaveBeenCalledTimes(1);
-      expect(searchContext.current?.started).toEqual(false);
-      expect(searchContext.current?.mainIndex.getWidgets()).toEqual([]);
+      expect(searchContext.current!.dispose).toHaveBeenCalledTimes(1);
+      expect(searchContext.current!.started).toEqual(false);
+      expect(searchContext.current!.mainIndex.getWidgets()).toEqual([]);
     });
   });
 

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -278,6 +278,6 @@ function getNextVersion() {
   return (
     (typeof window !== 'undefined' &&
       ((window as any).next?.version as string | undefined)) ||
-    (typeof process !== 'undefined' && process.env?.NEXT_RUNTIME)
+    (typeof process !== 'undefined' ? process.env?.NEXT_RUNTIME : undefined)
   );
 }

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -271,12 +271,13 @@ You can ignore this warning if you are using a custom router that suits your nee
 
 /**
  * Gets the version of Next.js if it is available in the `window` object,
- * otherwise it returns the version from the npm package dependencies (in SSR).
+ * otherwise it returns the NEXT_RUNTIME environment variable (in SSR),
+ * which is either `nodejs` or `edge`.
  */
 function getNextVersion() {
   return (
     (typeof window !== 'undefined' &&
       ((window as any).next?.version as string | undefined)) ||
-    process.env.npm_package_dependencies_next
+    process.env?.NEXT_RUNTIME
   );
 }

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -180,7 +180,6 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
   const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const store = useSyncExternalStore<InstantSearch<TUiState, TRouteState>>(
     useCallback(() => {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       const search = searchRef.current!;
 
       // Scenario 1: the component mounts.
@@ -219,10 +218,8 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
         search._preventWidgetCleanup = true;
       };
     }, [forceUpdate]),
-    /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
     () => searchRef.current!,
     () => searchRef.current!
-    /* eslint-enable @typescript-eslint/no-unnecessary-type-assertion */
   );
 
   return store;

--- a/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-hooks/src/lib/useInstantSearchApi.ts
@@ -278,6 +278,6 @@ function getNextVersion() {
   return (
     (typeof window !== 'undefined' &&
       ((window as any).next?.version as string | undefined)) ||
-    process.env?.NEXT_RUNTIME
+    (typeof process !== 'undefined' && process.env?.NEXT_RUNTIME)
   );
 }


### PR DESCRIPTION
**Summary**

This PR tracks the Next.js version by adding it as an Algolia agent when a Next.js app is detected.
To get the Next.js version:
- on the browser: `window.next.version` (e.g. `12.1.6`).
- in SSR: `process.env.NEXT_RUNTIME` (`nodejs` or `edge`).