### PR TITLE
docs(helper): move remaining GitHub links to its new location

### DIFF
--- a/packages/algoliasearch-helper/documentation-src/layouts/common/footer.pug
+++ b/packages/algoliasearch-helper/documentation-src/layouts/common/footer.pug
@@ -4,8 +4,8 @@ section.ac-footer
       | Code licensed under
       a.ac-footer-link-item(href='https://raw.githubusercontent.com/algolia/algoliasearch-helper-js/master/LICENSE') MIT
       br
-      a.ac-footer-link-item(href='https://github.com/algolia/algoliasearch-helper-js') GitHub
-      a.ac-footer-link-item(href='https://github.com/algolia/algoliasearch-helper-js/issues') issues
+      a.ac-footer-link-item(href='https://github.com/algolia/instantsearch/tree/master/packages/algoliasearch-helper') GitHub
+      a.ac-footer-link-item(href='https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Library%3A+AlgoliaSearch+Helper%22') issues
   .ac-footer-container.ac-footer-brand
     p This project is part of
     img.ac-footer-brand-icon(src='images/community-badge.svg')

--- a/packages/algoliasearch-helper/index.html
+++ b/packages/algoliasearch-helper/index.html
@@ -40,7 +40,7 @@
           Checkout the project with
           <span class="code"
             >git clone
-            https://github.com/algolia/algoliasearch-helper-js.git</span
+            https://github.com/algolia/instantsearch.git</span
           >
         </li>
         <li>In your command line, do <span class="code">npm install</span></li>

--- a/packages/algoliasearch-helper/package.json
+++ b/packages/algoliasearch-helper/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/algolia/algoliasearch-helper-js.git"
+    "url": "https://github.com/algolia/instantsearch/tree/master/packages/algoliasearch-helper"
   },
   "files": [
     "dist",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

links in the doc website and package.json still went to algoliasearch-helper-js

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

links go to the actual current source code

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
