### PR TITLE
fix(use): compatibility for modern babel

### DIFF
--- a/packages/instantsearch-codemods/src/rish-to-ris.ts
+++ b/packages/instantsearch-codemods/src/rish-to-ris.ts
@@ -45,11 +45,15 @@ export default function transformer(
           path.value.id.type === 'ObjectPattern' &&
           (path.value.id.properties.find((prop) => {
             return (
-              prop.type === 'Property' &&
+              // Babel 5/6 in JSCodeshift, Babel 7 in codeshift
+              // https://github.com/babel/babel/blob/main/.github/CHANGELOG-v6.md#600
+              (prop.type === 'Property' || prop.type === 'ObjectProperty') &&
               prop.key.type === 'Identifier' &&
               prop.key.name === 'use'
             );
           }) as ObjectProperty);
+
+        console.log(path.value.id.properties[0].type);
 
         if (!useProperty) {
           return;

--- a/packages/instantsearch-codemods/src/rish-to-ris.ts
+++ b/packages/instantsearch-codemods/src/rish-to-ris.ts
@@ -53,8 +53,6 @@ export default function transformer(
             );
           }) as ObjectProperty);
 
-        console.log(path.value.id.properties[0].type);
-
         if (!useProperty) {
           return;
         }


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

`use` now properly gets renamed

this is used by codeshift somehow (found by trying it out in the doc-code-samples), not sure why our tests are using an old version of babel (i see `return require('../parser/babel5Compat')(options);` in node_modules)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

Unfortunately no new test for this: https://github.com/facebook/jscodeshift/issues/510
