### PR TITLE
fix(router): do not update ui state if there are no widgets

### DIFF
--- a/packages/instantsearch.js/src/middlewares/__tests__/createRouterMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createRouterMiddleware.ts
@@ -8,6 +8,8 @@ import { wait } from '@instantsearch/testutils/wait';
 import instantsearch from '../../index.es';
 import { searchBox } from '../../widgets';
 
+import type { Router } from '../../index.es';
+
 describe('router', () => {
   it('sets initial ui state after reading URL', async () => {
     const searchClient = createSearchClient();
@@ -101,5 +103,42 @@ describe('router', () => {
         },
       }
     `);
+  });
+
+  it('does not update ui state with onUpdate if no widgets have been added', async () => {
+    const state = {
+      'my-index': {
+        query: 'iPhone',
+      },
+    };
+
+    const searchClient = createSearchClient();
+    const router: Router = {
+      onUpdate: jest.fn((callback) => {
+        callback(state);
+      }),
+      read: () => state,
+      write: () => {},
+      createURL: () => '',
+      dispose: () => {},
+    };
+
+    const search = instantsearch({
+      indexName: 'my-index',
+      searchClient,
+      routing: {
+        router,
+      },
+    });
+
+    const setUiStateSpy = jest.spyOn(search, 'setUiState');
+
+    search.mainIndex.getHelper = jest.fn(() => search.mainHelper);
+    search.start();
+
+    await wait(0);
+
+    expect(router.onUpdate).toHaveBeenCalledTimes(1);
+    expect(setUiStateSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/instantsearch.js/src/middlewares/__tests__/createRouterMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createRouterMiddleware.ts
@@ -132,8 +132,6 @@ describe('router', () => {
     });
 
     const setUiStateSpy = jest.spyOn(search, 'setUiState');
-
-    search.mainIndex.getHelper = jest.fn(() => search.mainHelper);
     search.start();
 
     await wait(0);

--- a/packages/instantsearch.js/src/middlewares/createRouterMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createRouterMiddleware.ts
@@ -92,7 +92,9 @@ export const createRouterMiddleware = <
         };
 
         router.onUpdate((route) => {
-          instantSearchInstance.setUiState(stateMapping.routeToState(route));
+          if (instantSearchInstance.mainIndex.getWidgets().length > 0) {
+            instantSearchInstance.setUiState(stateMapping.routeToState(route));
+          }
         });
       },
 


### PR DESCRIPTION
**Summary**

This PR prevents the UI state from being updated when there are no widgets mounted. This can happen intermittently with Next.js when the route is changed to an InstantSearch-enabled page.

See [CR-3772](https://algolia.atlassian.net/browse/CR-3475).

**Result**

When using routing, UI state is not updated on subscribe if widgets are not yet mounted.

[CR-3772]: https://algolia.atlassian.net/browse/CR-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ