### PR TITLE
fix(react-storybook): exclude helper from babel config

### DIFF
--- a/packages/react-instantsearch-dom/.storybook/webpack.config.js
+++ b/packages/react-instantsearch-dom/.storybook/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = ({ config }) => ({
             options: {
               rootMode: 'upward',
               presets: [['react-app', { typescript: true }]],
+              exclude: /node_modules|algoliasearch-helper/,
             },
           },
         ],


### PR DESCRIPTION
**Summary**

### [CR-3986](https://algolia.atlassian.net/browse/CR-3986)

**Result**

Same fix as for `instantsearch.js`


[CR-3986]: https://algolia.atlassian.net/browse/CR-3986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ