### PR TITLE
chore(connectToggleRefinement): remove duplicated types

### DIFF
--- a/packages/instantsearch.js/src/connectors/toggle-refinement/types.ts
+++ b/packages/instantsearch.js/src/connectors/toggle-refinement/types.ts
@@ -1,50 +1,6 @@
-import type { SendEventForFacet } from '../../lib/utils';
-import type { Connector, CreateURL, WidgetRenderState } from '../../types';
-
-type ToggleRefinementConnectorParams = {
-  attribute: string;
-  on: string | string[];
-  off: string | string[];
-};
-
-type FacetValue = {
-  isRefined: boolean;
-  count: number;
-};
-
-type ToggleRefinementRenderState = {
-  value: {
-    name: string;
-    isRefined: boolean;
-    count: number | null;
-    onFacetValue: FacetValue;
-    offFacetValue: FacetValue;
-  };
-  createURL: CreateURL<string>;
-  sendEvent: SendEventForFacet;
-  canRefine: boolean;
-  refine: (value: string) => void;
-};
-
-export type ToggleRefinementWidgetDescription = {
-  $$type: 'ais.toggleRefinement';
-  renderState: ToggleRefinementRenderState;
-  indexRenderState: {
-    toggleRefinement: {
-      [attribute: string]: WidgetRenderState<
-        ToggleRefinementRenderState,
-        ToggleRefinementConnectorParams
-      >;
-    };
-  };
-  indexUiState: {
-    toggle: {
-      [attribute: string]: boolean;
-    };
-  };
-};
-
-export type ToggleRefinementConnector = Connector<
+export type {
+  /** @deprecated import from connectToggleRefinement directly */
+  ToggleRefinementConnector,
+  /** @deprecated import from connectToggleRefinement directly */
   ToggleRefinementWidgetDescription,
-  ToggleRefinementConnectorParams
->;
+} from './connectToggleRefinement';


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Types seems to have existed both in a types file and in the connector. I'm assuming this is an oversight from the TypeScript migration where it was migrated two times.

I did not remove the `types.ts` file in case someone depends on it, but can be removed in a next major. I did remove the duplicated types and re-export from the main file instead.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

- dead types removed in toggle-refinement/types.ts
- re-exported the types from main file, but mark them as deprecated

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
