### PR TITLE
test(common): validate that all tests are implemented

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common-connectors.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-connectors.test.tsx
@@ -1,18 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import {
-  createHierarchicalMenuConnectorTests,
-  createBreadcrumbConnectorTests,
-  createRefinementListConnectorTests,
-  createPaginationConnectorTests,
-  createMenuConnectorTests,
-  createHitsPerPageConnectorTests,
-  createNumericMenuConnectorTests,
-  createRatingMenuConnectorTests,
-  createToggleRefinementConnectorTests,
-  createCurrentRefinementsConnectorTests,
-} from '@instantsearch/tests';
+import * as suites from '@instantsearch/tests/connectors';
 
 import {
   connectBreadcrumb,
@@ -29,8 +18,14 @@ import {
 import instantsearch from '../index.es';
 import { refinementList } from '../widgets';
 
-createHierarchicalMenuConnectorTests(
-  ({ instantSearchOptions, widgetParams }) => {
+type TestSuites = typeof suites;
+const testSuites: TestSuites = suites;
+type TestSetups = {
+  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
+};
+
+const setups: TestSetups = {
+  createHierarchicalMenuConnectorTests({ instantSearchOptions, widgetParams }) {
     const customHierarchicalMenu = connectHierarchicalMenu<{
       container: HTMLElement;
     }>((renderOptions) => {
@@ -67,13 +62,11 @@ createHierarchicalMenuConnectorTests(
          */
       })
       .start();
-  }
-);
-
-createBreadcrumbConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  const customBreadcrumb = connectBreadcrumb<{ container: HTMLElement }>(
-    (renderOptions) => {
-      renderOptions.widgetParams.container.innerHTML = `
+  },
+  createBreadcrumbConnectorTests({ instantSearchOptions, widgetParams }) {
+    const customBreadcrumb = connectBreadcrumb<{ container: HTMLElement }>(
+      (renderOptions) => {
+        renderOptions.widgetParams.container.innerHTML = `
         <a
           data-testid="Breadcrumb-link"
           href="${renderOptions.createURL('Apple > iPhone')}"
@@ -85,29 +78,28 @@ createBreadcrumbConnectorTests(({ instantSearchOptions, widgetParams }) => {
         </button>
       `;
 
-      renderOptions.widgetParams.container
-        .querySelector('[data-testid="Breadcrumb-refine"]')!
-        .addEventListener('click', () => {
-          renderOptions.refine('Apple');
-        });
-    }
-  );
+        renderOptions.widgetParams.container
+          .querySelector('[data-testid="Breadcrumb-refine"]')!
+          .addEventListener('click', () => {
+            renderOptions.refine('Apple');
+          });
+      }
+    );
 
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      customBreadcrumb({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .start();
-});
-
-createRefinementListConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  const customRefinementList = connectRefinementList<{
-    container: HTMLElement;
-  }>((renderOptions) => {
-    renderOptions.widgetParams.container.innerHTML = `
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        customBreadcrumb({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .start();
+  },
+  createRefinementListConnectorTests({ instantSearchOptions, widgetParams }) {
+    const customRefinementList = connectRefinementList<{
+      container: HTMLElement;
+    }>((renderOptions) => {
+      renderOptions.widgetParams.container.innerHTML = `
         <a
           data-testid="RefinementList-link"
           href="${renderOptions.createURL('value')}"
@@ -119,27 +111,26 @@ createRefinementListConnectorTests(({ instantSearchOptions, widgetParams }) => {
         </button>
       `;
 
-    renderOptions.widgetParams.container
-      .querySelector('[data-testid="RefinementList-refine"]')!
-      .addEventListener('click', () => {
-        renderOptions.refine('Apple');
-      });
-  });
+      renderOptions.widgetParams.container
+        .querySelector('[data-testid="RefinementList-refine"]')!
+        .addEventListener('click', () => {
+          renderOptions.refine('Apple');
+        });
+    });
 
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      customRefinementList({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .start();
-});
-
-createMenuConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  const customMenu = connectMenu<{ container: HTMLElement }>(
-    (renderOptions) => {
-      renderOptions.widgetParams.container.innerHTML = `
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        customRefinementList({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .start();
+  },
+  createMenuConnectorTests({ instantSearchOptions, widgetParams }) {
+    const customMenu = connectMenu<{ container: HTMLElement }>(
+      (renderOptions) => {
+        renderOptions.widgetParams.container.innerHTML = `
         <a
           data-testid="Menu-link"
           href="${renderOptions.createURL('value')}"
@@ -151,28 +142,27 @@ createMenuConnectorTests(({ instantSearchOptions, widgetParams }) => {
         </button>
       `;
 
-      renderOptions.widgetParams.container
-        .querySelector('[data-testid="Menu-refine"]')!
-        .addEventListener('click', () => {
-          renderOptions.refine('Apple');
-        });
-    }
-  );
+        renderOptions.widgetParams.container
+          .querySelector('[data-testid="Menu-refine"]')!
+          .addEventListener('click', () => {
+            renderOptions.refine('Apple');
+          });
+      }
+    );
 
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      customMenu({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .start();
-});
-
-createPaginationConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  const customPagination = connectPagination<{ container: HTMLElement }>(
-    (renderOptions) => {
-      renderOptions.widgetParams.container.innerHTML = `
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        customMenu({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .start();
+  },
+  createPaginationConnectorTests({ instantSearchOptions, widgetParams }) {
+    const customPagination = connectPagination<{ container: HTMLElement }>(
+      (renderOptions) => {
+        renderOptions.widgetParams.container.innerHTML = `
         <a
           data-testid="Pagination-link"
           href="${renderOptions.createURL(10)}"
@@ -184,26 +174,27 @@ createPaginationConnectorTests(({ instantSearchOptions, widgetParams }) => {
         </button>
       `;
 
-      renderOptions.widgetParams.container
-        .querySelector('[data-testid="Pagination-refine"]')!
-        .addEventListener('click', () => {
-          renderOptions.refine(10);
-        });
-    }
-  );
+        renderOptions.widgetParams.container
+          .querySelector('[data-testid="Pagination-refine"]')!
+          .addEventListener('click', () => {
+            renderOptions.refine(10);
+          });
+      }
+    );
 
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      customPagination({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .start();
-});
-
-createCurrentRefinementsConnectorTests(
-  ({ instantSearchOptions, widgetParams }) => {
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        customPagination({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .start();
+  },
+  createCurrentRefinementsConnectorTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
     const customCurrentRefinements = connectCurrentRefinements<{
       container: HTMLElement;
     }>((renderOptions) => {
@@ -248,13 +239,11 @@ createCurrentRefinementsConnectorTests(
         }),
       ])
       .start();
-  }
-);
-
-createHitsPerPageConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  const customHitsPerPage = connectHitsPerPage<{ container: HTMLElement }>(
-    (renderOptions) => {
-      renderOptions.widgetParams.container.innerHTML = `
+  },
+  createHitsPerPageConnectorTests({ instantSearchOptions, widgetParams }) {
+    const customHitsPerPage = connectHitsPerPage<{ container: HTMLElement }>(
+      (renderOptions) => {
+        renderOptions.widgetParams.container.innerHTML = `
         <a
           data-testid="HitsPerPage-link"
           href="${renderOptions.createURL(12)}"
@@ -266,28 +255,27 @@ createHitsPerPageConnectorTests(({ instantSearchOptions, widgetParams }) => {
         </button>
       `;
 
-      renderOptions.widgetParams.container
-        .querySelector('[data-testid="HitsPerPage-refine"]')!
-        .addEventListener('click', () => {
-          renderOptions.refine(12);
-        });
-    }
-  );
+        renderOptions.widgetParams.container
+          .querySelector('[data-testid="HitsPerPage-refine"]')!
+          .addEventListener('click', () => {
+            renderOptions.refine(12);
+          });
+      }
+    );
 
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      customHitsPerPage({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .start();
-});
-
-createNumericMenuConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  const customNumericMenu = connectNumericMenu<{ container: HTMLElement }>(
-    (renderOptions) => {
-      renderOptions.widgetParams.container.innerHTML = `
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        customHitsPerPage({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .start();
+  },
+  createNumericMenuConnectorTests({ instantSearchOptions, widgetParams }) {
+    const customNumericMenu = connectNumericMenu<{ container: HTMLElement }>(
+      (renderOptions) => {
+        renderOptions.widgetParams.container.innerHTML = `
         <a
           data-testid="NumericMenu-link"
           href="${renderOptions.createURL(encodeURI('{ "start": 500 }'))}"
@@ -299,28 +287,27 @@ createNumericMenuConnectorTests(({ instantSearchOptions, widgetParams }) => {
         </button>
       `;
 
-      renderOptions.widgetParams.container
-        .querySelector('[data-testid="NumericMenu-refine"]')!
-        .addEventListener('click', () => {
-          renderOptions.refine('500');
-        });
-    }
-  );
+        renderOptions.widgetParams.container
+          .querySelector('[data-testid="NumericMenu-refine"]')!
+          .addEventListener('click', () => {
+            renderOptions.refine('500');
+          });
+      }
+    );
 
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      customNumericMenu({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .start();
-});
-
-createRatingMenuConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  const customRatingMenu = connectRatingMenu<{ container: HTMLElement }>(
-    (renderOptions) => {
-      renderOptions.widgetParams.container.innerHTML = `
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        customNumericMenu({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .start();
+  },
+  createRatingMenuConnectorTests({ instantSearchOptions, widgetParams }) {
+    const customRatingMenu = connectRatingMenu<{ container: HTMLElement }>(
+      (renderOptions) => {
+        renderOptions.widgetParams.container.innerHTML = `
         <a
           data-testid="RatingMenu-link"
           href="${renderOptions.createURL('5')}"
@@ -332,26 +319,24 @@ createRatingMenuConnectorTests(({ instantSearchOptions, widgetParams }) => {
         </button>
       `;
 
-      renderOptions.widgetParams.container
-        .querySelector('[data-testid="RatingMenu-refine"]')!
-        .addEventListener('click', () => {
-          renderOptions.refine('5');
-        });
-    }
-  );
+        renderOptions.widgetParams.container
+          .querySelector('[data-testid="RatingMenu-refine"]')!
+          .addEventListener('click', () => {
+            renderOptions.refine('5');
+          });
+      }
+    );
 
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      customRatingMenu({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .start();
-});
-
-createToggleRefinementConnectorTests(
-  ({ instantSearchOptions, widgetParams }) => {
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        customRatingMenu({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .start();
+  },
+  createToggleRefinementConnectorTests({ instantSearchOptions, widgetParams }) {
     const customToggleRefinement = connectToggleRefinement<{
       container: HTMLElement;
     }>((renderOptions) => {
@@ -388,5 +373,17 @@ createToggleRefinementConnectorTests(
          */
       })
       .start();
-  }
-);
+  },
+};
+
+describe('Common connector tests (InstantSearch.js)', () => {
+  test('has all the tests', () => {
+    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
+  });
+
+  Object.keys(testSuites).forEach((testName) => {
+    // @ts-ignore (typescript is only referentially typed)
+    // https://github.com/microsoft/TypeScript/issues/38520
+    testSuites[testName](setups[testName]);
+  });
+});

--- a/packages/instantsearch.js/src/__tests__/common-shared.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-shared.test.tsx
@@ -1,15 +1,22 @@
 /**
  * @jest-environment jsdom
  */
-import { createSharedTests } from '@instantsearch/tests';
+import * as suites from '@instantsearch/tests/shared';
 
 import { connectMenu, connectPagination } from '../connectors';
 import instantsearch from '../index.es';
 import { menu, pagination, hits } from '../widgets';
 
-createSharedTests(({ instantSearchOptions, widgetParams }) => {
-  const menuURL = connectMenu<{ container: HTMLElement }>((renderOptions) => {
-    renderOptions.widgetParams.container.innerHTML = `
+type TestSuites = typeof suites;
+const testSuites: TestSuites = suites;
+type TestSetups = {
+  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
+};
+
+const setups: TestSetups = {
+  createSharedTests({ instantSearchOptions, widgetParams }) {
+    const menuURL = connectMenu<{ container: HTMLElement }>((renderOptions) => {
+      renderOptions.widgetParams.container.innerHTML = `
         <a
           data-testid="Menu-link"
           href="${renderOptions.createURL('value')}"
@@ -17,10 +24,10 @@ createSharedTests(({ instantSearchOptions, widgetParams }) => {
           LINK
         </a>
       `;
-  });
-  const paginationURL = connectPagination<{ container: HTMLElement }>(
-    (renderOptions) => {
-      renderOptions.widgetParams.container.innerHTML = `
+    });
+    const paginationURL = connectPagination<{ container: HTMLElement }>(
+      (renderOptions) => {
+        renderOptions.widgetParams.container.innerHTML = `
         <a
           data-testid="Pagination-link"
           href="${renderOptions.createURL(10)}"
@@ -28,37 +35,50 @@ createSharedTests(({ instantSearchOptions, widgetParams }) => {
           LINK
         </a>
       `;
-    }
-  );
+      }
+    );
 
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      menuURL({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams.menu,
-      }),
-      menu({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams.menu,
-      }),
-      hits({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams.hits,
-      }),
-      paginationURL({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams.pagination,
-      }),
-      pagination({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams.pagination,
-      }),
-    ])
-    .on('error', () => {
-      /*
-       * prevent rethrowing InstantSearch errors, so tests can be asserted.
-       * IRL this isn't needed, as the error doesn't stop execution.
-       */
-    })
-    .start();
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        menuURL({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams.menu,
+        }),
+        menu({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams.menu,
+        }),
+        hits({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams.hits,
+        }),
+        paginationURL({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams.pagination,
+        }),
+        pagination({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams.pagination,
+        }),
+      ])
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
+  },
+};
+
+describe('Common widget tests (InstantSearch.js)', () => {
+  test('has all the tests', () => {
+    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
+  });
+
+  Object.keys(testSuites).forEach((testName) => {
+    // @ts-ignore (typescript is only referentially typed)
+    // https://github.com/microsoft/TypeScript/issues/38520
+    testSuites[testName](setups[testName]);
+  });
 });

--- a/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
@@ -1,17 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import {
-  createHierarchicalMenuWidgetTests,
-  createBreadcrumbWidgetTests,
-  createRefinementListWidgetTests,
-  createPaginationWidgetTests,
-  createMenuWidgetTests,
-  createInfiniteHitsWidgetTests,
-  createHitsWidgetTests,
-  createRangeInputWidgetTests,
-  createInstantSearchWidgetTests,
-} from '@instantsearch/tests';
+
+import * as suites from '@instantsearch/tests/widgets';
 
 import instantsearch from '../index.es';
 import {
@@ -27,258 +18,270 @@ import {
   rangeInput,
 } from '../widgets';
 
-createHierarchicalMenuWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      hierarchicalMenu({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .on('error', () => {
-      /*
-       * prevent rethrowing InstantSearch errors, so tests can be asserted.
-       * IRL this isn't needed, as the error doesn't stop execution.
-       */
-    })
-    .start();
-});
+type TestSuites = typeof suites;
+const testSuites: TestSuites = suites;
+type TestSetups = {
+  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
+};
 
-createBreadcrumbWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  const { transformItems, templates, ...hierarchicalWidgetParams } =
-    widgetParams;
+const setups: TestSetups = {
+  createHierarchicalMenuWidgetTests({ instantSearchOptions, widgetParams }) {
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        hierarchicalMenu({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
+  },
+  createBreadcrumbWidgetTests({ instantSearchOptions, widgetParams }) {
+    const { transformItems, templates, ...hierarchicalWidgetParams } =
+      widgetParams;
 
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      breadcrumb({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-      hierarchicalMenu({
-        container: document.body.appendChild(document.createElement('div')),
-        ...hierarchicalWidgetParams,
-      }),
-    ])
-    .on('error', () => {
-      /*
-       * prevent rethrowing InstantSearch errors, so tests can be asserted.
-       * IRL this isn't needed, as the error doesn't stop execution.
-       */
-    })
-    .start();
-});
-
-createRefinementListWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      refinementList({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .on('error', () => {
-      /*
-       * prevent rethrowing InstantSearch errors, so tests can be asserted.
-       * IRL this isn't needed, as the error doesn't stop execution.
-       */
-    })
-    .start();
-});
-
-createMenuWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      menu({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .on('error', () => {
-      /*
-       * prevent rethrowing InstantSearch errors, so tests can be asserted.
-       * IRL this isn't needed, as the error doesn't stop execution.
-       */
-    })
-    .start();
-});
-
-createPaginationWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      pagination({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .on('error', () => {
-      /*
-       * prevent rethrowing InstantSearch errors, so tests can be asserted.
-       * IRL this isn't needed, as the error doesn't stop execution.
-       */
-    })
-    .start();
-});
-
-createInfiniteHitsWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      searchBox({
-        container: document.body.appendChild(document.createElement('div')),
-      }),
-      infiniteHits({
-        container: document.body.appendChild(
-          Object.assign(document.createElement('div'), {
-            id: 'main-hits',
-          })
-        ),
-        templates: {
-          item: (hit, { html, sendEvent }) =>
-            html`<div data-testid=${`main-hits-top-level-${hit.__position}`}>
-              ${hit.objectID}
-              <button
-                data-testid=${`main-hits-convert-${hit.__position}`}
-                onClick=${() => sendEvent('conversion', hit, 'Converted')}
-              >
-                convert
-              </button>
-              <button
-                data-testid=${`main-hits-click-${hit.__position}`}
-                onClick=${() => sendEvent('click', hit, 'Clicked')}
-              >
-                click
-              </button>
-            </div>`,
-        },
-        ...widgetParams,
-      }),
-      index({ indexName: 'nested' }).addWidgets([
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        breadcrumb({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+        hierarchicalMenu({
+          container: document.body.appendChild(document.createElement('div')),
+          ...hierarchicalWidgetParams,
+        }),
+      ])
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
+  },
+  createRefinementListWidgetTests({ instantSearchOptions, widgetParams }) {
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        refinementList({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
+  },
+  createMenuWidgetTests({ instantSearchOptions, widgetParams }) {
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        menu({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
+  },
+  createPaginationWidgetTests({ instantSearchOptions, widgetParams }) {
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        pagination({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
+  },
+  createInfiniteHitsWidgetTests({ instantSearchOptions, widgetParams }) {
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        searchBox({
+          container: document.body.appendChild(document.createElement('div')),
+        }),
         infiniteHits({
           container: document.body.appendChild(
             Object.assign(document.createElement('div'), {
-              id: 'nested-hits',
+              id: 'main-hits',
             })
           ),
           templates: {
             item: (hit, { html, sendEvent }) =>
-              html`<div
-                data-testid=${`nested-hits-top-level-${hit.__position}`}
-              >
+              html`<div data-testid=${`main-hits-top-level-${hit.__position}`}>
                 ${hit.objectID}
                 <button
-                  data-testid=${`nested-hits-click-${hit.__position}`}
-                  onClick=${() => sendEvent('click', hit, 'Clicked nested')}
+                  data-testid=${`main-hits-convert-${hit.__position}`}
+                  onClick=${() => sendEvent('conversion', hit, 'Converted')}
+                >
+                  convert
+                </button>
+                <button
+                  data-testid=${`main-hits-click-${hit.__position}`}
+                  onClick=${() => sendEvent('click', hit, 'Clicked')}
                 >
                   click
                 </button>
               </div>`,
           },
+          ...widgetParams,
         }),
-      ]),
-    ])
-    .on('error', () => {
-      /*
-       * prevent rethrowing InstantSearch errors, so tests can be asserted.
-       * IRL this isn't needed, as the error doesn't stop execution.
-       */
-    })
-    .start();
-});
-
-createHitsWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      searchBox({
-        container: document.body.appendChild(document.createElement('div')),
-      }),
-      hits({
-        container: document.body.appendChild(
-          Object.assign(document.createElement('div'), {
-            id: 'main-hits',
-          })
-        ),
-        templates: {
-          item: (hit, { html, sendEvent }) =>
-            html`<div data-testid=${`main-hits-top-level-${hit.__position}`}>
-              ${hit.objectID}
-              <button
-                data-testid=${`main-hits-convert-${hit.__position}`}
-                onClick=${() => sendEvent('conversion', hit, 'Converted')}
-              >
-                convert
-              </button>
-              <button
-                data-testid=${`main-hits-click-${hit.__position}`}
-                onClick=${() => sendEvent('click', hit, 'Clicked')}
-              >
-                click
-              </button>
-            </div>`,
-        },
-        ...widgetParams,
-      }),
-      index({ indexName: 'nested' }).addWidgets([
+        index({ indexName: 'nested' }).addWidgets([
+          infiniteHits({
+            container: document.body.appendChild(
+              Object.assign(document.createElement('div'), {
+                id: 'nested-hits',
+              })
+            ),
+            templates: {
+              item: (hit, { html, sendEvent }) =>
+                html`<div
+                  data-testid=${`nested-hits-top-level-${hit.__position}`}
+                >
+                  ${hit.objectID}
+                  <button
+                    data-testid=${`nested-hits-click-${hit.__position}`}
+                    onClick=${() => sendEvent('click', hit, 'Clicked nested')}
+                  >
+                    click
+                  </button>
+                </div>`,
+            },
+          }),
+        ]),
+      ])
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
+  },
+  createHitsWidgetTests({ instantSearchOptions, widgetParams }) {
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        searchBox({
+          container: document.body.appendChild(document.createElement('div')),
+        }),
         hits({
           container: document.body.appendChild(
             Object.assign(document.createElement('div'), {
-              id: 'nested-hits',
+              id: 'main-hits',
             })
           ),
           templates: {
             item: (hit, { html, sendEvent }) =>
-              html`<div data-testid=${`nested-hits-${hit.__position}`}>
+              html`<div data-testid=${`main-hits-top-level-${hit.__position}`}>
                 ${hit.objectID}
                 <button
-                  data-testid=${`nested-hits-click-${hit.__position}`}
-                  onClick=${() => sendEvent('click', hit, 'Clicked nested')}
+                  data-testid=${`main-hits-convert-${hit.__position}`}
+                  onClick=${() => sendEvent('conversion', hit, 'Converted')}
+                >
+                  convert
+                </button>
+                <button
+                  data-testid=${`main-hits-click-${hit.__position}`}
+                  onClick=${() => sendEvent('click', hit, 'Clicked')}
                 >
                   click
                 </button>
               </div>`,
           },
+          ...widgetParams,
         }),
-      ]),
-    ])
-    .on('error', () => {
-      /*
-       * prevent rethrowing InstantSearch errors, so tests can be asserted.
-       * IRL this isn't needed, as the error doesn't stop execution.
-       */
-    })
-    .start();
-});
+        index({ indexName: 'nested' }).addWidgets([
+          hits({
+            container: document.body.appendChild(
+              Object.assign(document.createElement('div'), {
+                id: 'nested-hits',
+              })
+            ),
+            templates: {
+              item: (hit, { html, sendEvent }) =>
+                html`<div data-testid=${`nested-hits-${hit.__position}`}>
+                  ${hit.objectID}
+                  <button
+                    data-testid=${`nested-hits-click-${hit.__position}`}
+                    onClick=${() => sendEvent('click', hit, 'Clicked nested')}
+                  >
+                    click
+                  </button>
+                </div>`,
+            },
+          }),
+        ]),
+      ])
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
+  },
+  createRangeInputWidgetTests({ instantSearchOptions, widgetParams }) {
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        rangeInput({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
+  },
+  createInstantSearchWidgetTests({ instantSearchOptions }) {
+    instantsearch(instantSearchOptions)
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
 
-createRangeInputWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  instantsearch(instantSearchOptions)
-    .addWidgets([
-      rangeInput({
-        container: document.body.appendChild(document.createElement('div')),
-        ...widgetParams,
-      }),
-    ])
-    .on('error', () => {
-      /*
-       * prevent rethrowing InstantSearch errors, so tests can be asserted.
-       * IRL this isn't needed, as the error doesn't stop execution.
-       */
-    })
-    .start();
-});
+    return {
+      algoliaAgents: [
+        `instantsearch.js (${
+          require('../../../instantsearch.js/package.json').version
+        })`,
+      ],
+    };
+  },
+};
 
-createInstantSearchWidgetTests(({ instantSearchOptions }) => {
-  instantsearch(instantSearchOptions)
-    .on('error', () => {
-      /*
-       * prevent rethrowing InstantSearch errors, so tests can be asserted.
-       * IRL this isn't needed, as the error doesn't stop execution.
-       */
-    })
-    .start();
+describe('Common shared tests (InstantSearch.js)', () => {
+  test('has all the tests', () => {
+    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
+  });
 
-  return {
-    algoliaAgents: [
-      `instantsearch.js (${
-        require('../../../instantsearch.js/package.json').version
-      })`,
-    ],
-  };
+  Object.keys(testSuites).forEach((testName) => {
+    // @ts-ignore (typescript is only referentially typed)
+    // https://github.com/microsoft/TypeScript/issues/38520
+    testSuites[testName](setups[testName]);
+  });
 });

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common-connector.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common-connector.test.tsx
@@ -1,18 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import {
-  createRefinementListConnectorTests,
-  createHierarchicalMenuConnectorTests,
-  createBreadcrumbConnectorTests,
-  createMenuConnectorTests,
-  createPaginationConnectorTests,
-  createHitsPerPageConnectorTests,
-  createNumericMenuConnectorTests,
-  createRatingMenuConnectorTests,
-  createToggleRefinementConnectorTests,
-  createCurrentRefinementsConnectorTests,
-} from '@instantsearch/tests';
+import * as suites from '@instantsearch/tests/connectors';
 import { act, render } from '@testing-library/react';
 import { connectRatingMenu } from 'instantsearch.js/es/connectors';
 import React from 'react';
@@ -48,32 +37,38 @@ import type {
   RatingMenuWidgetDescription,
 } from 'instantsearch.js/es/connectors/rating-menu/connectRatingMenu';
 
-createRefinementListConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  function CustomRefinementList(props: UseRefinementListProps) {
-    const { createURL, refine } = useRefinementList(props);
-    return (
-      <>
-        <a data-testid="RefinementList-link" href={createURL('value')}>
-          LINK
-        </a>
-        <button
-          data-testid="RefinementList-refine"
-          onClick={() => refine('Apple')}
-        >
-          BUTTON
-        </button>
-      </>
-    );
-  }
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <CustomRefinementList {...widgetParams} />
-    </InstantSearch>
-  );
-}, act);
+type TestSuites = typeof suites;
+const testSuites: TestSuites = suites;
+type TestSetups = {
+  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
+};
 
-createHierarchicalMenuConnectorTests(
-  ({ instantSearchOptions, widgetParams }) => {
+const setups: TestSetups = {
+  createRefinementListConnectorTests({ instantSearchOptions, widgetParams }) {
+    function CustomRefinementList(props: UseRefinementListProps) {
+      const { createURL, refine } = useRefinementList(props);
+      return (
+        <>
+          <a data-testid="RefinementList-link" href={createURL('value')}>
+            LINK
+          </a>
+          <button
+            data-testid="RefinementList-refine"
+            onClick={() => refine('Apple')}
+          >
+            BUTTON
+          </button>
+        </>
+      );
+    }
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <CustomRefinementList {...widgetParams} />
+      </InstantSearch>
+    );
+  },
+
+  createHierarchicalMenuConnectorTests({ instantSearchOptions, widgetParams }) {
     function CustomHierarchicalMenu(props: UseHierarchicalMenuProps) {
       const { createURL, refine } = useHierarchicalMenu(props);
       return (
@@ -97,75 +92,78 @@ createHierarchicalMenuConnectorTests(
       </InstantSearch>
     );
   },
-  act
-);
 
-createBreadcrumbConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  function CustomBreadcrumb(props: UseBreadcrumbProps) {
-    const { createURL, refine } = useBreadcrumb(props);
-    return (
-      <>
-        <a data-testid="Breadcrumb-link" href={createURL('Apple > iPhone')}>
-          LINK
-        </a>
-        <button data-testid="Breadcrumb-refine" onClick={() => refine('Apple')}>
-          BUTTON
-        </button>
-      </>
+  createBreadcrumbConnectorTests({ instantSearchOptions, widgetParams }) {
+    function CustomBreadcrumb(props: UseBreadcrumbProps) {
+      const { createURL, refine } = useBreadcrumb(props);
+      return (
+        <>
+          <a data-testid="Breadcrumb-link" href={createURL('Apple > iPhone')}>
+            LINK
+          </a>
+          <button
+            data-testid="Breadcrumb-refine"
+            onClick={() => refine('Apple')}
+          >
+            BUTTON
+          </button>
+        </>
+      );
+    }
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <CustomBreadcrumb {...widgetParams} />
+      </InstantSearch>
     );
-  }
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <CustomBreadcrumb {...widgetParams} />
-    </InstantSearch>
-  );
-}, act);
+  },
 
-createMenuConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  function CustomMenu(props: UseMenuProps) {
-    const { createURL, refine } = useMenu(props);
-    return (
-      <>
-        <a data-testid="Menu-link" href={createURL('value')}>
-          LINK
-        </a>
-        <button data-testid="Menu-refine" onClick={() => refine('Apple')}>
-          BUTTON
-        </button>
-      </>
+  createMenuConnectorTests({ instantSearchOptions, widgetParams }) {
+    function CustomMenu(props: UseMenuProps) {
+      const { createURL, refine } = useMenu(props);
+      return (
+        <>
+          <a data-testid="Menu-link" href={createURL('value')}>
+            LINK
+          </a>
+          <button data-testid="Menu-refine" onClick={() => refine('Apple')}>
+            BUTTON
+          </button>
+        </>
+      );
+    }
+
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <CustomMenu {...widgetParams} />
+      </InstantSearch>
     );
-  }
+  },
 
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <CustomMenu {...widgetParams} />
-    </InstantSearch>
-  );
-}, act);
-
-createPaginationConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  function CustomPagination(props: UsePaginationProps) {
-    const { createURL, refine } = usePagination(props);
-    return (
-      <>
-        <a data-testid="Pagination-link" href={createURL(10)}>
-          LINK
-        </a>
-        <button data-testid="Pagination-refine" onClick={() => refine(10)}>
-          BUTTON
-        </button>
-      </>
+  createPaginationConnectorTests({ instantSearchOptions, widgetParams }) {
+    function CustomPagination(props: UsePaginationProps) {
+      const { createURL, refine } = usePagination(props);
+      return (
+        <>
+          <a data-testid="Pagination-link" href={createURL(10)}>
+            LINK
+          </a>
+          <button data-testid="Pagination-refine" onClick={() => refine(10)}>
+            BUTTON
+          </button>
+        </>
+      );
+    }
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <CustomPagination {...widgetParams} />
+      </InstantSearch>
     );
-  }
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <CustomPagination {...widgetParams} />
-    </InstantSearch>
-  );
-}, act);
+  },
 
-createCurrentRefinementsConnectorTests(
-  ({ instantSearchOptions, widgetParams }) => {
+  createCurrentRefinementsConnectorTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
     function CustomCurrentRefinements(props: UseCurrentRefinementsProps) {
       const { createURL, refine } = useCurrentRefinements(props);
       return (
@@ -205,89 +203,82 @@ createCurrentRefinementsConnectorTests(
       </InstantSearch>
     );
   },
-  act,
-  {
-    skippedTests: {
-      /** createURL uses helper state instead of ui state as it can't be translated */
-      routing: true,
-    },
-  }
-);
+  createHitsPerPageConnectorTests({ instantSearchOptions, widgetParams }) {
+    function CustomHitsPerPage(props: UseHitsPerPageProps) {
+      const { createURL, refine } = useHitsPerPage(props);
+      return (
+        <>
+          <a data-testid="HitsPerPage-link" href={createURL(12)}>
+            LINK
+          </a>
+          <button data-testid="HitsPerPage-refine" onClick={() => refine(5)}>
+            BUTTON
+          </button>
+        </>
+      );
+    }
 
-createHitsPerPageConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  function CustomHitsPerPage(props: UseHitsPerPageProps) {
-    const { createURL, refine } = useHitsPerPage(props);
-    return (
-      <>
-        <a data-testid="HitsPerPage-link" href={createURL(12)}>
-          LINK
-        </a>
-        <button data-testid="HitsPerPage-refine" onClick={() => refine(5)}>
-          BUTTON
-        </button>
-      </>
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <CustomHitsPerPage {...widgetParams} />
+      </InstantSearch>
     );
-  }
+  },
 
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <CustomHitsPerPage {...widgetParams} />
-    </InstantSearch>
-  );
-}, act);
+  createNumericMenuConnectorTests({ instantSearchOptions, widgetParams }) {
+    function CustomNumericMenu(props: UseNumericMenuProps) {
+      const { createURL, refine } = useNumericMenu(props);
+      return (
+        <>
+          <a
+            data-testid="NumericMenu-link"
+            href={createURL(encodeURI('{ "start": 500 }'))}
+          >
+            LINK
+          </a>
+          <button
+            data-testid="NumericMenu-refine"
+            onClick={() => refine('500')}
+          >
+            BUTTON
+          </button>
+        </>
+      );
+    }
 
-createNumericMenuConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  function CustomNumericMenu(props: UseNumericMenuProps) {
-    const { createURL, refine } = useNumericMenu(props);
-    return (
-      <>
-        <a
-          data-testid="NumericMenu-link"
-          href={createURL(encodeURI('{ "start": 500 }'))}
-        >
-          LINK
-        </a>
-        <button data-testid="NumericMenu-refine" onClick={() => refine('500')}>
-          BUTTON
-        </button>
-      </>
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <CustomNumericMenu {...widgetParams} />
+      </InstantSearch>
     );
-  }
+  },
 
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <CustomNumericMenu {...widgetParams} />
-    </InstantSearch>
-  );
-}, act);
+  createRatingMenuConnectorTests({ instantSearchOptions, widgetParams }) {
+    function CustomRatingMenu(props: RatingMenuConnectorParams) {
+      const { createURL, refine } = useConnector<
+        RatingMenuConnectorParams,
+        RatingMenuWidgetDescription
+      >(connectRatingMenu, props);
+      return (
+        <>
+          <a data-testid="RatingMenu-link" href={createURL(encodeURI('5'))}>
+            LINK
+          </a>
+          <button data-testid="RatingMenu-refine" onClick={() => refine('5')}>
+            BUTTON
+          </button>
+        </>
+      );
+    }
 
-createRatingMenuConnectorTests(({ instantSearchOptions, widgetParams }) => {
-  function CustomRatingMenu(props: RatingMenuConnectorParams) {
-    const { createURL, refine } = useConnector<
-      RatingMenuConnectorParams,
-      RatingMenuWidgetDescription
-    >(connectRatingMenu, props);
-    return (
-      <>
-        <a data-testid="RatingMenu-link" href={createURL(encodeURI('5'))}>
-          LINK
-        </a>
-        <button data-testid="RatingMenu-refine" onClick={() => refine('5')}>
-          BUTTON
-        </button>
-      </>
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <CustomRatingMenu {...widgetParams} />
+      </InstantSearch>
     );
-  }
+  },
 
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <CustomRatingMenu {...widgetParams} />
-    </InstantSearch>
-  );
-}, act);
-
-createToggleRefinementConnectorTests(
-  ({ instantSearchOptions, widgetParams }) => {
+  createToggleRefinementConnectorTests({ instantSearchOptions, widgetParams }) {
     function CustomToggleRefinement(props: UseToggleRefinementProps) {
       const { createURL, refine, value } = useToggleRefinement(props);
       return (
@@ -311,5 +302,25 @@ createToggleRefinementConnectorTests(
       </InstantSearch>
     );
   },
-  act
-);
+};
+
+describe('Common connector tests (React InstantSearch)', () => {
+  test('has all the tests', () => {
+    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
+  });
+
+  const skippedTests: Record<string, Record<string, boolean>> = {
+    createCurrentRefinementsConnectorTests: {
+      /** createURL uses helper state instead of ui state as it can't be translated */
+      routing: true,
+    },
+  };
+
+  Object.keys(testSuites).forEach((testName) => {
+    // @ts-ignore (typescript is only referentially typed)
+    // https://github.com/microsoft/TypeScript/issues/38520
+    testSuites[testName](setups[testName], act, {
+      skippedTests: skippedTests[testName],
+    });
+  });
+});

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common-connector.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common-connector.test.tsx
@@ -42,6 +42,9 @@ const testSuites: TestSuites = suites;
 type TestSetups = {
   [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
 };
+type TestOptions = {
+  [key in keyof TestSuites]?: Parameters<TestSuites[key]>[2];
+};
 
 const setups: TestSetups = {
   createRefinementListConnectorTests({ instantSearchOptions, widgetParams }) {
@@ -309,18 +312,18 @@ describe('Common connector tests (React InstantSearch)', () => {
     expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
   });
 
-  const skippedTests: Record<string, Record<string, boolean>> = {
+  const testOptions: TestOptions = {
     createCurrentRefinementsConnectorTests: {
-      /** createURL uses helper state instead of ui state as it can't be translated */
-      routing: true,
+      skippedTests: {
+        /** createURL uses helper state instead of ui state as it can't be translated */
+        routing: true,
+      },
     },
   };
 
   Object.keys(testSuites).forEach((testName) => {
     // @ts-ignore (typescript is only referentially typed)
     // https://github.com/microsoft/TypeScript/issues/38520
-    testSuites[testName](setups[testName], act, {
-      skippedTests: skippedTests[testName],
-    });
+    testSuites[testName](setups[testName], act, testOptions[testName]);
   });
 });

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common-shared.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common-shared.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { createSharedTests } from '@instantsearch/tests';
+import * as suites from '@instantsearch/tests/shared';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 
@@ -16,32 +16,52 @@ import {
 
 import type { UseMenuProps, UsePaginationProps } from '..';
 
-createSharedTests(({ instantSearchOptions, widgetParams }) => {
-  function MenuURL(props: UseMenuProps) {
-    const { createURL } = useMenu(props);
-    return (
-      <a data-testid="Menu-link" href={createURL('value')}>
-        LINK
-      </a>
-    );
-  }
+type TestSuites = typeof suites;
+const testSuites: TestSuites = suites;
+type TestSetups = {
+  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
+};
 
-  function PaginationURL(props: UsePaginationProps) {
-    const { createURL } = usePagination(props);
-    return (
-      <a data-testid="Pagination-link" href={createURL(10)}>
-        LINK
-      </a>
-    );
-  }
+const setups: TestSetups = {
+  createSharedTests({ instantSearchOptions, widgetParams }) {
+    function MenuURL(props: UseMenuProps) {
+      const { createURL } = useMenu(props);
+      return (
+        <a data-testid="Menu-link" href={createURL('value')}>
+          LINK
+        </a>
+      );
+    }
 
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <MenuURL {...widgetParams.menu} />
-      <Menu {...widgetParams.menu} />
-      <Hits {...widgetParams.hits} />
-      <PaginationURL {...widgetParams.pagination} />
-      <Pagination {...widgetParams.pagination} />
-    </InstantSearch>
-  );
-}, act);
+    function PaginationURL(props: UsePaginationProps) {
+      const { createURL } = usePagination(props);
+      return (
+        <a data-testid="Pagination-link" href={createURL(10)}>
+          LINK
+        </a>
+      );
+    }
+
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <MenuURL {...widgetParams.menu} />
+        <Menu {...widgetParams.menu} />
+        <Hits {...widgetParams.hits} />
+        <PaginationURL {...widgetParams.pagination} />
+        <Pagination {...widgetParams.pagination} />
+      </InstantSearch>
+    );
+  },
+};
+
+describe('Common shared tests (React InstantSearch)', () => {
+  test('has all the tests', () => {
+    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
+  });
+
+  Object.keys(testSuites).forEach((testName) => {
+    // @ts-ignore (typescript is only referentially typed)
+    // https://github.com/microsoft/TypeScript/issues/38520
+    testSuites[testName](setups[testName], act);
+  });
+});

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common-widget.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common-widget.test.tsx
@@ -1,17 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import {
-  createRefinementListWidgetTests,
-  createHierarchicalMenuWidgetTests,
-  createBreadcrumbWidgetTests,
-  createMenuWidgetTests,
-  createPaginationWidgetTests,
-  createInfiniteHitsWidgetTests,
-  createHitsWidgetTests,
-  createRangeInputWidgetTests,
-  createInstantSearchWidgetTests,
-} from '@instantsearch/tests';
+import * as suites from '@instantsearch/tests/widgets';
 import { act, render } from '@testing-library/react';
 import React from 'react';
 
@@ -33,6 +23,201 @@ import {
 import type { Hit } from 'instantsearch.js';
 import type { SendEventForHits } from 'instantsearch.js/es/lib/utils';
 
+type TestSuites = typeof suites;
+const testSuites: TestSuites = suites;
+type TestSetups = {
+  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
+};
+
+const setups: TestSetups = {
+  createRefinementListWidgetTests({ instantSearchOptions, widgetParams }) {
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <RefinementList {...widgetParams} />
+        <GlobalErrorSwallower />
+      </InstantSearch>
+    );
+  },
+  createHierarchicalMenuWidgetTests({ instantSearchOptions, widgetParams }) {
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <HierarchicalMenu {...widgetParams} />
+        <GlobalErrorSwallower />
+      </InstantSearch>
+    );
+  },
+  createBreadcrumbWidgetTests({ instantSearchOptions, widgetParams }) {
+    const { transformItems, ...hierarchicalWidgetParams } = widgetParams;
+
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <Breadcrumb {...widgetParams} />
+        <HierarchicalMenu {...hierarchicalWidgetParams} />
+        <GlobalErrorSwallower />
+      </InstantSearch>
+    );
+  },
+  createMenuWidgetTests({ instantSearchOptions, widgetParams }) {
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <Menu {...widgetParams} />
+        <GlobalErrorSwallower />
+      </InstantSearch>
+    );
+  },
+  createPaginationWidgetTests({ instantSearchOptions, widgetParams }) {
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <Pagination {...widgetParams} />
+        <GlobalErrorSwallower />
+      </InstantSearch>
+    );
+  },
+  createInfiniteHitsWidgetTests({ instantSearchOptions, widgetParams }) {
+    function MainHit({
+      hit,
+      sendEvent,
+    }: {
+      hit: Hit;
+      sendEvent: SendEventForHits;
+    }) {
+      return (
+        <div data-testid={`main-hits-top-level-${hit.__position}`}>
+          {hit.objectID}
+          <button
+            data-testid={`main-hits-convert-${hit.__position}`}
+            onClick={() => sendEvent('conversion', hit, 'Converted')}
+          >
+            convert
+          </button>
+          <button
+            data-testid={`main-hits-click-${hit.__position}`}
+            onClick={() => sendEvent('click', hit, 'Clicked')}
+          >
+            click
+          </button>
+        </div>
+      );
+    }
+
+    function NestedHit({
+      hit,
+      sendEvent,
+    }: {
+      hit: Hit;
+      sendEvent: SendEventForHits;
+    }) {
+      return (
+        <div data-testid={`nested-hits-${hit.__position}`}>
+          {hit.objectID}
+          <button
+            data-testid={`nested-hits-click-${hit.__position}`}
+            onClick={() => sendEvent('click', hit, 'Clicked nested')}
+          >
+            click
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <SearchBox />
+        <InfiniteHits id="main-hits" hitComponent={MainHit} {...widgetParams} />
+        <Index indexName="nested">
+          <InfiniteHits id="nested-hits" hitComponent={NestedHit} />
+        </Index>
+        <GlobalErrorSwallower />
+      </InstantSearch>
+    );
+  },
+  createHitsWidgetTests({ instantSearchOptions, widgetParams }) {
+    function MainHit({
+      hit,
+      sendEvent,
+    }: {
+      hit: Hit;
+      sendEvent: SendEventForHits;
+    }) {
+      return (
+        <div data-testid={`main-hits-top-level-${hit.__position}`}>
+          {hit.objectID}
+          <button
+            data-testid={`main-hits-convert-${hit.__position}`}
+            onClick={() => sendEvent('conversion', hit, 'Converted')}
+          >
+            convert
+          </button>
+          <button
+            data-testid={`main-hits-click-${hit.__position}`}
+            onClick={() => sendEvent('click', hit, 'Clicked')}
+          >
+            click
+          </button>
+        </div>
+      );
+    }
+
+    function NestedHit({
+      hit,
+      sendEvent,
+    }: {
+      hit: Hit;
+      sendEvent: SendEventForHits;
+    }) {
+      return (
+        <div data-testid={`nested-hits-${hit.__position}`}>
+          {hit.objectID}
+          <button
+            data-testid={`nested-hits-click-${hit.__position}`}
+            onClick={() => sendEvent('click', hit, 'Clicked nested')}
+          >
+            click
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <SearchBox />
+        <Hits id="main-hits" hitComponent={MainHit} {...widgetParams} />
+        <Index indexName="nested">
+          <Hits id="nested-hits" hitComponent={NestedHit} />
+        </Index>
+        <GlobalErrorSwallower />
+      </InstantSearch>
+    );
+  },
+  createRangeInputWidgetTests({ instantSearchOptions, widgetParams }) {
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <RangeInput {...widgetParams} />
+        <GlobalErrorSwallower />
+      </InstantSearch>
+    );
+  },
+  createInstantSearchWidgetTests({ instantSearchOptions }) {
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <GlobalErrorSwallower />
+      </InstantSearch>
+    );
+
+    return {
+      algoliaAgents: [
+        `instantsearch.js (${
+          require('../../../instantsearch.js/package.json').version
+        })`,
+        `react-instantsearch (${
+          require('../../../react-instantsearch-hooks/package.json').version
+        })`,
+        `react (${require('react').version})`,
+      ],
+    };
+  },
+};
+
 /**
  * prevent rethrowing InstantSearch errors, so tests can be asserted.
  * IRL this isn't needed, as the error doesn't stop execution.
@@ -43,197 +228,14 @@ function GlobalErrorSwallower() {
   return null;
 }
 
-createRefinementListWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <RefinementList {...widgetParams} />
-      <GlobalErrorSwallower />
-    </InstantSearch>
-  );
-}, act);
+describe('Common widget tests (React InstantSearch)', () => {
+  test('has all the tests', () => {
+    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
+  });
 
-createHierarchicalMenuWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <HierarchicalMenu {...widgetParams} />
-      <GlobalErrorSwallower />
-    </InstantSearch>
-  );
-}, act);
-
-createBreadcrumbWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  const { transformItems, ...hierarchicalWidgetParams } = widgetParams;
-
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <Breadcrumb {...widgetParams} />
-      <HierarchicalMenu {...hierarchicalWidgetParams} />
-      <GlobalErrorSwallower />
-    </InstantSearch>
-  );
-}, act);
-
-createMenuWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <Menu {...widgetParams} />
-      <GlobalErrorSwallower />
-    </InstantSearch>
-  );
-}, act);
-
-createPaginationWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <Pagination {...widgetParams} />
-      <GlobalErrorSwallower />
-    </InstantSearch>
-  );
-}, act);
-
-createInfiniteHitsWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  function MainHit({
-    hit,
-    sendEvent,
-  }: {
-    hit: Hit;
-    sendEvent: SendEventForHits;
-  }) {
-    return (
-      <div data-testid={`main-hits-top-level-${hit.__position}`}>
-        {hit.objectID}
-        <button
-          data-testid={`main-hits-convert-${hit.__position}`}
-          onClick={() => sendEvent('conversion', hit, 'Converted')}
-        >
-          convert
-        </button>
-        <button
-          data-testid={`main-hits-click-${hit.__position}`}
-          onClick={() => sendEvent('click', hit, 'Clicked')}
-        >
-          click
-        </button>
-      </div>
-    );
-  }
-
-  function NestedHit({
-    hit,
-    sendEvent,
-  }: {
-    hit: Hit;
-    sendEvent: SendEventForHits;
-  }) {
-    return (
-      <div data-testid={`nested-hits-${hit.__position}`}>
-        {hit.objectID}
-        <button
-          data-testid={`nested-hits-click-${hit.__position}`}
-          onClick={() => sendEvent('click', hit, 'Clicked nested')}
-        >
-          click
-        </button>
-      </div>
-    );
-  }
-
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <SearchBox />
-      <InfiniteHits id="main-hits" hitComponent={MainHit} {...widgetParams} />
-      <Index indexName="nested">
-        <InfiniteHits id="nested-hits" hitComponent={NestedHit} />
-      </Index>
-      <GlobalErrorSwallower />
-    </InstantSearch>
-  );
-}, act);
-
-createHitsWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  function MainHit({
-    hit,
-    sendEvent,
-  }: {
-    hit: Hit;
-    sendEvent: SendEventForHits;
-  }) {
-    return (
-      <div data-testid={`main-hits-top-level-${hit.__position}`}>
-        {hit.objectID}
-        <button
-          data-testid={`main-hits-convert-${hit.__position}`}
-          onClick={() => sendEvent('conversion', hit, 'Converted')}
-        >
-          convert
-        </button>
-        <button
-          data-testid={`main-hits-click-${hit.__position}`}
-          onClick={() => sendEvent('click', hit, 'Clicked')}
-        >
-          click
-        </button>
-      </div>
-    );
-  }
-
-  function NestedHit({
-    hit,
-    sendEvent,
-  }: {
-    hit: Hit;
-    sendEvent: SendEventForHits;
-  }) {
-    return (
-      <div data-testid={`nested-hits-${hit.__position}`}>
-        {hit.objectID}
-        <button
-          data-testid={`nested-hits-click-${hit.__position}`}
-          onClick={() => sendEvent('click', hit, 'Clicked nested')}
-        >
-          click
-        </button>
-      </div>
-    );
-  }
-
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <SearchBox />
-      <Hits id="main-hits" hitComponent={MainHit} {...widgetParams} />
-      <Index indexName="nested">
-        <Hits id="nested-hits" hitComponent={NestedHit} />
-      </Index>
-      <GlobalErrorSwallower />
-    </InstantSearch>
-  );
-}, act);
-
-createRangeInputWidgetTests(({ instantSearchOptions, widgetParams }) => {
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <RangeInput {...widgetParams} />
-      <GlobalErrorSwallower />
-    </InstantSearch>
-  );
-}, act);
-
-createInstantSearchWidgetTests(({ instantSearchOptions }) => {
-  render(
-    <InstantSearch {...instantSearchOptions}>
-      <GlobalErrorSwallower />
-    </InstantSearch>
-  );
-
-  return {
-    algoliaAgents: [
-      `instantsearch.js (${
-        require('../../../instantsearch.js/package.json').version
-      })`,
-      `react-instantsearch (${
-        require('../../../react-instantsearch-hooks/package.json').version
-      })`,
-      `react (${require('react').version})`,
-    ],
-  };
-}, act);
+  Object.keys(testSuites).forEach((testName) => {
+    // @ts-ignore (typescript is only referentially typed)
+    // https://github.com/microsoft/TypeScript/issues/38520
+    testSuites[testName](setups[testName], act);
+  });
+});

--- a/packages/vue-instantsearch/src/__tests__/common-connectors.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-connectors.test.js
@@ -1,18 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import {
-  createBreadcrumbConnectorTests,
-  createCurrentRefinementsConnectorTests,
-  createHierarchicalMenuConnectorTests,
-  createHitsPerPageConnectorTests,
-  createMenuConnectorTests,
-  createNumericMenuConnectorTests,
-  createPaginationConnectorTests,
-  createRatingMenuConnectorTests,
-  createRefinementListConnectorTests,
-  createToggleRefinementConnectorTests,
-} from '@instantsearch/tests';
+import * as suites from '@instantsearch/tests/connectors';
 
 import { nextTick, mountApp } from '../../test/utils';
 import { renderCompat } from '../util/vue-compat';
@@ -36,8 +25,11 @@ import {
 } from 'instantsearch.js/es/connectors';
 jest.unmock('instantsearch.js/es');
 
-createRefinementListConnectorTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+const setups = {
+  async createRefinementListConnectorTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
     const CustomRefinementList = createCustomWidget({
       connector: connectRefinementList,
       name: 'RefinementList',
@@ -58,11 +50,11 @@ createRefinementListConnectorTests(
     );
 
     await nextTick();
-  }
-);
-
-createHierarchicalMenuConnectorTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+  },
+  async createHierarchicalMenuConnectorTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
     const CustomHierarchicalMenu = createCustomWidget({
       connector: connectHierarchicalMenu,
       name: 'HierarchicalMenu',
@@ -83,11 +75,8 @@ createHierarchicalMenuConnectorTests(
     );
 
     await nextTick();
-  }
-);
-
-createBreadcrumbConnectorTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+  },
+  async createBreadcrumbConnectorTests({ instantSearchOptions, widgetParams }) {
     const CustomBreadcrumb = createCustomWidget({
       connector: connectBreadcrumb,
       name: 'Breadcrumb',
@@ -108,35 +97,31 @@ createBreadcrumbConnectorTests(
     );
 
     await nextTick();
-  }
-);
+  },
+  async createMenuConnectorTests({ instantSearchOptions, widgetParams }) {
+    const CustomMenu = createCustomWidget({
+      connector: connectMenu,
+      name: 'Menu',
+      requiredProps: ['attribute'],
+      urlValue: 'value',
+      refineValue: 'Apple',
+    });
 
-createMenuConnectorTests(async ({ instantSearchOptions, widgetParams }) => {
-  const CustomMenu = createCustomWidget({
-    connector: connectMenu,
-    name: 'Menu',
-    requiredProps: ['attribute'],
-    urlValue: 'value',
-    refineValue: 'Apple',
-  });
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(CustomMenu, { props: widgetParams }),
+            h(AisMenu, { props: widgetParams }),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
 
-  mountApp(
-    {
-      render: renderCompat((h) =>
-        h(AisInstantSearch, { props: instantSearchOptions }, [
-          h(CustomMenu, { props: widgetParams }),
-          h(AisMenu, { props: widgetParams }),
-        ])
-      ),
-    },
-    document.body.appendChild(document.createElement('div'))
-  );
-
-  await nextTick();
-});
-
-createPaginationConnectorTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+    await nextTick();
+  },
+  async createPaginationConnectorTests({ instantSearchOptions, widgetParams }) {
     const CustomPagination = createCustomWidget({
       connector: connectPagination,
       name: 'Pagination',
@@ -156,11 +141,11 @@ createPaginationConnectorTests(
     );
 
     await nextTick();
-  }
-);
-
-createCurrentRefinementsConnectorTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+  },
+  async createCurrentRefinementsConnectorTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
     const CustomCurrentRefinements = createCustomWidget({
       connector: connectCurrentRefinements,
       name: 'CurrentRefinements',
@@ -191,11 +176,11 @@ createCurrentRefinementsConnectorTests(
     );
 
     await nextTick();
-  }
-);
-
-createHitsPerPageConnectorTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+  },
+  async createHitsPerPageConnectorTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
     const CustomHitsPerPage = createCustomWidget({
       connector: connectHitsPerPage,
       name: 'HitsPerPage',
@@ -216,11 +201,11 @@ createHitsPerPageConnectorTests(
     );
 
     await nextTick();
-  }
-);
-
-createNumericMenuConnectorTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+  },
+  async createNumericMenuConnectorTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
     const CustomNumericMenu = createCustomWidget({
       connector: connectNumericMenu,
       name: 'NumericMenu',
@@ -240,11 +225,8 @@ createNumericMenuConnectorTests(
     );
 
     await nextTick();
-  }
-);
-
-createRatingMenuConnectorTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+  },
+  async createRatingMenuConnectorTests({ instantSearchOptions, widgetParams }) {
     const CustomRatingMenu = createCustomWidget({
       connector: connectRatingMenu,
       name: 'RatingMenu',
@@ -264,11 +246,11 @@ createRatingMenuConnectorTests(
     );
 
     await nextTick();
-  }
-);
-
-createToggleRefinementConnectorTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+  },
+  async createToggleRefinementConnectorTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
     const CustomToggleRefinement = createCustomWidget({
       name: 'ToggleRefinement',
       connector: connectToggleRefinement,
@@ -294,8 +276,8 @@ createToggleRefinementConnectorTests(
     );
 
     await nextTick();
-  }
-);
+  },
+};
 
 function createCustomWidget({
   connector,
@@ -353,3 +335,13 @@ function createCustomWidget({
     }),
   };
 }
+
+describe('Common connector tests (Vue InstantSearch)', () => {
+  test('has all the tests', () => {
+    expect(Object.keys(setups).sort()).toEqual(Object.keys(suites).sort());
+  });
+
+  Object.keys(suites).forEach((testName) => {
+    suites[testName](setups[testName]);
+  });
+});

--- a/packages/vue-instantsearch/src/__tests__/common-shared.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-shared.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { createSharedTests } from '@instantsearch/tests';
+import * as suites from '@instantsearch/tests/shared';
 
 import { nextTick, mountApp } from '../../test/utils';
 import { renderCompat } from '../util/vue-compat';
@@ -15,36 +15,38 @@ import {
 import { connectMenu, connectPagination } from 'instantsearch.js/es/connectors';
 jest.unmock('instantsearch.js/es');
 
-createSharedTests(async ({ instantSearchOptions, widgetParams }) => {
-  const CustomMenu = createCustomWidget({
-    connector: connectMenu,
-    name: 'Menu',
-    requiredProps: ['attribute'],
-    urlValue: 'value',
-  });
-  const CustomPagination = createCustomWidget({
-    connector: connectPagination,
-    name: 'Pagination',
-    urlValue: 10,
-  });
+const setups = {
+  async createSharedTests({ instantSearchOptions, widgetParams }) {
+    const CustomMenu = createCustomWidget({
+      connector: connectMenu,
+      name: 'Menu',
+      requiredProps: ['attribute'],
+      urlValue: 'value',
+    });
+    const CustomPagination = createCustomWidget({
+      connector: connectPagination,
+      name: 'Pagination',
+      urlValue: 10,
+    });
 
-  mountApp(
-    {
-      render: renderCompat((h) =>
-        h(AisInstantSearch, { props: instantSearchOptions }, [
-          h(CustomMenu, { props: widgetParams.menu }),
-          h(AisMenu, { props: widgetParams.menu }),
-          h(AisHits, { props: widgetParams.hits }),
-          h(CustomPagination, { props: widgetParams.pagination }),
-          h(AisPagination, { props: widgetParams.pagination }),
-        ])
-      ),
-    },
-    document.body.appendChild(document.createElement('div'))
-  );
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(CustomMenu, { props: widgetParams.menu }),
+            h(AisMenu, { props: widgetParams.menu }),
+            h(AisHits, { props: widgetParams.hits }),
+            h(CustomPagination, { props: widgetParams.pagination }),
+            h(AisPagination, { props: widgetParams.pagination }),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
 
-  await nextTick();
-});
+    await nextTick();
+  },
+};
 
 function createCustomWidget({ connector, name, urlValue, requiredProps = [] }) {
   return {
@@ -76,3 +78,13 @@ function createCustomWidget({ connector, name, urlValue, requiredProps = [] }) {
     }),
   };
 }
+
+describe('Common shared tests (Vue InstantSearch)', () => {
+  test('has all the tests', () => {
+    expect(Object.keys(setups).sort()).toEqual(Object.keys(suites).sort());
+  });
+
+  Object.keys(suites).forEach((testName) => {
+    suites[testName](setups[testName]);
+  });
+});

--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -1,17 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import {
-  createRefinementListWidgetTests,
-  createHierarchicalMenuWidgetTests,
-  createBreadcrumbWidgetTests,
-  createMenuWidgetTests,
-  createPaginationWidgetTests,
-  createInfiniteHitsWidgetTests,
-  createHitsWidgetTests,
-  createRangeInputWidgetTests,
-  createInstantSearchWidgetTests,
-} from '@instantsearch/tests';
+import * as suites from '@instantsearch/tests/widgets';
 
 import { nextTick, mountApp } from '../../test/utils';
 import { renderCompat } from '../util/vue-compat';
@@ -45,8 +35,11 @@ const GlobalErrorSwallower = {
   },
 };
 
-createRefinementListWidgetTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+const setups = {
+  async createRefinementListWidgetTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
     mountApp(
       {
         render: renderCompat((h) =>
@@ -60,11 +53,11 @@ createRefinementListWidgetTests(
     );
 
     await nextTick();
-  }
-);
-
-createHierarchicalMenuWidgetTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+  },
+  async createHierarchicalMenuWidgetTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
     mountApp(
       {
         render: renderCompat((h) =>
@@ -78,65 +71,59 @@ createHierarchicalMenuWidgetTests(
     );
 
     await nextTick();
-  }
-);
+  },
+  async createBreadcrumbWidgetTests({ instantSearchOptions, widgetParams }) {
+    // The passed `transformItems` prop is meant to apply only to the breadcrumb,
+    // not the hierarchical menu
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { transformItems, ...hierarchicalWidgetParams } = widgetParams;
 
-createBreadcrumbWidgetTests(async ({ instantSearchOptions, widgetParams }) => {
-  // The passed `transformItems` prop is meant to apply only to the breadcrumb,
-  // not the hierarchical menu
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { transformItems, ...hierarchicalWidgetParams } = widgetParams;
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisBreadcrumb, { props: widgetParams }),
+            h(AisHierarchicalMenu, { props: hierarchicalWidgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
 
-  mountApp(
-    {
-      render: renderCompat((h) =>
-        h(AisInstantSearch, { props: instantSearchOptions }, [
-          h(AisBreadcrumb, { props: widgetParams }),
-          h(AisHierarchicalMenu, { props: hierarchicalWidgetParams }),
-          h(GlobalErrorSwallower),
-        ])
-      ),
-    },
-    document.body.appendChild(document.createElement('div'))
-  );
+    await nextTick();
+  },
+  async createMenuWidgetTests({ instantSearchOptions, widgetParams }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisMenu, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
 
-  await nextTick();
-});
+    await nextTick();
+  },
+  async createPaginationWidgetTests({ instantSearchOptions, widgetParams }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisPagination, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
 
-createMenuWidgetTests(async ({ instantSearchOptions, widgetParams }) => {
-  mountApp(
-    {
-      render: renderCompat((h) =>
-        h(AisInstantSearch, { props: instantSearchOptions }, [
-          h(AisMenu, { props: widgetParams }),
-          h(GlobalErrorSwallower),
-        ])
-      ),
-    },
-    document.body.appendChild(document.createElement('div'))
-  );
-
-  await nextTick();
-});
-
-createPaginationWidgetTests(async ({ instantSearchOptions, widgetParams }) => {
-  mountApp(
-    {
-      render: renderCompat((h) =>
-        h(AisInstantSearch, { props: instantSearchOptions }, [
-          h(AisPagination, { props: widgetParams }),
-          h(GlobalErrorSwallower),
-        ])
-      ),
-    },
-    document.body.appendChild(document.createElement('div'))
-  );
-
-  await nextTick();
-});
-
-createInfiniteHitsWidgetTests(
-  async ({ instantSearchOptions, widgetParams }) => {
+    await nextTick();
+  },
+  async createInfiniteHitsWidgetTests({ instantSearchOptions, widgetParams }) {
     mountApp(
       {
         render: renderCompat((h) =>
@@ -213,124 +200,132 @@ createInfiniteHitsWidgetTests(
     );
 
     await nextTick();
-  }
-);
-
-createHitsWidgetTests(async ({ instantSearchOptions, widgetParams }) => {
-  mountApp(
-    {
-      render: renderCompat((h) =>
-        h(AisInstantSearch, { props: instantSearchOptions }, [
-          h(AisSearchBox),
-          h(AisHits, {
-            attrs: { id: 'main-hits' },
-            props: widgetParams,
-            scopedSlots: {
-              item: ({ item: hit, sendEvent }) =>
-                h(
-                  'div',
-                  {
-                    attrs: {
-                      'data-testid': `main-hits-top-level-${hit.__position}`,
-                    },
-                  },
-                  [
-                    hit.objectID,
-                    h('button', {
-                      attrs: {
-                        'data-testid': `main-hits-convert-${hit.__position}`,
-                      },
-                      on: {
-                        click: () => sendEvent('conversion', hit, 'Converted'),
-                      },
-                    }),
-                    h('button', {
-                      attrs: {
-                        'data-testid': `main-hits-click-${hit.__position}`,
-                      },
-                      on: {
-                        click: () => sendEvent('click', hit, 'Clicked'),
-                      },
-                    }),
-                  ]
-                ),
-            },
-          }),
-          h(AisIndex, { props: { indexName: 'nested' } }, [
+  },
+  async createHitsWidgetTests({ instantSearchOptions, widgetParams }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisSearchBox),
             h(AisHits, {
-              attrs: { id: 'nested-hits' },
+              attrs: { id: 'main-hits' },
+              props: widgetParams,
               scopedSlots: {
                 item: ({ item: hit, sendEvent }) =>
                   h(
                     'div',
                     {
                       attrs: {
-                        'data-testid': `nested-hits-top-level-${hit.__position}`,
+                        'data-testid': `main-hits-top-level-${hit.__position}`,
                       },
                     },
                     [
                       hit.objectID,
                       h('button', {
                         attrs: {
-                          'data-testid': `nested-hits-click-${hit.__position}`,
+                          'data-testid': `main-hits-convert-${hit.__position}`,
                         },
                         on: {
                           click: () =>
-                            sendEvent('click', hit, 'Clicked nested'),
+                            sendEvent('conversion', hit, 'Converted'),
+                        },
+                      }),
+                      h('button', {
+                        attrs: {
+                          'data-testid': `main-hits-click-${hit.__position}`,
+                        },
+                        on: {
+                          click: () => sendEvent('click', hit, 'Clicked'),
                         },
                       }),
                     ]
                   ),
               },
             }),
-          ]),
-          h(GlobalErrorSwallower),
-        ])
-      ),
-    },
-    document.body.appendChild(document.createElement('div'))
-  );
+            h(AisIndex, { props: { indexName: 'nested' } }, [
+              h(AisHits, {
+                attrs: { id: 'nested-hits' },
+                scopedSlots: {
+                  item: ({ item: hit, sendEvent }) =>
+                    h(
+                      'div',
+                      {
+                        attrs: {
+                          'data-testid': `nested-hits-top-level-${hit.__position}`,
+                        },
+                      },
+                      [
+                        hit.objectID,
+                        h('button', {
+                          attrs: {
+                            'data-testid': `nested-hits-click-${hit.__position}`,
+                          },
+                          on: {
+                            click: () =>
+                              sendEvent('click', hit, 'Clicked nested'),
+                          },
+                        }),
+                      ]
+                    ),
+                },
+              }),
+            ]),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
 
-  await nextTick();
-});
+    await nextTick();
+  },
+  async createRangeInputWidgetTests({ instantSearchOptions, widgetParams }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisRangeInput, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
 
-createRangeInputWidgetTests(async ({ instantSearchOptions, widgetParams }) => {
-  mountApp(
-    {
-      render: renderCompat((h) =>
-        h(AisInstantSearch, { props: instantSearchOptions }, [
-          h(AisRangeInput, { props: widgetParams }),
-          h(GlobalErrorSwallower),
-        ])
-      ),
-    },
-    document.body.appendChild(document.createElement('div'))
-  );
+    await nextTick();
+  },
+  createInstantSearchWidgetTests({ instantSearchOptions }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
 
-  await nextTick();
-});
+    return {
+      algoliaAgents: [
+        `instantsearch.js (${
+          require('../../../instantsearch.js/package.json').version
+        })`,
+        `Vue InstantSearch (${
+          require('../../../vue-instantsearch/package.json').version
+        })`,
+        `Vue (${require('../util/vue-compat').version})`,
+      ],
+    };
+  },
+};
 
-createInstantSearchWidgetTests(({ instantSearchOptions }) => {
-  mountApp(
-    {
-      render: renderCompat((h) =>
-        h(AisInstantSearch, { props: instantSearchOptions }, [
-          h(GlobalErrorSwallower),
-        ])
-      ),
-    },
-    document.body.appendChild(document.createElement('div'))
-  );
+describe('Common widget tests (Vue InstantSearch)', () => {
+  test('has all the tests', () => {
+    expect(Object.keys(setups).sort()).toEqual(Object.keys(suites).sort());
+  });
 
-  return {
-    algoliaAgents: [
-      `instantsearch.js (${
-        require('../../../instantsearch.js/package.json').version
-      })`,
-      `Vue InstantSearch (${
-        require('../../../vue-instantsearch/package.json').version
-      })`,
-      `Vue (${require('../util/vue-compat').version})`,
-    ],
-  };
+  Object.keys(suites).forEach((testName) => {
+    suites[testName](setups[testName]);
+  });
 });


### PR DESCRIPTION
The common test suite tests are now moved into an object of "setups" and ran separately.

This allows for a couple things that are nice
- you can easily skip running a test or run just a single one by putting a condition in the loop
- TypeScript enforces all tests are implemented
- jest enforces all tests are implemented