### PR TITLE
feat(react-instantsearch-hooks web): rename `<Stats>` translation

### DIFF
--- a/packages/react-instantsearch-hooks-web/src/ui/Stats.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/Stats.tsx
@@ -9,7 +9,7 @@ export type StatsProps = React.ComponentProps<'div'> & {
   areHitsSorted?: boolean;
   classNames?: Partial<StatsClassNames>;
   translations: {
-    stats: StatsTranslations;
+    rootElementText: StatsTranslations;
   };
 };
 
@@ -49,7 +49,7 @@ export function Stats({
       className={cx('ais-Stats', classNames.root, props.className)}
     >
       <span className="ais-Stats-text">
-        {translations.stats(translationOptions)}
+        {translations.rootElementText(translationOptions)}
       </span>
     </div>
   );

--- a/packages/react-instantsearch-hooks-web/src/ui/__tests__/Stats.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/ui/__tests__/Stats.test.tsx
@@ -17,7 +17,7 @@ describe('Stats', () => {
       areHitsSorted: false,
       nbSortedHits: 100,
       translations: {
-        stats: ({
+        rootElementText: ({
           nbHits,
           processingTimeMS,
           nbSortedHits,
@@ -153,7 +153,9 @@ describe('Stats', () => {
   test('renders with translations', () => {
     const translationFn = ({ areHitsSorted }: StatsTranslationOptions) =>
       areHitsSorted ? 'Sorted' : 'Unsorted';
-    let props = createProps({ translations: { stats: translationFn } });
+    let props = createProps({
+      translations: { rootElementText: translationFn },
+    });
 
     const { getByText, rerender } = render(<Stats {...props} />);
 
@@ -163,7 +165,7 @@ describe('Stats', () => {
       areHitsSorted: true,
       nbSortedHits: 1,
       nbHits: 2,
-      translations: { stats: translationFn },
+      translations: { rootElementText: translationFn },
     });
 
     rerender(<Stats {...props} />);

--- a/packages/react-instantsearch-hooks-web/src/widgets/Stats.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/Stats.tsx
@@ -8,6 +8,7 @@ import type {
   StatsTranslationOptions,
 } from '../ui/Stats';
 import type { UseStatsProps } from 'react-instantsearch-hooks';
+import { warn } from '../../../react-instantsearch-hooks/src/lib/warn';
 
 type UiProps = Pick<
   StatsUiComponentProps,
@@ -19,12 +20,24 @@ type UiProps = Pick<
 >;
 
 export type StatsProps = Omit<StatsUiComponentProps, keyof UiProps> &
-  UseStatsProps & { translations?: Partial<UiProps['translations']> };
+  UseStatsProps & {
+    translations?: Partial<UiProps['translations']> & {
+      /**
+       * @deprecated Use `rootElementText` instead.
+       */
+      stats?: Partial<UiProps['translations']>['rootElementText'];
+    };
+  };
 
 export function Stats({ translations, ...props }: StatsProps) {
   const { nbHits, nbSortedHits, processingTimeMS, areHitsSorted } = useStats(
     undefined,
     { $$widgetType: 'ais.stats' }
+  );
+
+  warn(
+    !translations?.stats,
+    'The `stats` translation is deprecated. Please use `rootElementText` instead.'
   );
 
   const statsTranslation = (options: StatsTranslationOptions): string =>
@@ -38,7 +51,7 @@ export function Stats({ translations, ...props }: StatsProps) {
     processingTimeMS,
     areHitsSorted,
     translations: {
-      rootElementText: statsTranslation,
+      rootElementText: translations?.stats || statsTranslation,
       ...translations,
     },
   };

--- a/packages/react-instantsearch-hooks-web/src/widgets/Stats.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/Stats.tsx
@@ -38,7 +38,7 @@ export function Stats({ translations, ...props }: StatsProps) {
     processingTimeMS,
     areHitsSorted,
     translations: {
-      stats: statsTranslation,
+      rootElementText: statsTranslation,
       ...translations,
     },
   };

--- a/packages/react-instantsearch-hooks-web/src/widgets/Stats.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/Stats.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useStats } from 'react-instantsearch-hooks';
+import { useStats, warn } from 'react-instantsearch-hooks';
 
 import { Stats as StatsUiComponent } from '../ui/Stats';
 
@@ -8,7 +8,6 @@ import type {
   StatsTranslationOptions,
 } from '../ui/Stats';
 import type { UseStatsProps } from 'react-instantsearch-hooks';
-import { warn } from '../../../react-instantsearch-hooks/src/lib/warn';
 
 type UiProps = Pick<
   StatsUiComponentProps,

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Stats.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Stats.test.tsx
@@ -172,7 +172,7 @@ describe('Stats', () => {
     const client = createMockedSearchClient();
     let result: ReturnType<typeof render> | undefined = undefined;
 
-    expect(async () => {
+    expect(() => {
       result = render(
         <InstantSearchHooksTestWrapper searchClient={client}>
           <Stats

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Stats.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Stats.test.tsx
@@ -143,7 +143,7 @@ describe('Stats', () => {
       <InstantSearchHooksTestWrapper searchClient={client}>
         <Stats
           translations={{
-            stats: () => 'Nice stats',
+            rootElementText: () => 'Nice stats',
           }}
         />
       </InstantSearchHooksTestWrapper>

--- a/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Stats.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/widgets/__tests__/Stats.test.tsx
@@ -168,6 +168,45 @@ describe('Stats', () => {
     });
   });
 
+  test('renders with deprecated translations (with a deprecation warning)', async () => {
+    const client = createMockedSearchClient();
+    let result: ReturnType<typeof render> | undefined = undefined;
+
+    expect(async () => {
+      result = render(
+        <InstantSearchHooksTestWrapper searchClient={client}>
+          <Stats
+            translations={{
+              stats: () => 'Nice stats',
+            }}
+          />
+        </InstantSearchHooksTestWrapper>
+      );
+    }).toWarnDev(
+      '[InstantSearch] The `stats` translation is deprecated. Please use `rootElementText` instead.'
+    );
+
+    await waitFor(() => {
+      expect(client.search).toHaveBeenCalledTimes(1);
+    });
+
+    const { container } = result!;
+
+    await waitFor(() => {
+      expect(container.querySelector('.ais-Stats')).toMatchInlineSnapshot(`
+      <div
+        class="ais-Stats"
+      >
+        <span
+          class="ais-Stats-text"
+        >
+          Nice stats
+        </span>
+      </div>
+      `);
+    });
+  });
+
   test('forwards custom class names and `div` props to the root element', () => {
     const { container } = render(
       <InstantSearchHooksTestWrapper>

--- a/packages/react-instantsearch-hooks/src/index.ts
+++ b/packages/react-instantsearch-hooks/src/index.ts
@@ -28,3 +28,4 @@ export * from './connectors/useStats';
 export * from './connectors/useToggleRefinement';
 export * from './hooks/useConnector';
 export * from './hooks/useInstantSearch';
+export * from './lib/warn';


### PR DESCRIPTION
The `<Stats>` widget was introduced in https://github.com/algolia/instantsearch/pull/5427 but the translation name isn't consistent with the convention we agreed on in the [Translations RFC](https://github.com/algolia/instantsearch-rfcs/blob/master/implemented/translations-api-rish.md#naming).

This changes the name for something more consistent and conventional.

The change is breaking for anyone already using the `<Stats>` widget.