### PR TITLE
feat(caching): sort filters and queries

### DIFF
--- a/packages/algoliasearch-helper/src/SearchParameters/index.js
+++ b/packages/algoliasearch-helper/src/SearchParameters/index.js
@@ -1446,7 +1446,8 @@ SearchParameters.prototype = {
         return self.disjunctiveFacetsRefinements[facet].length > 0;
       })
       .concat(disjunctiveNumericRefinedFacets)
-      .concat(this.getRefinedHierarchicalFacets());
+      .concat(this.getRefinedHierarchicalFacets())
+      .sort();
   },
   /**
    * Returns the list of all disjunctive facets refined
@@ -1467,7 +1468,7 @@ SearchParameters.prototype = {
       Object.keys(this.hierarchicalFacetsRefinements).filter(function (facet) {
         return self.hierarchicalFacetsRefinements[facet].length > 0;
       })
-    );
+    ).sort();
   },
   /**
    * Returned the list of all disjunctive facets not refined

--- a/packages/algoliasearch-helper/src/requestBuilder.js
+++ b/packages/algoliasearch-helper/src/requestBuilder.js
@@ -4,9 +4,7 @@ var merge = require('./functions/merge');
 
 function sortObject(obj) {
   return Object.keys(obj)
-    .sort(function (a, b) {
-      return a.localeCompare(b);
-    })
+    .sort()
     .reduce(function (acc, curr) {
       acc[curr] = obj[curr];
       return acc;

--- a/packages/algoliasearch-helper/src/requestBuilder.js
+++ b/packages/algoliasearch-helper/src/requestBuilder.js
@@ -32,102 +32,96 @@ var requestBuilder = {
     });
 
     // One for each disjunctive facets
-    state
-      .getRefinedDisjunctiveFacets()
-      .sort()
-      .forEach(function (refinedFacet) {
-        queries.push({
-          indexName: index,
-          params: requestBuilder._getDisjunctiveFacetSearchParams(
-            state,
-            refinedFacet
-          ),
-        });
+    state.getRefinedDisjunctiveFacets().forEach(function (refinedFacet) {
+      queries.push({
+        indexName: index,
+        params: requestBuilder._getDisjunctiveFacetSearchParams(
+          state,
+          refinedFacet
+        ),
       });
+    });
 
     // More to get the parent levels of the hierarchical facets when refined
-    state
-      .getRefinedHierarchicalFacets()
-      .sort()
-      .forEach(function (refinedFacet) {
-        var hierarchicalFacet = state.getHierarchicalFacetByName(refinedFacet);
-        var currentRefinement = state.getHierarchicalRefinement(refinedFacet);
-        var separator = state._getHierarchicalFacetSeparator(hierarchicalFacet);
+    state.getRefinedHierarchicalFacets().forEach(function (refinedFacet) {
+      var hierarchicalFacet = state.getHierarchicalFacetByName(refinedFacet);
+      var currentRefinement = state.getHierarchicalRefinement(refinedFacet);
+      var separator = state._getHierarchicalFacetSeparator(hierarchicalFacet);
 
-        // If we are deeper than level 0 (starting from `beer > IPA`)
-        // we want to get all parent values
-        if (
-          currentRefinement.length > 0 &&
-          currentRefinement[0].split(separator).length > 1
-        ) {
-          // We generate a map of the filters we will use for our facet values queries
-          var filtersMap = currentRefinement[0]
-            .split(separator)
-            .slice(0, -1)
-            .reduce(function createFiltersMap(map, segment, level) {
-              return map.concat({
-                attribute: hierarchicalFacet.attributes[level],
-                value:
-                  level === 0
-                    ? segment
-                    : [map[map.length - 1].value, segment].join(separator),
-              });
-            }, []);
+      // If we are deeper than level 0 (starting from `beer > IPA`)
+      // we want to get all parent values
+      if (
+        currentRefinement.length > 0 &&
+        currentRefinement[0].split(separator).length > 1
+      ) {
+        // We generate a map of the filters we will use for our facet values queries
+        var filtersMap = currentRefinement[0]
+          .split(separator)
+          .slice(0, -1)
+          .reduce(function createFiltersMap(map, segment, level) {
+            return map.concat({
+              attribute: hierarchicalFacet.attributes[level],
+              value:
+                level === 0
+                  ? segment
+                  : [map[map.length - 1].value, segment].join(separator),
+            });
+          }, []);
 
-          filtersMap.forEach(function (filter, level) {
-            var params = requestBuilder._getDisjunctiveFacetSearchParams(
-              state,
-              filter.attribute,
-              level === 0
-            );
+        filtersMap.forEach(function (filter, level) {
+          var params = requestBuilder._getDisjunctiveFacetSearchParams(
+            state,
+            filter.attribute,
+            level === 0
+          );
 
-            // Keep facet filters unrelated to current hierarchical attributes
-            function hasHierarchicalFacetFilter(value) {
-              return hierarchicalFacet.attributes.some(function (attribute) {
-                return attribute === value.split(':')[0];
-              });
-            }
+          // Keep facet filters unrelated to current hierarchical attributes
+          function hasHierarchicalFacetFilter(value) {
+            return hierarchicalFacet.attributes.some(function (attribute) {
+              return attribute === value.split(':')[0];
+            });
+          }
 
-            var filteredFacetFilters = (params.facetFilters || []).reduce(
-              function (acc, facetFilter) {
-                if (Array.isArray(facetFilter)) {
-                  var filtered = facetFilter.filter(function (filterValue) {
-                    return !hasHierarchicalFacetFilter(filterValue);
-                  });
+          var filteredFacetFilters = (params.facetFilters || []).reduce(
+            function (acc, facetFilter) {
+              if (Array.isArray(facetFilter)) {
+                var filtered = facetFilter.filter(function (filterValue) {
+                  return !hasHierarchicalFacetFilter(filterValue);
+                });
 
-                  if (filtered.length > 0) {
-                    acc.push(filtered);
-                  }
+                if (filtered.length > 0) {
+                  acc.push(filtered);
                 }
+              }
 
-                if (
-                  typeof facetFilter === 'string' &&
-                  !hasHierarchicalFacetFilter(facetFilter)
-                ) {
-                  acc.push(facetFilter);
-                }
+              if (
+                typeof facetFilter === 'string' &&
+                !hasHierarchicalFacetFilter(facetFilter)
+              ) {
+                acc.push(facetFilter);
+              }
 
-                return acc;
-              },
-              []
+              return acc;
+            },
+            []
+          );
+
+          var parent = filtersMap[level - 1];
+          if (level > 0) {
+            params.facetFilters = filteredFacetFilters.concat(
+              parent.attribute + ':' + parent.value
             );
+          } else {
+            params.facetFilters =
+              filteredFacetFilters.length > 0
+                ? filteredFacetFilters
+                : undefined;
+          }
 
-            var parent = filtersMap[level - 1];
-            if (level > 0) {
-              params.facetFilters = filteredFacetFilters.concat(
-                parent.attribute + ':' + parent.value
-              );
-            } else {
-              params.facetFilters =
-                filteredFacetFilters.length > 0
-                  ? filteredFacetFilters
-                  : undefined;
-            }
-
-            queries.push({ indexName: index, params: params });
-          });
-        }
-      });
+          queries.push({ indexName: index, params: params });
+        });
+      }
+    });
 
     return queries;
   },
@@ -144,9 +138,9 @@ var requestBuilder = {
       .concat(requestBuilder._getHitsHierarchicalFacetsAttributes(state))
       .sort();
 
-    var facetFilters = requestBuilder._getFacetFilters(state).sort();
-    var numericFilters = requestBuilder._getNumericFilters(state).sort();
-    var tagFilters = requestBuilder._getTagFilters(state).sort();
+    var facetFilters = requestBuilder._getFacetFilters(state);
+    var numericFilters = requestBuilder._getNumericFilters(state);
+    var tagFilters = requestBuilder._getTagFilters(state);
     var additionalParams = {
       facets: facets.indexOf('*') > -1 ? ['*'] : facets,
       tagFilters: tagFilters,

--- a/packages/algoliasearch-helper/test/datasets/SearchParameters/search.dataset.js
+++ b/packages/algoliasearch-helper/test/datasets/SearchParameters/search.dataset.js
@@ -188,7 +188,7 @@ function getData() {
     index: 'test_hotels-node',
     disjunctiveFacets: ['city'],
     disjunctiveFacetsRefinements: {
-      city: ['Paris', 'New York'],
+      city: ['New York', 'Paris'],
     },
   });
 

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/getQuery.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/getQuery.js
@@ -23,7 +23,7 @@ test('getQuery', function () {
   expect(helper.getQuery()).toEqual({
     minWordSizefor1Typo: 8,
     ignorePlurals: true,
-    facets: ['facet1', 'facet2', 'facet3', 'df1', 'df2', 'df3'],
+    facets: ['df1', 'df2', 'df3', 'facet1', 'facet2', 'facet3'],
     tagFilters: '',
     facetFilters: [
       'facet1:FACET1-VAL-1',

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/with-a-disjunctive-facet.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/with-a-disjunctive-facet.js
@@ -29,7 +29,7 @@ test('hierarchical facets: combined with a disjunctive facet', function () {
 
   helper.setQuery('a').search();
 
-  var disjunctiveFacetsValuesQuery = client.search.mock.calls[0][0][1];
+  var disjunctiveFacetsValuesQuery = client.search.mock.calls[0][0][2];
 
   expect(disjunctiveFacetsValuesQuery.params.facetFilters).toEqual([
     ['categories.lvl1:beers > IPA'],

--- a/packages/algoliasearch-helper/test/spec/requestBuilder.js
+++ b/packages/algoliasearch-helper/test/spec/requestBuilder.js
@@ -176,12 +176,10 @@ test('orders parameters alphabetically in every query', function () {
         'this is last in parameters, but first in queries',
       ],
       clickAnalytics: false,
-      facetFilters: [
-        ['test_disjunctive:test_disjunctive_value'],
-        ['whatever:item'],
-      ],
-      facets: 'test_numeric',
+      facetFilters: [['test_disjunctive:test_disjunctive_value']],
+      facets: ['whatever'],
       hitsPerPage: 0,
+      numericFilters: ['test_numeric>=10'],
       page: 0,
     })
   );
@@ -192,10 +190,12 @@ test('orders parameters alphabetically in every query', function () {
         'this is last in parameters, but first in queries',
       ],
       clickAnalytics: false,
-      facetFilters: [['test_disjunctive:test_disjunctive_value']],
-      facets: ['whatever'],
+      facetFilters: [
+        ['test_disjunctive:test_disjunctive_value'],
+        ['whatever:item'],
+      ],
+      facets: 'test_numeric',
       hitsPerPage: 0,
-      numericFilters: ['test_numeric>=10'],
       page: 0,
     })
   );

--- a/packages/algoliasearch-helper/test/spec/requestBuilder.js
+++ b/packages/algoliasearch-helper/test/spec/requestBuilder.js
@@ -269,3 +269,121 @@ describe('wildcard facets', function () {
     expect(queries[1].params.facets).toEqual('test_disjunctive');
   });
 });
+
+describe('request ordering', function () {
+  test('should order queries and facet values by name', function () {
+    // These facets are all sorted reverse-alphabetically
+    var searchParams = new SearchParameters({
+      facets: [
+        'c_test_conjunctive_2',
+        'c_conjunctive_1',
+        'd_exclude_2',
+        'd_exclude_1',
+      ],
+      disjunctiveFacets: ['b_disjunctive_2', 'b_disjunctive_1'],
+      hierarchicalFacets: [
+        {
+          name: 'a_hierarchical_2',
+          attributes: ['a_hierarchical_2'],
+        },
+        {
+          name: 'a_hierarchical_1',
+          attributes: ['a_hierarchical_1'],
+        },
+      ],
+      hierarchicalFacetsRefinements: {
+        a_hierarchical_2: ['beta'],
+        a_hierarchical_1: ['alpha'],
+      },
+      disjunctiveFacetsRefinements: {
+        b_disjunctive_2: ['beta', 'alpha'],
+        b_disjunctive_1: ['beta', 'alpha'],
+      },
+      facetsRefinements: {
+        c_conjunctive_2: ['beta', 'alpha'],
+        c_conjunctive_1: ['beta', 'alpha'],
+      },
+      facetsExcludes: {
+        d_exclude_2: ['beta', 'alpha'],
+        d_exclude_1: ['beta', 'alpha'],
+      },
+    });
+
+    var queries = getQueries(searchParams.index, searchParams);
+
+    // Order of filters is alphabetical within type
+    // Order of queries is alphabetical within type
+    expect(queries.length).toBe(5);
+    // Hits
+    expect(queries[0].params.facetFilters).toEqual([
+      'c_conjunctive_1:alpha',
+      'c_conjunctive_1:beta',
+      'c_conjunctive_2:alpha',
+      'c_conjunctive_2:beta',
+      'd_exclude_1:-alpha',
+      'd_exclude_1:-beta',
+      'd_exclude_2:-alpha',
+      'd_exclude_2:-beta',
+      ['b_disjunctive_1:alpha', 'b_disjunctive_1:beta'],
+      ['b_disjunctive_2:alpha', 'b_disjunctive_2:beta'],
+      ['a_hierarchical_1:alpha'],
+      ['a_hierarchical_2:beta'],
+    ]);
+    // Hierarchical 1
+    expect(queries[1].params.facetFilters).toEqual([
+      'c_conjunctive_1:alpha',
+      'c_conjunctive_1:beta',
+      'c_conjunctive_2:alpha',
+      'c_conjunctive_2:beta',
+      'd_exclude_1:-alpha',
+      'd_exclude_1:-beta',
+      'd_exclude_2:-alpha',
+      'd_exclude_2:-beta',
+      ['b_disjunctive_1:alpha', 'b_disjunctive_1:beta'],
+      ['b_disjunctive_2:alpha', 'b_disjunctive_2:beta'],
+      ['a_hierarchical_2:beta'],
+    ]);
+    // Hierarchical 2
+    expect(queries[2].params.facetFilters).toEqual([
+      'c_conjunctive_1:alpha',
+      'c_conjunctive_1:beta',
+      'c_conjunctive_2:alpha',
+      'c_conjunctive_2:beta',
+      'd_exclude_1:-alpha',
+      'd_exclude_1:-beta',
+      'd_exclude_2:-alpha',
+      'd_exclude_2:-beta',
+      ['b_disjunctive_1:alpha', 'b_disjunctive_1:beta'],
+      ['b_disjunctive_2:alpha', 'b_disjunctive_2:beta'],
+      ['a_hierarchical_1:alpha'],
+    ]);
+    // Disjunctive 1
+    expect(queries[3].params.facetFilters).toEqual([
+      'c_conjunctive_1:alpha',
+      'c_conjunctive_1:beta',
+      'c_conjunctive_2:alpha',
+      'c_conjunctive_2:beta',
+      'd_exclude_1:-alpha',
+      'd_exclude_1:-beta',
+      'd_exclude_2:-alpha',
+      'd_exclude_2:-beta',
+      ['b_disjunctive_2:alpha', 'b_disjunctive_2:beta'],
+      ['a_hierarchical_1:alpha'],
+      ['a_hierarchical_2:beta'],
+    ]);
+    // Disjunctive 2
+    expect(queries[4].params.facetFilters).toEqual([
+      'c_conjunctive_1:alpha',
+      'c_conjunctive_1:beta',
+      'c_conjunctive_2:alpha',
+      'c_conjunctive_2:beta',
+      'd_exclude_1:-alpha',
+      'd_exclude_1:-beta',
+      'd_exclude_2:-alpha',
+      'd_exclude_2:-beta',
+      ['b_disjunctive_1:alpha', 'b_disjunctive_1:beta'],
+      ['a_hierarchical_1:alpha'],
+      ['a_hierarchical_2:beta'],
+    ]);
+  });
+});


### PR DESCRIPTION
This allows a better cache hit rate, because when widgets mount and unmount, it's possible that while the filters are the same, they are requested in a different order.

This PR fixes that on two approaches:

- sorting the filters (alphabetically by value per type), which has no impact on the SearchResponse
- sorting the queries (alphabetically by facet name per type), which also needs to be taken in account for the SearchResponse (so it is implemented in SearchParameters)


fixes [CR-3813](https://algolia.atlassian.net/browse/CR-3813)

[CR-3813]: https://algolia.atlassian.net/browse/CR-3813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ