### PR TITLE
feat(GeoSearch): expose useGeoSearch() hook in RISH

### DIFF
--- a/examples/react-hooks/getting-started/src/index.tsx
+++ b/examples/react-hooks/getting-started/src/index.tsx
@@ -1,3 +1,4 @@
+import './env';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 

--- a/examples/react-hooks/getting-started/src/index.tsx
+++ b/examples/react-hooks/getting-started/src/index.tsx
@@ -1,4 +1,3 @@
-import './env';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 

--- a/packages/react-instantsearch-hooks/src/connectors/__tests__/useGeoSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/connectors/__tests__/useGeoSearch.test.tsx
@@ -1,0 +1,45 @@
+import { createInstantSearchTestWrapper } from '@instantsearch/testutils';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useGeoSearch } from '../useGeoSearch';
+
+describe('useGeoSearch', () => {
+  test('returns the connector render state', async () => {
+    const wrapper = createInstantSearchTestWrapper();
+    const { result, waitForNextUpdate } = renderHook(() => useGeoSearch(), {
+      wrapper,
+    });
+
+    // Initial render state from manual `getWidgetRenderState`
+    expect(result.current).toEqual({
+      clearMapRefinement: expect.any(Function),
+      currentRefinement: expect.objectContaining({}),
+      hasMapMoveSinceLastRefine: expect.any(Function),
+      isRefinedWithMap: expect.any(Function),
+      isRefineOnMapMove: expect.any(Function),
+      items: [],
+      position: expect.objectContaining({}),
+      refine: expect.any(Function),
+      sendEvent: expect.objectContaining({}),
+      setMapMoveSinceLastRefine: expect.any(Function),
+      toggleRefineOnMapMove: expect.any(Function),
+    });
+
+    await waitForNextUpdate();
+
+    // InstantSearch.js state from the `render` lifecycle step
+    expect(result.current).toEqual({
+      clearMapRefinement: expect.any(Function),
+      currentRefinement: expect.objectContaining({}),
+      hasMapMoveSinceLastRefine: expect.any(Function),
+      isRefinedWithMap: expect.any(Function),
+      isRefineOnMapMove: expect.any(Function),
+      items: [],
+      position: expect.objectContaining({}),
+      refine: expect.any(Function),
+      sendEvent: expect.objectContaining({}),
+      setMapMoveSinceLastRefine: expect.any(Function),
+      toggleRefineOnMapMove: expect.any(Function),
+    });
+  });
+});

--- a/packages/react-instantsearch-hooks/src/connectors/__tests__/useGeoSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/connectors/__tests__/useGeoSearch.test.tsx
@@ -13,14 +13,14 @@ describe('useGeoSearch', () => {
     // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
       clearMapRefinement: expect.any(Function),
-      currentRefinement: expect.objectContaining({}),
+      currentRefinement: undefined,
       hasMapMoveSinceLastRefine: expect.any(Function),
       isRefinedWithMap: expect.any(Function),
       isRefineOnMapMove: expect.any(Function),
       items: [],
-      position: expect.objectContaining({}),
+      position: undefined,
       refine: expect.any(Function),
-      sendEvent: expect.objectContaining({}),
+      sendEvent: expect.any(Function),
       setMapMoveSinceLastRefine: expect.any(Function),
       toggleRefineOnMapMove: expect.any(Function),
     });
@@ -30,14 +30,14 @@ describe('useGeoSearch', () => {
     // InstantSearch.js state from the `render` lifecycle step
     expect(result.current).toEqual({
       clearMapRefinement: expect.any(Function),
-      currentRefinement: expect.objectContaining({}),
+      currentRefinement: undefined,
       hasMapMoveSinceLastRefine: expect.any(Function),
       isRefinedWithMap: expect.any(Function),
       isRefineOnMapMove: expect.any(Function),
       items: [],
-      position: expect.objectContaining({}),
+      position: undefined,
       refine: expect.any(Function),
-      sendEvent: expect.objectContaining({}),
+      sendEvent: expect.any(Function),
       setMapMoveSinceLastRefine: expect.any(Function),
       toggleRefineOnMapMove: expect.any(Function),
     });

--- a/packages/react-instantsearch-hooks/src/connectors/useGeoSearch.ts
+++ b/packages/react-instantsearch-hooks/src/connectors/useGeoSearch.ts
@@ -1,0 +1,28 @@
+import connectGeoSearch from 'instantsearch.js/es/connectors/geo-search/connectGeoSearch';
+
+import { useConnector } from '../hooks/useConnector';
+
+import type { AdditionalWidgetProperties } from '../hooks/useConnector';
+import type { BaseHit } from 'instantsearch.js';
+import type {
+  GeoSearchConnector,
+  GeoSearchConnectorParams,
+  GeoSearchWidgetDescription,
+} from 'instantsearch.js/es/connectors/geo-search/connectGeoSearch';
+
+export type UseGeoSearchProps<THit extends BaseHit = BaseHit> =
+  GeoSearchConnectorParams<THit>;
+
+export function useGeoSearch<THit extends BaseHit>(
+  props?: UseGeoSearchProps<THit>,
+  additionalWidgetProperties?: AdditionalWidgetProperties
+) {
+  return useConnector<
+    GeoSearchConnectorParams<THit>,
+    GeoSearchWidgetDescription<THit>
+  >(
+    connectGeoSearch as GeoSearchConnector<THit>,
+    props,
+    additionalWidgetProperties
+  );
+}


### PR DESCRIPTION
**Summary**

Adds `useGeoSearch()` hook to Reach InstantSearch Hooks

**Result**