### PR TITLE
chore(examples): update vue examples to transpile local helper dependency

### DIFF
--- a/examples/vue/default-theme/babel.config.js
+++ b/examples/vue/default-theme/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['@vue/app'],
+  sourceType: 'unambiguous',
 };

--- a/examples/vue/e-commerce/babel.config.js
+++ b/examples/vue/e-commerce/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['@vue/app'],
+  sourceType: 'unambiguous',
 };

--- a/examples/vue/getting-started/babel.config.js
+++ b/examples/vue/getting-started/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['@vue/app'],
+  sourceType: 'unambiguous',
 };

--- a/examples/vue/media/babel.config.js
+++ b/examples/vue/media/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: ['@vue/app'],
+  sourceType: 'unambiguous',
 };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Since the integration of `algoliasearch-helper` into the monorepo, e2e tests fail on vue-instantsearch examples because of a runtime error.

This is due to babel not transpiling CJS dependencies into ESM when they are locally linked, which is now the case. By setting the relevant config option in babel.config.js on all applicable examples, we can force babel to transpile the helper and prevent this issue from appearing at runtime.

- https://babeljs.io/docs/options#sourcetype
- https://github.com/vuejs/vue-cli/issues/2746

**Result**

e2e tests should now work as expected, because the vue-instantsearch examples are not failing at runtime anymore.
