### PR TITLE
fix: add a future warning when the package name changes

### DIFF
--- a/packages/react-instantsearch-hooks-router-nextjs/src/index.ts
+++ b/packages/react-instantsearch-hooks-router-nextjs/src/index.ts
@@ -1,8 +1,14 @@
 import history from 'instantsearch.js/es/lib/routers/history';
+import { warn } from 'react-instantsearch-hooks';
 
 import type { Router, UiState } from 'instantsearch.js';
 import type { BrowserHistoryArgs } from 'instantsearch.js/es/lib/routers/history';
 import type { Router as NextRouter, SingletonRouter } from 'next/router';
+
+warn(
+  Date.now() < new Date('2023-08-09').getTime(),
+  'The package `react-instantsearch-hooks-router-nextjs` is replaced by `react-instantsearch-router-nextjs`. The API is the same, but the package name has changed. Please update your dependencies.'
+);
 
 type BeforePopStateCallback = NonNullable<NextRouter['_bps']>;
 type NextHistoryState = Parameters<BeforePopStateCallback>[0];

--- a/packages/react-instantsearch-hooks-router-nextjs/src/index.ts
+++ b/packages/react-instantsearch-hooks-router-nextjs/src/index.ts
@@ -7,7 +7,7 @@ import type { Router as NextRouter, SingletonRouter } from 'next/router';
 
 warn(
   Date.now() < new Date('2023-08-09').getTime(),
-  'The package `react-instantsearch-hooks-router-nextjs` is replaced by `react-instantsearch-router-nextjs`. The API is the same, but the package name has changed. Please update your dependencies.'
+  'The package `react-instantsearch-hooks-router-nextjs` is replaced by `react-instantsearch-router-nextjs`. The API is the same, but the package name has changed. Please update your dependencies and follow the migration guide: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/'
 );
 
 type BeforePopStateCallback = NonNullable<NextRouter['_bps']>;

--- a/packages/react-instantsearch-hooks-server/src/__tests__/index.test.ts
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/index.test.ts
@@ -1,0 +1,15 @@
+describe('warnings', () => {
+  it('warns on import after release', () => {
+    jest.useFakeTimers('modern').setSystemTime(new Date('2023-08-09'));
+
+    expect(() => require('../index')).toWarnDev(
+      '[InstantSearch] The package `react-instantsearch-hooks-server` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies.'
+    );
+  });
+
+  it('does not warn on import before release', () => {
+    jest.useFakeTimers('modern').setSystemTime(new Date('2023-08-08'));
+
+    expect(() => require('../index')).not.toWarnDev();
+  });
+});

--- a/packages/react-instantsearch-hooks-server/src/__tests__/index.test.ts
+++ b/packages/react-instantsearch-hooks-server/src/__tests__/index.test.ts
@@ -3,7 +3,7 @@ describe('warnings', () => {
     jest.useFakeTimers('modern').setSystemTime(new Date('2023-08-09'));
 
     expect(() => require('../index')).toWarnDev(
-      '[InstantSearch] The package `react-instantsearch-hooks-server` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies.'
+      '[InstantSearch] The package `react-instantsearch-hooks-server` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies and follow the migration guide: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/'
     );
   });
 

--- a/packages/react-instantsearch-hooks-server/src/index.ts
+++ b/packages/react-instantsearch-hooks-server/src/index.ts
@@ -1,1 +1,8 @@
+import { warn } from 'react-instantsearch-hooks';
+
+warn(
+  Date.now() < new Date('2023-08-09').getTime(),
+  'The package `react-instantsearch-hooks-server` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies.'
+);
+
 export * from './getServerState';

--- a/packages/react-instantsearch-hooks-server/src/index.ts
+++ b/packages/react-instantsearch-hooks-server/src/index.ts
@@ -2,7 +2,7 @@ import { warn } from 'react-instantsearch-hooks';
 
 warn(
   Date.now() < new Date('2023-08-09').getTime(),
-  'The package `react-instantsearch-hooks-server` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies.'
+  'The package `react-instantsearch-hooks-server` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies and follow the migration guide: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/'
 );
 
 export * from './getServerState';

--- a/packages/react-instantsearch-hooks-web/src/__tests__/index.test.ts
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/index.test.ts
@@ -3,7 +3,7 @@ describe('warnings', () => {
     jest.useFakeTimers('modern').setSystemTime(new Date('2023-08-09'));
 
     expect(() => require('../index')).toWarnDev(
-      '[InstantSearch] The package `react-instantsearch-hooks-web` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies.'
+      '[InstantSearch] The package `react-instantsearch-hooks-web` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies and follow the migration guide: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/'
     );
   });
 

--- a/packages/react-instantsearch-hooks-web/src/__tests__/index.test.ts
+++ b/packages/react-instantsearch-hooks-web/src/__tests__/index.test.ts
@@ -1,0 +1,15 @@
+describe('warnings', () => {
+  it('warns on import after release', () => {
+    jest.useFakeTimers('modern').setSystemTime(new Date('2023-08-09'));
+
+    expect(() => require('../index')).toWarnDev(
+      '[InstantSearch] The package `react-instantsearch-hooks-web` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies.'
+    );
+  });
+
+  it('does not warn on import before release', () => {
+    jest.useFakeTimers('modern').setSystemTime(new Date('2023-08-08'));
+
+    expect(() => require('../index')).not.toWarnDev();
+  });
+});

--- a/packages/react-instantsearch-hooks-web/src/index.ts
+++ b/packages/react-instantsearch-hooks-web/src/index.ts
@@ -1,2 +1,9 @@
+import { warn } from 'react-instantsearch-hooks';
+
+warn(
+  Date.now() < new Date('2023-08-09').getTime(),
+  'The package `react-instantsearch-hooks-web` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies.'
+);
+
 export * from 'react-instantsearch-hooks';
 export * from './widgets';

--- a/packages/react-instantsearch-hooks-web/src/index.ts
+++ b/packages/react-instantsearch-hooks-web/src/index.ts
@@ -2,7 +2,7 @@ import { warn } from 'react-instantsearch-hooks';
 
 warn(
   Date.now() < new Date('2023-08-09').getTime(),
-  'The package `react-instantsearch-hooks-web` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies.'
+  'The package `react-instantsearch-hooks-web` is replaced by `react-instantsearch`. The API is the same, but the package name has changed. Please update your dependencies and follow the migration guide: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/'
 );
 
 export * from 'react-instantsearch-hooks';

--- a/packages/react-instantsearch-hooks/src/__tests__/index.test.ts
+++ b/packages/react-instantsearch-hooks/src/__tests__/index.test.ts
@@ -3,7 +3,7 @@ describe('warnings', () => {
     jest.useFakeTimers('modern').setSystemTime(new Date('2023-08-09'));
 
     expect(() => require('../index')).toWarnDev(
-      '[InstantSearch] The package `react-instantsearch-hooks` is replaced by `react-instantsearch-core`. The API is the same, but the package name has changed. Please update your dependencies.'
+      '[InstantSearch] The package `react-instantsearch-hooks` is replaced by `react-instantsearch-core`. The API is the same, but the package name has changed. Please update your dependencies and follow the migration guide: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/'
     );
   });
 

--- a/packages/react-instantsearch-hooks/src/__tests__/index.test.ts
+++ b/packages/react-instantsearch-hooks/src/__tests__/index.test.ts
@@ -1,0 +1,15 @@
+describe('warnings', () => {
+  it('warns on import after release', () => {
+    jest.useFakeTimers('modern').setSystemTime(new Date('2023-08-09'));
+
+    expect(() => require('../index')).toWarnDev(
+      '[InstantSearch] The package `react-instantsearch-hooks` is replaced by `react-instantsearch-core`. The API is the same, but the package name has changed. Please update your dependencies.'
+    );
+  });
+
+  it('does not warn on import before release', () => {
+    jest.useFakeTimers('modern').setSystemTime(new Date('2023-08-08'));
+
+    expect(() => require('../index')).not.toWarnDev();
+  });
+});

--- a/packages/react-instantsearch-hooks/src/index.ts
+++ b/packages/react-instantsearch-hooks/src/index.ts
@@ -2,7 +2,7 @@ import { warn } from './lib/warn';
 
 warn(
   Date.now() < new Date('2023-08-09').getTime(),
-  'The package `react-instantsearch-hooks` is replaced by `react-instantsearch-core`. The API is the same, but the package name has changed. Please update your dependencies.'
+  'The package `react-instantsearch-hooks` is replaced by `react-instantsearch-core`. The API is the same, but the package name has changed. Please update your dependencies and follow the migration guide: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/'
 );
 
 export { default as version } from './version';

--- a/packages/react-instantsearch-hooks/src/index.ts
+++ b/packages/react-instantsearch-hooks/src/index.ts
@@ -1,3 +1,10 @@
+import { warn } from './lib/warn';
+
+warn(
+  Date.now() < new Date('2023-08-09').getTime(),
+  'The package `react-instantsearch-hooks` is replaced by `react-instantsearch-core`. The API is the same, but the package name has changed. Please update your dependencies.'
+);
+
 export { default as version } from './version';
 export * from './components/Configure';
 export * from './components/DynamicWidgets';


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

A warning on import of the packages to let people know to change packages.

**Result**

A warning on import of the root entry point of React InstantSearch Hooks, React InstantSearch Hooks web, React InstantSearch Hooks server and React InstantSearch Hooks router nextjs with the next name

The warning is dated for 9 August, to give us a day margin to definitely have released, happy to move it a little later as well if we prefer.

Note that if you're using React InstantSearch Hooks web, you'll get the warning for both React InstantSearch Hooks and React InstantSearch Hooks web, I didn't find how to avoid it

FX-2391

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
