### PR TITLE
test(common): make test loop typesafe

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common-connectors.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-connectors.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { runTestSuites } from '@instantsearch/tests';
 import * as suites from '@instantsearch/tests/connectors';
 
 import {
@@ -18,13 +19,12 @@ import {
 import instantsearch from '../index.es';
 import { refinementList } from '../widgets';
 
+import type { TestOptionsMap, TestSetupsMap } from '@instantsearch/tests';
+
 type TestSuites = typeof suites;
 const testSuites: TestSuites = suites;
-type TestSetups = {
-  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
-};
 
-const setups: TestSetups = {
+const testSetups: TestSetupsMap<TestSuites> = {
   createHierarchicalMenuConnectorTests({ instantSearchOptions, widgetParams }) {
     const customHierarchicalMenu = connectHierarchicalMenu<{
       container: HTMLElement;
@@ -376,14 +376,23 @@ const setups: TestSetups = {
   },
 };
 
-describe('Common connector tests (InstantSearch.js)', () => {
-  test('has all the tests', () => {
-    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
-  });
+const testOptions: TestOptionsMap<TestSuites> = {
+  createHierarchicalMenuConnectorTests: undefined,
+  createBreadcrumbConnectorTests: undefined,
+  createRefinementListConnectorTests: undefined,
+  createMenuConnectorTests: undefined,
+  createPaginationConnectorTests: undefined,
+  createCurrentRefinementsConnectorTests: undefined,
+  createHitsPerPageConnectorTests: undefined,
+  createNumericMenuConnectorTests: undefined,
+  createRatingMenuConnectorTests: undefined,
+  createToggleRefinementConnectorTests: undefined,
+};
 
-  Object.keys(testSuites).forEach((testName) => {
-    // @ts-ignore (typescript is only referentially typed)
-    // https://github.com/microsoft/TypeScript/issues/38520
-    testSuites[testName](setups[testName]);
+describe('Common connector tests (InstantSearch.js)', () => {
+  runTestSuites({
+    testSuites,
+    testSetups,
+    testOptions,
   });
 });

--- a/packages/instantsearch.js/src/__tests__/common-shared.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-shared.test.tsx
@@ -1,19 +1,19 @@
 /**
  * @jest-environment jsdom
  */
+import { runTestSuites } from '@instantsearch/tests';
 import * as suites from '@instantsearch/tests/shared';
 
 import { connectMenu, connectPagination } from '../connectors';
 import instantsearch from '../index.es';
 import { menu, pagination, hits } from '../widgets';
 
+import type { TestOptionsMap, TestSetupsMap } from '@instantsearch/tests';
+
 type TestSuites = typeof suites;
 const testSuites: TestSuites = suites;
-type TestSetups = {
-  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
-};
 
-const setups: TestSetups = {
+const testSetups: TestSetupsMap<TestSuites> = {
   createSharedTests({ instantSearchOptions, widgetParams }) {
     const menuURL = connectMenu<{ container: HTMLElement }>((renderOptions) => {
       renderOptions.widgetParams.container.innerHTML = `
@@ -71,14 +71,14 @@ const setups: TestSetups = {
   },
 };
 
-describe('Common widget tests (InstantSearch.js)', () => {
-  test('has all the tests', () => {
-    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
-  });
+const testOptions: TestOptionsMap<TestSuites> = {
+  createSharedTests: undefined,
+};
 
-  Object.keys(testSuites).forEach((testName) => {
-    // @ts-ignore (typescript is only referentially typed)
-    // https://github.com/microsoft/TypeScript/issues/38520
-    testSuites[testName](setups[testName]);
+describe('Common shared tests (InstantSearch.js)', () => {
+  runTestSuites({
+    testSuites,
+    testSetups,
+    testOptions,
   });
 });

--- a/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { runTestSuites } from '@instantsearch/tests';
 import * as suites from '@instantsearch/tests/widgets';
 
 import instantsearch from '../index.es';
@@ -18,13 +19,12 @@ import {
   rangeInput,
 } from '../widgets';
 
+import type { TestOptionsMap, TestSetupsMap } from '@instantsearch/tests';
+
 type TestSuites = typeof suites;
 const testSuites: TestSuites = suites;
-type TestSetups = {
-  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
-};
 
-const setups: TestSetups = {
+const testSetups: TestSetupsMap<TestSuites> = {
   createHierarchicalMenuWidgetTests({ instantSearchOptions, widgetParams }) {
     instantsearch(instantSearchOptions)
       .addWidgets([
@@ -274,14 +274,22 @@ const setups: TestSetups = {
   },
 };
 
-describe('Common shared tests (InstantSearch.js)', () => {
-  test('has all the tests', () => {
-    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
-  });
+const testOptions: TestOptionsMap<TestSuites> = {
+  createRefinementListWidgetTests: undefined,
+  createHierarchicalMenuWidgetTests: undefined,
+  createBreadcrumbWidgetTests: undefined,
+  createMenuWidgetTests: undefined,
+  createPaginationWidgetTests: undefined,
+  createInfiniteHitsWidgetTests: undefined,
+  createHitsWidgetTests: undefined,
+  createRangeInputWidgetTests: undefined,
+  createInstantSearchWidgetTests: undefined,
+};
 
-  Object.keys(testSuites).forEach((testName) => {
-    // @ts-ignore (typescript is only referentially typed)
-    // https://github.com/microsoft/TypeScript/issues/38520
-    testSuites[testName](setups[testName]);
+describe('Common widget tests (InstantSearch.js)', () => {
+  runTestSuites({
+    testSuites,
+    testSetups,
+    testOptions,
   });
 });

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common-connectors.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common-connectors.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { runTestSuites } from '@instantsearch/tests';
 import * as suites from '@instantsearch/tests/connectors';
 import { act, render } from '@testing-library/react';
 import { connectRatingMenu } from 'instantsearch.js/es/connectors';
@@ -32,6 +33,7 @@ import type {
   UseRefinementListProps,
   UseToggleRefinementProps,
 } from '..';
+import type { TestOptionsMap, TestSetupsMap } from '@instantsearch/tests';
 import type {
   RatingMenuConnectorParams,
   RatingMenuWidgetDescription,
@@ -39,14 +41,8 @@ import type {
 
 type TestSuites = typeof suites;
 const testSuites: TestSuites = suites;
-type TestSetups = {
-  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
-};
-type TestOptions = {
-  [key in keyof TestSuites]?: Parameters<TestSuites[key]>[2];
-};
 
-const setups: TestSetups = {
+const testSetups: TestSetupsMap<TestSuites> = {
   createRefinementListConnectorTests({ instantSearchOptions, widgetParams }) {
     function CustomRefinementList(props: UseRefinementListProps) {
       const { createURL, refine } = useRefinementList(props);
@@ -307,23 +303,29 @@ const setups: TestSetups = {
   },
 };
 
-describe('Common connector tests (React InstantSearch)', () => {
-  test('has all the tests', () => {
-    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
-  });
-
-  const testOptions: TestOptions = {
-    createCurrentRefinementsConnectorTests: {
-      skippedTests: {
-        /** createURL uses helper state instead of ui state as it can't be translated */
-        routing: true,
-      },
+const testOptions: TestOptionsMap<TestSuites> = {
+  createCurrentRefinementsConnectorTests: {
+    skippedTests: {
+      /** createURL uses helper state instead of ui state as it can't be translated */
+      routing: true,
     },
-  };
+  },
+  createHierarchicalMenuConnectorTests: undefined,
+  createBreadcrumbConnectorTests: undefined,
+  createMenuConnectorTests: undefined,
+  createPaginationConnectorTests: undefined,
+  createRefinementListConnectorTests: undefined,
+  createHitsPerPageConnectorTests: undefined,
+  createNumericMenuConnectorTests: undefined,
+  createRatingMenuConnectorTests: undefined,
+  createToggleRefinementConnectorTests: undefined,
+};
 
-  Object.keys(testSuites).forEach((testName) => {
-    // @ts-ignore (typescript is only referentially typed)
-    // https://github.com/microsoft/TypeScript/issues/38520
-    testSuites[testName](setups[testName], act, testOptions[testName]);
+describe('Common connector tests (React InstantSearch)', () => {
+  runTestSuites({
+    testSuites,
+    testSetups,
+    testOptions,
+    act,
   });
 });

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common-shared.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common-shared.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { runTestSuites } from '@instantsearch/tests';
 import * as suites from '@instantsearch/tests/shared';
 import { act, render } from '@testing-library/react';
 import React from 'react';
@@ -15,14 +16,12 @@ import {
 } from '..';
 
 import type { UseMenuProps, UsePaginationProps } from '..';
+import type { TestOptionsMap, TestSetupsMap } from '@instantsearch/tests';
 
 type TestSuites = typeof suites;
 const testSuites: TestSuites = suites;
-type TestSetups = {
-  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
-};
 
-const setups: TestSetups = {
+const testSetups: TestSetupsMap<TestSuites> = {
   createSharedTests({ instantSearchOptions, widgetParams }) {
     function MenuURL(props: UseMenuProps) {
       const { createURL } = useMenu(props);
@@ -54,14 +53,15 @@ const setups: TestSetups = {
   },
 };
 
-describe('Common shared tests (React InstantSearch)', () => {
-  test('has all the tests', () => {
-    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
-  });
+const testOptions: TestOptionsMap<TestSuites> = {
+  createSharedTests: undefined,
+};
 
-  Object.keys(testSuites).forEach((testName) => {
-    // @ts-ignore (typescript is only referentially typed)
-    // https://github.com/microsoft/TypeScript/issues/38520
-    testSuites[testName](setups[testName], act);
+describe('Common shared tests (React InstantSearch)', () => {
+  runTestSuites({
+    testSuites,
+    testSetups,
+    testOptions,
+    act,
   });
 });

--- a/packages/react-instantsearch-hooks-web/src/__tests__/common-widgets.test.tsx
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/common-widgets.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { runTestSuites } from '@instantsearch/tests';
 import * as suites from '@instantsearch/tests/widgets';
 import { act, render } from '@testing-library/react';
 import React from 'react';
@@ -20,16 +21,14 @@ import {
   RangeInput,
 } from '..';
 
+import type { TestOptionsMap, TestSetupsMap } from '@instantsearch/tests';
 import type { Hit } from 'instantsearch.js';
 import type { SendEventForHits } from 'instantsearch.js/es/lib/utils';
 
 type TestSuites = typeof suites;
 const testSuites: TestSuites = suites;
-type TestSetups = {
-  [key in keyof TestSuites]: Parameters<TestSuites[key]>[0];
-};
 
-const setups: TestSetups = {
+const testSetups: TestSetupsMap<TestSuites> = {
   createRefinementListWidgetTests({ instantSearchOptions, widgetParams }) {
     render(
       <InstantSearch {...instantSearchOptions}>
@@ -218,6 +217,18 @@ const setups: TestSetups = {
   },
 };
 
+const testOptions: TestOptionsMap<TestSuites> = {
+  createRefinementListWidgetTests: undefined,
+  createHierarchicalMenuWidgetTests: undefined,
+  createBreadcrumbWidgetTests: undefined,
+  createMenuWidgetTests: undefined,
+  createPaginationWidgetTests: undefined,
+  createInfiniteHitsWidgetTests: undefined,
+  createHitsWidgetTests: undefined,
+  createRangeInputWidgetTests: undefined,
+  createInstantSearchWidgetTests: undefined,
+};
+
 /**
  * prevent rethrowing InstantSearch errors, so tests can be asserted.
  * IRL this isn't needed, as the error doesn't stop execution.
@@ -229,13 +240,10 @@ function GlobalErrorSwallower() {
 }
 
 describe('Common widget tests (React InstantSearch)', () => {
-  test('has all the tests', () => {
-    expect(Object.keys(setups).sort()).toEqual(Object.keys(testSuites).sort());
-  });
-
-  Object.keys(testSuites).forEach((testName) => {
-    // @ts-ignore (typescript is only referentially typed)
-    // https://github.com/microsoft/TypeScript/issues/38520
-    testSuites[testName](setups[testName], act);
+  runTestSuites({
+    testSuites,
+    testSetups,
+    testOptions,
+    act,
   });
 });

--- a/packages/vue-instantsearch/src/__tests__/common-connectors.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-connectors.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import * as suites from '@instantsearch/tests/connectors';
+import * as testSuites from '@instantsearch/tests/connectors';
 
 import { nextTick, mountApp } from '../../test/utils';
 import { renderCompat } from '../util/vue-compat';
@@ -23,9 +23,10 @@ import {
   connectRefinementList,
   connectToggleRefinement,
 } from 'instantsearch.js/es/connectors';
+import { runTestSuites } from '@instantsearch/tests/common';
 jest.unmock('instantsearch.js/es');
 
-const setups = {
+const testSetups = {
   async createRefinementListConnectorTests({
     instantSearchOptions,
     widgetParams,
@@ -336,12 +337,23 @@ function createCustomWidget({
   };
 }
 
-describe('Common connector tests (Vue InstantSearch)', () => {
-  test('has all the tests', () => {
-    expect(Object.keys(setups).sort()).toEqual(Object.keys(suites).sort());
-  });
+const testOptions = {
+  createHierarchicalMenuConnectorTests: undefined,
+  createBreadcrumbConnectorTests: undefined,
+  createRefinementListConnectorTests: undefined,
+  createMenuConnectorTests: undefined,
+  createPaginationConnectorTests: undefined,
+  createCurrentRefinementsConnectorTests: undefined,
+  createHitsPerPageConnectorTests: undefined,
+  createNumericMenuConnectorTests: undefined,
+  createRatingMenuConnectorTests: undefined,
+  createToggleRefinementConnectorTests: undefined,
+};
 
-  Object.keys(suites).forEach((testName) => {
-    suites[testName](setups[testName]);
+describe('Common connector tests (Vue InstantSearch)', () => {
+  runTestSuites({
+    testSuites,
+    testSetups,
+    testOptions,
   });
 });

--- a/packages/vue-instantsearch/src/__tests__/common-shared.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-shared.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import * as suites from '@instantsearch/tests/shared';
+import * as testSuites from '@instantsearch/tests/shared';
 
 import { nextTick, mountApp } from '../../test/utils';
 import { renderCompat } from '../util/vue-compat';
@@ -13,9 +13,10 @@ import {
   createWidgetMixin,
 } from '../instantsearch';
 import { connectMenu, connectPagination } from 'instantsearch.js/es/connectors';
+import { runTestSuites } from '@instantsearch/tests/common';
 jest.unmock('instantsearch.js/es');
 
-const setups = {
+const testSetups = {
   async createSharedTests({ instantSearchOptions, widgetParams }) {
     const CustomMenu = createCustomWidget({
       connector: connectMenu,
@@ -79,12 +80,14 @@ function createCustomWidget({ connector, name, urlValue, requiredProps = [] }) {
   };
 }
 
-describe('Common shared tests (Vue InstantSearch)', () => {
-  test('has all the tests', () => {
-    expect(Object.keys(setups).sort()).toEqual(Object.keys(suites).sort());
-  });
+const testOptions = {
+  createSharedTests: undefined,
+};
 
-  Object.keys(suites).forEach((testName) => {
-    suites[testName](setups[testName]);
+describe('Common shared tests (Vue InstantSearch)', () => {
+  runTestSuites({
+    testSuites,
+    testSetups,
+    testOptions,
   });
 });

--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import * as suites from '@instantsearch/tests/widgets';
+import * as testSuites from '@instantsearch/tests/widgets';
 
 import { nextTick, mountApp } from '../../test/utils';
 import { renderCompat } from '../util/vue-compat';
@@ -19,6 +19,8 @@ import {
   AisIndex,
   AisRangeInput,
 } from '../instantsearch';
+import { runTestSuites } from '@instantsearch/tests/common';
+
 jest.unmock('instantsearch.js/es');
 
 /**
@@ -35,7 +37,7 @@ const GlobalErrorSwallower = {
   },
 };
 
-const setups = {
+const testSetups = {
   async createRefinementListWidgetTests({
     instantSearchOptions,
     widgetParams,
@@ -320,12 +322,22 @@ const setups = {
   },
 };
 
-describe('Common widget tests (Vue InstantSearch)', () => {
-  test('has all the tests', () => {
-    expect(Object.keys(setups).sort()).toEqual(Object.keys(suites).sort());
-  });
+const testOptions = {
+  createRefinementListWidgetTests: undefined,
+  createHierarchicalMenuWidgetTests: undefined,
+  createBreadcrumbWidgetTests: undefined,
+  createMenuWidgetTests: undefined,
+  createPaginationWidgetTests: undefined,
+  createInfiniteHitsWidgetTests: undefined,
+  createHitsWidgetTests: undefined,
+  createRangeInputWidgetTests: undefined,
+  createInstantSearchWidgetTests: undefined,
+};
 
-  Object.keys(suites).forEach((testName) => {
-    suites[testName](setups[testName]);
+describe('Common widget tests (Vue InstantSearch)', () => {
+  runTestSuites({
+    testSuites,
+    testSetups,
+    testOptions,
   });
 });

--- a/tests/common/common.ts
+++ b/tests/common/common.ts
@@ -25,3 +25,60 @@ export function skippableDescribe(
 ) {
   return (skippedTests[name] ? describe.skip : describe)(name, fn);
 }
+
+export type TestOptions = {
+  skippedTests?: SkippedTests;
+};
+
+export type AnyTestSuite = (
+  setup: TestSetup<Record<string, unknown>, any>,
+  act: Act,
+  options: TestOptions
+) => any;
+
+export type TestSetupsMap<TTestSuites extends Record<string, AnyTestSuite>> = {
+  [key in keyof TTestSuites]: Parameters<TTestSuites[key]>[0];
+};
+export type TestOptionsMap<TTestSuites extends Record<string, AnyTestSuite>> = {
+  [key in keyof TTestSuites]: Parameters<TTestSuites[key]>[2];
+};
+export type TestSuite<
+  TTestSuites extends Record<string, AnyTestSuite>,
+  TKey extends keyof TTestSuites
+> = {
+  [key in keyof TTestSuites]: (
+    setup: TestSetupsMap<TTestSuites>[key],
+    act: Act,
+    option: TestOptionsMap<TTestSuites>[key]
+  ) => void;
+}[TKey];
+
+/**
+ * Run all the test suites.
+ */
+export function runTestSuites<
+  TTestSuites extends Record<string, AnyTestSuite>
+>({
+  testSuites,
+  testSetups,
+  testOptions,
+  act = fakeAct,
+}: {
+  testSuites: TTestSuites;
+  testSetups: TestSetupsMap<TTestSuites>;
+  act?: Act;
+  testOptions: TestOptionsMap<TTestSuites>;
+}) {
+  test('has all the tests', () => {
+    expect(Object.keys(testSetups).sort()).toEqual(
+      Object.keys(testSuites).sort()
+    );
+  });
+
+  (Object.keys(testSuites) as Array<keyof TTestSuites>).forEach(
+    <T extends keyof TTestSuites>(key: T) => {
+      const suite: TestSuite<TTestSuites, T> = testSuites[key];
+      suite(testSetups[key], act, testOptions[key]);
+    }
+  );
+}

--- a/tests/common/connectors/current-refinements/index.ts
+++ b/tests/common/connectors/current-refinements/index.ts
@@ -1,5 +1,5 @@
 import type { CurrentRefinementsWidget } from 'instantsearch.js/es/widgets/current-refinements/current-refinements';
-import type { Act, SkippedTests, TestSetup } from '../../common';
+import type { TestSetup, TestOptions } from '../../common';
 import { fakeAct } from '../../common';
 import { createRoutingTests } from './routing';
 
@@ -10,8 +10,8 @@ export type CurrentRefinementsConnectorSetup = TestSetup<{
 
 export function createCurrentRefinementsConnectorTests(
   setup: CurrentRefinementsConnectorSetup,
-  act: Act = fakeAct,
-  { skippedTests = {} }: { skippedTests?: SkippedTests } = {}
+  act = fakeAct,
+  { skippedTests = {} }: TestOptions = {}
 ) {
   beforeEach(() => {
     document.body.innerHTML = '';

--- a/tests/common/index.ts
+++ b/tests/common/index.ts
@@ -1,3 +1,4 @@
 export * from './connectors';
 export * from './widgets';
 export * from './shared';
+export * from './common';


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

In a previous iteration of ensuring all common tests suites are implemented, we conceded and assumed you can't type-safe loop over multiple objects (with the same key).

This is actually possible thanks to: https://github.com/microsoft/TypeScript/issues/49506#issuecomment-1639884200

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- No more ts-ignore in the common-test suite runner
- more consistency between tests