### PR TITLE
fix(useInstantSearch): deprecate `use` function

### DIFF
--- a/examples/react-hooks/e-commerce/components/ScrollTo.tsx
+++ b/examples/react-hooks/e-commerce/components/ScrollTo.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef } from 'react';
 import { useInstantSearch } from 'react-instantsearch-hooks-web';
 
 export function ScrollTo({ children }: { children: React.ReactNode }) {
-  const { use } = useInstantSearch();
+  const { addMiddlewares } = useInstantSearch();
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -24,8 +24,8 @@ export function ScrollTo({ children }: { children: React.ReactNode }) {
       };
     };
 
-    return use(middleware);
-  }, [use]);
+    return addMiddlewares(middleware);
+  }, [addMiddlewares]);
 
   return (
     <div ref={containerRef} className="ais-ScrollTo">

--- a/packages/react-instantsearch-hooks/src/hooks/__tests__/useInstantSearch.test.tsx
+++ b/packages/react-instantsearch-hooks/src/hooks/__tests__/useInstantSearch.test.tsx
@@ -173,7 +173,7 @@ describe('useInstantSearch', () => {
   });
 
   describe('middleware', () => {
-    test('gives access to the use function', async () => {
+    test('gives access to the addMiddlewares function', async () => {
       const subscribe = jest.fn();
       const onStateChange = jest.fn();
       const unsubscribe = jest.fn();
@@ -184,8 +184,8 @@ describe('useInstantSearch', () => {
       }));
 
       function Middleware() {
-        const { use } = useInstantSearch();
-        useEffect(() => use(middleware), [use]);
+        const { addMiddlewares } = useInstantSearch();
+        useEffect(() => addMiddlewares(middleware), [addMiddlewares]);
 
         return null;
       }
@@ -232,13 +232,40 @@ describe('useInstantSearch', () => {
         wrapper,
       });
 
-      expect(result.current.use).toBeInstanceOf(Function);
+      expect(result.current.addMiddlewares).toBeInstanceOf(Function);
 
-      const ref = result.current.use;
+      const ref = result.current.addMiddlewares;
 
       rerender();
 
-      expect(result.current.use).toBe(ref);
+      expect(result.current.addMiddlewares).toBe(ref);
+    });
+
+    test('warns when using the deprecated use function', () => {
+      function Middleware() {
+        const { use } = useInstantSearch();
+        useEffect(
+          () =>
+            use(() => ({
+              subscribe() {},
+            })),
+          [use]
+        );
+
+        return null;
+      }
+
+      function App() {
+        return (
+          <InstantSearchHooksTestWrapper>
+            <Middleware />
+          </InstantSearchHooksTestWrapper>
+        );
+      }
+
+      expect(() => render(<App />)).toWarnDev(
+        '[InstantSearch] The `use` function is deprecated and will be removed in the next major version. Please use `addMiddlewares` instead.'
+      );
     });
   });
 


### PR DESCRIPTION
**Summary**

To prevent confusion caused by the upcoming React `use()` Hook, and also to better describe the intent of our function, this PR deprecates our current `use()` function available from `useInstantSearch()` and replaces it with `addMiddlewares()`.

The API is the same.

Closes FX-2548