### PR TITLE
fix(instantsearch): keep algoliasearch-helper as external dependency during build

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "74.50 kB"
+      "maxSize": "84.25 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "165 kB"
+      "maxSize": "175.5 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Core.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "84.25 kB"
+      "maxSize": "74.50 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "175.5 kB"
+      "maxSize": "165 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/Core.min.js",

--- a/packages/instantsearch.js/scripts/rollup/rollup.config.js
+++ b/packages/instantsearch.js/scripts/rollup/rollup.config.js
@@ -25,6 +25,7 @@ const plugins = [
     rootMode: 'upward',
     exclude: /node_modules/,
     extensions: ['.js', '.ts', '.tsx'],
+    sourceType: 'unambiguous',
   }),
   commonjs(),
   filesize({

--- a/packages/instantsearch.js/scripts/rollup/rollup.config.js
+++ b/packages/instantsearch.js/scripts/rollup/rollup.config.js
@@ -23,9 +23,8 @@ const plugins = [
   }),
   babel({
     rootMode: 'upward',
-    exclude: /node_modules/,
+    exclude: /node_modules|algoliasearch-helper/,
     extensions: ['.js', '.ts', '.tsx'],
-    sourceType: 'unambiguous',
   }),
   commonjs(),
   filesize({

--- a/packages/react-instantsearch-core/rollup.config.js
+++ b/packages/react-instantsearch-core/rollup.config.js
@@ -16,7 +16,7 @@ const createBanner = (name) =>
 
 const plugins = [
   babel({
-    exclude: ['../../node_modules/**', 'node_modules/**'],
+    exclude: /node_modules|algoliasearch-helper/,
     extensions: ['.js', '.ts', '.tsx'],
     rootMode: 'upward',
     runtimeHelpers: true,

--- a/packages/react-instantsearch-dom-maps/rollup.config.js
+++ b/packages/react-instantsearch-dom-maps/rollup.config.js
@@ -16,7 +16,7 @@ const createBanner = (name) =>
 
 const plugins = [
   babel({
-    exclude: ['../../node_modules/**', 'node_modules/**'],
+    exclude: /node_modules|algoliasearch-helper/,
     extensions: ['.js', '.ts', '.tsx'],
     rootMode: 'upward',
     runtimeHelpers: true,

--- a/packages/react-instantsearch-dom/rollup.config.js
+++ b/packages/react-instantsearch-dom/rollup.config.js
@@ -16,7 +16,7 @@ const createBanner = (name) =>
 
 const plugins = [
   babel({
-    exclude: ['../../node_modules/**', 'node_modules/**'],
+    exclude: /node_modules|algoliasearch-helper/,
     extensions: ['.js', '.ts', '.tsx'],
     rootMode: 'upward',
     runtimeHelpers: true,

--- a/packages/react-instantsearch-hooks-web/rollup.config.js
+++ b/packages/react-instantsearch-hooks-web/rollup.config.js
@@ -16,7 +16,7 @@ const createBanner = (name) =>
 
 const plugins = [
   babel({
-    exclude: ['../../node_modules/**', 'node_modules/**'],
+    exclude: /node_modules|algoliasearch-helper/,
     extensions: ['.js', '.ts', '.tsx'],
     rootMode: 'upward',
     runtimeHelpers: true,

--- a/packages/react-instantsearch-hooks/rollup.config.js
+++ b/packages/react-instantsearch-hooks/rollup.config.js
@@ -16,7 +16,7 @@ const createBanner = (name) =>
 
 const plugins = [
   babel({
-    exclude: ['../../node_modules/**', 'node_modules/**'],
+    exclude: /node_modules|algoliasearch-helper/,
     extensions: ['.js', '.ts', '.tsx'],
     rootMode: 'upward',
     runtimeHelpers: true,

--- a/packages/react-instantsearch/rollup.config.js
+++ b/packages/react-instantsearch/rollup.config.js
@@ -16,7 +16,7 @@ const createBanner = () =>
 
 const plugins = [
   babel({
-    exclude: ['../../node_modules/**', 'node_modules/**'],
+    exclude: /node_modules|algoliasearch-helper/,
     extensions: ['.js', '.ts', '.tsx'],
     rootMode: 'upward',
     runtimeHelpers: true,

--- a/packages/vue-instantsearch/rollup.config.js
+++ b/packages/vue-instantsearch/rollup.config.js
@@ -115,6 +115,7 @@ export * from './src/instantsearch.js';`
         JSON.stringify({ type: 'module', sideEffects: true })
       ),
       babel({
+        exclude: /node_modules|algoliasearch-helper/,
         extensions: ['.js', '.jsx', '.es6', '.es', '.mjs', '.vue'],
         babelrc: false,
         plugins: [


### PR DESCRIPTION
**Summary**

Since the integration of the algoliasearch-helper to the monorepo, it is locally linked to other packages that depend on it (most notably, instantsearch.js). This created an issue during the building of the UMD version of the package, where babel doesn't transpile the helper dependency because now it is locally linked thanks to lerna.

This PR adds a babel configuration option that forces the library to be transpiled.

**Result**

InstantSearch.js's UMD package now works correctly and doesn't throw an error at runtime.

[CR-3961](https://algolia.atlassian.net/browse/CR-3961)  
Closes https://github.com/algolia/instantsearch/issues/5763

[CR-3961]: https://algolia.atlassian.net/browse/CR-3961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ