### PR TITLE
fix(pagination): correctly use 1-based pagination in createURL

### DIFF
--- a/packages/instantsearch.js/src/connectors/pagination/connectPagination.ts
+++ b/packages/instantsearch.js/src/connectors/pagination/connectPagination.ts
@@ -171,7 +171,7 @@ const connectPagination: PaginationConnector = function connectPagination(
           connectorState.createURL = (page) =>
             createURL((uiState) => ({
               ...uiState,
-              page,
+              page: page + 1,
             }));
         }
 

--- a/packages/react-instantsearch/src/widgets/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Pagination.test.tsx
@@ -2025,7 +2025,7 @@ describe('Pagination', () => {
   });
 
   test('renders with translations', async () => {
-    const { getByRole, findByRole, debug } = render(
+    const { getByRole, findByRole } = render(
       <InstantSearchTestWrapper
         searchClient={createMockedSearchClient({ nbPages: 3 })}
       >
@@ -2065,8 +2065,6 @@ describe('Pagination', () => {
       name: 'First page',
     });
     expect(firstPageLink).toHaveTextContent('First');
-
-    debug();
 
     const previousPageLink = getByRole('link', {
       name: 'Previous page',

--- a/tests/common/connectors/pagination/routing.ts
+++ b/tests/common/connectors/pagination/routing.ts
@@ -65,7 +65,7 @@ export function createRoutingTests(
             // eslint-disable-next-line jest/no-conditional-expect
             expect(link).toHaveAttribute(
               'href',
-              router.createURL({ indexName: { page: 10 } })
+              router.createURL({ indexName: { page: 11 } })
             );
           }
         }
@@ -80,7 +80,7 @@ export function createRoutingTests(
         {
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({ indexName: { page: 10 } })
+            router.createURL({ indexName: { page: 11 } })
           );
         }
 

--- a/tests/common/connectors/pagination/routing.ts
+++ b/tests/common/connectors/pagination/routing.ts
@@ -96,7 +96,7 @@ export function createRoutingTests(
           // URL is still the same, as it overrides the current state
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({ indexName: { page: 10 } })
+            router.createURL({ indexName: { page: 11 } })
           );
         }
 
@@ -108,7 +108,7 @@ export function createRoutingTests(
 
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({ indexName: { page: 10 } })
+            router.createURL({ indexName: { page: 11 } })
           );
         }
 
@@ -124,7 +124,7 @@ export function createRoutingTests(
           // URL is still the same, as it overrides the current state
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({ indexName: { page: 10 } })
+            router.createURL({ indexName: { page: 11 } })
           );
         }
 
@@ -137,7 +137,7 @@ export function createRoutingTests(
 
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({ indexName: { page: 10 } })
+            router.createURL({ indexName: { page: 11 } })
           );
         }
       });

--- a/tests/common/shared/routing.ts
+++ b/tests/common/shared/routing.ts
@@ -167,7 +167,7 @@ export function createRoutingTests(
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
             router.createURL({
-              indexName: { menu: { [attribute]: 'Apple' }, page: 10 },
+              indexName: { menu: { [attribute]: 'Apple' }, page: 11 },
             })
           );
         }
@@ -193,9 +193,7 @@ export function createRoutingTests(
 
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({
-              indexName: { page: 10 },
-            })
+            router.createURL({ indexName: { page: 11 } })
           );
         }
 
@@ -214,9 +212,7 @@ export function createRoutingTests(
 
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({
-              indexName: { page: 10 },
-            })
+            router.createURL({ indexName: { page: 11 } })
           );
         }
 
@@ -232,7 +228,7 @@ export function createRoutingTests(
           // URL is still the same, as it overrides the current state
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({ indexName: { page: 10 } })
+            router.createURL({ indexName: { page: 11 } })
           );
 
           expect(screen.getByTestId('Menu-link')).toHaveAttribute(
@@ -251,7 +247,7 @@ export function createRoutingTests(
 
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({ indexName: { page: 10 } })
+            router.createURL({ indexName: { page: 11 } })
           );
 
           expect(screen.getByTestId('Menu-link')).toHaveAttribute(
@@ -274,7 +270,7 @@ export function createRoutingTests(
           // URL is still the same, as it overrides the current state
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({ indexName: { page: 10 } })
+            router.createURL({ indexName: { page: 11 } })
           );
 
           expect(screen.getByTestId('Menu-link')).toHaveAttribute(
@@ -294,7 +290,7 @@ export function createRoutingTests(
 
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({ indexName: { page: 10 } })
+            router.createURL({ indexName: { page: 11 } })
           );
 
           expect(screen.getByTestId('Menu-link')).toHaveAttribute(

--- a/tests/common/shared/routing.ts
+++ b/tests/common/shared/routing.ts
@@ -98,11 +98,7 @@ export function createRoutingTests(
             // eslint-disable-next-line jest/no-conditional-expect
             expect(paginationLink).toHaveAttribute(
               'href',
-              router.createURL({
-                indexName: {
-                  page: 10,
-                },
-              })
+              router.createURL({ indexName: { page: 11 } })
             );
           }
         }
@@ -124,9 +120,7 @@ export function createRoutingTests(
 
           expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
             'href',
-            router.createURL({
-              indexName: { page: 10 },
-            })
+            router.createURL({ indexName: { page: 11 } })
           );
         }
 
@@ -149,12 +143,12 @@ export function createRoutingTests(
             })
           );
 
-          // expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
-          //   'href',
-          //   router.createURL({
-          //     indexName: { menu: { [attribute]: 'Apple' }, page: 10 },
-          //   })
-          // );
+          expect(screen.getByTestId('Pagination-link')).toHaveAttribute(
+            'href',
+            router.createURL({
+              indexName: { menu: { [attribute]: 'Apple' }, page: 11 },
+            })
+          );
         }
 
         // Wait for new results to come in


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Unlike search parameters and what's returned in pages, UiState uses 1-based pagination, during the migration in #5696 this was overlooked

**Result**

fix #5797

createURL and refine of pagination now both correctly use 0-based pagination in the argument, agreeing on the values.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
