### PR TITLE
fix: use npm registry to retrieve library versions

### DIFF
--- a/packages/create-instantsearch-app/src/utils/__tests__/fetchLibraryVersions.test.js
+++ b/packages/create-instantsearch-app/src/utils/__tests__/fetchLibraryVersions.test.js
@@ -1,0 +1,24 @@
+const https = require('https');
+
+const { fetchLibraryVersions } = require('../fetchLibraryVersions');
+
+describe('fetchLibraryVersions', () => {
+  test('return versions for a library', async () => {
+    expect(await fetchLibraryVersions('react-instantsearch')).toEqual(
+      expect.arrayContaining([expect.any(String)])
+    );
+  });
+
+  test('return versions from cache if available', async () => {
+    const httpsSpy = jest.spyOn(https, 'get');
+
+    await fetchLibraryVersions('react-instantsearch-core');
+    expect(httpsSpy).toHaveBeenCalledTimes(1);
+
+    await fetchLibraryVersions('react-instantsearch-core');
+    expect(httpsSpy).toHaveBeenCalledTimes(1);
+
+    await fetchLibraryVersions('instantsearch.js');
+    expect(httpsSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/create-instantsearch-app/src/utils/fetchLibraryVersions.js
+++ b/packages/create-instantsearch-app/src/utils/fetchLibraryVersions.js
@@ -1,0 +1,31 @@
+const https = require('https');
+
+function fetchCachedLibraryVersions() {
+  const cache = new Map();
+  return function fetchLibraryVersions(libraryName) {
+    if (cache.has(libraryName)) {
+      return Promise.resolve(cache.get(libraryName));
+    }
+
+    return new Promise((resolve) => {
+      https.get(`https://registry.npmjs.org/${libraryName}`, (res) => {
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+
+        res.on('end', () => {
+          const library = JSON.parse(body);
+          const versions = Object.keys(library.versions).reverse();
+
+          cache.set(libraryName, versions);
+          resolve(versions);
+        });
+      });
+    });
+  };
+}
+
+module.exports = {
+  fetchLibraryVersions: fetchCachedLibraryVersions(),
+};

--- a/packages/create-instantsearch-app/src/utils/fetchLibraryVersions.js
+++ b/packages/create-instantsearch-app/src/utils/fetchLibraryVersions.js
@@ -7,21 +7,27 @@ function fetchCachedLibraryVersions() {
       return Promise.resolve(cache.get(libraryName));
     }
 
-    return new Promise((resolve) => {
-      https.get(`https://registry.npmjs.org/${libraryName}`, (res) => {
-        let body = '';
-        res.on('data', (chunk) => {
-          body += chunk;
-        });
+    return new Promise((resolve, reject) => {
+      https
+        .get(`https://registry.npmjs.org/${libraryName}`, (res) => {
+          let body = '';
+          res.on('data', (chunk) => {
+            body += chunk;
+          });
 
-        res.on('end', () => {
-          const library = JSON.parse(body);
-          const versions = Object.keys(library.versions).reverse();
+          res.on('end', () => {
+            try {
+              const library = JSON.parse(body);
+              const versions = Object.keys(library.versions).reverse();
 
-          cache.set(libraryName, versions);
-          resolve(versions);
-        });
-      });
+              cache.set(libraryName, versions);
+              resolve(versions);
+            } catch (err) {
+              reject(err);
+            }
+          });
+        })
+        .on('error', reject);
     });
   };
 }

--- a/packages/create-instantsearch-app/src/utils/index.js
+++ b/packages/create-instantsearch-app/src/utils/index.js
@@ -2,21 +2,12 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const algoliasearch = require('algoliasearch');
 const chalk = require('chalk');
 const semver = require('semver');
 const validateProjectName = require('validate-npm-package-name');
 
+const { fetchLibraryVersions } = require('./fetchLibraryVersions');
 const TEMPLATES_FOLDER = path.join(__dirname, '../templates');
-
-const algoliaConfig = {
-  appId: 'OFCNCOG2CU',
-  apiKey: 'f54e21fa3a2a0160595bb058179bfb1e',
-  indexName: 'npm-search',
-};
-
-const client = algoliasearch(algoliaConfig.appId, algoliaConfig.apiKey);
-const index = client.initIndex(algoliaConfig.indexName);
 
 function checkAppName(appName) {
   const validationResult = validateProjectName(appName);
@@ -128,14 +119,6 @@ function getTemplatePath(templateName) {
 
   // This is a custom template, it's a path already
   return templateName;
-}
-
-async function fetchLibraryVersions(libraryName) {
-  const library = await index.getObject(libraryName, {
-    attributesToRetrieve: ['versions'],
-  });
-
-  return Object.keys(library.versions).reverse();
 }
 
 function getLibraryVersion({ libraryName, supportedVersion = '' }) {


### PR DESCRIPTION
**Summary**

We currently rely on an Algolia index to retrieve package versions for libraries. This index currently has issues and is not up to date. We've identified that this will cause problem in our CI pipeline when we release the new version of React InstantSearch, as we replace the `react-instantsearch` package in a major, which will require setting version constraint on our CISA CLI.

**Result**

We now directly query the NPM registry to get versions for libraries, and there's an in-memory cache to optimize for multiple queries for the same package in the same CISA CLI session.