### PR TITLE
e2e: fix ie11 test suite and prevent parallel e2e jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,10 @@ workflows:
       - examples:
           requires:
             - build
-          # filters:
-          #   branches:
-          #     only:
-          #       - master
+          filters:
+            branches:
+              only:
+                - master
       - helper docs:
           requires:
             - build
@@ -75,18 +75,18 @@ workflows:
           context: fx-libraries
           requires:
             - examples
-          # filters:
-          #   branches:
-          #     only:
-          #       - master
+          filters:
+            branches:
+              only:
+                - master
       - e2e tests router nextjs:
           context: fx-libraries
           requires:
             - build
-          # filters:
-          #   branches:
-          #     only:
-          #       - master
+          filters:
+            branches:
+              only:
+                - master
       - release if needed:
           context: fx-libraries
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,10 @@ workflows:
       - examples:
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - master
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - helper docs:
           requires:
             - build
@@ -75,18 +75,18 @@ workflows:
           context: fx-libraries
           requires:
             - examples
-          filters:
-            branches:
-              only:
-                - master
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - e2e tests router nextjs:
           context: fx-libraries
           requires:
-            - examples
-          filters:
-            branches:
-              only:
-                - master
+            - build
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - release if needed:
           context: fx-libraries
           requires:
@@ -131,7 +131,7 @@ workflows:
       - e2e tests router nextjs:
           context: fx-libraries
           requires:
-            - examples
+            - build
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,10 @@ workflows:
       - examples:
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - master
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - helper docs:
           requires:
             - build
@@ -75,18 +75,18 @@ workflows:
           context: fx-libraries
           requires:
             - examples
-          filters:
-            branches:
-              only:
-                - master
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - e2e tests router nextjs:
           context: fx-libraries
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - master
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - release if needed:
           context: fx-libraries
           requires:

--- a/tests/e2e/wdio.saucelabs.conf.js
+++ b/tests/e2e/wdio.saucelabs.conf.js
@@ -4,6 +4,7 @@ const baseConfig = require('./wdio.base.conf');
 
 module.exports = {
   ...baseConfig,
+  logLevel: 'debug',
   /*
    * List of reporters to use
    * https://webdriver.io/docs/options.html#reporters
@@ -60,6 +61,7 @@ module.exports = {
      */
     connectRetries: 2,
     connectRetryTimeout: 10000,
+    verbose: true,
   },
   /*
    * Sauce Labs Open Source offer has a maximum of 5 concurrent session
@@ -78,31 +80,31 @@ module.exports = {
    * https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/
    */
   capabilities: [
-    {
-      browserName: 'chrome',
-      browserVersion: '76.0',
-      /*
-       * Sauce Labs specific options
-       * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
-       */
-      'sauce:options': {
-        screenResolution: '1680x1050',
-      },
-    },
-    {
-      browserName: 'firefox',
-      browserVersion: '68.0',
-      /*
-       * Sauce Labs specific options
-       * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
-       */
-      'sauce:options': {
-        screenResolution: '1680x1050',
-        // Force Selenium version on Firefox, solves an issue with `setValue`
-        // https://github.com/webdriverio/webdriverio/issues/3443
-        seleniumVersion: '3.11.0',
-      },
-    },
+    // {
+    //   browserName: 'chrome',
+    //   browserVersion: '76.0',
+    //   /*
+    //    * Sauce Labs specific options
+    //    * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+    //    */
+    //   'sauce:options': {
+    //     screenResolution: '1680x1050',
+    //   },
+    // },
+    // {
+    //   browserName: 'firefox',
+    //   browserVersion: '68.0',
+    //   /*
+    //    * Sauce Labs specific options
+    //    * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+    //    */
+    //   'sauce:options': {
+    //     screenResolution: '1680x1050',
+    //     // Force Selenium version on Firefox, solves an issue with `setValue`
+    //     // https://github.com/webdriverio/webdriverio/issues/3443
+    //     seleniumVersion: '3.11.0',
+    //   },
+    // },
     {
       browserName: 'internet explorer',
       browserVersion: '11.285',

--- a/tests/e2e/wdio.saucelabs.conf.js
+++ b/tests/e2e/wdio.saucelabs.conf.js
@@ -105,7 +105,7 @@ module.exports = {
     },
     {
       browserName: 'internet explorer',
-      browserVersion: '11.21185',
+      browserVersion: '11',
       platformName: 'Windows 7',
       /*
        * Sauce Labs specific options

--- a/tests/e2e/wdio.saucelabs.conf.js
+++ b/tests/e2e/wdio.saucelabs.conf.js
@@ -4,7 +4,6 @@ const baseConfig = require('./wdio.base.conf');
 
 module.exports = {
   ...baseConfig,
-  logLevel: 'debug',
   /*
    * List of reporters to use
    * https://webdriver.io/docs/options.html#reporters
@@ -61,7 +60,6 @@ module.exports = {
      */
     connectRetries: 2,
     connectRetryTimeout: 10000,
-    verbose: true,
   },
   /*
    * Sauce Labs Open Source offer has a maximum of 5 concurrent session
@@ -80,34 +78,9 @@ module.exports = {
    * https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/
    */
   capabilities: [
-    // {
-    //   browserName: 'chrome',
-    //   browserVersion: '76.0',
-    //   /*
-    //    * Sauce Labs specific options
-    //    * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
-    //    */
-    //   'sauce:options': {
-    //     screenResolution: '1680x1050',
-    //   },
-    // },
-    // {
-    //   browserName: 'firefox',
-    //   browserVersion: '68.0',
-    //   /*
-    //    * Sauce Labs specific options
-    //    * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
-    //    */
-    //   'sauce:options': {
-    //     screenResolution: '1680x1050',
-    //     // Force Selenium version on Firefox, solves an issue with `setValue`
-    //     // https://github.com/webdriverio/webdriverio/issues/3443
-    //     seleniumVersion: '3.11.0',
-    //   },
-    // },
     {
-      browserName: 'internet explorer',
-      browserVersion: '11.285',
+      browserName: 'chrome',
+      browserVersion: '76.0',
       /*
        * Sauce Labs specific options
        * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
@@ -115,11 +88,36 @@ module.exports = {
       'sauce:options': {
         screenResolution: '1680x1050',
       },
-      'se:ieOptions': {
-        // Required for drag and drop to work
-        // https://stackoverflow.com/questions/14299392/selenium-webdriver-draganddrop-for-ie9
-        requireWindowFocus: true,
+    },
+    {
+      browserName: 'firefox',
+      browserVersion: '68.0',
+      /*
+       * Sauce Labs specific options
+       * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+       */
+      'sauce:options': {
+        screenResolution: '1680x1050',
+        // Force Selenium version on Firefox, solves an issue with `setValue`
+        // https://github.com/webdriverio/webdriverio/issues/3443
+        seleniumVersion: '3.11.0',
       },
     },
+    // {
+    //   browserName: 'internet explorer',
+    //   browserVersion: '11.285',
+    //   /*
+    //    * Sauce Labs specific options
+    //    * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+    //    */
+    //   'sauce:options': {
+    //     screenResolution: '1680x1050',
+    //   },
+    //   'se:ieOptions': {
+    //     // Required for drag and drop to work
+    //     // https://stackoverflow.com/questions/14299392/selenium-webdriver-draganddrop-for-ie9
+    //     requireWindowFocus: true,
+    //   },
+    // },
   ],
 };

--- a/tests/e2e/wdio.saucelabs.conf.js
+++ b/tests/e2e/wdio.saucelabs.conf.js
@@ -103,21 +103,22 @@ module.exports = {
         seleniumVersion: '3.11.0',
       },
     },
-    // {
-    //   browserName: 'internet explorer',
-    //   browserVersion: '11.285',
-    //   /*
-    //    * Sauce Labs specific options
-    //    * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
-    //    */
-    //   'sauce:options': {
-    //     screenResolution: '1680x1050',
-    //   },
-    //   'se:ieOptions': {
-    //     // Required for drag and drop to work
-    //     // https://stackoverflow.com/questions/14299392/selenium-webdriver-draganddrop-for-ie9
-    //     requireWindowFocus: true,
-    //   },
-    // },
+    {
+      browserName: 'internet explorer',
+      browserVersion: '11.21185',
+      platformName: 'Windows 7',
+      /*
+       * Sauce Labs specific options
+       * https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options
+       */
+      'sauce:options': {
+        screenResolution: '1680x1050',
+      },
+      'se:ieOptions': {
+        // Required for drag and drop to work
+        // https://stackoverflow.com/questions/14299392/selenium-webdriver-draganddrop-for-ie9
+        requireWindowFocus: true,
+      },
+    },
   ],
 };


### PR DESCRIPTION
**Summary**

This PR runs the **e2e router nextjs** job without waiting for examples to be built. Examples are not necessary for this e2e test suite to run, and it will help optimize sauce labs resources by not having both e2e jobs running at the same time.

In addition, the IE11 test suite now asks to be run in a Windows 7 VM, as Sauce labs has issues with it running on Windows 10.

Passing CI: https://app.circleci.com/pipelines/github/algolia/instantsearch/9231/workflows/2cd0f56d-7cde-4460-9d1e-6b38611fb0d4