### PR TITLE
fix(server): allow detached index (no rootIndexName) in SSR

### DIFF
--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -78,7 +78,11 @@ describe('getInitialResults', () => {
       searchClient: createSearchClient(),
     });
 
-    expect(() => getInitialResults(search.mainIndex)).toThrow();
+    expect(() =>
+      getInitialResults(search.mainIndex)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"The root index does not have any results. Make sure you have at least one widget that provides results."`
+    );
   });
 
   test('returns the current results from one index', async () => {
@@ -86,6 +90,47 @@ describe('getInitialResults', () => {
       indexName: 'indexName',
       searchClient: createSearchClient(),
     });
+
+    search.start();
+
+    await waitForResults(search);
+
+    expect(getInitialResults(search.mainIndex)).toEqual({
+      indexName: {
+        state: {
+          disjunctiveFacets: [],
+          disjunctiveFacetsRefinements: {},
+          facets: [],
+          facetsExcludes: {},
+          facetsRefinements: {},
+          hierarchicalFacets: [],
+          hierarchicalFacetsRefinements: {},
+          index: 'indexName',
+          numericRefinements: {},
+          tagRefinements: [],
+        },
+        results: [
+          {
+            exhaustiveFacetsCount: true,
+            exhaustiveNbHits: true,
+            hits: [],
+            hitsPerPage: 20,
+            nbHits: 0,
+            nbPages: 0,
+            page: 0,
+            params: '',
+            processingTimeMS: 0,
+            query: '',
+          },
+        ],
+      },
+    });
+  });
+
+  test('returns the current results from one non-rootindex', async () => {
+    const search = instantsearch({
+      searchClient: createSearchClient(),
+    }).addWidgets([index({ indexName: 'indexName' })]);
 
     search.start();
 

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -41,14 +41,22 @@ export function getInitialResults(rootIndex: IndexWidget): InitialResults {
   const initialResults: InitialResults = {};
 
   walkIndex(rootIndex, (widget) => {
-    const searchResults = widget.getResults()!;
-    initialResults[widget.getIndexId()] = {
-      // We convert the Helper state to a plain object to pass parsable data
-      // structures from server to client.
-      state: { ...searchResults._state },
-      results: searchResults._rawResults,
-    };
+    const searchResults = widget.getResults();
+    if (searchResults) {
+      initialResults[widget.getIndexId()] = {
+        // We convert the Helper state to a plain object to pass parsable data
+        // structures from server to client.
+        state: { ...searchResults._state },
+        results: searchResults._rawResults,
+      };
+    }
   });
+
+  if (Object.keys(initialResults).length === 0) {
+    throw new Error(
+      'The root index does not have any results. Make sure you have at least one widget that provides results.'
+    );
+  }
 
   return initialResults;
 }


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

When you don't pass a root indexName, no search gets done for the root, therefore the searchResults are also `null` for that index.

With this fix, getInitialResults is resilient for this behaviour and ensures results are still returned as expected.

This also changes the error from an implicit "can't read _state from results" when there are no results and you're trying to read the results, to an explicit error.


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

fixes #5831

root `indexName` is also optional in server side rendering 

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
