### PR TITLE
chore(docs): replace algolia/instantsearch.js with algolia/instantsearch

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,7 +1,7 @@
 {
   "sandboxes": [
     "instantsearchjs-es-template-pcw1k",
-    "github/algolia/instantsearch.js/tree/templates/react-instantsearch",
+    "github/algolia/instantsearch/tree/templates/react-instantsearch",
     "/examples/react/default-theme",
     "/examples/vue/default-theme"
   ],

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -3,76 +3,76 @@ description: Help us improve InstantSearch
 labels:
   - triage
 body:
-- type: textarea
-  id: current-behavior
-  attributes:
-    label: 🐛 Current behavior
-    description: A clear and concise description of what the bug is.
-  validations:
-    required: true
-- type: textarea
-  id: reproduction-steps
-  attributes:
-    label: 🔍 Steps to reproduce
-    description: Steps to reproduce the behavior.
-    placeholder: |
-      1. Go to ...
-      2. Click on ...
-      3. Scroll down to ...
-      4. See error
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: 🐛 Current behavior
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: 🔍 Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. Scroll down to ...
+        4. See error
 
-      You can attach screenshots by dragging and dropping, or selecting and pasting them in the text field.
-  validations:
-    required: true
-- type: input
-  id: reproduction-links
-  attributes:
-    label: Live reproduction
-    description: |
-      A live example helps a lot! Fork the sandbox relevant to the library you're using, reproduce the bug, and paste the URL here.
+        You can attach screenshots by dragging and dropping, or selecting and pasting them in the text field.
+    validations:
+      required: true
+  - type: input
+    id: reproduction-links
+    attributes:
+      label: Live reproduction
+      description: |
+        A live example helps a lot! Fork the sandbox relevant to the library you're using, reproduce the bug, and paste the URL here.
 
-      <table>
-        <tr>
-          <th>Sandboxes</th>
-          <td><a href="https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/instantsearch.js" target="_blank">InstantSearch.js</a></td>
-          <td><a href="https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/react-instantsearch" target="_blank">React InstantSearch</a></td>
-          <td><a href="https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/vue-instantsearch" target="_blank">Vue InstantSearch</a></td>
-          <td><a href="https://codesandbox.io/s/github/algolia/instantsearch.js/tree/templates/angular-instantsearch" target="_blank">Angular InstantSearch</a></td>
-        </tr>
-      </table>
+        <table>
+          <tr>
+            <th>Sandboxes</th>
+            <td><a href="https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/instantsearch.js" target="_blank">InstantSearch.js</a></td>
+            <td><a href="https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/react-instantsearch" target="_blank">React InstantSearch</a></td>
+            <td><a href="https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/vue-instantsearch" target="_blank">Vue InstantSearch</a></td>
+            <td><a href="https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/angular-instantsearch" target="_blank">Angular InstantSearch</a></td>
+          </tr>
+        </table>
 
-    placeholder: https://codesandbox.io/...
-  validations:
-    required: true
-- type: textarea
-  id: expected-behavior
-  attributes:
-    label: 💭 Expected behavior
-    description: A clear and concise description of what you expected to happen.
-  validations:
-    required: true
-- type: input
-  id: version
-  attributes:
-    label: Package version
-    description: What library and version you're experiencing the issue with.
-    placeholder: e.g., instantsearch.js 4.49.2, react-instantsearch 6.38.1
-  validations:
-    required: true
-- type: input
-  id: os
-  attributes:
-    label: Operating system
-    placeholder: e.g., macOS 13.1
-- type: input
-  id: browser
-  attributes:
-    label: Browser
-    placeholder: e.g., Firefox 108.0.1
-- type: checkboxes
-  attributes:
-    label: Code of Conduct
-    description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/algolia/.github/blob/main/CODE_OF_CONDUCT.md).
-    options:
-      - label: I agree to follow this project's Code of Conduct
-        required: true
+      placeholder: https://codesandbox.io/...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: 💭 Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      description: What library and version you're experiencing the issue with.
+      placeholder: e.g., instantsearch.js 4.49.2, react-instantsearch 6.38.1
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g., macOS 13.1
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      placeholder: e.g., Firefox 108.0.1
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/algolia/.github/blob/main/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Request
-    url: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage&title=Feature%20request%3A%20
+    url: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage&title=Feature%20request%3A%20
     about: Request a feature to add to InstantSearch.
   - name: Ask a Question
-    url: https://github.com/algolia/instantsearch.js/discussions/new?category=q-a&labels=triage
+    url: https://github.com/algolia/instantsearch/discussions/new?category=q-a&labels=triage
     about: Ask questions and discuss with other community members.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,10 @@
 
 Hello and welcome to the contributing guide for InstantSearch. Thanks for considering participating in our project 🙇
 
-If this guide does not contain what you are looking for and thus prevents you from contributing, don't hesitate to leave a message on the [community forum](https://discourse.algolia.com/) or to [open an issue](https://github.com/algolia/instantsearch.js/issues).
+If this guide does not contain what you are looking for and thus prevents you from contributing, don't hesitate to leave a message on the [community forum](https://discourse.algolia.com/) or to [open an issue](https://github.com/algolia/instantsearch/issues).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 
 - [Reporting an issue](#reporting-an-issue)
 - [The code contribution process](#the-code-contribution-process)
@@ -36,7 +35,7 @@ If this guide does not contain what you are looking for and thus prevents you fr
 
 Opening an issue is very effective way to contribute because many users might also be impacted. We'll make sure to fix it quickly if it's technically feasible and doesn't have important side effects for other users.
 
-Before reporting an issue, first check that there is not an already open issue for the same topic using the [issues page](https://github.com/algolia/instantsearch.js/issues). Don't hesitate to thumb up an issue that corresponds to the problem you have.
+Before reporting an issue, first check that there is not an already open issue for the same topic using the [issues page](https://github.com/algolia/instantsearch/issues). Don't hesitate to thumb up an issue that corresponds to the problem you have.
 
 Another element that will help us go faster at solving the issue is to provide a reproducible test case. We often recommend to [use this CodeSandbox template](https://codesandbox.io/s/github/algolia/instantsearch-templates/tree/master/src/InstantSearch.js).
 
@@ -162,7 +161,7 @@ This monorepo has as goal to be used for all InstantSearch flavors and tools. To
 
 The general philosophy of testing in InstantSearch follows [Testing Library's guiding principles](https://testing-library.com/docs/guiding-principles):
 
->The more your tests resemble the way your software is used, the more confidence they can give you.
+> The more your tests resemble the way your software is used, the more confidence they can give you.
 
 We rely on [Jest](https://jestjs.io/) for unit tests on all flavors of InstantSearch. In addition, [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) is used to test interactions in React InstantSearch.
 
@@ -214,7 +213,9 @@ fireEvent.click(button);
 // Don't manually dispatch with lower-level APIs or create custom-made events,
 // the browser might do other things you don't see or know about.
 fireEvent(button, new MouseEvent('click', { bubbles: true, cancelable: true }));
-button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+button.dispatchEvent(
+  new MouseEvent('click', { bubbles: true, cancelable: true })
+);
 ```
 
 **✅ Correct**
@@ -284,8 +285,7 @@ await waitFor(() => {
 });
 ```
 
-> **Note**
->Sometimes, a second (focused) snapshot is clearer and shorter than a series of isolated assertions. Use your judgment to determine what will make the test the tersest and easiest to understand.
+> **Note** Sometimes, a second (focused) snapshot is clearer and shorter than a series of isolated assertions. Use your judgment to determine what will make the test the tersest and easiest to understand.
 
 ### Testing a widget
 
@@ -294,6 +294,7 @@ Widgets in InstantSearch are building blocks that have a predefined behavior and
 When testing a widget, you should focus on **user interactions, rendering, and possibly side-effects**.
 
 For example, you should test:
+
 - The rendering of a widget after passing all possible props.
 - The rendering of a widget or its side-effects (e.g., URL updates when used with routing) after interacting with it.
 
@@ -338,12 +339,12 @@ yarn test:e2e:local
 ```
 
 To run them on Sauce Labs:
+
 ```sh
 yarn test:e2e:saucelabs
 ```
 
-> **Note**
->Make sure to set up Sauce Labs credentials with the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables.
+> **Note** Make sure to set up Sauce Labs credentials with the `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables.
 
 For more info, including how to write end-to-end tests, check the `tests/e2e` [CONTRIBUTING](./tests/e2e/CONTRIBUTING.md) and [README](./tests/e2e/README.md) files.
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 
 ---
 
-[![License][license-image]][license-url]
-[![Build Status][ci-svg]][ci-url]
+[![License][license-image]][license-url] [![Build Status][ci-svg]][ci-url]
 
 [InstantSearch][instantsearch-docs] is a JavaScript library that lets you create an instant-search result experience using [Algolia][algolia-website]’s search API.
 
@@ -26,7 +25,6 @@ It is part of the InstantSearch family which is designed for different platforms
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 
 - [Packages](#packages)
 - [Contributing](#contributing)
@@ -44,7 +42,7 @@ It is part of the InstantSearch family which is designed for different platforms
 | [`create-instantsearch-app`](packages/create-instantsearch-app) | [![create-instantsearch-app npm version](https://img.shields.io/npm/v/create-instantsearch-app.svg?style=flat-square)](https://npmjs.org/package/create-instantsearch-app) | Command-line utility to quickly bootstrap a project with InstantSearch |
 | [`instantsearch.css`](packages/instantsearch.css) | [![instantsearch.css npm version](https://img.shields.io/npm/v/instantsearch.css.svg?style=flat-square)](https://npmjs.org/package/instantsearch.css) | Default CSS themes for InstantSearch |
 | [`instantsearch.js`](packages/instantsearch.js) | [![instantsearch.js npm version](https://img.shields.io/npm/v/instantsearch.js.svg?style=flat-square)](https://npmjs.org/package/instantsearch.js) | InstantSearch.js |
-| [`react-instantsearch`](packages/react-instantsearch) | [![react-instantsearch npm version](https://img.shields.io/npm/v/react-instantsearch.svg?style=flat-square)](https://npmjs.org/package/react-instantsearch)| React InstantSearch bundled library |
+| [`react-instantsearch`](packages/react-instantsearch) | [![react-instantsearch npm version](https://img.shields.io/npm/v/react-instantsearch.svg?style=flat-square)](https://npmjs.org/package/react-instantsearch) | React InstantSearch bundled library |
 | [`react-instantsearch-core`](packages/react-instantsearch-core) | [![react-instantsearch-core npm version](https://img.shields.io/npm/v/react-instantsearch-core.svg?style=flat-square)](https://npmjs.org/package/react-instantsearch-core) | Runtime-independent React InstantSearch version |
 | [`vue-instantsearch`](packages/vue-instantsearch) | [![vue-instantsearch npm version](https://img.shields.io/npm/v/vue-instantsearch.svg?style=flat-square)](https://npmjs.org/package/vue-instantsearch) | Vue InstantSearch |
 
@@ -80,16 +78,16 @@ InstantSearch is [MIT licensed][license-url].
 <!-- Links -->
 
 [algolia-website]: https://www.algolia.com/?utm_source=instantsearch.js&utm_campaign=repository "Algolia's website"
-[instantsearch-docs]: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/?utm_source=instantsearch.js&utm_campaign=repository "InstantSearch.js documentation"
-[react-instantsearch-docs]: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/?utm_source=instantsearch.js&utm_campaign=repository "React InstantSearch documentation"
-[vue-instantsearch-docs]: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/vue/?utm_source=instantsearch.js&utm_campaign=repository "Vue InstantSearch documentation"
-[angular-instantsearch-docs]: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/angular/?utm_source=instantsearch.js&utm_campaign=repository "Angular InstantSearch documentation"
+[instantsearch-docs]: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/?utm_source=instantsearch.js&utm_campaign=repository 'InstantSearch.js documentation'
+[react-instantsearch-docs]: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/?utm_source=instantsearch.js&utm_campaign=repository 'React InstantSearch documentation'
+[vue-instantsearch-docs]: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/vue/?utm_source=instantsearch.js&utm_campaign=repository 'Vue InstantSearch documentation'
+[angular-instantsearch-docs]: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/angular/?utm_source=instantsearch.js&utm_campaign=repository 'Angular InstantSearch documentation'
 [instantsearch-android-github]: https://github.com/algolia/instantsearch-android
 [instantsearch-ios-github]: https://github.com/algolia/instantsearch-ios
 [instantsearch-angular-github]: https://github.com/algolia/angular-instantsearch
-[contributing-bugreport]: https://github.com/algolia/instantsearch.js/issues/new?template=BUG_REPORT.yml&labels=triage
-[contributing-featurerequest]: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage&title=Feature%20request%3A%20
-[contributing-newissue]: https://github.com/algolia/instantsearch.js/issues/new?labels=triage
-[contributing-label-easy]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22
-[contributing-label-bug]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22
-[contributing-label-chore]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22
+[contributing-bugreport]: https://github.com/algolia/instantsearch/issues/new?template=BUG_REPORT.yml&labels=triage
+[contributing-featurerequest]: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage&title=Feature%20request%3A%20
+[contributing-newissue]: https://github.com/algolia/instantsearch/issues/new?labels=triage
+[contributing-label-easy]: https://github.com/algolia/instantsearch/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22
+[contributing-label-bug]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22
+[contributing-label-chore]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22

--- a/examples/js/calendar-widget/index.html
+++ b/examples/js/calendar-widget/index.html
@@ -1,48 +1,53 @@
 <html>
+  <head>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.3.1/themes/algolia.min.css"
+    />
+    <link rel="stylesheet" type="text/css" href="main.css" />
+    <link rel="stylesheet" type="text/css" href="calendar.css" />
+    <title>InstantSearch Calendar Widget</title>
+  </head>
 
-<head>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/instantsearch.css@7.3.1/themes/algolia.min.css">
-  <link rel="stylesheet" type="text/css" href="main.css">
-  <link rel="stylesheet" type="text/css" href="calendar.css">
-  <title>InstantSearch Calendar Widget</title>
-</head>
+  <body>
+    <header class="topbar">
+      <h1 class="title">
+        <a href=".">Calendar Widget Demo</a>
+      </h1>
+      <p class="subtitle">
+        powered by
+        <a href="https://github.com/algolia/instantsearch/">InstantSearch.js</a>
+      </p>
+    </header>
 
-<body>
-  <header class="topbar">
-    <h1 class="title">
-      <a href=".">Calendar Widget Demo</a>
-    </h1>
-    <p class="subtitle">powered by
-      <a href="https://github.com/algolia/instantsearch.js/">InstantSearch.js</a>
-    </p>
-  </header>
+    <main class="wrapper">
+      <aside class="left">
+        <div id="refinement-list">
+          <h3>Dates</h3>
+          <div id="calendar" class="daterange"></div>
+        </div>
 
-  <main class="wrapper">
-    <aside class="left">
-      <div id="refinement-list">
-        <h3>Dates</h3>
-        <div id="calendar" class="daterange"></div>
+        <footer class="left-footer">
+          <p>
+            <a
+              href="https://github.com/algolia/instantsearch/tree/master/examples/calendar-widget"
+              >View on GitHub</a
+            >.
+          </p>
+        </footer>
+      </aside>
+
+      <div class="right">
+        <div id="search-box"></div>
+
+        <ul id="hits" class="hits-container"></ul>
       </div>
+    </main>
 
-      <footer class="left-footer">
-        <p>
-          <a href="https://github.com/algolia/instantsearch.js/tree/master/examples/calendar-widget">View on GitHub</a>.
-        </p>
-      </footer>
-    </aside>
-
-    <div class="right">
-      <div id="search-box"></div>
-
-      <ul id="hits" class="hits-container"></ul>
-    </div>
-  </main>
-
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment.min.js"></script>
-  <script src="https://unpkg.com/BaremetricsCalendar@1.0.11/public/js/Calendar.js"></script>
-  <script type="module" src="env.js"></script>
-  <script type="module" src="app.js"></script>
-</body>
-
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment.min.js"></script>
+    <script src="https://unpkg.com/BaremetricsCalendar@1.0.11/public/js/Calendar.js"></script>
+    <script type="module" src="env.js"></script>
+    <script type="module" src="app.js"></script>
+  </body>
 </html>

--- a/examples/js/e-commerce-umd/README.md
+++ b/examples/js/e-commerce-umd/README.md
@@ -2,7 +2,7 @@
 
 [![Edit e-commerce UMD](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/js/e-commerce-umd)
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/examples/js/e-commerce/README.md
+++ b/examples/js/e-commerce/README.md
@@ -2,7 +2,7 @@
 
 [![Edit e-commerce](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/js/e-commerce)
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/examples/js/media/README.md
+++ b/examples/js/media/README.md
@@ -2,7 +2,7 @@
 
 [![Edit media](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/js/media)
 
-_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch.js/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
+_This project was generated with [create-instantsearch-app](https://github.com/algolia/instantsearch/tree/master/packages/create-instantsearch-app) by [Algolia](https://algolia.com)._
 
 ## Get started
 

--- a/examples/react/next-routing/README.md
+++ b/examples/react/next-routing/README.md
@@ -1,4 +1,4 @@
-This example shows how to do server side rendering with next.js and React InstantSearch. There's a live example here: https://codesandbox.io/s/github/algolia/instantsearch.js/tree/master/examples/react/next.
+This example shows how to do server side rendering with next.js and React InstantSearch. There's a live example here: https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react/next.
 
 [![Edit next-routing](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react/next-routing)
 

--- a/examples/react/next/README.md
+++ b/examples/react/next/README.md
@@ -1,4 +1,4 @@
-This example shows how to do server side rendering with next.js and React InstantSearch. There's a live example here: https://codesandbox.io/s/github/algolia/instantsearch.js/tree/master/examples/react/next.
+This example shows how to do server side rendering with next.js and React InstantSearch. There's a live example here: https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react/next.
 
 [![Edit next](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react/next)
 

--- a/packages/algoliasearch-helper/CHANGELOG.md
+++ b/packages/algoliasearch-helper/CHANGELOG.md
@@ -1,1098 +1,753 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 # [3.14.0](https://github.com/algolia/instantsearch/compare/algoliasearch-helper@3.13.5...algoliasearch-helper@3.14.0) (2023-07-25)
 
-
 ### Features
 
-* **caching:** sort filters and queries ([#5764](https://github.com/algolia/instantsearch/issues/5764)) ([f3d2019](https://github.com/algolia/instantsearch/commit/f3d2019748512a66c748da5d18750eaffd9e53b9))
-
-
-
-
+- **caching:** sort filters and queries ([#5764](https://github.com/algolia/instantsearch/issues/5764)) ([f3d2019](https://github.com/algolia/instantsearch/commit/f3d2019748512a66c748da5d18750eaffd9e53b9))
 
 ## [3.13.5](https://github.com/algolia/instantsearch/compare/algoliasearch-helper@3.13.4...algoliasearch-helper@3.13.5) (2023-07-19)
 
-
 ### Bug Fixes
 
-* **version:** ensure version file/export matches package ([#5762](https://github.com/algolia/instantsearch/issues/5762)) ([eb0bb32](https://github.com/algolia/instantsearch/commit/eb0bb3230735e498cbcb2d5096365534d1fae575))
-
-
-
-
+- **version:** ensure version file/export matches package ([#5762](https://github.com/algolia/instantsearch/issues/5762)) ([eb0bb32](https://github.com/algolia/instantsearch/commit/eb0bb3230735e498cbcb2d5096365534d1fae575))
 
 ## [3.13.4](https://github.com/algolia/instantsearch/compare/algoliasearch-helper@3.13.3...algoliasearch-helper@3.13.4) (2023-07-18)
 
 **Note:** Version bump only for package algoliasearch-helper
 
-
-
-
-
 ## [3.13.3](https://github.com/algolia/algoliasearch-helper-js/compare/3.13.2...3.13.3) (2023-06-21)
-
 
 ### Bug Fixes
 
-* **getFacetValues:** ignore `rootPath` for hierarchical facets ([#949](https://github.com/algolia/algoliasearch-helper-js/issues/949)) ([deb5daf](https://github.com/algolia/algoliasearch-helper-js/commit/deb5dafbe7ffb2c53d7c227ae236592ec9a9e02d))
-
-
+- **getFacetValues:** ignore `rootPath` for hierarchical facets ([#949](https://github.com/algolia/algoliasearch-helper-js/issues/949)) ([deb5daf](https://github.com/algolia/algoliasearch-helper-js/commit/deb5dafbe7ffb2c53d7c227ae236592ec9a9e02d))
 
 ## [3.13.2](https://github.com/algolia/algoliasearch-helper-js/compare/3.13.1...3.13.2) (2023-06-14)
 
-
 ### Bug Fixes
 
-* **types:** improve conditional for client version ([#943](https://github.com/algolia/algoliasearch-helper-js/issues/943)) ([6c22185](https://github.com/algolia/algoliasearch-helper-js/commit/6c2218508361c8a4130426a22ac4302328ba86ad))
-
-
+- **types:** improve conditional for client version ([#943](https://github.com/algolia/algoliasearch-helper-js/issues/943)) ([6c22185](https://github.com/algolia/algoliasearch-helper-js/commit/6c2218508361c8a4130426a22ac4302328ba86ad))
 
 ## [3.13.1](https://github.com/algolia/algoliasearch-helper-js/compare/3.13.0...3.13.1) (2023-06-12)
 
-
 ### Bug Fixes
 
-* **SearchResults:** use empty facets object for exclusion when results are artificial ([#940](https://github.com/algolia/algoliasearch-helper-js/issues/940)) ([a51e8cb](https://github.com/algolia/algoliasearch-helper-js/commit/a51e8cb37e10c41ca816be1630bab2078980947b))
-
-
+- **SearchResults:** use empty facets object for exclusion when results are artificial ([#940](https://github.com/algolia/algoliasearch-helper-js/issues/940)) ([a51e8cb](https://github.com/algolia/algoliasearch-helper-js/commit/a51e8cb37e10c41ca816be1630bab2078980947b))
 
 # [3.13.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.12.0...3.13.0) (2023-05-03)
 
-
 ### Features
 
-* **DerivedHelper:** skip request for empty index ([#938](https://github.com/algolia/algoliasearch-helper-js/issues/938)) ([79caa4b](https://github.com/algolia/algoliasearch-helper-js/commit/79caa4b0ca2537c0f4431ee11556464031935436))
-
-
+- **DerivedHelper:** skip request for empty index ([#938](https://github.com/algolia/algoliasearch-helper-js/issues/938)) ([79caa4b](https://github.com/algolia/algoliasearch-helper-js/commit/79caa4b0ca2537c0f4431ee11556464031935436))
 
 # [3.12.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.11.3...3.12.0) (2023-03-03)
 
-
 ### Features
 
-* **types:** add `queryAfterRemoval` to `SearchResults` ([#934](https://github.com/algolia/algoliasearch-helper-js/issues/934)) ([4fb5a03](https://github.com/algolia/algoliasearch-helper-js/commit/4fb5a0345f0cf438fb026d8010faf843bd3b0a01))
-
-
+- **types:** add `queryAfterRemoval` to `SearchResults` ([#934](https://github.com/algolia/algoliasearch-helper-js/issues/934)) ([4fb5a03](https://github.com/algolia/algoliasearch-helper-js/commit/4fb5a0345f0cf438fb026d8010faf843bd3b0a01))
 
 ## [3.11.3](https://github.com/algolia/algoliasearch-helper-js/compare/3.11.2...3.11.3) (2023-01-23)
 
-
 ### Bug Fixes
 
-* **getFacetValues:** reflect the value of _state in hierarchicalFacetValues ([#925](https://github.com/algolia/algoliasearch-helper-js/issues/925)) ([4d093b4](https://github.com/algolia/algoliasearch-helper-js/commit/4d093b464e62dc6963dc6676aee19ff78145f48a))
-
-
+- **getFacetValues:** reflect the value of \_state in hierarchicalFacetValues ([#925](https://github.com/algolia/algoliasearch-helper-js/issues/925)) ([4d093b4](https://github.com/algolia/algoliasearch-helper-js/commit/4d093b464e62dc6963dc6676aee19ff78145f48a))
 
 ## [3.11.2](https://github.com/algolia/algoliasearch-helper-js/compare/3.11.1...3.11.2) (2023-01-09)
 
-
 ### Bug Fixes
 
-* **answers:** deprecate findAnswers ([#919](https://github.com/algolia/algoliasearch-helper-js/issues/919)) ([0711861](https://github.com/algolia/algoliasearch-helper-js/commit/07118610d3da07d04390d7b79e857122e98a3db5))
-* prevent prototype pollution in rare error-cases ([#923](https://github.com/algolia/algoliasearch-helper-js/issues/923)) ([7ae16ea](https://github.com/algolia/algoliasearch-helper-js/commit/7ae16eaa3f5732b96f1fa40973778c5494e77b89)), closes [#922](https://github.com/algolia/algoliasearch-helper-js/issues/922) [#880](https://github.com/algolia/algoliasearch-helper-js/issues/880)
-
+- **answers:** deprecate findAnswers ([#919](https://github.com/algolia/algoliasearch-helper-js/issues/919)) ([0711861](https://github.com/algolia/algoliasearch-helper-js/commit/07118610d3da07d04390d7b79e857122e98a3db5))
+- prevent prototype pollution in rare error-cases ([#923](https://github.com/algolia/algoliasearch-helper-js/issues/923)) ([7ae16ea](https://github.com/algolia/algoliasearch-helper-js/commit/7ae16eaa3f5732b96f1fa40973778c5494e77b89)), closes [#922](https://github.com/algolia/algoliasearch-helper-js/issues/922) [#880](https://github.com/algolia/algoliasearch-helper-js/issues/880)
 
 ### Features
 
-* update Algolia logo ([#918](https://github.com/algolia/algoliasearch-helper-js/issues/918)) ([58e0e58](https://github.com/algolia/algoliasearch-helper-js/commit/58e0e588195dde8f411383ad248bd112a9c01eb5))
-
-
+- update Algolia logo ([#918](https://github.com/algolia/algoliasearch-helper-js/issues/918)) ([58e0e58](https://github.com/algolia/algoliasearch-helper-js/commit/58e0e588195dde8f411383ad248bd112a9c01eb5))
 
 ## [3.11.1](https://github.com/algolia/algoliasearch-helper-js/compare/3.11.0...3.11.1) (2022-09-12)
 
-
 ### Bug Fixes
 
-* **facetValues:** use existing facet filters in multi queries for hierarchical facet values ([#915](https://github.com/algolia/algoliasearch-helper-js/issues/915)) ([bae388c](https://github.com/algolia/algoliasearch-helper-js/commit/bae388c7143653e74628dbd3c72979a51be6ab7f))
-
-
+- **facetValues:** use existing facet filters in multi queries for hierarchical facet values ([#915](https://github.com/algolia/algoliasearch-helper-js/issues/915)) ([bae388c](https://github.com/algolia/algoliasearch-helper-js/commit/bae388c7143653e74628dbd3c72979a51be6ab7f))
 
 # [3.11.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.10.0...3.11.0) (2022-08-03)
 
-
 ### Features
 
-* **typing:** Update SearchResults hits, expose optional hit typings ([#914](https://github.com/algolia/algoliasearch-helper-js/issues/914)) ([bf4c4c6](https://github.com/algolia/algoliasearch-helper-js/commit/bf4c4c6cdc84a5b9d8daff60d591a419df01beed))
-
-
+- **typing:** Update SearchResults hits, expose optional hit typings ([#914](https://github.com/algolia/algoliasearch-helper-js/issues/914)) ([bf4c4c6](https://github.com/algolia/algoliasearch-helper-js/commit/bf4c4c6cdc84a5b9d8daff60d591a419df01beed))
 
 # [3.10.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.9.0...3.10.0) (2022-06-27)
 
-
 ### Features
 
-* **disjunctiveFacetParams:** reduce payload size ([#912](https://github.com/algolia/algoliasearch-helper-js/issues/912)) ([9518575](https://github.com/algolia/algoliasearch-helper-js/commit/95185750fb05e82c06d3ddd9e907f06ce66d0317))
-* **types:** support algoliasearch v5 ([#910](https://github.com/algolia/algoliasearch-helper-js/issues/910)) ([524272a](https://github.com/algolia/algoliasearch-helper-js/commit/524272a2fe62c852d9ed8d0cd698cc184897b9c5))
-
-
+- **disjunctiveFacetParams:** reduce payload size ([#912](https://github.com/algolia/algoliasearch-helper-js/issues/912)) ([9518575](https://github.com/algolia/algoliasearch-helper-js/commit/95185750fb05e82c06d3ddd9e907f06ce66d0317))
+- **types:** support algoliasearch v5 ([#910](https://github.com/algolia/algoliasearch-helper-js/issues/910)) ([524272a](https://github.com/algolia/algoliasearch-helper-js/commit/524272a2fe62c852d9ed8d0cd698cc184897b9c5))
 
 # [3.9.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.8.3...3.9.0) (2022-06-20)
 
-
 ### Bug Fixes
 
-* **requests:** send a sorted object of parameters ([#911](https://github.com/algolia/algoliasearch-helper-js/issues/911)) ([832507f](https://github.com/algolia/algoliasearch-helper-js/commit/832507fae48c54ab41d3241254753100bb86910b))
-
+- **requests:** send a sorted object of parameters ([#911](https://github.com/algolia/algoliasearch-helper-js/issues/911)) ([832507f](https://github.com/algolia/algoliasearch-helper-js/commit/832507fae48c54ab41d3241254753100bb86910b))
 
 ### Features
 
-* **searchForFacetValues:** fall back to client.search if it's present ([#906](https://github.com/algolia/algoliasearch-helper-js/issues/906)) ([d9ebb01](https://github.com/algolia/algoliasearch-helper-js/commit/d9ebb01382ec83e0c579c393c3e9df83a9261699)), closes [/github.com/algolia/algoliasearch-client-javascript/blob/v3/src/AlgoliaSearchCore.js#L638-L654](https://github.com//github.com/algolia/algoliasearch-client-javascript/blob/v3/src/AlgoliaSearchCore.js/issues/L638-L654)
-
-
+- **searchForFacetValues:** fall back to client.search if it's present ([#906](https://github.com/algolia/algoliasearch-helper-js/issues/906)) ([d9ebb01](https://github.com/algolia/algoliasearch-helper-js/commit/d9ebb01382ec83e0c579c393c3e9df83a9261699)), closes [/github.com/algolia/algoliasearch-client-javascript/blob/v3/src/AlgoliaSearchCore.js#L638-L654](https://github.com//github.com/algolia/algoliasearch-client-javascript/blob/v3/src/AlgoliaSearchCore.js/issues/L638-L654)
 
 ## [3.8.3](https://github.com/algolia/algoliasearch-helper-js/compare/3.8.2...3.8.3) (2022-06-15)
 
-
 ### Bug Fixes
 
-* **facetValues:** retrieve all hierarchical facet parent values ([#908](https://github.com/algolia/algoliasearch-helper-js/issues/908)) ([420111b](https://github.com/algolia/algoliasearch-helper-js/commit/420111b29f82fe3af8e5861a977f024a61f4025f))
-
-
+- **facetValues:** retrieve all hierarchical facet parent values ([#908](https://github.com/algolia/algoliasearch-helper-js/issues/908)) ([420111b](https://github.com/algolia/algoliasearch-helper-js/commit/420111b29f82fe3af8e5861a977f024a61f4025f))
 
 ## [3.8.2](https://github.com/algolia/algoliasearch-helper-js/compare/3.8.1...3.8.2) (2022-04-08)
 
-
 ### Bug Fixes
 
-* **types:** correct type for addTag ([#903](https://github.com/algolia/algoliasearch-helper-js/issues/903)) ([ca82ef3](https://github.com/algolia/algoliasearch-helper-js/commit/ca82ef302ceff8e0e31767c90e2f272914c703af))
-
-
+- **types:** correct type for addTag ([#903](https://github.com/algolia/algoliasearch-helper-js/issues/903)) ([ca82ef3](https://github.com/algolia/algoliasearch-helper-js/commit/ca82ef302ceff8e0e31767c90e2f272914c703af))
 
 ## [3.8.1](https://github.com/algolia/algoliasearch-helper-js/compare/3.8.0...3.8.1) (2022-04-05)
 
-
 ### Bug Fixes
 
-* **disjunctiveFacets:** avoid escaping non-string values ([#902](https://github.com/algolia/algoliasearch-helper-js/issues/902)) ([4ac67bd](https://github.com/algolia/algoliasearch-helper-js/commit/4ac67bda2a8e5a2b8c53c960637b72a77951af76))
-
-
+- **disjunctiveFacets:** avoid escaping non-string values ([#902](https://github.com/algolia/algoliasearch-helper-js/issues/902)) ([4ac67bd](https://github.com/algolia/algoliasearch-helper-js/commit/4ac67bda2a8e5a2b8c53c960637b72a77951af76))
 
 # [3.8.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.7.4...3.8.0) (2022-04-04)
 
-
 ### Features
 
-* **facetValues:** offer escaped value ([#889](https://github.com/algolia/algoliasearch-helper-js/issues/889)) ([4bae51b](https://github.com/algolia/algoliasearch-helper-js/commit/4bae51bdefd217f3ef9ab9bf02fb653f3b8ae643)), closes [#900](https://github.com/algolia/algoliasearch-helper-js/issues/900) [#901](https://github.com/algolia/algoliasearch-helper-js/issues/901)
-
-
+- **facetValues:** offer escaped value ([#889](https://github.com/algolia/algoliasearch-helper-js/issues/889)) ([4bae51b](https://github.com/algolia/algoliasearch-helper-js/commit/4bae51bdefd217f3ef9ab9bf02fb653f3b8ae643)), closes [#900](https://github.com/algolia/algoliasearch-helper-js/issues/900) [#901](https://github.com/algolia/algoliasearch-helper-js/issues/901)
 
 ## [3.7.4](https://github.com/algolia/algoliasearch-helper-js/compare/3.7.3...3.7.4) (2022-03-21)
 
-
 ### Bug Fixes
 
-* **type:** implement correctly ([1c8670b](https://github.com/algolia/algoliasearch-helper-js/commit/1c8670b21a507024d2ddf797feae5bb15343c244))
-
-
+- **type:** implement correctly ([1c8670b](https://github.com/algolia/algoliasearch-helper-js/commit/1c8670b21a507024d2ddf797feae5bb15343c244))
 
 ## [3.7.3](https://github.com/algolia/algoliasearch-helper-js/compare/3.7.2...3.7.3) (2022-03-18)
 
-
 ### Bug Fixes
 
-* **ts:** remove stray comment ([24fe8de](https://github.com/algolia/algoliasearch-helper-js/commit/24fe8de4bebc74500b33c95b124500b8499ef588))
-
-
+- **ts:** remove stray comment ([24fe8de](https://github.com/algolia/algoliasearch-helper-js/commit/24fe8de4bebc74500b33c95b124500b8499ef588))
 
 ## [3.7.2](https://github.com/algolia/algoliasearch-helper-js/compare/3.7.1...3.7.2) (2022-03-18)
 
-
 ### Bug Fixes
 
-* **results:** implement search result options via an argument ([4e6ac69](https://github.com/algolia/algoliasearch-helper-js/commit/4e6ac6926bd284c7eafe060480fc4258844d121a))
-
-
+- **results:** implement search result options via an argument ([4e6ac69](https://github.com/algolia/algoliasearch-helper-js/commit/4e6ac6926bd284c7eafe060480fc4258844d121a))
 
 ## [3.7.1](https://github.com/algolia/algoliasearch-helper-js/compare/3.7.0...3.7.1) (2022-03-17)
 
-
 ### Bug Fixes
 
-* **types:** allow "__isArtificial" ([#890](https://github.com/algolia/algoliasearch-helper-js/issues/890)) ([1e2aef0](https://github.com/algolia/algoliasearch-helper-js/commit/1e2aef0fb8aa88c80b985ef009bff5a3dd71ca80))
-
-
+- **types:** allow "\_\_isArtificial" ([#890](https://github.com/algolia/algoliasearch-helper-js/issues/890)) ([1e2aef0](https://github.com/algolia/algoliasearch-helper-js/commit/1e2aef0fb8aa88c80b985ef009bff5a3dd71ca80))
 
 # [3.7.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.6.2...3.7.0) (2021-12-13)
 
-
 ### Features
 
-* **events:** move to @algolia/events ([#883](https://github.com/algolia/algoliasearch-helper-js/issues/883)) ([0c33fdc](https://github.com/algolia/algoliasearch-helper-js/commit/0c33fdc0063d7486db71ba0c6952339dc8b93ae5))
-
-
+- **events:** move to @algolia/events ([#883](https://github.com/algolia/algoliasearch-helper-js/issues/883)) ([0c33fdc](https://github.com/algolia/algoliasearch-helper-js/commit/0c33fdc0063d7486db71ba0c6952339dc8b93ae5))
 
 ## [3.6.2](https://github.com/algolia/algoliasearch-helper-js/compare/3.6.1...3.6.2) (2021-10-19)
 
-
 ### Bug Fixes
 
-* **SearchParameters:** ignore invalid parameters ([#880](https://github.com/algolia/algoliasearch-helper-js/issues/880)) ([4ff542b](https://github.com/algolia/algoliasearch-helper-js/commit/4ff542b70b92a6b81cce8b9255700b0bc0817edd))
-
-
+- **SearchParameters:** ignore invalid parameters ([#880](https://github.com/algolia/algoliasearch-helper-js/issues/880)) ([4ff542b](https://github.com/algolia/algoliasearch-helper-js/commit/4ff542b70b92a6b81cce8b9255700b0bc0817edd))
 
 ## [3.6.1](https://github.com/algolia/algoliasearch-helper-js/compare/3.6.0...3.6.1) (2021-10-15)
 
-
 ### Bug Fixes
 
-* **facetOrdering:** make sure ordered facets is a dense array ([#879](https://github.com/algolia/algoliasearch-helper-js/issues/879)) ([990f8bc](https://github.com/algolia/algoliasearch-helper-js/commit/990f8bc133dd379c457c52f750a87944e2f2924c))
-
-
+- **facetOrdering:** make sure ordered facets is a dense array ([#879](https://github.com/algolia/algoliasearch-helper-js/issues/879)) ([990f8bc](https://github.com/algolia/algoliasearch-helper-js/commit/990f8bc133dd379c457c52f750a87944e2f2924c))
 
 # [3.6.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.5.5...3.6.0) (2021-10-08)
 
-
 ### Features
 
-* **facets:** when * is present, only send that parameter ([#874](https://github.com/algolia/algoliasearch-helper-js/issues/874)) ([fc183ec](https://github.com/algolia/algoliasearch-helper-js/commit/fc183ec2910d4ba33067b3487f3a70e940fd24d3))
-
-
+- **facets:** when \* is present, only send that parameter ([#874](https://github.com/algolia/algoliasearch-helper-js/issues/874)) ([fc183ec](https://github.com/algolia/algoliasearch-helper-js/commit/fc183ec2910d4ba33067b3487f3a70e940fd24d3))
 
 ## [3.5.5](https://github.com/algolia/algoliasearch-helper-js/compare/3.5.4...3.5.5) (2021-07-30)
 
-
 ### Features
 
-* **ts:** allow showParentLevel in hierarchicalFacet ([cef547d](https://github.com/algolia/algoliasearch-helper-js/commit/cef547d8f48bf2cdb2d28476f8d3715c1b1a40d8))
-
-
+- **ts:** allow showParentLevel in hierarchicalFacet ([cef547d](https://github.com/algolia/algoliasearch-helper-js/commit/cef547d8f48bf2cdb2d28476f8d3715c1b1a40d8))
 
 ## [3.5.4](https://github.com/algolia/algoliasearch-helper-js/compare/3.5.3...3.5.4) (2021-07-05)
 
-
 ### Bug Fixes
 
-* **facetOrdering:** facetOrdering.facets, not facetOrdering.facet ([97d769a](https://github.com/algolia/algoliasearch-helper-js/commit/97d769adf68458a04605ca7ac0e35ade5c4bc646))
-
-
+- **facetOrdering:** facetOrdering.facets, not facetOrdering.facet ([97d769a](https://github.com/algolia/algoliasearch-helper-js/commit/97d769adf68458a04605ca7ac0e35ade5c4bc646))
 
 ## [3.5.3](https://github.com/algolia/algoliasearch-helper-js/compare/3.5.2...3.5.3) (2021-06-14)
 
-
 ### Bug Fixes
 
-* **ts:** correct required for getFacetValues ([55a909f](https://github.com/algolia/algoliasearch-helper-js/commit/55a909fe1ef892b3e76ddc109155336c77875292))
-
-
+- **ts:** correct required for getFacetValues ([55a909f](https://github.com/algolia/algoliasearch-helper-js/commit/55a909fe1ef892b3e76ddc109155336c77875292))
 
 ## [3.5.2](https://github.com/algolia/algoliasearch-helper-js/compare/3.5.1...3.5.2) (2021-06-14)
 
-
 ### Bug Fixes
 
-* **facetOrdering:** hierarchical attributes sort by path ([c1d9764](https://github.com/algolia/algoliasearch-helper-js/commit/c1d9764b7ed9492356a8b9ccfdb980fe0361c46f))
-
-
+- **facetOrdering:** hierarchical attributes sort by path ([c1d9764](https://github.com/algolia/algoliasearch-helper-js/commit/c1d9764b7ed9492356a8b9ccfdb980fe0361c46f))
 
 ## [3.5.1](https://github.com/algolia/algoliasearch-helper-js/compare/3.5.0...3.5.1) (2021-06-14)
 
-
 ### Bug Fixes
 
-* **ts:** correctly optional renderingContent ([41d27f8](https://github.com/algolia/algoliasearch-helper-js/commit/41d27f8336f48dd2eaec53afafcceb81a58d0dfb))
-
-
+- **ts:** correctly optional renderingContent ([41d27f8](https://github.com/algolia/algoliasearch-helper-js/commit/41d27f8336f48dd2eaec53afafcceb81a58d0dfb))
 
 # [3.5.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.4.5...3.5.0) (2021-06-14)
 
-
 ### Features
 
-* **getFacetValues:** process facetOrdering ([#822](https://github.com/algolia/algoliasearch-helper-js/issues/822)) ([8c7ff44](https://github.com/algolia/algoliasearch-helper-js/commit/8c7ff444407cc7855c4d76b15954f4a6864d0b5d))
-
-
+- **getFacetValues:** process facetOrdering ([#822](https://github.com/algolia/algoliasearch-helper-js/issues/822)) ([8c7ff44](https://github.com/algolia/algoliasearch-helper-js/commit/8c7ff444407cc7855c4d76b15954f4a6864d0b5d))
 
 ## [3.4.5](https://github.com/algolia/algoliasearch-helper-js/compare/3.4.4...3.4.5) (2021-06-10)
 
-
 ### Features
 
-* **ts:** document renderingContent ([#823](https://github.com/algolia/algoliasearch-helper-js/issues/823)) ([7b176a7](https://github.com/algolia/algoliasearch-helper-js/commit/7b176a7bbc38de193ac1c6a34dacde63059e4b3b))
-
-
+- **ts:** document renderingContent ([#823](https://github.com/algolia/algoliasearch-helper-js/issues/823)) ([7b176a7](https://github.com/algolia/algoliasearch-helper-js/commit/7b176a7bbc38de193ac1c6a34dacde63059e4b3b))
 
 ## [3.4.4](https://github.com/algolia/algoliasearch-helper-js/compare/3.4.3...3.4.4) (2021-02-16)
 
-
 ### Bug Fixes
 
-* **ts:** add rootPath to HierarchicalFacet ([06fb959](https://github.com/algolia/algoliasearch-helper-js/commit/06fb959f119cc0e7b91268154c01e0f6f4aa3ba1))
-
-
+- **ts:** add rootPath to HierarchicalFacet ([06fb959](https://github.com/algolia/algoliasearch-helper-js/commit/06fb959f119cc0e7b91268154c01e0f6f4aa3ba1))
 
 ## [3.4.3](https://github.com/algolia/algoliasearch-helper-js/compare/3.4.2...3.4.3) (2021-02-15)
 
-
 ### Bug Fixes
 
-* **ts:** correct type for HierarchicalFacet parameter ([#811](https://github.com/algolia/algoliasearch-helper-js/issues/811)) ([3b705dd](https://github.com/algolia/algoliasearch-helper-js/commit/3b705dd4b22aa57c0ecd6533ea515fdafa7fd5f9)), closes [/github.com/algolia/instantsearch.js/blob/1ede1ae392d3a12f5b0fe29075ffeb05e572a874/src/connectors/menu/connectMenu.js#L283-L286](https://github.com//github.com/algolia/instantsearch.js/blob/1ede1ae392d3a12f5b0fe29075ffeb05e572a874/src/connectors/menu/connectMenu.js/issues/L283-L286) [/github.com/algolia/instantsearch.js/blob/1ede1ae392d3a12f5b0fe29075ffeb05e572a874/src/connectors/menu/__tests__/connectMenu-test.js#L98-L101](https://github.com//github.com/algolia/instantsearch.js/blob/1ede1ae392d3a12f5b0fe29075ffeb05e572a874/src/connectors/menu/__tests__/connectMenu-test.js/issues/L98-L101)
-
-
+- **ts:** correct type for HierarchicalFacet parameter ([#811](https://github.com/algolia/algoliasearch-helper-js/issues/811)) ([3b705dd](https://github.com/algolia/algoliasearch-helper-js/commit/3b705dd4b22aa57c0ecd6533ea515fdafa7fd5f9)), closes [/github.com/algolia/instantsearch/blob/1ede1ae392d3a12f5b0fe29075ffeb05e572a874/src/connectors/menu/connectMenu.js#L283-L286](https://github.com//github.com/algolia/instantsearch/blob/1ede1ae392d3a12f5b0fe29075ffeb05e572a874/src/connectors/menu/connectMenu.js/issues/L283-L286) [/github.com/algolia/instantsearch/blob/1ede1ae392d3a12f5b0fe29075ffeb05e572a874/src/connectors/menu/**tests**/connectMenu-test.js#L98-L101](https://github.com//github.com/algolia/instantsearch/blob/1ede1ae392d3a12f5b0fe29075ffeb05e572a874/src/connectors/menu/__tests__/connectMenu-test.js/issues/L98-L101)
 
 ## [3.4.2](https://github.com/algolia/algoliasearch-helper-js/compare/3.4.1...3.4.2) (2021-02-10)
 
-
 ### Bug Fixes
 
-* **types:** add relevancyStrictness to SearchParameters ([#810](https://github.com/algolia/algoliasearch-helper-js/issues/810)) ([3860179](https://github.com/algolia/algoliasearch-helper-js/commit/3860179c63c31bce0df82337d4000c7449ef516a))
-
-
+- **types:** add relevancyStrictness to SearchParameters ([#810](https://github.com/algolia/algoliasearch-helper-js/issues/810)) ([3860179](https://github.com/algolia/algoliasearch-helper-js/commit/3860179c63c31bce0df82337d4000c7449ef516a))
 
 ## [3.4.1](https://github.com/algolia/algoliasearch-helper-js/compare/3.4.0...3.4.1) (2021-02-10)
 
-
 ### Bug Fixes
 
-* **ts:** add types for smart sort ([#809](https://github.com/algolia/algoliasearch-helper-js/issues/809)) ([236822e](https://github.com/algolia/algoliasearch-helper-js/commit/236822e0f041ecb2e926740cff7e6ecdadccc604))
-* **ts:** make queryID optional ([#806](https://github.com/algolia/algoliasearch-helper-js/issues/806)) ([67ad89b](https://github.com/algolia/algoliasearch-helper-js/commit/67ad89bace2b3795a4d4281f97b4edf557b6903d))
-
-
+- **ts:** add types for smart sort ([#809](https://github.com/algolia/algoliasearch-helper-js/issues/809)) ([236822e](https://github.com/algolia/algoliasearch-helper-js/commit/236822e0f041ecb2e926740cff7e6ecdadccc604))
+- **ts:** make queryID optional ([#806](https://github.com/algolia/algoliasearch-helper-js/issues/806)) ([67ad89b](https://github.com/algolia/algoliasearch-helper-js/commit/67ad89bace2b3795a4d4281f97b4edf557b6903d))
 
 # [3.4.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.3.4...3.4.0) (2021-01-12)
 
-
 ### Features
 
-* **answers:** add `findAnswers` ([#804](https://github.com/algolia/algoliasearch-helper-js/issues/804)) ([4635dd5](https://github.com/algolia/algoliasearch-helper-js/commit/4635dd5b911713be7d2a868a79f9150b7bd175bd))
-
-
+- **answers:** add `findAnswers` ([#804](https://github.com/algolia/algoliasearch-helper-js/issues/804)) ([4635dd5](https://github.com/algolia/algoliasearch-helper-js/commit/4635dd5b911713be7d2a868a79f9150b7bd175bd))
 
 ## [3.3.4](https://github.com/algolia/algoliasearch-helper-js/compare/3.3.3...3.3.4) (2020-12-09)
 
-
 ### Bug Fixes
 
-* ignore invalid userToken ([#802](https://github.com/algolia/algoliasearch-helper-js/issues/802)) ([a2876c5](https://github.com/algolia/algoliasearch-helper-js/commit/a2876c59fb7bdf7bd564c727bc70e7514362e189))
-
-
+- ignore invalid userToken ([#802](https://github.com/algolia/algoliasearch-helper-js/issues/802)) ([a2876c5](https://github.com/algolia/algoliasearch-helper-js/commit/a2876c59fb7bdf7bd564c727bc70e7514362e189))
 
 ## [3.3.3](https://github.com/algolia/algoliasearch-helper-js/compare/3.3.2...3.3.3) (2020-12-02)
 
-
 ### Bug Fixes
 
-* **removeNumericRefinement:** clear empty refinements ([#801](https://github.com/algolia/algoliasearch-helper-js/issues/801)) ([844f7d7](https://github.com/algolia/algoliasearch-helper-js/commit/844f7d787de4897f17ebd5982f20316d7cb75a7d))
-
-
+- **removeNumericRefinement:** clear empty refinements ([#801](https://github.com/algolia/algoliasearch-helper-js/issues/801)) ([844f7d7](https://github.com/algolia/algoliasearch-helper-js/commit/844f7d787de4897f17ebd5982f20316d7cb75a7d))
 
 ## [3.3.2](https://github.com/algolia/algoliasearch-helper-js/compare/3.3.1...3.3.2) (2020-11-19)
 
-
 ### Bug Fixes
 
-* **ts:** add queryLanguages to parameters ([51f5448](https://github.com/algolia/algoliasearch-helper-js/commit/51f544855a38031e36c70e3c9b2212446cc4a1fa))
-* **ts:** add searchWithoutTriggeringOnStateChange ([fb91e27](https://github.com/algolia/algoliasearch-helper-js/commit/fb91e277325fa7c6c534370323dc2bdaee590b6d))
-* **ts:** correct type for clearCache ([684d5c0](https://github.com/algolia/algoliasearch-helper-js/commit/684d5c02f54de51512c282117c70d86cf09ba098))
-* **ts:** detailed type for facet.stats ([234cb19](https://github.com/algolia/algoliasearch-helper-js/commit/234cb19d0f8bf98a490b8e3d9042c9e0317b69e7))
-
-
+- **ts:** add queryLanguages to parameters ([51f5448](https://github.com/algolia/algoliasearch-helper-js/commit/51f544855a38031e36c70e3c9b2212446cc4a1fa))
+- **ts:** add searchWithoutTriggeringOnStateChange ([fb91e27](https://github.com/algolia/algoliasearch-helper-js/commit/fb91e277325fa7c6c534370323dc2bdaee590b6d))
+- **ts:** correct type for clearCache ([684d5c0](https://github.com/algolia/algoliasearch-helper-js/commit/684d5c02f54de51512c282117c70d86cf09ba098))
+- **ts:** detailed type for facet.stats ([234cb19](https://github.com/algolia/algoliasearch-helper-js/commit/234cb19d0f8bf98a490b8e3d9042c9e0317b69e7))
 
 ## [3.3.1](https://github.com/algolia/algoliasearch-helper-js/compare/3.3.0...3.3.1) (2020-11-19)
 
-
 ### Bug Fixes
 
-* **setup:** run postinstall only locally ([9df09e4](https://github.com/algolia/algoliasearch-helper-js/commit/9df09e465a3fff44bc3737b6660a076df0aebeec))
-
-
+- **setup:** run postinstall only locally ([9df09e4](https://github.com/algolia/algoliasearch-helper-js/commit/9df09e465a3fff44bc3737b6660a076df0aebeec))
 
 # [3.3.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.2.2...3.3.0) (2020-11-19)
 
-
 ### Bug Fixes
 
-* **ts:** correct type for getNumericRefinements ([#800](https://github.com/algolia/algoliasearch-helper-js/issues/800)) ([0920d94](https://github.com/algolia/algoliasearch-helper-js/commit/0920d945b09134b0b2ef7e5ccf7a71947504f9f0))
-
+- **ts:** correct type for getNumericRefinements ([#800](https://github.com/algolia/algoliasearch-helper-js/issues/800)) ([0920d94](https://github.com/algolia/algoliasearch-helper-js/commit/0920d945b09134b0b2ef7e5ccf7a71947504f9f0))
 
 ### Features
 
-* **ts:** fill in more of the types ([34ae5cd](https://github.com/algolia/algoliasearch-helper-js/commit/34ae5cd58977fa3c935ae74aa43b5049c9e6a6f9))
-
-
+- **ts:** fill in more of the types ([34ae5cd](https://github.com/algolia/algoliasearch-helper-js/commit/34ae5cd58977fa3c935ae74aa43b5049c9e6a6f9))
 
 ## [3.2.2](https://github.com/algolia/algoliasearch-helper-js/compare/3.2.1...3.2.2) (2020-07-30)
 
-
 ### Bug Fixes
 
-* **insideBoundingBox:** prevent invalid parameter from throwing ([#787](https://github.com/algolia/algoliasearch-helper-js/issues/787)) ([ba5ef68](https://github.com/algolia/algoliasearch-helper-js/commit/ba5ef685a4263cba154de30e2b1bd335fe5982e2))
-* **ts:** use a dedicated key to determine client version ([#789](https://github.com/algolia/algoliasearch-helper-js/issues/789)) ([deb4f4f](https://github.com/algolia/algoliasearch-helper-js/commit/deb4f4fa1f154fb7c437b5c7352bb9f5ca39b2bd))
-
-
+- **insideBoundingBox:** prevent invalid parameter from throwing ([#787](https://github.com/algolia/algoliasearch-helper-js/issues/787)) ([ba5ef68](https://github.com/algolia/algoliasearch-helper-js/commit/ba5ef685a4263cba154de30e2b1bd335fe5982e2))
+- **ts:** use a dedicated key to determine client version ([#789](https://github.com/algolia/algoliasearch-helper-js/issues/789)) ([deb4f4f](https://github.com/algolia/algoliasearch-helper-js/commit/deb4f4fa1f154fb7c437b5c7352bb9f5ca39b2bd))
 
 ## [3.2.1](https://github.com/algolia/algoliasearch-helper-js/compare/3.2.0...3.2.1) (2020-07-23)
 
-
 ### Bug Fixes
 
-* **defaultsPure:** fix the regression where the order was wrong with addFacetRefinement ([#786](https://github.com/algolia/algoliasearch-helper-js/issues/786)) ([b54fddb](https://github.com/algolia/algoliasearch-helper-js/commit/b54fddb9196b2dc19b6c259306262f2e1da2cf78))
-
-
+- **defaultsPure:** fix the regression where the order was wrong with addFacetRefinement ([#786](https://github.com/algolia/algoliasearch-helper-js/issues/786)) ([b54fddb](https://github.com/algolia/algoliasearch-helper-js/commit/b54fddb9196b2dc19b6c259306262f2e1da2cf78))
 
 # [3.2.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.1.2...3.2.0) (2020-07-21)
 
-
 ### Bug Fixes
 
-* accept all fields implicitly instead of the allow list ([#779](https://github.com/algolia/algoliasearch-helper-js/issues/779)) ([89a7aab](https://github.com/algolia/algoliasearch-helper-js/commit/89a7aab6d0189fcc963832e418399aad98c159ec))
-
-
+- accept all fields implicitly instead of the allow list ([#779](https://github.com/algolia/algoliasearch-helper-js/issues/779)) ([89a7aab](https://github.com/algolia/algoliasearch-helper-js/commit/89a7aab6d0189fcc963832e418399aad98c159ec))
 
 ## [3.1.2](https://github.com/algolia/algoliasearch-helper-js/compare/3.1.1...3.1.2) (2020-06-02)
 
-
 ### Bug Fixes
 
-* **defaultsPure:** don't change keys order, fix [#761](https://github.com/algolia/algoliasearch-helper-js/issues/761) ([#762](https://github.com/algolia/algoliasearch-helper-js/issues/762)) ([6b835ff](https://github.com/algolia/algoliasearch-helper-js/commit/6b835ffd07742f2d6b314022cce6848f5cfecd4a))
-* **types:** add `resetPage` state method ([#773](https://github.com/algolia/algoliasearch-helper-js/issues/773)) ([e2a88a1](https://github.com/algolia/algoliasearch-helper-js/commit/e2a88a169d3b82f4fd756cb4b0e9317d5bcc6b9e))
-* **typescript:** fix TypeScript 3.9 compatibility ([#775](https://github.com/algolia/algoliasearch-helper-js/issues/775)) ([c83c501](https://github.com/algolia/algoliasearch-helper-js/commit/c83c501938e803ca9fa74601dcd1ed896583ac0e)), closes [#774](https://github.com/algolia/algoliasearch-helper-js/issues/774)
-
-
+- **defaultsPure:** don't change keys order, fix [#761](https://github.com/algolia/algoliasearch-helper-js/issues/761) ([#762](https://github.com/algolia/algoliasearch-helper-js/issues/762)) ([6b835ff](https://github.com/algolia/algoliasearch-helper-js/commit/6b835ffd07742f2d6b314022cce6848f5cfecd4a))
+- **types:** add `resetPage` state method ([#773](https://github.com/algolia/algoliasearch-helper-js/issues/773)) ([e2a88a1](https://github.com/algolia/algoliasearch-helper-js/commit/e2a88a169d3b82f4fd756cb4b0e9317d5bcc6b9e))
+- **typescript:** fix TypeScript 3.9 compatibility ([#775](https://github.com/algolia/algoliasearch-helper-js/issues/775)) ([c83c501](https://github.com/algolia/algoliasearch-helper-js/commit/c83c501938e803ca9fa74601dcd1ed896583ac0e)), closes [#774](https://github.com/algolia/algoliasearch-helper-js/issues/774)
 
 ## [3.1.1](https://github.com/algolia/algoliasearch-helper-js/compare/3.1.0...3.1.1) (2020-02-21)
 
-
 ### Bug Fixes
 
-* fix omit calls to pass excluded value as an array ([#760](https://github.com/algolia/algoliasearch-helper-js/issues/760)) ([dd375ab](https://github.com/algolia/algoliasearch-helper-js/commit/dd375ab18513336817bd8d5d78341ac33ae94954))
-
-
+- fix omit calls to pass excluded value as an array ([#760](https://github.com/algolia/algoliasearch-helper-js/issues/760)) ([dd375ab](https://github.com/algolia/algoliasearch-helper-js/commit/dd375ab18513336817bd8d5d78341ac33ae94954))
 
 # [3.1.0](https://github.com/algolia/algoliasearch-helper-js/compare/3.0.0...3.1.0) (2020-01-21)
 
-
 ### Bug Fixes
 
-* **types:** add `optionalFilters` search parameter ([#754](https://github.com/algolia/algoliasearch-helper-js/issues/754)) ([faba4d7](https://github.com/algolia/algoliasearch-helper-js/commit/faba4d7f52abae1c18f1023a03c41cfb5cffefb0))
-
+- **types:** add `optionalFilters` search parameter ([#754](https://github.com/algolia/algoliasearch-helper-js/issues/754)) ([faba4d7](https://github.com/algolia/algoliasearch-helper-js/commit/faba4d7f52abae1c18f1023a03c41cfb5cffefb0))
 
 ### Features
 
-* **algoliasearch:** add support for algoliasearch v4 the helper v3 ([#756](https://github.com/algolia/algoliasearch-helper-js/issues/756)) ([67407a0](https://github.com/algolia/algoliasearch-helper-js/commit/67407a0dfd99402bc1a77bd005385633c3881624))
-
-
+- **algoliasearch:** add support for algoliasearch v4 the helper v3 ([#756](https://github.com/algolia/algoliasearch-helper-js/issues/756)) ([67407a0](https://github.com/algolia/algoliasearch-helper-js/commit/67407a0dfd99402bc1a77bd005385633c3881624))
 
 # [3.0.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.28.0...3.0.0) (2019-11-18)
 
-
 ### Bug Fixes
 
-* **defaults:** remove const ([48a0c48](https://github.com/algolia/algoliasearch-helper-js/commit/48a0c488a966c02230caf51c07e20b5cbf7a10d0))
-* **errors:** remove isRefined ([#731](https://github.com/algolia/algoliasearch-helper-js/issues/731)) ([5761885](https://github.com/algolia/algoliasearch-helper-js/commit/5761885f9b2f1f505d27cfce7f3845a0d5a7bbba))
-* **getConjunctiveRefinements:** no error when requested facet is not conjunctive ([#724](https://github.com/algolia/algoliasearch-helper-js/issues/724)) ([cf852e7](https://github.com/algolia/algoliasearch-helper-js/commit/cf852e7d8741f2a7f675deacaf0c4f6d3cc0ad4f)), closes [#722](https://github.com/algolia/algoliasearch-helper-js/issues/722)
-* **getDisjunctiveRefinements:** remove error ([#725](https://github.com/algolia/algoliasearch-helper-js/issues/725)) ([211e390](https://github.com/algolia/algoliasearch-helper-js/commit/211e390fd73b0fedecded5e64f29630c44fa15e5)), closes [#722](https://github.com/algolia/algoliasearch-helper-js/issues/722)
-* **getExcludeRefinements:** replace error by default value ([#726](https://github.com/algolia/algoliasearch-helper-js/issues/726)) ([9d7ae87](https://github.com/algolia/algoliasearch-helper-js/commit/9d7ae871d6b4bec9117e69b90fc7bfa53e6cb3c1))
-* **getFacetStats:** remove error ([#721](https://github.com/algolia/algoliasearch-helper-js/issues/721)) ([96b6ec8](https://github.com/algolia/algoliasearch-helper-js/commit/96b6ec8552289eca0ac484c04b303fe2c8bc1af8)), closes [#720](https://github.com/algolia/algoliasearch-helper-js/issues/720)
-* **getFacetValues:** don't throw error when there's no facet ([#720](https://github.com/algolia/algoliasearch-helper-js/issues/720)) ([e15e39e](https://github.com/algolia/algoliasearch-helper-js/commit/e15e39e88c7599b8ff92754fdee86d5ba4a1e44f))
-* **getHierarchicalFacetBreadcrumb:** don't throw an error ([#723](https://github.com/algolia/algoliasearch-helper-js/issues/723)) ([40e1d61](https://github.com/algolia/algoliasearch-helper-js/commit/40e1d61eba366bbfece5945c1693bc04d21427e4))
-* **isDisjunctiveFacetRefined:** return false if not in disjunctiveFacets ([#729](https://github.com/algolia/algoliasearch-helper-js/issues/729)) ([13ec09b](https://github.com/algolia/algoliasearch-helper-js/commit/13ec09bff8bbefcc1ad3200cd196c8832c816eca)), closes [#727](https://github.com/algolia/algoliasearch-helper-js/issues/727)
-* **isExcludeRefined:** remove error in favor of false ([#728](https://github.com/algolia/algoliasearch-helper-js/issues/728)) ([3f0ab6b](https://github.com/algolia/algoliasearch-helper-js/commit/3f0ab6b4800181d4b20ac9dae856ed480ef90001)), closes [#727](https://github.com/algolia/algoliasearch-helper-js/issues/727)
-* **isFacetRefined:** return false if facet isn't declared ([#727](https://github.com/algolia/algoliasearch-helper-js/issues/727)) ([7151f56](https://github.com/algolia/algoliasearch-helper-js/commit/7151f56e4be9e71ef8b1427b2746f11b1edfb2f8))
-* **isHierarchicalFacetRefined:** return false if refinement isn't a facet ([#730](https://github.com/algolia/algoliasearch-helper-js/issues/730)) ([89fa010](https://github.com/algolia/algoliasearch-helper-js/commit/89fa01087201290b4d26aa6a0780d0b505d17622)), closes [#722](https://github.com/algolia/algoliasearch-helper-js/issues/722)
-* **lodash/intersection:** replace with custom implementation ([#718](https://github.com/algolia/algoliasearch-helper-js/issues/718)) ([00dfb4e](https://github.com/algolia/algoliasearch-helper-js/commit/00dfb4e67fc3b343ec96321b1cb5dd527d074419)), closes [#696](https://github.com/algolia/algoliasearch-helper-js/issues/696)
-* **removeXFacet:** make sure this fully removes empty arrays ([#743](https://github.com/algolia/algoliasearch-helper-js/issues/743)) ([ea5a22a](https://github.com/algolia/algoliasearch-helper-js/commit/ea5a22a8afd64d9c68279a4aff284a1a5c023835))
-* **results:** remove lodash looping over objects ([#648](https://github.com/algolia/algoliasearch-helper-js/issues/648)) ([bb025c2](https://github.com/algolia/algoliasearch-helper-js/commit/bb025c27aa1af7c31763970151f90b7bb401b164)), closes [#258](https://github.com/algolia/algoliasearch-helper-js/issues/258) [#651](https://github.com/algolia/algoliasearch-helper-js/issues/651)
-* **sortBy:** compare whole prefix instead of first character ([#702](https://github.com/algolia/algoliasearch-helper-js/issues/702)) ([b85fb50](https://github.com/algolia/algoliasearch-helper-js/commit/b85fb502ea48d0142a1400887bf353645ab5fbda)), closes [/github.com/algolia/algoliasearch-helper-js/pull/690#discussion_r282467917](https://github.com//github.com/algolia/algoliasearch-helper-js/pull/690/issues/discussion_r282467917)
-* **toggleRefinement:** keep an empty array when clearing ([#738](https://github.com/algolia/algoliasearch-helper-js/issues/738)) ([5b3fc11](https://github.com/algolia/algoliasearch-helper-js/commit/5b3fc1189c93c480b3de5cdd0e37c8b86edfb89a))
-* **types:** add state.removeNumericRefinement ([#742](https://github.com/algolia/algoliasearch-helper-js/issues/742)) ([e58c24a](https://github.com/algolia/algoliasearch-helper-js/commit/e58c24ab5a858698ef27bd50c9f2d7ee93d6dd53))
-
+- **defaults:** remove const ([48a0c48](https://github.com/algolia/algoliasearch-helper-js/commit/48a0c488a966c02230caf51c07e20b5cbf7a10d0))
+- **errors:** remove isRefined ([#731](https://github.com/algolia/algoliasearch-helper-js/issues/731)) ([5761885](https://github.com/algolia/algoliasearch-helper-js/commit/5761885f9b2f1f505d27cfce7f3845a0d5a7bbba))
+- **getConjunctiveRefinements:** no error when requested facet is not conjunctive ([#724](https://github.com/algolia/algoliasearch-helper-js/issues/724)) ([cf852e7](https://github.com/algolia/algoliasearch-helper-js/commit/cf852e7d8741f2a7f675deacaf0c4f6d3cc0ad4f)), closes [#722](https://github.com/algolia/algoliasearch-helper-js/issues/722)
+- **getDisjunctiveRefinements:** remove error ([#725](https://github.com/algolia/algoliasearch-helper-js/issues/725)) ([211e390](https://github.com/algolia/algoliasearch-helper-js/commit/211e390fd73b0fedecded5e64f29630c44fa15e5)), closes [#722](https://github.com/algolia/algoliasearch-helper-js/issues/722)
+- **getExcludeRefinements:** replace error by default value ([#726](https://github.com/algolia/algoliasearch-helper-js/issues/726)) ([9d7ae87](https://github.com/algolia/algoliasearch-helper-js/commit/9d7ae871d6b4bec9117e69b90fc7bfa53e6cb3c1))
+- **getFacetStats:** remove error ([#721](https://github.com/algolia/algoliasearch-helper-js/issues/721)) ([96b6ec8](https://github.com/algolia/algoliasearch-helper-js/commit/96b6ec8552289eca0ac484c04b303fe2c8bc1af8)), closes [#720](https://github.com/algolia/algoliasearch-helper-js/issues/720)
+- **getFacetValues:** don't throw error when there's no facet ([#720](https://github.com/algolia/algoliasearch-helper-js/issues/720)) ([e15e39e](https://github.com/algolia/algoliasearch-helper-js/commit/e15e39e88c7599b8ff92754fdee86d5ba4a1e44f))
+- **getHierarchicalFacetBreadcrumb:** don't throw an error ([#723](https://github.com/algolia/algoliasearch-helper-js/issues/723)) ([40e1d61](https://github.com/algolia/algoliasearch-helper-js/commit/40e1d61eba366bbfece5945c1693bc04d21427e4))
+- **isDisjunctiveFacetRefined:** return false if not in disjunctiveFacets ([#729](https://github.com/algolia/algoliasearch-helper-js/issues/729)) ([13ec09b](https://github.com/algolia/algoliasearch-helper-js/commit/13ec09bff8bbefcc1ad3200cd196c8832c816eca)), closes [#727](https://github.com/algolia/algoliasearch-helper-js/issues/727)
+- **isExcludeRefined:** remove error in favor of false ([#728](https://github.com/algolia/algoliasearch-helper-js/issues/728)) ([3f0ab6b](https://github.com/algolia/algoliasearch-helper-js/commit/3f0ab6b4800181d4b20ac9dae856ed480ef90001)), closes [#727](https://github.com/algolia/algoliasearch-helper-js/issues/727)
+- **isFacetRefined:** return false if facet isn't declared ([#727](https://github.com/algolia/algoliasearch-helper-js/issues/727)) ([7151f56](https://github.com/algolia/algoliasearch-helper-js/commit/7151f56e4be9e71ef8b1427b2746f11b1edfb2f8))
+- **isHierarchicalFacetRefined:** return false if refinement isn't a facet ([#730](https://github.com/algolia/algoliasearch-helper-js/issues/730)) ([89fa010](https://github.com/algolia/algoliasearch-helper-js/commit/89fa01087201290b4d26aa6a0780d0b505d17622)), closes [#722](https://github.com/algolia/algoliasearch-helper-js/issues/722)
+- **lodash/intersection:** replace with custom implementation ([#718](https://github.com/algolia/algoliasearch-helper-js/issues/718)) ([00dfb4e](https://github.com/algolia/algoliasearch-helper-js/commit/00dfb4e67fc3b343ec96321b1cb5dd527d074419)), closes [#696](https://github.com/algolia/algoliasearch-helper-js/issues/696)
+- **removeXFacet:** make sure this fully removes empty arrays ([#743](https://github.com/algolia/algoliasearch-helper-js/issues/743)) ([ea5a22a](https://github.com/algolia/algoliasearch-helper-js/commit/ea5a22a8afd64d9c68279a4aff284a1a5c023835))
+- **results:** remove lodash looping over objects ([#648](https://github.com/algolia/algoliasearch-helper-js/issues/648)) ([bb025c2](https://github.com/algolia/algoliasearch-helper-js/commit/bb025c27aa1af7c31763970151f90b7bb401b164)), closes [#258](https://github.com/algolia/algoliasearch-helper-js/issues/258) [#651](https://github.com/algolia/algoliasearch-helper-js/issues/651)
+- **sortBy:** compare whole prefix instead of first character ([#702](https://github.com/algolia/algoliasearch-helper-js/issues/702)) ([b85fb50](https://github.com/algolia/algoliasearch-helper-js/commit/b85fb502ea48d0142a1400887bf353645ab5fbda)), closes [/github.com/algolia/algoliasearch-helper-js/pull/690#discussion_r282467917](https://github.com//github.com/algolia/algoliasearch-helper-js/pull/690/issues/discussion_r282467917)
+- **toggleRefinement:** keep an empty array when clearing ([#738](https://github.com/algolia/algoliasearch-helper-js/issues/738)) ([5b3fc11](https://github.com/algolia/algoliasearch-helper-js/commit/5b3fc1189c93c480b3de5cdd0e37c8b86edfb89a))
+- **types:** add state.removeNumericRefinement ([#742](https://github.com/algolia/algoliasearch-helper-js/issues/742)) ([e58c24a](https://github.com/algolia/algoliasearch-helper-js/commit/e58c24ab5a858698ef27bd50c9f2d7ee93d6dd53))
 
 ### Features
 
-* **getState:** remove "filter" option ([#707](https://github.com/algolia/algoliasearch-helper-js/issues/707)) ([ac52791](https://github.com/algolia/algoliasearch-helper-js/commit/ac527915fee3dfaf29dce26fcedb5a8c7e2007b7))
-* **getState:** remove getState ([#708](https://github.com/algolia/algoliasearch-helper-js/issues/708)) ([7de698c](https://github.com/algolia/algoliasearch-helper-js/commit/7de698cfa9fa9518e3a40cdb2caa34da7e9ba52e))
-* implement dedicated reset page method ([#673](https://github.com/algolia/algoliasearch-helper-js/issues/673)) ([666501e](https://github.com/algolia/algoliasearch-helper-js/commit/666501eb4149c1f0558ef1cdeb8239fc1bdc2d2f))
-* **requestBuilder:** prevent needless extra requests for empty refinements ([#737](https://github.com/algolia/algoliasearch-helper-js/issues/737)) ([db0a392](https://github.com/algolia/algoliasearch-helper-js/commit/db0a3929ab236f0435a81544ca721dd6b9f9319a))
-* **search:** allow the search only with Derived Helpers ([#704](https://github.com/algolia/algoliasearch-helper-js/issues/704)) ([aa128fc](https://github.com/algolia/algoliasearch-helper-js/commit/aa128fc928a999438b8efaad050170f812f85b33))
-* **SearchParameters:** avoid undefined values ([#703](https://github.com/algolia/algoliasearch-helper-js/issues/703)) ([9757e0a](https://github.com/algolia/algoliasearch-helper-js/commit/9757e0a78d8e6fec64999e45d4452019d4a13a8f))
-* **typescript:** move typings inline ([#719](https://github.com/algolia/algoliasearch-helper-js/issues/719)) ([a12272e](https://github.com/algolia/algoliasearch-helper-js/commit/a12272ead5ba87b32c1b8528deeeae555ace26e3)), closes [/github.com/algolia/algoliasearch-helper-js/pull/719/files#r301510978](https://github.com//github.com/algolia/algoliasearch-helper-js/pull/719/files/issues/r301510978) [/github.com/algolia/algoliasearch-helper-js/pull/719#commitcomment-34233548](https://github.com//github.com/algolia/algoliasearch-helper-js/pull/719/issues/commitcomment-34233548)
-
+- **getState:** remove "filter" option ([#707](https://github.com/algolia/algoliasearch-helper-js/issues/707)) ([ac52791](https://github.com/algolia/algoliasearch-helper-js/commit/ac527915fee3dfaf29dce26fcedb5a8c7e2007b7))
+- **getState:** remove getState ([#708](https://github.com/algolia/algoliasearch-helper-js/issues/708)) ([7de698c](https://github.com/algolia/algoliasearch-helper-js/commit/7de698cfa9fa9518e3a40cdb2caa34da7e9ba52e))
+- implement dedicated reset page method ([#673](https://github.com/algolia/algoliasearch-helper-js/issues/673)) ([666501e](https://github.com/algolia/algoliasearch-helper-js/commit/666501eb4149c1f0558ef1cdeb8239fc1bdc2d2f))
+- **requestBuilder:** prevent needless extra requests for empty refinements ([#737](https://github.com/algolia/algoliasearch-helper-js/issues/737)) ([db0a392](https://github.com/algolia/algoliasearch-helper-js/commit/db0a3929ab236f0435a81544ca721dd6b9f9319a))
+- **search:** allow the search only with Derived Helpers ([#704](https://github.com/algolia/algoliasearch-helper-js/issues/704)) ([aa128fc](https://github.com/algolia/algoliasearch-helper-js/commit/aa128fc928a999438b8efaad050170f812f85b33))
+- **SearchParameters:** avoid undefined values ([#703](https://github.com/algolia/algoliasearch-helper-js/issues/703)) ([9757e0a](https://github.com/algolia/algoliasearch-helper-js/commit/9757e0a78d8e6fec64999e45d4452019d4a13a8f))
+- **typescript:** move typings inline ([#719](https://github.com/algolia/algoliasearch-helper-js/issues/719)) ([a12272e](https://github.com/algolia/algoliasearch-helper-js/commit/a12272ead5ba87b32c1b8528deeeae555ace26e3)), closes [/github.com/algolia/algoliasearch-helper-js/pull/719/files#r301510978](https://github.com//github.com/algolia/algoliasearch-helper-js/pull/719/files/issues/r301510978) [/github.com/algolia/algoliasearch-helper-js/pull/719#commitcomment-34233548](https://github.com//github.com/algolia/algoliasearch-helper-js/pull/719/issues/commitcomment-34233548)
 
 ### BREAKING CHANGES
 
-* **errors:** removed helper.isRefined, use helper.hasRefinements instead
-* **getState:** use helper.state instead of helper.getState()
-* **getState:** getState(filters) is replaced my manually filtering the returned object
-* **getState:** SearchParameters.filter is removed
+- **errors:** removed helper.isRefined, use helper.hasRefinements instead
+- **getState:** use helper.state instead of helper.getState()
+- **getState:** getState(filters) is replaced my manually filtering the returned object
+- **getState:** SearchParameters.filter is removed
 
-* doc(filter): remove reference
-
-
+- doc(filter): remove reference
 
 # [2.28.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.26.1...2.28.0) (2019-05-07)
 
-
 ### Bug Fixes
 
-* **ua:** change the User-Agent to use the new specs lib (version) ([#647](https://github.com/algolia/algoliasearch-helper-js/issues/647)) ([eafd4cf](https://github.com/algolia/algoliasearch-helper-js/commit/eafd4cfd3e78b49bb5425784bab413f0702cbc04))
-
+- **ua:** change the User-Agent to use the new specs lib (version) ([#647](https://github.com/algolia/algoliasearch-helper-js/issues/647)) ([eafd4cf](https://github.com/algolia/algoliasearch-helper-js/commit/eafd4cfd3e78b49bb5425784bab413f0702cbc04))
 
 ### Features
 
-* **sffv:** throw an error if it's called and the client doesn't have the functions ([#623](https://github.com/algolia/algoliasearch-helper-js/issues/623)) ([dd61360](https://github.com/algolia/algoliasearch-helper-js/commit/dd61360cabd24f1baf33e242f4337c0e2245e9fd))
-
-
+- **sffv:** throw an error if it's called and the client doesn't have the functions ([#623](https://github.com/algolia/algoliasearch-helper-js/issues/623)) ([dd61360](https://github.com/algolia/algoliasearch-helper-js/commit/dd61360cabd24f1baf33e242f4337c0e2245e9fd))
 
 ## [2.26.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.26.0...2.26.1) (2018-06-19)
 
-
 ### Bug Fixes
 
-* **_dispatchAlgoliaResponse:** avoid mutate the client response ([#611](https://github.com/algolia/algoliasearch-helper-js/issues/611)) ([d6bd801](https://github.com/algolia/algoliasearch-helper-js/commit/d6bd801f3b3dc07ccd31b57947b8086c3fe07195))
-
-
+- **\_dispatchAlgoliaResponse:** avoid mutate the client response ([#611](https://github.com/algolia/algoliasearch-helper-js/issues/611)) ([d6bd801](https://github.com/algolia/algoliasearch-helper-js/commit/d6bd801f3b3dc07ccd31b57947b8086c3fe07195))
 
 # [2.26.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.25.1...2.26.0) (2018-04-25)
 
-
 ### Features
 
-* Make `addAlgoliaAgent()` and `clearCache()` optional ([#577](https://github.com/algolia/algoliasearch-helper-js/issues/577)) ([220b013](https://github.com/algolia/algoliasearch-helper-js/commit/220b01323d75202d5531dd56d9b8211ff22b902c))
-
-
+- Make `addAlgoliaAgent()` and `clearCache()` optional ([#577](https://github.com/algolia/algoliasearch-helper-js/issues/577)) ([220b013](https://github.com/algolia/algoliasearch-helper-js/commit/220b01323d75202d5531dd56d9b8211ff22b902c))
 
 ## [2.25.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.25.0...2.25.1) (2018-04-20)
 
-
 ### Bug Fixes
 
-* **sffv:** unwrap content when it comes from multi queries ([#574](https://github.com/algolia/algoliasearch-helper-js/issues/574)) ([fcb15d4](https://github.com/algolia/algoliasearch-helper-js/commit/fcb15d488a27e57b621fa5b26531626353c8bf41))
-
-
+- **sffv:** unwrap content when it comes from multi queries ([#574](https://github.com/algolia/algoliasearch-helper-js/issues/574)) ([fcb15d4](https://github.com/algolia/algoliasearch-helper-js/commit/fcb15d488a27e57b621fa5b26531626353c8bf41))
 
 # [2.25.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.24.0...2.25.0) (2018-04-18)
 
-
 ### Features
 
-* **search:** Promisify `client.search()` ([#571](https://github.com/algolia/algoliasearch-helper-js/issues/571)) ([d12cbda](https://github.com/algolia/algoliasearch-helper-js/commit/d12cbda2bb8ebafdf3d5f9e442378d3efb7353ee))
-* **sffv:** Use client SFFV over index SFFV ([#572](https://github.com/algolia/algoliasearch-helper-js/issues/572)) ([bb17720](https://github.com/algolia/algoliasearch-helper-js/commit/bb17720deed3d6325a28717a9452b278af456582))
-
-
+- **search:** Promisify `client.search()` ([#571](https://github.com/algolia/algoliasearch-helper-js/issues/571)) ([d12cbda](https://github.com/algolia/algoliasearch-helper-js/commit/d12cbda2bb8ebafdf3d5f9e442378d3efb7353ee))
+- **sffv:** Use client SFFV over index SFFV ([#572](https://github.com/algolia/algoliasearch-helper-js/issues/572)) ([bb17720](https://github.com/algolia/algoliasearch-helper-js/commit/bb17720deed3d6325a28717a9452b278af456582))
 
 # [2.24.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.23.2...2.24.0) (2018-01-31)
 
-
 ### Features
 
-* make Helper ready for insights ([03f8f31](https://github.com/algolia/algoliasearch-helper-js/commit/03f8f31931efe1d9913c57066539b4422963f1bc))
-
-
+- make Helper ready for insights ([03f8f31](https://github.com/algolia/algoliasearch-helper-js/commit/03f8f31931efe1d9913c57066539b4422963f1bc))
 
 ## [2.23.2](https://github.com/algolia/algoliasearch-helper-js/compare/2.23.1...2.23.2) (2017-12-14)
 
-
 ### Bug Fixes
 
-* **release-script:** actually build the library ([#559](https://github.com/algolia/algoliasearch-helper-js/issues/559)) ([421ec70](https://github.com/algolia/algoliasearch-helper-js/commit/421ec706606798035dda2e2226fd3eb9015ec901))
-
-
+- **release-script:** actually build the library ([#559](https://github.com/algolia/algoliasearch-helper-js/issues/559)) ([421ec70](https://github.com/algolia/algoliasearch-helper-js/commit/421ec706606798035dda2e2226fd3eb9015ec901))
 
 ## [2.23.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.23.0...2.23.1) (2017-12-12)
 
-
 ### Bug Fixes
 
-* **url:** treat insideBoundingBox in float form  as number ([#554](https://github.com/algolia/algoliasearch-helper-js/issues/554)) ([3a7423e](https://github.com/algolia/algoliasearch-helper-js/commit/3a7423eb444a798c50528e2296931074c8fad1d3)), closes [#553](https://github.com/algolia/algoliasearch-helper-js/issues/553)
-
-
+- **url:** treat insideBoundingBox in float form as number ([#554](https://github.com/algolia/algoliasearch-helper-js/issues/554)) ([3a7423e](https://github.com/algolia/algoliasearch-helper-js/commit/3a7423eb444a798c50528e2296931074c8fad1d3)), closes [#553](https://github.com/algolia/algoliasearch-helper-js/issues/553)
 
 # [2.23.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.22.0...2.23.0) (2017-10-18)
 
-
 ### Bug Fixes
 
-* **events:** only trigger change when there is an actual change ([#546](https://github.com/algolia/algoliasearch-helper-js/issues/546)) ([80f9724](https://github.com/algolia/algoliasearch-helper-js/commit/80f97242aaebaacbda0c5d750c62bf709fa0f502))
-
+- **events:** only trigger change when there is an actual change ([#546](https://github.com/algolia/algoliasearch-helper-js/issues/546)) ([80f9724](https://github.com/algolia/algoliasearch-helper-js/commit/80f97242aaebaacbda0c5d750c62bf709fa0f502))
 
 ### Features
 
-* **sffv:** can override search when using searchForFacetValues ([#549](https://github.com/algolia/algoliasearch-helper-js/issues/549)) ([55c2e75](https://github.com/algolia/algoliasearch-helper-js/commit/55c2e753be2236df91cd33a11a113e9dc4dd3038))
-
-
+- **sffv:** can override search when using searchForFacetValues ([#549](https://github.com/algolia/algoliasearch-helper-js/issues/549)) ([55c2e75](https://github.com/algolia/algoliasearch-helper-js/commit/55c2e753be2236df91cd33a11a113e9dc4dd3038))
 
 # [2.22.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.21.2...2.22.0) (2017-10-09)
 
-
 ### Bug Fixes
 
-* **FacetValue doc:** wrong attribute name in docs ([#539](https://github.com/algolia/algoliasearch-helper-js/issues/539)) ([7275a75](https://github.com/algolia/algoliasearch-helper-js/commit/7275a756510f5d7df460ae99cb88af6c2e617424)), closes [/github.com/algolia/algoliasearch-helper-js/blob/master/src/SearchResults/index.js#L541-L548](https://github.com//github.com/algolia/algoliasearch-helper-js/blob/master/src/SearchResults/index.js/issues/L541-L548)
-* **requestBuilder:** set analytics:false to subsequent queries ([#543](https://github.com/algolia/algoliasearch-helper-js/issues/543)) ([ebf41d9](https://github.com/algolia/algoliasearch-helper-js/commit/ebf41d97ea088af674e3661bfdd7f432018fc2c1)), closes [#540](https://github.com/algolia/algoliasearch-helper-js/issues/540)
-* **setState:** use .make() instead of constructor() ([#542](https://github.com/algolia/algoliasearch-helper-js/issues/542)) ([173da7c](https://github.com/algolia/algoliasearch-helper-js/commit/173da7cb256d007b7328b6c90aa037b17dcf95be))
-
+- **FacetValue doc:** wrong attribute name in docs ([#539](https://github.com/algolia/algoliasearch-helper-js/issues/539)) ([7275a75](https://github.com/algolia/algoliasearch-helper-js/commit/7275a756510f5d7df460ae99cb88af6c2e617424)), closes [/github.com/algolia/algoliasearch-helper-js/blob/master/src/SearchResults/index.js#L541-L548](https://github.com//github.com/algolia/algoliasearch-helper-js/blob/master/src/SearchResults/index.js/issues/L541-L548)
+- **requestBuilder:** set analytics:false to subsequent queries ([#543](https://github.com/algolia/algoliasearch-helper-js/issues/543)) ([ebf41d9](https://github.com/algolia/algoliasearch-helper-js/commit/ebf41d97ea088af674e3661bfdd7f432018fc2c1)), closes [#540](https://github.com/algolia/algoliasearch-helper-js/issues/540)
+- **setState:** use .make() instead of constructor() ([#542](https://github.com/algolia/algoliasearch-helper-js/issues/542)) ([173da7c](https://github.com/algolia/algoliasearch-helper-js/commit/173da7cb256d007b7328b6c90aa037b17dcf95be))
 
 ### Features
 
-* **query rules:** expose userData ([#544](https://github.com/algolia/algoliasearch-helper-js/issues/544)) ([2f93520](https://github.com/algolia/algoliasearch-helper-js/commit/2f935204b5fd92098d17b8579863d6a761a573a3)), closes [#529](https://github.com/algolia/algoliasearch-helper-js/issues/529)
-
-
+- **query rules:** expose userData ([#544](https://github.com/algolia/algoliasearch-helper-js/issues/544)) ([2f93520](https://github.com/algolia/algoliasearch-helper-js/commit/2f935204b5fd92098d17b8579863d6a761a573a3)), closes [#529](https://github.com/algolia/algoliasearch-helper-js/issues/529)
 
 ## [2.21.2](https://github.com/algolia/algoliasearch-helper-js/compare/2.21.1...2.21.2) (2017-07-27)
 
-
 ### Bug Fixes
 
-* **SearchResults:** add exhaustiveNbHits and exhaustiveFacetsCount ([fad31fb](https://github.com/algolia/algoliasearch-helper-js/commit/fad31fbb2ba32f472ca28a8a88faff08a0900e80)), closes [#489](https://github.com/algolia/algoliasearch-helper-js/issues/489)
-
-
+- **SearchResults:** add exhaustiveNbHits and exhaustiveFacetsCount ([fad31fb](https://github.com/algolia/algoliasearch-helper-js/commit/fad31fbb2ba32f472ca28a8a88faff08a0900e80)), closes [#489](https://github.com/algolia/algoliasearch-helper-js/issues/489)
 
 ## [2.21.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.21.0...2.21.1) (2017-07-20)
 
-
 ### Bug Fixes
 
-* **events:** We need searchEmptyQueue before result to avoid inconsistency ([4c58b0f](https://github.com/algolia/algoliasearch-helper-js/commit/4c58b0f597d5a1878723f79ce1cfe739c1358443))
-* **pending-search:** dispatch error event before searchQueueEmpty ([#503](https://github.com/algolia/algoliasearch-helper-js/issues/503)) ([30e3f07](https://github.com/algolia/algoliasearch-helper-js/commit/30e3f07d0b695c434cc52a1351d57b1779fe1946))
-* **url:** When there are no "other attributes" should not render last & ([#517](https://github.com/algolia/algoliasearch-helper-js/issues/517)) ([f376ff2](https://github.com/algolia/algoliasearch-helper-js/commit/f376ff237570b9a71cc9117d01220dba76324cba))
-
-
+- **events:** We need searchEmptyQueue before result to avoid inconsistency ([4c58b0f](https://github.com/algolia/algoliasearch-helper-js/commit/4c58b0f597d5a1878723f79ce1cfe739c1358443))
+- **pending-search:** dispatch error event before searchQueueEmpty ([#503](https://github.com/algolia/algoliasearch-helper-js/issues/503)) ([30e3f07](https://github.com/algolia/algoliasearch-helper-js/commit/30e3f07d0b695c434cc52a1351d57b1779fe1946))
+- **url:** When there are no "other attributes" should not render last & ([#517](https://github.com/algolia/algoliasearch-helper-js/issues/517)) ([f376ff2](https://github.com/algolia/algoliasearch-helper-js/commit/f376ff237570b9a71cc9117d01220dba76324cba))
 
 # [2.21.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.20.1...2.21.0) (2017-07-08)
 
-
 ### Bug Fixes
 
-* **events:** events for all kinds of searches ([b960fee](https://github.com/algolia/algoliasearch-helper-js/commit/b960fee47db7cf2ae04277e86d0ad992010e61d1)), closes [#513](https://github.com/algolia/algoliasearch-helper-js/issues/513)
-
-
+- **events:** events for all kinds of searches ([b960fee](https://github.com/algolia/algoliasearch-helper-js/commit/b960fee47db7cf2ae04277e86d0ad992010e61d1)), closes [#513](https://github.com/algolia/algoliasearch-helper-js/issues/513)
 
 ## [2.20.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.20.0...2.20.1) (2017-03-11)
 
-
 ### Bug Fixes
 
-* **build:** Remove es2015 module ([#487](https://github.com/algolia/algoliasearch-helper-js/issues/487)) ([0896a65](https://github.com/algolia/algoliasearch-helper-js/commit/0896a65b132beec91bf433ee9fe7a4154e29b80f)), closes [#486](https://github.com/algolia/algoliasearch-helper-js/issues/486)
-
-
+- **build:** Remove es2015 module ([#487](https://github.com/algolia/algoliasearch-helper-js/issues/487)) ([0896a65](https://github.com/algolia/algoliasearch-helper-js/commit/0896a65b132beec91bf433ee9fe7a4154e29b80f)), closes [#486](https://github.com/algolia/algoliasearch-helper-js/issues/486)
 
 # [2.20.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.19.0...2.20.0) (2017-03-10)
 
-
 ### Features
 
-* **maxFacetHits:** implement maxFacetHits for SFFV ([643c29a](https://github.com/algolia/algoliasearch-helper-js/commit/643c29a52a864d44e3fa3827f4eb1feceae634d7)), closes [#480](https://github.com/algolia/algoliasearch-helper-js/issues/480)
-* **pending-search:** let the dev know the state of the search requests queue ([c5b39d2](https://github.com/algolia/algoliasearch-helper-js/commit/c5b39d203236b9cddc1fe4afd1f42e7d7762161d))
-
-
+- **maxFacetHits:** implement maxFacetHits for SFFV ([643c29a](https://github.com/algolia/algoliasearch-helper-js/commit/643c29a52a864d44e3fa3827f4eb1feceae634d7)), closes [#480](https://github.com/algolia/algoliasearch-helper-js/issues/480)
+- **pending-search:** let the dev know the state of the search requests queue ([c5b39d2](https://github.com/algolia/algoliasearch-helper-js/commit/c5b39d203236b9cddc1fe4afd1f42e7d7762161d))
 
 # [2.19.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.18.1...2.19.0) (2017-03-06)
 
-
 ### Features
 
-* **search-response:** Exposed raw results ([8d4f938](https://github.com/algolia/algoliasearch-helper-js/commit/8d4f9387e0152b0a6ea637a4616bd3dbdd530fcf))
-
-
+- **search-response:** Exposed raw results ([8d4f938](https://github.com/algolia/algoliasearch-helper-js/commit/8d4f9387e0152b0a6ea637a4616bd3dbdd530fcf))
 
 ## [2.18.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.18.0...2.18.1) (2017-02-14)
 
-
 ### Bug Fixes
 
-* **agent:** sets the helper agent once ([#474](https://github.com/algolia/algoliasearch-helper-js/issues/474)) ([c94cac5](https://github.com/algolia/algoliasearch-helper-js/commit/c94cac52e5179a4b7a00ca276a27165ccc836c5d)), closes [#473](https://github.com/algolia/algoliasearch-helper-js/issues/473)
-* **toggleRefinement:** rename toggleRefinement to toggleFacetRefinement ([6700f98](https://github.com/algolia/algoliasearch-helper-js/commit/6700f98074662abb3bbae03b733c3029e542b59f)), closes [#447](https://github.com/algolia/algoliasearch-helper-js/issues/447)
-
-
+- **agent:** sets the helper agent once ([#474](https://github.com/algolia/algoliasearch-helper-js/issues/474)) ([c94cac5](https://github.com/algolia/algoliasearch-helper-js/commit/c94cac52e5179a4b7a00ca276a27165ccc836c5d)), closes [#473](https://github.com/algolia/algoliasearch-helper-js/issues/473)
+- **toggleRefinement:** rename toggleRefinement to toggleFacetRefinement ([6700f98](https://github.com/algolia/algoliasearch-helper-js/commit/6700f98074662abb3bbae03b733c3029e542b59f)), closes [#447](https://github.com/algolia/algoliasearch-helper-js/issues/447)
 
 # [2.18.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.17.1...2.18.0) (2017-01-10)
 
-
 ### Features
 
-* **client:** Adds methods to set/get the client. ([#460](https://github.com/algolia/algoliasearch-helper-js/issues/460)) ([2ddd7ec](https://github.com/algolia/algoliasearch-helper-js/commit/2ddd7ec23507831153cd994a0e1917d3ac1a74be))
-
-
+- **client:** Adds methods to set/get the client. ([#460](https://github.com/algolia/algoliasearch-helper-js/issues/460)) ([2ddd7ec](https://github.com/algolia/algoliasearch-helper-js/commit/2ddd7ec23507831153cd994a0e1917d3ac1a74be))
 
 ## [2.17.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.17.0...2.17.1) (2016-12-28)
 
-
 ### Bug Fixes
 
-* **agent:** Add a test if addAlgoliaAgent exists ([#455](https://github.com/algolia/algoliasearch-helper-js/issues/455)) ([0ab4e31](https://github.com/algolia/algoliasearch-helper-js/commit/0ab4e3115eed5c10b4d4f1aea4d84bcacc9c6239))
-
-
+- **agent:** Add a test if addAlgoliaAgent exists ([#455](https://github.com/algolia/algoliasearch-helper-js/issues/455)) ([0ab4e31](https://github.com/algolia/algoliasearch-helper-js/commit/0ab4e3115eed5c10b4d4f1aea4d84bcacc9c6239))
 
 # [2.17.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.16.0...2.17.0) (2016-12-22)
 
-
 ### Bug Fixes
 
-* **doc:** fix deep object documentation. ([#450](https://github.com/algolia/algoliasearch-helper-js/issues/450)) ([6e3146e](https://github.com/algolia/algoliasearch-helper-js/commit/6e3146e1059837c29ad763cf4bc6c733a414d923)), closes [#443](https://github.com/algolia/algoliasearch-helper-js/issues/443)
-
-
+- **doc:** fix deep object documentation. ([#450](https://github.com/algolia/algoliasearch-helper-js/issues/450)) ([6e3146e](https://github.com/algolia/algoliasearch-helper-js/commit/6e3146e1059837c29ad763cf4bc6c733a414d923)), closes [#443](https://github.com/algolia/algoliasearch-helper-js/issues/443)
 
 # [2.16.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.15.0...2.16.0) (2016-12-06)
 
-
 ### Features
 
-* **searchForFacetValues:** implement a new method to be able to search into facet values ([#423](https://github.com/algolia/algoliasearch-helper-js/issues/423)) ([8e2a5bb](https://github.com/algolia/algoliasearch-helper-js/commit/8e2a5bb3a9468d74d2cf5449895694bc2b184daf))
-
-
+- **searchForFacetValues:** implement a new method to be able to search into facet values ([#423](https://github.com/algolia/algoliasearch-helper-js/issues/423)) ([8e2a5bb](https://github.com/algolia/algoliasearch-helper-js/commit/8e2a5bb3a9468d74d2cf5449895694bc2b184daf))
 
 # [2.15.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.14.0...2.15.0) (2016-11-22)
 
-
-
 # [2.14.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.13.0...2.14.0) (2016-09-09)
-
 
 ### Features
 
-* **hierarchicalFacets:** add add and remove operations on hierarchical facets ([519d359](https://github.com/algolia/algoliasearch-helper-js/commit/519d3592e9bef913a066d221b2d53dbf4e763d37)), closes [#250](https://github.com/algolia/algoliasearch-helper-js/issues/250)
-
-
+- **hierarchicalFacets:** add add and remove operations on hierarchical facets ([519d359](https://github.com/algolia/algoliasearch-helper-js/commit/519d3592e9bef913a066d221b2d53dbf4e763d37)), closes [#250](https://github.com/algolia/algoliasearch-helper-js/issues/250)
 
 # [2.13.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.12.0...2.13.0) (2016-08-24)
 
-
 ### Bug Fixes
 
-* **excludes:** conjunctive facets results report exclusions ([0f3f844](https://github.com/algolia/algoliasearch-helper-js/commit/0f3f844a9b3d50961b86a4a8353e859cd86a1ca1))
-
+- **excludes:** conjunctive facets results report exclusions ([0f3f844](https://github.com/algolia/algoliasearch-helper-js/commit/0f3f844a9b3d50961b86a4a8353e859cd86a1ca1))
 
 ### Features
 
-* **add-remove-facet:** add methods to add and remove facets from SearchParameters configuration ([#330](https://github.com/algolia/algoliasearch-helper-js/issues/330)) ([fd0e777](https://github.com/algolia/algoliasearch-helper-js/commit/fd0e77714452ef71732c1b68356eba2aeb700d8b))
-* **add-remove-facet:** add methods to add and remove facets from SearchParameters configuration ([#333](https://github.com/algolia/algoliasearch-helper-js/issues/333)) ([f14dbbf](https://github.com/algolia/algoliasearch-helper-js/commit/f14dbbf40acc17d8efab6f0cfad1ddb83f9df641))
-* **no-set-page:** don't reset the page to 0 in SearchParameters methods ([64a116e](https://github.com/algolia/algoliasearch-helper-js/commit/64a116ea30ff70aef85b0eae09a1aa78491157ea)), closes [#343](https://github.com/algolia/algoliasearch-helper-js/issues/343)
-* **SearchResults:** backport instantsearch.js getRefinement method ([e3a3238](https://github.com/algolia/algoliasearch-helper-js/commit/e3a323840484d6a594edb7bc8eb8c01003d38b11)), closes [#195](https://github.com/algolia/algoliasearch-helper-js/issues/195)
-
+- **add-remove-facet:** add methods to add and remove facets from SearchParameters configuration ([#330](https://github.com/algolia/algoliasearch-helper-js/issues/330)) ([fd0e777](https://github.com/algolia/algoliasearch-helper-js/commit/fd0e77714452ef71732c1b68356eba2aeb700d8b))
+- **add-remove-facet:** add methods to add and remove facets from SearchParameters configuration ([#333](https://github.com/algolia/algoliasearch-helper-js/issues/333)) ([f14dbbf](https://github.com/algolia/algoliasearch-helper-js/commit/f14dbbf40acc17d8efab6f0cfad1ddb83f9df641))
+- **no-set-page:** don't reset the page to 0 in SearchParameters methods ([64a116e](https://github.com/algolia/algoliasearch-helper-js/commit/64a116ea30ff70aef85b0eae09a1aa78491157ea)), closes [#343](https://github.com/algolia/algoliasearch-helper-js/issues/343)
+- **SearchResults:** backport instantsearch.js getRefinement method ([e3a3238](https://github.com/algolia/algoliasearch-helper-js/commit/e3a323840484d6a594edb7bc8eb8c01003d38b11)), closes [#195](https://github.com/algolia/algoliasearch-helper-js/issues/195)
 
 ### BREAKING CHANGES
 
-* **no-set-page:** SearchParameters methods don't reset the page to 0 anymore.
-
-
+- **no-set-page:** SearchParameters methods don't reset the page to 0 anymore.
 
 # [2.12.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.11.1...2.12.0) (2016-07-22)
 
-
-
 ## [2.11.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.11.0...2.11.1) (2016-07-20)
-
-
 
 # [2.11.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.10.0...2.11.0) (2016-06-22)
 
-
 ### Features
 
-* **urls:** provide a `safe` option to fully encode the url ([3ef6ae1](https://github.com/algolia/algoliasearch-helper-js/commit/3ef6ae16f29f327af73d6d69b0917defcb267ab6))
-
-
+- **urls:** provide a `safe` option to fully encode the url ([3ef6ae1](https://github.com/algolia/algoliasearch-helper-js/commit/3ef6ae16f29f327af73d6d69b0917defcb267ab6))
 
 # [2.10.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.9.1...2.10.0) (2016-06-10)
 
-
 ### Performance Improvements
 
-* **deepFreeze:** Removing the calls to deepFreeze ([3a515b8](https://github.com/algolia/algoliasearch-helper-js/commit/3a515b8da400523e00ea926974672367798f65ae)), closes [#301](https://github.com/algolia/algoliasearch-helper-js/issues/301) [#301](https://github.com/algolia/algoliasearch-helper-js/issues/301)
-
-
+- **deepFreeze:** Removing the calls to deepFreeze ([3a515b8](https://github.com/algolia/algoliasearch-helper-js/commit/3a515b8da400523e00ea926974672367798f65ae)), closes [#301](https://github.com/algolia/algoliasearch-helper-js/issues/301) [#301](https://github.com/algolia/algoliasearch-helper-js/issues/301)
 
 ## [2.9.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.9.0...2.9.1) (2016-03-16)
 
-
 ### Bug Fixes
 
-* **filterState:** handle hierarchical facet attributes ([5bfdceb](https://github.com/algolia/algoliasearch-helper-js/commit/5bfdcebb43dc8fa867d00d4863cdd09eb2a06150))
-
-
+- **filterState:** handle hierarchical facet attributes ([5bfdceb](https://github.com/algolia/algoliasearch-helper-js/commit/5bfdcebb43dc8fa867d00d4863cdd09eb2a06150))
 
 # [2.9.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.8.1...2.9.0) (2016-02-19)
 
-
 ### Bug Fixes
 
-* **numeric filters:** Makes it possible to add then remove a string based numeric filter ([8b2bb97](https://github.com/algolia/algoliasearch-helper-js/commit/8b2bb970bb655871c8d6060e2fbe2f47d9601d10))
-* **numeric filters:** Makes it possible to add then remove a string based numeric filter ([d849f0b](https://github.com/algolia/algoliasearch-helper-js/commit/d849f0bdd020b7080620b53efb22ffbe84978b6a))
-* **pagination:** adds doc on reset behavior, changes the name of setter ([ec70c8b](https://github.com/algolia/algoliasearch-helper-js/commit/ec70c8b10c91f68589ddc36be551a4c3525737c3))
-
+- **numeric filters:** Makes it possible to add then remove a string based numeric filter ([8b2bb97](https://github.com/algolia/algoliasearch-helper-js/commit/8b2bb970bb655871c8d6060e2fbe2f47d9601d10))
+- **numeric filters:** Makes it possible to add then remove a string based numeric filter ([d849f0b](https://github.com/algolia/algoliasearch-helper-js/commit/d849f0bdd020b7080620b53efb22ffbe84978b6a))
+- **pagination:** adds doc on reset behavior, changes the name of setter ([ec70c8b](https://github.com/algolia/algoliasearch-helper-js/commit/ec70c8b10c91f68589ddc36be551a4c3525737c3))
 
 ### Features
 
-* **url:** new mapping option for URL methods ([7d93cac](https://github.com/algolia/algoliasearch-helper-js/commit/7d93cac8aac6ae1ca2e50b73270ba139ec9b72fa))
-
-
+- **url:** new mapping option for URL methods ([7d93cac](https://github.com/algolia/algoliasearch-helper-js/commit/7d93cac8aac6ae1ca2e50b73270ba139ec9b72fa))
 
 ## [2.8.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.8.0...2.8.1) (2016-02-01)
 
-
 ### Features
 
-* add snippetEllipsisText, disableExactOnAttributes, enableExactOnSingleWordQuery ([c6af7af](https://github.com/algolia/algoliasearch-helper-js/commit/c6af7af0f93548d2c2cb9bb4a053e1867765f07b))
-
-
+- add snippetEllipsisText, disableExactOnAttributes, enableExactOnSingleWordQuery ([c6af7af](https://github.com/algolia/algoliasearch-helper-js/commit/c6af7af0f93548d2c2cb9bb4a053e1867765f07b))
 
 # [2.8.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.7.0...2.8.0) (2015-12-11)
 
-
 ### Bug Fixes
 
-* **algoliasearch.helper:** fixes optionalTagFilters & optionalFacetFilters jsdoc ([e08ad78](https://github.com/algolia/algoliasearch-helper-js/commit/e08ad785724d4e11c91355e8b616aa971d4974a0))
-* **hierarchicalFacets:** ensures the order of the hierarchical facets matches the order of the declared hierarchical attributes to avoid (silent) failures when the API returns JSON with unordered facets ([8a326cc](https://github.com/algolia/algoliasearch-helper-js/commit/8a326cc00e49d37467de5026830951823baa786c))
-* **search-results:** adds missing results parameters ([1c4908a](https://github.com/algolia/algoliasearch-helper-js/commit/1c4908adec9c4b4b70a22e78638f881cbf60f354))
-
-
+- **algoliasearch.helper:** fixes optionalTagFilters & optionalFacetFilters jsdoc ([e08ad78](https://github.com/algolia/algoliasearch-helper-js/commit/e08ad785724d4e11c91355e8b616aa971d4974a0))
+- **hierarchicalFacets:** ensures the order of the hierarchical facets matches the order of the declared hierarchical attributes to avoid (silent) failures when the API returns JSON with unordered facets ([8a326cc](https://github.com/algolia/algoliasearch-helper-js/commit/8a326cc00e49d37467de5026830951823baa786c))
+- **search-results:** adds missing results parameters ([1c4908a](https://github.com/algolia/algoliasearch-helper-js/commit/1c4908adec9c4b4b70a22e78638f881cbf60f354))
 
 # [2.7.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.6.9...2.7.0) (2015-12-02)
 
-
 ### Bug Fixes
 
-* **core:** makes node dependencies explicit ([d532bc9](https://github.com/algolia/algoliasearch-helper-js/commit/d532bc9d8fe928b8a5ee40fdd187560a5e7426d6))
-* **request-builder:** Makes queries less ambiguous for client fix [#205](https://github.com/algolia/algoliasearch-helper-js/issues/205) ([9915c2f](https://github.com/algolia/algoliasearch-helper-js/commit/9915c2f1d0284cd8907ecc1217fcb8cfc04df3c2))
-
-
+- **core:** makes node dependencies explicit ([d532bc9](https://github.com/algolia/algoliasearch-helper-js/commit/d532bc9d8fe928b8a5ee40fdd187560a5e7426d6))
+- **request-builder:** Makes queries less ambiguous for client fix [#205](https://github.com/algolia/algoliasearch-helper-js/issues/205) ([9915c2f](https://github.com/algolia/algoliasearch-helper-js/commit/9915c2f1d0284cd8907ecc1217fcb8cfc04df3c2))
 
 ## [2.6.9](https://github.com/algolia/algoliasearch-helper-js/compare/2.6.8...2.6.9) (2015-11-24)
 
-
 ### Bug Fixes
 
-* **hierarchical:** exclude facet when the rootPath equal to the facet value ([42d386a](https://github.com/algolia/algoliasearch-helper-js/commit/42d386ae0dcc1b65a2317f32b6969a2dcf059e01))
-
-
+- **hierarchical:** exclude facet when the rootPath equal to the facet value ([42d386a](https://github.com/algolia/algoliasearch-helper-js/commit/42d386ae0dcc1b65a2317f32b6969a2dcf059e01))
 
 ## [2.6.8](https://github.com/algolia/algoliasearch-helper-js/compare/2.6.7...2.6.8) (2015-11-24)
 
-
 ### Features
 
-* **hierarchical:** add prefix path option to hierarchical facet ([10ee69e](https://github.com/algolia/algoliasearch-helper-js/commit/10ee69e2e50584a9cbdaa03aeea1db375dce5601))
-* **hierarchical:** finish rootPath and add showParentLevel options to the hierararchical facets) ([f27af29](https://github.com/algolia/algoliasearch-helper-js/commit/f27af29b3d46358fd1e47dfc23e83d73863c8a1f))
-
-
+- **hierarchical:** add prefix path option to hierarchical facet ([10ee69e](https://github.com/algolia/algoliasearch-helper-js/commit/10ee69e2e50584a9cbdaa03aeea1db375dce5601))
+- **hierarchical:** finish rootPath and add showParentLevel options to the hierararchical facets) ([f27af29](https://github.com/algolia/algoliasearch-helper-js/commit/f27af29b3d46358fd1e47dfc23e83d73863c8a1f))
 
 ## [2.6.7](https://github.com/algolia/algoliasearch-helper-js/compare/2.6.6...2.6.7) (2015-11-17)
 
-
 ### Bug Fixes
 
-* **hierarchicalWidget:** Error when faceted and no results ([6a6c554](https://github.com/algolia/algoliasearch-helper-js/commit/6a6c5547c65b71ef25186411c17e36b5c2f66914))
-
-
+- **hierarchicalWidget:** Error when faceted and no results ([6a6c554](https://github.com/algolia/algoliasearch-helper-js/commit/6a6c5547c65b71ef25186411c17e36b5c2f66914))
 
 ## [2.6.6](https://github.com/algolia/algoliasearch-helper-js/compare/2.6.5...2.6.6) (2015-11-04)
 
-
 ### Bug Fixes
 
-* removes window dependency ([b6c5043](https://github.com/algolia/algoliasearch-helper-js/commit/b6c50433841355ecd93959ec665bdd0717347b79))
-* **SearchParameters:** parses all numeric attributes ([4a8e770](https://github.com/algolia/algoliasearch-helper-js/commit/4a8e77012ffea6e7b6be93b246df698fea7997dc))
-
-
+- removes window dependency ([b6c5043](https://github.com/algolia/algoliasearch-helper-js/commit/b6c50433841355ecd93959ec665bdd0717347b79))
+- **SearchParameters:** parses all numeric attributes ([4a8e770](https://github.com/algolia/algoliasearch-helper-js/commit/4a8e77012ffea6e7b6be93b246df698fea7997dc))
 
 ## [2.6.5](https://github.com/algolia/algoliasearch-helper-js/compare/2.6.4...2.6.5) (2015-11-03)
 
-
 ### Bug Fixes
 
-* **hierarchical:** refined + no result ([d0337d3](https://github.com/algolia/algoliasearch-helper-js/commit/d0337d3fb2916550f157696909532a973f1cced2))
-
-
+- **hierarchical:** refined + no result ([d0337d3](https://github.com/algolia/algoliasearch-helper-js/commit/d0337d3fb2916550f157696909532a973f1cced2))
 
 ## [2.6.4](https://github.com/algolia/algoliasearch-helper-js/compare/2.6.3...2.6.4) (2015-11-02)
 
-
 ### Bug Fixes
 
-* **hierarchical:** reset pagination to 0 when refining ([e1193ef](https://github.com/algolia/algoliasearch-helper-js/commit/e1193ef5d79cfffd3962a5d5285410013c79c62f))
-
-
+- **hierarchical:** reset pagination to 0 when refining ([e1193ef](https://github.com/algolia/algoliasearch-helper-js/commit/e1193ef5d79cfffd3962a5d5285410013c79c62f))
 
 ## [2.6.3](https://github.com/algolia/algoliasearch-helper-js/compare/2.6.2...2.6.3) (2015-10-19)
 
-
-
 ## [2.6.2](https://github.com/algolia/algoliasearch-helper-js/compare/2.6.1...2.6.2) (2015-10-16)
-
-
 
 ## [2.6.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.6.0...2.6.1) (2015-10-15)
 
-
 ### Features
 
-* **SearchParameters:** toggleRefinement on SearchParameters ([ac71495](https://github.com/algolia/algoliasearch-helper-js/commit/ac714957bb04b42f03ce91b82b0c7d8765165ba9))
-
-
+- **SearchParameters:** toggleRefinement on SearchParameters ([ac71495](https://github.com/algolia/algoliasearch-helper-js/commit/ac714957bb04b42f03ce91b82b0c7d8765165ba9))
 
 # [2.6.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.5.1...2.6.0) (2015-10-15)
 
-
-
 ## [2.5.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.5.0...2.5.1) (2015-10-12)
-
 
 ### Bug Fixes
 
-* **facetStats:** a facet can be both in facets & disjunctiveFacets ([458a694](https://github.com/algolia/algoliasearch-helper-js/commit/458a694101ae61abdea88d257fd956e4f563f2da)), closes [#228](https://github.com/algolia/algoliasearch-helper-js/issues/228)
-
-
+- **facetStats:** a facet can be both in facets & disjunctiveFacets ([458a694](https://github.com/algolia/algoliasearch-helper-js/commit/458a694101ae61abdea88d257fd956e4f563f2da)), closes [#228](https://github.com/algolia/algoliasearch-helper-js/issues/228)
 
 # [2.5.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.4.0...2.5.0) (2015-10-09)
 
-
-
 # [2.4.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.3.6...2.4.0) (2015-09-23)
-
 
 ### Bug Fixes
 
-* avoid using console.error in IE8/9 when not available ([c4c6127](https://github.com/algolia/algoliasearch-helper-js/commit/c4c6127b23b6d8a23a2b447bc82fd9136be6d9fc))
-
-
+- avoid using console.error in IE8/9 when not available ([c4c6127](https://github.com/algolia/algoliasearch-helper-js/commit/c4c6127b23b6d8a23a2b447bc82fd9136be6d9fc))
 
 ## [2.3.6](https://github.com/algolia/algoliasearch-helper-js/compare/2.3.5...2.3.6) (2015-09-17)
 
-
 ### Bug Fixes
 
-* IE8 has no Array.indexOf ([4724048](https://github.com/algolia/algoliasearch-helper-js/commit/47240481b9c0e7341bd51a3021f092124837c8e1))
-
-
+- IE8 has no Array.indexOf ([4724048](https://github.com/algolia/algoliasearch-helper-js/commit/47240481b9c0e7341bd51a3021f092124837c8e1))
 
 ## [2.3.5](https://github.com/algolia/algoliasearch-helper-js/compare/2.3.4...2.3.5) (2015-09-11)
 
-
 ### Bug Fixes
 
-* getFacetStats should look in both facets, disjunctiveFacets ([95aa9b8](https://github.com/algolia/algoliasearch-helper-js/commit/95aa9b821ff45c09588b6b15280d5e459b56c418))
-
-
+- getFacetStats should look in both facets, disjunctiveFacets ([95aa9b8](https://github.com/algolia/algoliasearch-helper-js/commit/95aa9b821ff45c09588b6b15280d5e459b56c418))
 
 ## [2.3.4](https://github.com/algolia/algoliasearch-helper-js/compare/2.3.3...2.3.4) (2015-09-11)
 
-
-
 ## [2.3.3](https://github.com/algolia/algoliasearch-helper-js/compare/2.3.2...2.3.3) (2015-09-09)
-
 
 ### Bug Fixes
 
-* defaultNumericRefinement is an object not an array ([cf17d55](https://github.com/algolia/algoliasearch-helper-js/commit/cf17d5506f2e05c9bc79f1d95fb911ebf5d7c6fe))
-* hasRefinements should look for every type of refinement ([acb2719](https://github.com/algolia/algoliasearch-helper-js/commit/acb2719396bd2fef56eadb415319f19a10d56b6d)), closes [#204](https://github.com/algolia/algoliasearch-helper-js/issues/204)
-
-
+- defaultNumericRefinement is an object not an array ([cf17d55](https://github.com/algolia/algoliasearch-helper-js/commit/cf17d5506f2e05c9bc79f1d95fb911ebf5d7c6fe))
+- hasRefinements should look for every type of refinement ([acb2719](https://github.com/algolia/algoliasearch-helper-js/commit/acb2719396bd2fef56eadb415319f19a10d56b6d)), closes [#204](https://github.com/algolia/algoliasearch-helper-js/issues/204)
 
 ## [2.3.2](https://github.com/algolia/algoliasearch-helper-js/compare/2.3.1...2.3.2) (2015-09-04)
 
-
 ### Bug Fixes
 
-* accepts `length` parameter by fixing searchParameters iteration ([a6a9e53](https://github.com/algolia/algoliasearch-helper-js/commit/a6a9e53c16a0b5cc2ee0ba3311629fe2e5b233dc))
-
-
+- accepts `length` parameter by fixing searchParameters iteration ([a6a9e53](https://github.com/algolia/algoliasearch-helper-js/commit/a6a9e53c16a0b5cc2ee0ba3311629fe2e5b233dc))
 
 ## [2.3.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.3.0...2.3.1) (2015-09-02)
 
-
 ### Bug Fixes
 
-* add undocumented offset and length params ([87fdb81](https://github.com/algolia/algoliasearch-helper-js/commit/87fdb81ae1c2fae1d7b74062081216dc5940097d))
-* throw when unknown parameter ([8c97080](https://github.com/algolia/algoliasearch-helper-js/commit/8c97080e320a37dee2be06585118d607f1f3f89c))
-
-
+- add undocumented offset and length params ([87fdb81](https://github.com/algolia/algoliasearch-helper-js/commit/87fdb81ae1c2fae1d7b74062081216dc5940097d))
+- throw when unknown parameter ([8c97080](https://github.com/algolia/algoliasearch-helper-js/commit/8c97080e320a37dee2be06585118d607f1f3f89c))
 
 # [2.3.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.2.0...2.3.0) (2015-09-02)
 
-
 ### Bug Fixes
 
-* typo ([4979da2](https://github.com/algolia/algoliasearch-helper-js/commit/4979da20e2b2dce4c041320250676988b15325be))
-
-
+- typo ([4979da2](https://github.com/algolia/algoliasearch-helper-js/commit/4979da20e2b2dce4c041320250676988b15325be))
 
 # [2.2.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.1.2...2.2.0) (2015-07-29)
 
-
 ### Bug Fixes
 
-* bad results computation when alwaysGetRootLevel ([44e18d4](https://github.com/algolia/algoliasearch-helper-js/commit/44e18d41e3353f9048052461bf21d8db9b1faf1b))
-* change the default hierarchical facet behavior ([01cb48d](https://github.com/algolia/algoliasearch-helper-js/commit/01cb48da841f2a4e740fe5cc5f870bbc4f48b00b))
-* clear hierarchical refinements appropriately ([992d677](https://github.com/algolia/algoliasearch-helper-js/commit/992d6770b0e95f43fa1d906ce8880ac436762933))
-* edge case on toggleRefine hierarchical facet ([95ab755](https://github.com/algolia/algoliasearch-helper-js/commit/95ab755c722ff93406517b5ab4ef103ef289c371))
-* eslint fixes in hierarchical faceting ([14db531](https://github.com/algolia/algoliasearch-helper-js/commit/14db53153b646c7348f8ade46be3759581d2171c))
-* getFacetByName for hierarchical facets ([81829fc](https://github.com/algolia/algoliasearch-helper-js/commit/81829fcf4006dd4129d920068349350fc4b4eb4b))
-* handle multiple hierarchical facets ([b41b6a5](https://github.com/algolia/algoliasearch-helper-js/commit/b41b6a5acfae82bf19477f1543981150be410d4d))
-* handle objects with multiple categories values ([b81c17b](https://github.com/algolia/algoliasearch-helper-js/commit/b81c17b7dcce7ef9acdfa56071057a4b622edc91)), closes [#163](https://github.com/algolia/algoliasearch-helper-js/issues/163)
-* handle toggleRefine on a different parent leaf than the current one ([6734971](https://github.com/algolia/algoliasearch-helper-js/commit/6734971b19e657314e68dccd40b5bdc8fd70296b))
-* hierarchical alwaysGetRootLevel count was bad ([cf595ea](https://github.com/algolia/algoliasearch-helper-js/commit/cf595ea76e1d59c84d770cd49f3e6a881196cf5d))
-* hierarchicalFacets toggleRefine on parent should not refine parent ([4639cbf](https://github.com/algolia/algoliasearch-helper-js/commit/4639cbff676fad08ef0d718562e416385cbcff88)), closes [#164](https://github.com/algolia/algoliasearch-helper-js/issues/164)
-* hierarchicalFacetsRefinements is now an array ([762b588](https://github.com/algolia/algoliasearch-helper-js/commit/762b58817a90c2c7deb8499e6777402c501d14c6)), closes [#160](https://github.com/algolia/algoliasearch-helper-js/issues/160)
-* isDisjunctiveRefined() and isRefined() return true/false ([1bb31a3](https://github.com/algolia/algoliasearch-helper-js/commit/1bb31a371aed2350afd7163e3aefb3c8b21471ca)), closes [#123](https://github.com/algolia/algoliasearch-helper-js/issues/123)
-* isDisjunctiveRefined() and isRefined() return true/false ([2d9edd9](https://github.com/algolia/algoliasearch-helper-js/commit/2d9edd982a38a02186cb6fe813e7346e96c1056c)), closes [#123](https://github.com/algolia/algoliasearch-helper-js/issues/123)
-* params are optional right? ([5f43031](https://github.com/algolia/algoliasearch-helper-js/commit/5f430310d41a8969cbba743f9c7818214623e605))
-* stop triming facet filters values automatically ([8c67bb5](https://github.com/algolia/algoliasearch-helper-js/commit/8c67bb58271b0549c13e752575d88f453a15ddb0))
-* throw on unknown hierarchical facet ([5df3397](https://github.com/algolia/algoliasearch-helper-js/commit/5df339798029885c6253ce760bf35312b204f9ad))
-* toggleRefine on root level of a hierarchical refinement ([47ecdfe](https://github.com/algolia/algoliasearch-helper-js/commit/47ecdfebc15fee41b7f1bb565ccfc4525cefeed8))
-* use setQueryParameters() instead of mutateMe ([4fc3df9](https://github.com/algolia/algoliasearch-helper-js/commit/4fc3df9797fa836c303ad6826c8f7d0999a47b24))
-* wrong facetFilters on disjunctive + hierarchical facet ([88df8c5](https://github.com/algolia/algoliasearch-helper-js/commit/88df8c5c7f6028e0e2e6d4194138713c46e5f5b3)), closes [#161](https://github.com/algolia/algoliasearch-helper-js/issues/161)
-
+- bad results computation when alwaysGetRootLevel ([44e18d4](https://github.com/algolia/algoliasearch-helper-js/commit/44e18d41e3353f9048052461bf21d8db9b1faf1b))
+- change the default hierarchical facet behavior ([01cb48d](https://github.com/algolia/algoliasearch-helper-js/commit/01cb48da841f2a4e740fe5cc5f870bbc4f48b00b))
+- clear hierarchical refinements appropriately ([992d677](https://github.com/algolia/algoliasearch-helper-js/commit/992d6770b0e95f43fa1d906ce8880ac436762933))
+- edge case on toggleRefine hierarchical facet ([95ab755](https://github.com/algolia/algoliasearch-helper-js/commit/95ab755c722ff93406517b5ab4ef103ef289c371))
+- eslint fixes in hierarchical faceting ([14db531](https://github.com/algolia/algoliasearch-helper-js/commit/14db53153b646c7348f8ade46be3759581d2171c))
+- getFacetByName for hierarchical facets ([81829fc](https://github.com/algolia/algoliasearch-helper-js/commit/81829fcf4006dd4129d920068349350fc4b4eb4b))
+- handle multiple hierarchical facets ([b41b6a5](https://github.com/algolia/algoliasearch-helper-js/commit/b41b6a5acfae82bf19477f1543981150be410d4d))
+- handle objects with multiple categories values ([b81c17b](https://github.com/algolia/algoliasearch-helper-js/commit/b81c17b7dcce7ef9acdfa56071057a4b622edc91)), closes [#163](https://github.com/algolia/algoliasearch-helper-js/issues/163)
+- handle toggleRefine on a different parent leaf than the current one ([6734971](https://github.com/algolia/algoliasearch-helper-js/commit/6734971b19e657314e68dccd40b5bdc8fd70296b))
+- hierarchical alwaysGetRootLevel count was bad ([cf595ea](https://github.com/algolia/algoliasearch-helper-js/commit/cf595ea76e1d59c84d770cd49f3e6a881196cf5d))
+- hierarchicalFacets toggleRefine on parent should not refine parent ([4639cbf](https://github.com/algolia/algoliasearch-helper-js/commit/4639cbff676fad08ef0d718562e416385cbcff88)), closes [#164](https://github.com/algolia/algoliasearch-helper-js/issues/164)
+- hierarchicalFacetsRefinements is now an array ([762b588](https://github.com/algolia/algoliasearch-helper-js/commit/762b58817a90c2c7deb8499e6777402c501d14c6)), closes [#160](https://github.com/algolia/algoliasearch-helper-js/issues/160)
+- isDisjunctiveRefined() and isRefined() return true/false ([1bb31a3](https://github.com/algolia/algoliasearch-helper-js/commit/1bb31a371aed2350afd7163e3aefb3c8b21471ca)), closes [#123](https://github.com/algolia/algoliasearch-helper-js/issues/123)
+- isDisjunctiveRefined() and isRefined() return true/false ([2d9edd9](https://github.com/algolia/algoliasearch-helper-js/commit/2d9edd982a38a02186cb6fe813e7346e96c1056c)), closes [#123](https://github.com/algolia/algoliasearch-helper-js/issues/123)
+- params are optional right? ([5f43031](https://github.com/algolia/algoliasearch-helper-js/commit/5f430310d41a8969cbba743f9c7818214623e605))
+- stop triming facet filters values automatically ([8c67bb5](https://github.com/algolia/algoliasearch-helper-js/commit/8c67bb58271b0549c13e752575d88f453a15ddb0))
+- throw on unknown hierarchical facet ([5df3397](https://github.com/algolia/algoliasearch-helper-js/commit/5df339798029885c6253ce760bf35312b204f9ad))
+- toggleRefine on root level of a hierarchical refinement ([47ecdfe](https://github.com/algolia/algoliasearch-helper-js/commit/47ecdfebc15fee41b7f1bb565ccfc4525cefeed8))
+- use setQueryParameters() instead of mutateMe ([4fc3df9](https://github.com/algolia/algoliasearch-helper-js/commit/4fc3df9797fa836c303ad6826c8f7d0999a47b24))
+- wrong facetFilters on disjunctive + hierarchical facet ([88df8c5](https://github.com/algolia/algoliasearch-helper-js/commit/88df8c5c7f6028e0e2e6d4194138713c46e5f5b3)), closes [#161](https://github.com/algolia/algoliasearch-helper-js/issues/161)
 
 ### Features
 
-* add alwaysGetRootLevel option ([dd97d98](https://github.com/algolia/algoliasearch-helper-js/commit/dd97d98e5e8613ec9de29ba7be6c39a4acf275b8))
-* add hierarchical facet sortBy option ([04254c7](https://github.com/algolia/algoliasearch-helper-js/commit/04254c7af88ddce4e831ea71194835363081700e))
-* hierarchical facets ([695cf00](https://github.com/algolia/algoliasearch-helper-js/commit/695cf007a265a5c1529faadb029ec4220ed48c44))
-* IE8 compatibility ([e9898f9](https://github.com/algolia/algoliasearch-helper-js/commit/e9898f97d2ab06e7fc7c6e19c4e7a4825be03d13))
-
+- add alwaysGetRootLevel option ([dd97d98](https://github.com/algolia/algoliasearch-helper-js/commit/dd97d98e5e8613ec9de29ba7be6c39a4acf275b8))
+- add hierarchical facet sortBy option ([04254c7](https://github.com/algolia/algoliasearch-helper-js/commit/04254c7af88ddce4e831ea71194835363081700e))
+- hierarchical facets ([695cf00](https://github.com/algolia/algoliasearch-helper-js/commit/695cf007a265a5c1529faadb029ec4220ed48c44))
+- IE8 compatibility ([e9898f9](https://github.com/algolia/algoliasearch-helper-js/commit/e9898f97d2ab06e7fc7c6e19c4e7a4825be03d13))
 
 ### Reverts
 
-* Revert "test: remove travis cache, may be buggy" ([415dab6](https://github.com/algolia/algoliasearch-helper-js/commit/415dab6afa6217a36b78f79f67dba499ff6f32df))
-
-
+- Revert "test: remove travis cache, may be buggy" ([415dab6](https://github.com/algolia/algoliasearch-helper-js/commit/415dab6afa6217a36b78f79f67dba499ff6f32df))
 
 ## [2.1.2](https://github.com/algolia/algoliasearch-helper-js/compare/2.1.1...2.1.2) (2015-06-29)
 
-
-
 ## [2.1.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.1.0...2.1.1) (2015-06-19)
-
 
 ### Bug Fixes
 
-* **eslint:** Set eslintrc as a valid JSON. ([7bab8aa](https://github.com/algolia/algoliasearch-helper-js/commit/7bab8aac9f6bd2bc535d1eba6fb3cd5ba9070739))
-
-
+- **eslint:** Set eslintrc as a valid JSON. ([7bab8aa](https://github.com/algolia/algoliasearch-helper-js/commit/7bab8aac9f6bd2bc535d1eba6fb3cd5ba9070739))
 
 # [2.1.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.0.4...2.1.0) (2015-06-15)
 
-
-
 ## [2.0.4](https://github.com/algolia/algoliasearch-helper-js/compare/2.0.3...2.0.4) (2015-05-19)
-
-
 
 ## [2.0.3](https://github.com/algolia/algoliasearch-helper-js/compare/2.0.2...2.0.3) (2015-05-13)
 
-
-
 ## [2.0.2](https://github.com/algolia/algoliasearch-helper-js/compare/2.0.1...2.0.2) (2015-05-06)
-
-
 
 ## [2.0.1](https://github.com/algolia/algoliasearch-helper-js/compare/2.0.0...2.0.1) (2015-04-28)
 
-
-
 # [2.0.0](https://github.com/algolia/algoliasearch-helper-js/compare/2.0.0-rc5...2.0.0) (2015-04-28)
-
-
 
 # [2.0.0-rc5](https://github.com/algolia/algoliasearch-helper-js/compare/2.0.0-beta...2.0.0-rc5) (2015-04-21)
 
-
-
 # [2.0.0-beta](https://github.com/algolia/algoliasearch-helper-js/compare/1.0.0...2.0.0-beta) (2015-04-16)
-
-
 
 # 1.0.0 (2015-03-24)

--- a/packages/create-instantsearch-app/CHANGELOG.md
+++ b/packages/create-instantsearch-app/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [7.0.1](https://github.com/algolia/instantsearch/compare/create-instantsearch-app@7.0.0...create-instantsearch-app@7.0.1) (2023-09-05)
 
@@ -13,657 +12,496 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # [7.0.0](https://github.com/algolia/instantsearch/compare/create-instantsearch-app@6.4.2...create-instantsearch-app@7.0.0) (2023-08-08)
 
-
 ### Features
 
-* update react instantsearch templates ([#5790](https://github.com/algolia/instantsearch/issues/5790)) ([6f136ec](https://github.com/algolia/instantsearch/commit/6f136ec60a07f6cdbc5aac1382f6d77ea2554e95))
-* **cisa:** remove outdated templates ([#5805](https://github.com/algolia/instantsearch/pull/5805)) ([bc33605](https://github.com/algolia/instantsearch/commit/bc33605f4a820fdc21237813ce81ba953ac1714c))
-
-
-
-
+- update react instantsearch templates ([#5790](https://github.com/algolia/instantsearch/issues/5790)) ([6f136ec](https://github.com/algolia/instantsearch/commit/6f136ec60a07f6cdbc5aac1382f6d77ea2554e95))
+- **cisa:** remove outdated templates ([#5805](https://github.com/algolia/instantsearch/pull/5805)) ([bc33605](https://github.com/algolia/instantsearch/commit/bc33605f4a820fdc21237813ce81ba953ac1714c))
 
 ## [6.4.2](https://github.com/algolia/instantsearch/compare/create-instantsearch-app@6.4.1...create-instantsearch-app@6.4.2) (2023-08-07)
 
-
 ### Bug Fixes
 
-* use npm registry to retrieve library versions ([#5789](https://github.com/algolia/instantsearch/issues/5789)) ([f3906dc](https://github.com/algolia/instantsearch/commit/f3906dc72ddaaae7115cf948fb6c3ce6babc1783))
-
-
-
-
+- use npm registry to retrieve library versions ([#5789](https://github.com/algolia/instantsearch/issues/5789)) ([f3906dc](https://github.com/algolia/instantsearch/commit/f3906dc72ddaaae7115cf948fb6c3ce6babc1783))
 
 ## [6.4.1](https://github.com/algolia/instantsearch/compare/create-instantsearch-app@6.4.0...create-instantsearch-app@6.4.1) (2023-07-25)
 
 **Note:** Version bump only for package create-instantsearch-app
 
-
-
-
-
 # [6.4.0](https://github.com/algolia/instantsearch/compare/create-instantsearch-app@6.3.1...create-instantsearch-app@6.4.0) (2023-05-30)
-
 
 ### Bug Fixes
 
-* **dependencies:** remove fixed instantsearch.js dependency from react instantsearch hooks templates ([#5636](https://github.com/algolia/instantsearch/issues/5636)) ([9f41d7e](https://github.com/algolia/instantsearch/commit/9f41d7e702bfa482b229846e67ee4c7619f756cf))
-* **dependencies:** update metalsmith packages ([#5642](https://github.com/algolia/instantsearch/issues/5642)) ([e001aa9](https://github.com/algolia/instantsearch/commit/e001aa9a06bab28777906901f4f4ea007c92a2a1))
-* **js:** use html templates ([#5644](https://github.com/algolia/instantsearch/issues/5644)) ([4bcc426](https://github.com/algolia/instantsearch/commit/4bcc4267cdbecdb9274b0fe87e0a4f8701ec6475))
-
+- **dependencies:** remove fixed instantsearch.js dependency from react instantsearch hooks templates ([#5636](https://github.com/algolia/instantsearch/issues/5636)) ([9f41d7e](https://github.com/algolia/instantsearch/commit/9f41d7e702bfa482b229846e67ee4c7619f756cf))
+- **dependencies:** update metalsmith packages ([#5642](https://github.com/algolia/instantsearch/issues/5642)) ([e001aa9](https://github.com/algolia/instantsearch/commit/e001aa9a06bab28777906901f4f4ea007c92a2a1))
+- **js:** use html templates ([#5644](https://github.com/algolia/instantsearch/issues/5644)) ([4bcc426](https://github.com/algolia/instantsearch/commit/4bcc4267cdbecdb9274b0fe87e0a4f8701ec6475))
 
 ### Features
 
-* **templates:** add "insights" flag if supported ([#5639](https://github.com/algolia/instantsearch/issues/5639)) ([212ad4f](https://github.com/algolia/instantsearch/commit/212ad4fd2d40c525dfc5e49d0c77fc3013275c38))
-
-
-
-
+- **templates:** add "insights" flag if supported ([#5639](https://github.com/algolia/instantsearch/issues/5639)) ([212ad4f](https://github.com/algolia/instantsearch/commit/212ad4fd2d40c525dfc5e49d0c77fc3013275c38))
 
 ## [6.3.1](https://github.com/algolia/instantsearch/compare/create-instantsearch-app@6.3.0...create-instantsearch-app@6.3.1) (2023-04-24)
 
 **Note:** Version bump only for package create-instantsearch-app
 
-
-
-
-
-
-# [6.3.0](https://github.com/algolia/instantsearch.js/compare/create-instantsearch-app@6.2.1...create-instantsearch-app@6.3.0) (2023-01-03)
-
+# [6.3.0](https://github.com/algolia/instantsearch/compare/create-instantsearch-app@6.2.1...create-instantsearch-app@6.3.0) (2023-01-03)
 
 ### Bug Fixes
 
-* ignore templates for tsc ([2c574a9](https://github.com/algolia/instantsearch.js/commit/2c574a9fa966934cd259662a04b24d5e1b1f3c1e))
-* linting ([9712019](https://github.com/algolia/instantsearch.js/commit/9712019a242dc705505197018c4c4da23595e22e))
-* **tests:** merge jest config files and fix a test ([a376943](https://github.com/algolia/instantsearch.js/commit/a376943e189f488a198519c21c67dc7866cf4522))
-* **tests:** set concurrency to 1 ([34c6cc4](https://github.com/algolia/instantsearch.js/commit/34c6cc418028274d648a8712a62e5efeb4e2613b))
-* **tests:** use lerna to run tests ([eae255f](https://github.com/algolia/instantsearch.js/commit/eae255f278ba0c81591bf6d4aaa08a7d023269af))
-
+- ignore templates for tsc ([2c574a9](https://github.com/algolia/instantsearch/commit/2c574a9fa966934cd259662a04b24d5e1b1f3c1e))
+- linting ([9712019](https://github.com/algolia/instantsearch/commit/9712019a242dc705505197018c4c4da23595e22e))
+- **tests:** merge jest config files and fix a test ([a376943](https://github.com/algolia/instantsearch/commit/a376943e189f488a198519c21c67dc7866cf4522))
+- **tests:** set concurrency to 1 ([34c6cc4](https://github.com/algolia/instantsearch/commit/34c6cc418028274d648a8712a62e5efeb4e2613b))
+- **tests:** use lerna to run tests ([eae255f](https://github.com/algolia/instantsearch/commit/eae255f278ba0c81591bf6d4aaa08a7d023269af))
 
 ### Features
 
-* **cisa:** change URLs in templates + update template release scripts ([7ba7e63](https://github.com/algolia/instantsearch.js/commit/7ba7e633e1dd582557217196e0009af0582aaeca))
-
-
-
-
+- **cisa:** change URLs in templates + update template release scripts ([7ba7e63](https://github.com/algolia/instantsearch/commit/7ba7e633e1dd582557217196e0009af0582aaeca))
 
 ## [6.2.1](https://github.com/algolia/create-instantsearch-app/compare/v6.2.0...v6.2.1) (2022-08-23)
 
-
 ### Bug Fixes
 
-* **templates:** wrap React InstantSearch Hooks native hit attributes in `Fragment` ([#578](https://github.com/algolia/create-instantsearch-app/issues/578)) ([da7b811](https://github.com/algolia/create-instantsearch-app/commit/da7b811c3585f88214d7b8df2f07a5d5e5c13c63))
-
-
+- **templates:** wrap React InstantSearch Hooks native hit attributes in `Fragment` ([#578](https://github.com/algolia/create-instantsearch-app/issues/578)) ([da7b811](https://github.com/algolia/create-instantsearch-app/commit/da7b811c3585f88214d7b8df2f07a5d5e5c13c63))
 
 # [6.2.0](https://github.com/algolia/create-instantsearch-app/compare/v6.1.0...v6.2.0) (2022-08-01)
 
-
 ### Features
 
-* **templates:** update react instantsearch web templates to react 18 ([#576](https://github.com/algolia/create-instantsearch-app/issues/576)) ([25f170f](https://github.com/algolia/create-instantsearch-app/commit/25f170f9b074ea0cd628ec535059a56d57908bc0))
-
-
+- **templates:** update react instantsearch web templates to react 18 ([#576](https://github.com/algolia/create-instantsearch-app/issues/576)) ([25f170f](https://github.com/algolia/create-instantsearch-app/commit/25f170f9b074ea0cd628ec535059a56d57908bc0))
 
 # [6.1.0](https://github.com/algolia/create-instantsearch-app/compare/6.0.0...6.1.0) (2022-06-02)
 
-
 ### Bug Fixes
 
-* **vue instantsearch with vue 3:** use `yarn start` to run template ([#571](https://github.com/algolia/create-instantsearch-app/issues/571)) ([c17089f](https://github.com/algolia/create-instantsearch-app/commit/c17089fe59bb10cde5963c43016526a8a736d338))
-
+- **vue instantsearch with vue 3:** use `yarn start` to run template ([#571](https://github.com/algolia/create-instantsearch-app/issues/571)) ([c17089f](https://github.com/algolia/create-instantsearch-app/commit/c17089fe59bb10cde5963c43016526a8a736d338))
 
 ### Features
 
-* **react instantsearch widget:** add connector and widget metadata ([#570](https://github.com/algolia/create-instantsearch-app/issues/570)) ([b22a9e6](https://github.com/algolia/create-instantsearch-app/commit/b22a9e6977ea98d8c354d0a634bda50cccb4ecaf))
-
-
+- **react instantsearch widget:** add connector and widget metadata ([#570](https://github.com/algolia/create-instantsearch-app/issues/570)) ([b22a9e6](https://github.com/algolia/create-instantsearch-app/commit/b22a9e6977ea98d8c354d0a634bda50cccb4ecaf))
 
 # [6.0.0](https://github.com/algolia/create-instantsearch-app/compare/5.2.2...6.0.0) (2022-05-18)
 
-
 ### Bug Fixes
 
-* **js:** update and simplify dependencies ([#567](https://github.com/algolia/create-instantsearch-app/issues/567)) ([f42cf21](https://github.com/algolia/create-instantsearch-app/commit/f42cf21d5b6b433c9cf3a8d6b871bcaa5e1c8618)), closes [#566](https://github.com/algolia/create-instantsearch-app/issues/566)
-
+- **js:** update and simplify dependencies ([#567](https://github.com/algolia/create-instantsearch-app/issues/567)) ([f42cf21](https://github.com/algolia/create-instantsearch-app/commit/f42cf21d5b6b433c9cf3a8d6b871bcaa5e1c8618)), closes [#566](https://github.com/algolia/create-instantsearch-app/issues/566)
 
 ### Features
 
-* **hooks:** add react instantsearch hooks template ([#568](https://github.com/algolia/create-instantsearch-app/issues/568)) ([d91e970](https://github.com/algolia/create-instantsearch-app/commit/d91e970b4683de2b7511b0621468d61a10c4f3f7))
-* check for compatibility with current LTS versions of node ([#569](https://github.com/algolia/create-instantsearch-app/issues/569)) ([781642b](https://github.com/algolia/create-instantsearch-app/commit/781642b35a0df601f03b4cdf9b8b1f3b8aceaeac))
-
+- **hooks:** add react instantsearch hooks template ([#568](https://github.com/algolia/create-instantsearch-app/issues/568)) ([d91e970](https://github.com/algolia/create-instantsearch-app/commit/d91e970b4683de2b7511b0621468d61a10c4f3f7))
+- check for compatibility with current LTS versions of node ([#569](https://github.com/algolia/create-instantsearch-app/issues/569)) ([781642b](https://github.com/algolia/create-instantsearch-app/commit/781642b35a0df601f03b4cdf9b8b1f3b8aceaeac))
 
 ### BREAKING CHANGES
 
-* compatibility with versions that are EOL (up to 12) is not guaranteed
+- compatibility with versions that are EOL (up to 12) is not guaranteed
 
-* remove terminal colors from unit test snapshots
-
-
+- remove terminal colors from unit test snapshots
 
 ## [5.2.2](https://github.com/algolia/create-instantsearch-app/compare/5.2.1...5.2.2) (2022-02-21)
 
-
 ### Bug Fixes
 
-* **vue:** support optional chaining ([#564](https://github.com/algolia/create-instantsearch-app/issues/564)) ([2dfa2ec](https://github.com/algolia/create-instantsearch-app/commit/2dfa2ecebdbcea5604db451c0e0e57010b36de04))
-
-
+- **vue:** support optional chaining ([#564](https://github.com/algolia/create-instantsearch-app/issues/564)) ([2dfa2ec](https://github.com/algolia/create-instantsearch-app/commit/2dfa2ecebdbcea5604db451c0e0e57010b36de04))
 
 ## [5.2.1](https://github.com/algolia/create-instantsearch-app/compare/5.2.0...5.2.1) (2022-02-16)
 
-
 ### Bug Fixes
 
-* **Vue 3:** add vite plugin to correctly handle jsx ([#563](https://github.com/algolia/create-instantsearch-app/issues/563)) ([0a4162a](https://github.com/algolia/create-instantsearch-app/commit/0a4162ae2067a15b30242e0b54ae3ff768e836d9))
-
-
+- **Vue 3:** add vite plugin to correctly handle jsx ([#563](https://github.com/algolia/create-instantsearch-app/issues/563)) ([0a4162a](https://github.com/algolia/create-instantsearch-app/commit/0a4162ae2067a15b30242e0b54ae3ff768e836d9))
 
 # [5.2.0](https://github.com/algolia/create-instantsearch-app/compare/5.1.2...5.2.0) (2022-02-14)
 
-
 ### Features
 
-* **templates:** introduce React InstantSearch Hooks Native template ([#559](https://github.com/algolia/create-instantsearch-app/issues/559)) ([495f014](https://github.com/algolia/create-instantsearch-app/commit/495f0140301185bba9192ccd779597d4d5028241))
-* **vue:** add vue3 template ([#558](https://github.com/algolia/create-instantsearch-app/issues/558)) ([117067e](https://github.com/algolia/create-instantsearch-app/commit/117067ea0c4da0d08105d2de1e8b611f935b533a))
-
-
+- **templates:** introduce React InstantSearch Hooks Native template ([#559](https://github.com/algolia/create-instantsearch-app/issues/559)) ([495f014](https://github.com/algolia/create-instantsearch-app/commit/495f0140301185bba9192ccd779597d4d5028241))
+- **vue:** add vue3 template ([#558](https://github.com/algolia/create-instantsearch-app/issues/558)) ([117067e](https://github.com/algolia/create-instantsearch-app/commit/117067ea0c4da0d08105d2de1e8b611f935b533a))
 
 ## [5.1.2](https://github.com/algolia/create-instantsearch-app/compare/5.1.1...5.1.2) (2022-02-02)
 
-
 ### Bug Fixes
 
-* **angular:** remove @types/algoliasearch dep ([#553](https://github.com/algolia/create-instantsearch-app/issues/553)) ([b280725](https://github.com/algolia/create-instantsearch-app/commit/b2807252dff74f79d887c746327f03f28f53840d))
-* **angular:** update angular packages ([#555](https://github.com/algolia/create-instantsearch-app/issues/555)) ([9987264](https://github.com/algolia/create-instantsearch-app/commit/9987264f32582721ac2a8e7f3348fa3d54be3975))
-* **React InstantSearch:** import RefinementList if DynamicWidgets used ([#554](https://github.com/algolia/create-instantsearch-app/issues/554)) ([402ec63](https://github.com/algolia/create-instantsearch-app/commit/402ec63261db8a60aa6927e84ec46d45eb27fef3))
-
-
+- **angular:** remove @types/algoliasearch dep ([#553](https://github.com/algolia/create-instantsearch-app/issues/553)) ([b280725](https://github.com/algolia/create-instantsearch-app/commit/b2807252dff74f79d887c746327f03f28f53840d))
+- **angular:** update angular packages ([#555](https://github.com/algolia/create-instantsearch-app/issues/555)) ([9987264](https://github.com/algolia/create-instantsearch-app/commit/9987264f32582721ac2a8e7f3348fa3d54be3975))
+- **React InstantSearch:** import RefinementList if DynamicWidgets used ([#554](https://github.com/algolia/create-instantsearch-app/issues/554)) ([402ec63](https://github.com/algolia/create-instantsearch-app/commit/402ec63261db8a60aa6927e84ec46d45eb27fef3))
 
 ## [5.1.1](https://github.com/algolia/create-instantsearch-app/compare/5.1.0...5.1.1) (2022-01-03)
 
-
 ### Bug Fixes
 
-* **react-native:** update template and related dependencies ([#546](https://github.com/algolia/create-instantsearch-app/issues/546)) ([858d33f](https://github.com/algolia/create-instantsearch-app/commit/858d33fb01272e8a13964a739c247743cbd855dc))
-
-
+- **react-native:** update template and related dependencies ([#546](https://github.com/algolia/create-instantsearch-app/issues/546)) ([858d33f](https://github.com/algolia/create-instantsearch-app/commit/858d33fb01272e8a13964a739c247743cbd855dc))
 
 # [5.1.0](https://github.com/algolia/create-instantsearch-app/compare/5.0.1...5.1.0) (2021-12-14)
 
-
 ### Features
 
-* **templates:** use non-experimental dynamic widgets ([#544](https://github.com/algolia/create-instantsearch-app/issues/544)) ([efda539](https://github.com/algolia/create-instantsearch-app/commit/efda5395cef7865c7b4cebe741e7ab5e8ea4b2f8))
-
-
+- **templates:** use non-experimental dynamic widgets ([#544](https://github.com/algolia/create-instantsearch-app/issues/544)) ([efda539](https://github.com/algolia/create-instantsearch-app/commit/efda5395cef7865c7b4cebe741e7ab5e8ea4b2f8))
 
 ## [5.0.1](https://github.com/algolia/create-instantsearch-app/compare/5.0.0...5.0.1) (2021-12-02)
 
-
 ### Bug Fixes
 
-* **dynamicWidgets:** allow only dynamicWidgets as attribute ([3717de6](https://github.com/algolia/create-instantsearch-app/commit/3717de6fc5811c191629d366988dcc2e05773a9c))
-
-
+- **dynamicWidgets:** allow only dynamicWidgets as attribute ([3717de6](https://github.com/algolia/create-instantsearch-app/commit/3717de6fc5811c191629d366988dcc2e05773a9c))
 
 # [5.0.0](https://github.com/algolia/create-instantsearch-app/compare/4.11.1...5.0.0) (2021-12-02)
 
-
 ### Bug Fixes
 
-* **dynamicWidgets:** prevent "ais.dynamicWidgets" attribute showing up ([#542](https://github.com/algolia/create-instantsearch-app/issues/542)) ([559f705](https://github.com/algolia/create-instantsearch-app/commit/559f705ebcef48a3794efd7a588abd187d6642c9))
-
+- **dynamicWidgets:** prevent "ais.dynamicWidgets" attribute showing up ([#542](https://github.com/algolia/create-instantsearch-app/issues/542)) ([559f705](https://github.com/algolia/create-instantsearch-app/commit/559f705ebcef48a3794efd7a588abd187d6642c9))
 
 ### Code Refactoring
 
-* **index:** rewrite answer parsing ([#541](https://github.com/algolia/create-instantsearch-app/issues/541)) ([efd2799](https://github.com/algolia/create-instantsearch-app/commit/efd279943e23545c3c0806f8e9632ae32c83c0d6))
-
+- **index:** rewrite answer parsing ([#541](https://github.com/algolia/create-instantsearch-app/issues/541)) ([efd2799](https://github.com/algolia/create-instantsearch-app/commit/efd279943e23545c3c0806f8e9632ae32c83c0d6))
 
 ### BREAKING CHANGES
 
 the program now asks questions if some of the parameters are sent via arguments. Before this, giving an argument would cause it not to ask any questions anymore, even if they still would be useful. You can avoid this behaviour by passing --config or --no-interactive
 
-
 ## [4.11.1](https://github.com/algolia/create-instantsearch-app/compare/4.11.0...4.11.1) (2021-11-18)
-
 
 ### Bug Fixes
 
-* **react:** add missing configure widget import ([#540](https://github.com/algolia/create-instantsearch-app/issues/540)) ([626a568](https://github.com/algolia/create-instantsearch-app/commit/626a56859c48e756429da66195d7da1a6c79e39e))
-
-
+- **react:** add missing configure widget import ([#540](https://github.com/algolia/create-instantsearch-app/issues/540)) ([626a568](https://github.com/algolia/create-instantsearch-app/commit/626a56859c48e756429da66195d7da1a6c79e39e))
 
 # [4.11.0](https://github.com/algolia/create-instantsearch-app/compare/4.10.3...4.11.0) (2021-11-16)
 
-
 ### Bug Fixes
 
-* **angular:** move styles import to angular.json ([#532](https://github.com/algolia/create-instantsearch-app/issues/532)) ([d2f73b8](https://github.com/algolia/create-instantsearch-app/commit/d2f73b895c0ed7a2530920f770f67879cca0a9a5))
-* **angular:** replace css imports with CDN <link>s ([#537](https://github.com/algolia/create-instantsearch-app/issues/537)) ([fb4c2a8](https://github.com/algolia/create-instantsearch-app/commit/fb4c2a87852fe2f4b3d2289a21234fdf04bddc98))
-* **Angular IS:** enable esModuleInterop ([#527](https://github.com/algolia/create-instantsearch-app/issues/527)) ([502e776](https://github.com/algolia/create-instantsearch-app/commit/502e776cf9ca9eca489d6acbde5f8c603de56bd0))
-* **ci:** replace legacy circleci node images ([#533](https://github.com/algolia/create-instantsearch-app/issues/533)) ([9ffb469](https://github.com/algolia/create-instantsearch-app/commit/9ffb46925db6e2a6e015be98b589f1b7cf22a9f3))
-* **cli:** configure inquirer with correct initial values for attributesToDisplay ([#530](https://github.com/algolia/create-instantsearch-app/issues/530)) ([5cd6142](https://github.com/algolia/create-instantsearch-app/commit/5cd6142d12658dde616690ab1b045c613adf711a))
-
+- **angular:** move styles import to angular.json ([#532](https://github.com/algolia/create-instantsearch-app/issues/532)) ([d2f73b8](https://github.com/algolia/create-instantsearch-app/commit/d2f73b895c0ed7a2530920f770f67879cca0a9a5))
+- **angular:** replace css imports with CDN <link>s ([#537](https://github.com/algolia/create-instantsearch-app/issues/537)) ([fb4c2a8](https://github.com/algolia/create-instantsearch-app/commit/fb4c2a87852fe2f4b3d2289a21234fdf04bddc98))
+- **Angular IS:** enable esModuleInterop ([#527](https://github.com/algolia/create-instantsearch-app/issues/527)) ([502e776](https://github.com/algolia/create-instantsearch-app/commit/502e776cf9ca9eca489d6acbde5f8c603de56bd0))
+- **ci:** replace legacy circleci node images ([#533](https://github.com/algolia/create-instantsearch-app/issues/533)) ([9ffb469](https://github.com/algolia/create-instantsearch-app/commit/9ffb46925db6e2a6e015be98b589f1b7cf22a9f3))
+- **cli:** configure inquirer with correct initial values for attributesToDisplay ([#530](https://github.com/algolia/create-instantsearch-app/issues/530)) ([5cd6142](https://github.com/algolia/create-instantsearch-app/commit/5cd6142d12658dde616690ab1b045c613adf711a))
 
 ### Features
 
-* **autocomplete:** add Autocomplete v1 template ([#528](https://github.com/algolia/create-instantsearch-app/issues/528)) ([5c72d05](https://github.com/algolia/create-instantsearch-app/commit/5c72d05100d90900afbc848eaa7417c175c126cc))
-* **facets:** use dynamicWidgets ([#534](https://github.com/algolia/create-instantsearch-app/issues/534)) ([7df3225](https://github.com/algolia/create-instantsearch-app/commit/7df32252a0558f0e09288735cfddd8062af5dc09))
-
-
+- **autocomplete:** add Autocomplete v1 template ([#528](https://github.com/algolia/create-instantsearch-app/issues/528)) ([5c72d05](https://github.com/algolia/create-instantsearch-app/commit/5c72d05100d90900afbc848eaa7417c175c126cc))
+- **facets:** use dynamicWidgets ([#534](https://github.com/algolia/create-instantsearch-app/issues/534)) ([7df3225](https://github.com/algolia/create-instantsearch-app/commit/7df32252a0558f0e09288735cfddd8062af5dc09))
 
 ## [4.10.3](https://github.com/algolia/create-instantsearch-app/compare/4.10.2...4.10.3) (2021-09-01)
 
-
 ### Bug Fixes
 
-* **js:** enable typescript completion using window ([1fd684b](https://github.com/algolia/create-instantsearch-app/commit/1fd684bf4c5c15b0f7c5d20a6bcf25037ddf9684))
-
-
+- **js:** enable typescript completion using window ([1fd684b](https://github.com/algolia/create-instantsearch-app/commit/1fd684bf4c5c15b0f7c5d20a6bcf25037ddf9684))
 
 ## [4.10.2](https://github.com/algolia/create-instantsearch-app/compare/4.10.1...4.10.2) (2021-09-01)
 
-
-
 ## [4.10.1](https://github.com/algolia/create-instantsearch-app/compare/4.10.0...4.10.1) (2021-08-30)
-
 
 ### Bug Fixes
 
-* **js:** correct umd url for algoliasearch ([a5d005d](https://github.com/algolia/create-instantsearch-app/commit/a5d005d4acba1f8833b8b2d50fb63e7b199c735e))
-
-
+- **js:** correct umd url for algoliasearch ([a5d005d](https://github.com/algolia/create-instantsearch-app/commit/a5d005d4acba1f8833b8b2d50fb63e7b199c735e))
 
 # [4.10.0](https://github.com/algolia/create-instantsearch-app/compare/4.9.0...4.10.0) (2021-08-24)
 
-
 ### Features
 
-* **is widget:** upgrade to standard types ([#463](https://github.com/algolia/create-instantsearch-app/issues/463)) ([174c0ab](https://github.com/algolia/create-instantsearch-app/commit/174c0ab7901d09da24b3aeebba17b7dd62073810))
-* **js:** add typescript to the js template ([#464](https://github.com/algolia/create-instantsearch-app/issues/464)) ([9b16b13](https://github.com/algolia/create-instantsearch-app/commit/9b16b1365659053821ad2fdac4ce73037c347819))
-* **js-widget:** add example ([#461](https://github.com/algolia/create-instantsearch-app/issues/461)) ([017325d](https://github.com/algolia/create-instantsearch-app/commit/017325dd79d5d8ae849e5c17b7a20527bd142ed8))
-* **vue:** support Vue InstantSearch 4 ([#465](https://github.com/algolia/create-instantsearch-app/issues/465)) ([f0ebec5](https://github.com/algolia/create-instantsearch-app/commit/f0ebec52f8013450a86b5b5fda191822a8b94a1e))
-
-
+- **is widget:** upgrade to standard types ([#463](https://github.com/algolia/create-instantsearch-app/issues/463)) ([174c0ab](https://github.com/algolia/create-instantsearch-app/commit/174c0ab7901d09da24b3aeebba17b7dd62073810))
+- **js:** add typescript to the js template ([#464](https://github.com/algolia/create-instantsearch-app/issues/464)) ([9b16b13](https://github.com/algolia/create-instantsearch-app/commit/9b16b1365659053821ad2fdac4ce73037c347819))
+- **js-widget:** add example ([#461](https://github.com/algolia/create-instantsearch-app/issues/461)) ([017325d](https://github.com/algolia/create-instantsearch-app/commit/017325dd79d5d8ae849e5c17b7a20527bd142ed8))
+- **vue:** support Vue InstantSearch 4 ([#465](https://github.com/algolia/create-instantsearch-app/issues/465)) ([f0ebec5](https://github.com/algolia/create-instantsearch-app/commit/f0ebec52f8013450a86b5b5fda191822a8b94a1e))
 
 # [4.9.0](https://github.com/algolia/create-instantsearch-app/compare/4.8.0...4.9.0) (2021-07-22)
 
-
 ### Bug Fixes
 
-* **templates:** add `packageNamePrefix` to widget templates ([#458](https://github.com/algolia/create-instantsearch-app/issues/458)) ([25da57e](https://github.com/algolia/create-instantsearch-app/commit/25da57eeea01b9e77b34460ea8179e7411a71588))
-
+- **templates:** add `packageNamePrefix` to widget templates ([#458](https://github.com/algolia/create-instantsearch-app/issues/458)) ([25da57e](https://github.com/algolia/create-instantsearch-app/commit/25da57eeea01b9e77b34460ea8179e7411a71588))
 
 ### Features
 
-* **cli:** make app path optional ([#457](https://github.com/algolia/create-instantsearch-app/issues/457)) ([d5a5655](https://github.com/algolia/create-instantsearch-app/commit/d5a5655c2c284eb43499aad6c490b95a2b7b4b0c))
-* **templates:** update README and LICENSE for widget templates ([#459](https://github.com/algolia/create-instantsearch-app/issues/459)) ([813c7bf](https://github.com/algolia/create-instantsearch-app/commit/813c7bfbaebdba5eb7277c59022455b51ea65b23))
-
-
+- **cli:** make app path optional ([#457](https://github.com/algolia/create-instantsearch-app/issues/457)) ([d5a5655](https://github.com/algolia/create-instantsearch-app/commit/d5a5655c2c284eb43499aad6c490b95a2b7b4b0c))
+- **templates:** update README and LICENSE for widget templates ([#459](https://github.com/algolia/create-instantsearch-app/issues/459)) ([813c7bf](https://github.com/algolia/create-instantsearch-app/commit/813c7bfbaebdba5eb7277c59022455b51ea65b23))
 
 # [4.8.0](https://github.com/algolia/create-instantsearch-app/compare/4.7.0...4.8.0) (2021-06-10)
 
 ### Features
 
-* **template:** add widget template for react ([#456](https://github.com/algolia/create-instantsearch-app/issues/456)) ([cf2c81b](https://github.com/algolia/create-instantsearch-app/commit/cf2c81bf76601dea82556f89df2846321384b1b9))
-
-
+- **template:** add widget template for react ([#456](https://github.com/algolia/create-instantsearch-app/issues/456)) ([cf2c81b](https://github.com/algolia/create-instantsearch-app/commit/cf2c81bf76601dea82556f89df2846321384b1b9))
 
 # [4.7.0](https://github.com/algolia/create-instantsearch-app/compare/4.6.0...4.7.0) (2021-05-19)
 
-
 ### Bug Fixes
 
-* **templates:** add `main` entry point ([#447](https://github.com/algolia/create-instantsearch-app/issues/447)) ([988336d](https://github.com/algolia/create-instantsearch-app/commit/988336dac4e92ce545e9ea0ebb79565f5043f61a))
-* **templates:** remove `main` entry points for Vue and React ([51c5f3c](https://github.com/algolia/create-instantsearch-app/commit/51c5f3cdc73d32a0008fc2bdb05ab3378ba2d422))
-* **templates:** update to latest Parcel version ([#454](https://github.com/algolia/create-instantsearch-app/issues/454)) ([7bb892e](https://github.com/algolia/create-instantsearch-app/commit/7bb892ea0d61db2562b2e76246e928ec7deb3b96))
-* **templates:** use function component in React template ([#445](https://github.com/algolia/create-instantsearch-app/issues/445)) ([17f8cc9](https://github.com/algolia/create-instantsearch-app/commit/17f8cc98c3e0b1bb1930cd94e88033c6d8b10071))
-
+- **templates:** add `main` entry point ([#447](https://github.com/algolia/create-instantsearch-app/issues/447)) ([988336d](https://github.com/algolia/create-instantsearch-app/commit/988336dac4e92ce545e9ea0ebb79565f5043f61a))
+- **templates:** remove `main` entry points for Vue and React ([51c5f3c](https://github.com/algolia/create-instantsearch-app/commit/51c5f3cdc73d32a0008fc2bdb05ab3378ba2d422))
+- **templates:** update to latest Parcel version ([#454](https://github.com/algolia/create-instantsearch-app/issues/454)) ([7bb892e](https://github.com/algolia/create-instantsearch-app/commit/7bb892ea0d61db2562b2e76246e928ec7deb3b96))
+- **templates:** use function component in React template ([#445](https://github.com/algolia/create-instantsearch-app/issues/445)) ([17f8cc9](https://github.com/algolia/create-instantsearch-app/commit/17f8cc98c3e0b1bb1930cd94e88033c6d8b10071))
 
 ### Features
 
-* **template:** add widget template ([#455](https://github.com/algolia/create-instantsearch-app/issues/455)) ([e48f9c6](https://github.com/algolia/create-instantsearch-app/commit/e48f9c6cd1721625e2de5f43336ab812ef70cae2))
-* **templates:** update Autocomplete.js template to Satellite ([#450](https://github.com/algolia/create-instantsearch-app/issues/450)) ([1ce212b](https://github.com/algolia/create-instantsearch-app/commit/1ce212bd206c5e09c3ee2873bf41720e8aa85dcb))
-* **vue:** update vue template for vue-instantsearch 3 ([#452](https://github.com/algolia/create-instantsearch-app/issues/452)) ([2b3d6ff](https://github.com/algolia/create-instantsearch-app/commit/2b3d6ffd106b6cf3969b075a1451d8ec4ed4b381))
-
-
+- **template:** add widget template ([#455](https://github.com/algolia/create-instantsearch-app/issues/455)) ([e48f9c6](https://github.com/algolia/create-instantsearch-app/commit/e48f9c6cd1721625e2de5f43336ab812ef70cae2))
+- **templates:** update Autocomplete.js template to Satellite ([#450](https://github.com/algolia/create-instantsearch-app/issues/450)) ([1ce212b](https://github.com/algolia/create-instantsearch-app/commit/1ce212bd206c5e09c3ee2873bf41720e8aa85dcb))
+- **vue:** update vue template for vue-instantsearch 3 ([#452](https://github.com/algolia/create-instantsearch-app/issues/452)) ([2b3d6ff](https://github.com/algolia/create-instantsearch-app/commit/2b3d6ffd106b6cf3969b075a1451d8ec4ed4b381))
 
 # [4.6.0](https://github.com/algolia/create-instantsearch-app/compare/4.5.0...4.6.0) (2019-12-18)
 
-
 ### Features
 
-* **templates:** add JavaScript Helper 3 template ([#444](https://github.com/algolia/create-instantsearch-app/issues/444)) ([dea6714](https://github.com/algolia/create-instantsearch-app/commit/dea6714a16e4f47e52a7824348064a962b9a93ff))
-
-
+- **templates:** add JavaScript Helper 3 template ([#444](https://github.com/algolia/create-instantsearch-app/issues/444)) ([dea6714](https://github.com/algolia/create-instantsearch-app/commit/dea6714a16e4f47e52a7824348064a962b9a93ff))
 
 ## [4.4.2](https://github.com/algolia/create-instantsearch-app/compare/4.4.1...4.4.2) (2019-04-10)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency chalk to v2.4.2 ([#385](https://github.com/algolia/create-instantsearch-app/issues/385)) ([1bb0e23](https://github.com/algolia/create-instantsearch-app/commit/1bb0e23))
-* **deps:** update dependency load-json-file to v5.2.0 ([#387](https://github.com/algolia/create-instantsearch-app/issues/387)) ([2b5f396](https://github.com/algolia/create-instantsearch-app/commit/2b5f396))
-* **templates:** use expo for react-native ([#392](https://github.com/algolia/create-instantsearch-app/issues/392)) ([e7de93c](https://github.com/algolia/create-instantsearch-app/commit/e7de93c))
-
-
+- **deps:** update dependency chalk to v2.4.2 ([#385](https://github.com/algolia/create-instantsearch-app/issues/385)) ([1bb0e23](https://github.com/algolia/create-instantsearch-app/commit/1bb0e23))
+- **deps:** update dependency load-json-file to v5.2.0 ([#387](https://github.com/algolia/create-instantsearch-app/issues/387)) ([2b5f396](https://github.com/algolia/create-instantsearch-app/commit/2b5f396))
+- **templates:** use expo for react-native ([#392](https://github.com/algolia/create-instantsearch-app/issues/392)) ([e7de93c](https://github.com/algolia/create-instantsearch-app/commit/e7de93c))
 
 ## [4.4.1](https://github.com/algolia/create-instantsearch-app/compare/4.4.0...4.4.1) (2019-02-26)
 
-
 ### Bug Fixes
 
-* **api:** resolve template path ([375212b](https://github.com/algolia/create-instantsearch-app/commit/375212b))
-
-
+- **api:** resolve template path ([375212b](https://github.com/algolia/create-instantsearch-app/commit/375212b))
 
 # [4.4.0](https://github.com/algolia/create-instantsearch-app/compare/4.3.2...4.4.0) (2019-02-20)
 
-
 ### Features
 
-* **vue:** add template for Vue v2 ([#370](https://github.com/algolia/create-instantsearch-app/issues/370)) ([ec43d28](https://github.com/algolia/create-instantsearch-app/commit/ec43d28))
-
-
+- **vue:** add template for Vue v2 ([#370](https://github.com/algolia/create-instantsearch-app/issues/370)) ([ec43d28](https://github.com/algolia/create-instantsearch-app/commit/ec43d28))
 
 ## [4.3.2](https://github.com/algolia/create-instantsearch-app/compare/4.3.1...4.3.2) (2019-02-15)
 
-
 ### Bug Fixes
 
-* **api:** fix template resolver ([1b0d2a1](https://github.com/algolia/create-instantsearch-app/commit/1b0d2a1))
-
-
+- **api:** fix template resolver ([1b0d2a1](https://github.com/algolia/create-instantsearch-app/commit/1b0d2a1))
 
 ## [4.3.1](https://github.com/algolia/create-instantsearch-app/compare/4.3.0...4.3.1) (2019-02-15)
 
-
 ### Bug Fixes
 
-* **api:** resolve relative paths ([#365](https://github.com/algolia/create-instantsearch-app/issues/365)) ([fc8c421](https://github.com/algolia/create-instantsearch-app/commit/fc8c421))
-
-
+- **api:** resolve relative paths ([#365](https://github.com/algolia/create-instantsearch-app/issues/365)) ([fc8c421](https://github.com/algolia/create-instantsearch-app/commit/fc8c421))
 
 # [4.3.0](https://github.com/algolia/create-instantsearch-app/compare/4.2.0...4.3.0) (2019-02-14)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency inquirer to v6.2.2 ([#340](https://github.com/algolia/create-instantsearch-app/issues/340)) ([40d7419](https://github.com/algolia/create-instantsearch-app/commit/40d7419))
-* **deps:** update vue monorepo to v2.6.2 ([#345](https://github.com/algolia/create-instantsearch-app/issues/345)) ([53cc4dc](https://github.com/algolia/create-instantsearch-app/commit/53cc4dc))
-* **React InstantSearch:** placeholder template ([#361](https://github.com/algolia/create-instantsearch-app/issues/361)) ([caf15a0](https://github.com/algolia/create-instantsearch-app/commit/caf15a0))
-* **templates:** remove community links ([#362](https://github.com/algolia/create-instantsearch-app/issues/362)) ([8709534](https://github.com/algolia/create-instantsearch-app/commit/8709534))
-
+- **deps:** update dependency inquirer to v6.2.2 ([#340](https://github.com/algolia/create-instantsearch-app/issues/340)) ([40d7419](https://github.com/algolia/create-instantsearch-app/commit/40d7419))
+- **deps:** update vue monorepo to v2.6.2 ([#345](https://github.com/algolia/create-instantsearch-app/issues/345)) ([53cc4dc](https://github.com/algolia/create-instantsearch-app/commit/53cc4dc))
+- **React InstantSearch:** placeholder template ([#361](https://github.com/algolia/create-instantsearch-app/issues/361)) ([caf15a0](https://github.com/algolia/create-instantsearch-app/commit/caf15a0))
+- **templates:** remove community links ([#362](https://github.com/algolia/create-instantsearch-app/issues/362)) ([8709534](https://github.com/algolia/create-instantsearch-app/commit/8709534))
 
 ### Features
 
-* **api:** add support for template versioning ([#351](https://github.com/algolia/create-instantsearch-app/issues/351)) ([e679daa](https://github.com/algolia/create-instantsearch-app/commit/e679daa))
-* **api:** throw when unsupported template version ([#354](https://github.com/algolia/create-instantsearch-app/issues/354)) ([f7a6a4e](https://github.com/algolia/create-instantsearch-app/commit/f7a6a4e))
-
-
+- **api:** add support for template versioning ([#351](https://github.com/algolia/create-instantsearch-app/issues/351)) ([e679daa](https://github.com/algolia/create-instantsearch-app/commit/e679daa))
+- **api:** throw when unsupported template version ([#354](https://github.com/algolia/create-instantsearch-app/issues/354)) ([f7a6a4e](https://github.com/algolia/create-instantsearch-app/commit/f7a6a4e))
 
 # [4.2.0](https://github.com/algolia/create-instantsearch-app/compare/4.1.0...4.2.0) (2019-01-14)
 
-
 ### Bug Fixes
 
-* **angular:** use instantsearch.css styles directly ([#347](https://github.com/algolia/create-instantsearch-app/issues/347)) ([4e410d5](https://github.com/algolia/create-instantsearch-app/commit/4e410d5))
-* **deps:** update dependency react-scripts to v2.1.1 ([20bbb6a](https://github.com/algolia/create-instantsearch-app/commit/20bbb6a))
-* **deps:** update react monorepo to v16.6.3 ([66fd398](https://github.com/algolia/create-instantsearch-app/commit/66fd398))
-
+- **angular:** use instantsearch.css styles directly ([#347](https://github.com/algolia/create-instantsearch-app/issues/347)) ([4e410d5](https://github.com/algolia/create-instantsearch-app/commit/4e410d5))
+- **deps:** update dependency react-scripts to v2.1.1 ([20bbb6a](https://github.com/algolia/create-instantsearch-app/commit/20bbb6a))
+- **deps:** update react monorepo to v16.6.3 ([66fd398](https://github.com/algolia/create-instantsearch-app/commit/66fd398))
 
 ### Features
 
-* **js:** migrate template to InstantSearch.js 3 ([#350](https://github.com/algolia/create-instantsearch-app/issues/350)) ([819b056](https://github.com/algolia/create-instantsearch-app/commit/819b056)), closes [#349](https://github.com/algolia/create-instantsearch-app/issues/349)
-
-
+- **js:** migrate template to InstantSearch.js 3 ([#350](https://github.com/algolia/create-instantsearch-app/issues/350)) ([819b056](https://github.com/algolia/create-instantsearch-app/commit/819b056)), closes [#349](https://github.com/algolia/create-instantsearch-app/issues/349)
 
 <a name="4.1.0"></a>
+
 # [4.1.0](https://github.com/algolia/create-instantsearch-app/compare/4.0.0...4.1.0) (2018-10-29)
 
-
 ### Bug Fixes
 
-* **angular:** add prod param to build command ([#278](https://github.com/algolia/create-instantsearch-app/issues/278)) ([0bc801b](https://github.com/algolia/create-instantsearch-app/commit/0bc801b))
-* **angular:** fix manifest and Angular dependencies ([#310](https://github.com/algolia/create-instantsearch-app/issues/310)) ([d4dd811](https://github.com/algolia/create-instantsearch-app/commit/d4dd811))
-* **autocomplete:** remove useless $hits variable ([#252](https://github.com/algolia/create-instantsearch-app/issues/252)) ([1b04e8d](https://github.com/algolia/create-instantsearch-app/commit/1b04e8d))
-* **cli:** Fix prompt typo ([#230](https://github.com/algolia/create-instantsearch-app/issues/230)) ([bf74d80](https://github.com/algolia/create-instantsearch-app/commit/bf74d80))
-* **deps:** update angular monorepo to v6.1.10 ([#287](https://github.com/algolia/create-instantsearch-app/issues/287)) ([173ae07](https://github.com/algolia/create-instantsearch-app/commit/173ae07))
-* **deps:** update angular monorepo to v6.1.7 ([#234](https://github.com/algolia/create-instantsearch-app/issues/234)) ([976612e](https://github.com/algolia/create-instantsearch-app/commit/976612e))
-* **deps:** update angular monorepo to v6.1.9 ([#269](https://github.com/algolia/create-instantsearch-app/issues/269)) ([f696ac0](https://github.com/algolia/create-instantsearch-app/commit/f696ac0))
-* **deps:** update dependency commander to v2.18.0 ([#235](https://github.com/algolia/create-instantsearch-app/issues/235)) ([ea3ab43](https://github.com/algolia/create-instantsearch-app/commit/ea3ab43))
-* **deps:** update dependency commander to v2.19.0 ([#288](https://github.com/algolia/create-instantsearch-app/issues/288)) ([4ab3fd3](https://github.com/algolia/create-instantsearch-app/commit/4ab3fd3))
-* **deps:** update dependency expo to v29.0.1 ([#249](https://github.com/algolia/create-instantsearch-app/issues/249)) ([9eed507](https://github.com/algolia/create-instantsearch-app/commit/9eed507))
-* **deps:** update dependency expo to v30 ([#241](https://github.com/algolia/create-instantsearch-app/issues/241)) ([45b7ae5](https://github.com/algolia/create-instantsearch-app/commit/45b7ae5))
-* **deps:** update dependency load-json-file to v5.1.0 ([#270](https://github.com/algolia/create-instantsearch-app/issues/270)) ([2c16283](https://github.com/algolia/create-instantsearch-app/commit/2c16283))
-* **deps:** update dependency metalsmith-ignore to v1 ([#242](https://github.com/algolia/create-instantsearch-app/issues/242)) ([2352281](https://github.com/algolia/create-instantsearch-app/commit/2352281))
-* **deps:** update dependency rxjs to v6.3.2 ([#236](https://github.com/algolia/create-instantsearch-app/issues/236)) ([950a737](https://github.com/algolia/create-instantsearch-app/commit/950a737))
-* **deps:** update dependency rxjs to v6.3.3 ([#271](https://github.com/algolia/create-instantsearch-app/issues/271)) ([a13c192](https://github.com/algolia/create-instantsearch-app/commit/a13c192))
-* **deps:** update dependency vue to v2.5.17 ([#176](https://github.com/algolia/create-instantsearch-app/issues/176)) ([99fd4c1](https://github.com/algolia/create-instantsearch-app/commit/99fd4c1))
-* **deps:** update react monorepo to v16.5.0 ([#238](https://github.com/algolia/create-instantsearch-app/issues/238)) ([cf5d036](https://github.com/algolia/create-instantsearch-app/commit/cf5d036))
-* **deps:** update react monorepo to v16.5.1 ([#251](https://github.com/algolia/create-instantsearch-app/issues/251)) ([0086764](https://github.com/algolia/create-instantsearch-app/commit/0086764))
-* **deps:** update react monorepo to v16.5.2 ([#272](https://github.com/algolia/create-instantsearch-app/issues/272)) ([8401d1b](https://github.com/algolia/create-instantsearch-app/commit/8401d1b))
-* **InstantSearch:** disable autofocus ([#257](https://github.com/algolia/create-instantsearch-app/issues/257)) ([ed1d98a](https://github.com/algolia/create-instantsearch-app/commit/ed1d98a))
-* **templates:** Add Vue ESLint config ([#240](https://github.com/algolia/create-instantsearch-app/issues/240)) ([c1a5ecf](https://github.com/algolia/create-instantsearch-app/commit/c1a5ecf))
-
+- **angular:** add prod param to build command ([#278](https://github.com/algolia/create-instantsearch-app/issues/278)) ([0bc801b](https://github.com/algolia/create-instantsearch-app/commit/0bc801b))
+- **angular:** fix manifest and Angular dependencies ([#310](https://github.com/algolia/create-instantsearch-app/issues/310)) ([d4dd811](https://github.com/algolia/create-instantsearch-app/commit/d4dd811))
+- **autocomplete:** remove useless \$hits variable ([#252](https://github.com/algolia/create-instantsearch-app/issues/252)) ([1b04e8d](https://github.com/algolia/create-instantsearch-app/commit/1b04e8d))
+- **cli:** Fix prompt typo ([#230](https://github.com/algolia/create-instantsearch-app/issues/230)) ([bf74d80](https://github.com/algolia/create-instantsearch-app/commit/bf74d80))
+- **deps:** update angular monorepo to v6.1.10 ([#287](https://github.com/algolia/create-instantsearch-app/issues/287)) ([173ae07](https://github.com/algolia/create-instantsearch-app/commit/173ae07))
+- **deps:** update angular monorepo to v6.1.7 ([#234](https://github.com/algolia/create-instantsearch-app/issues/234)) ([976612e](https://github.com/algolia/create-instantsearch-app/commit/976612e))
+- **deps:** update angular monorepo to v6.1.9 ([#269](https://github.com/algolia/create-instantsearch-app/issues/269)) ([f696ac0](https://github.com/algolia/create-instantsearch-app/commit/f696ac0))
+- **deps:** update dependency commander to v2.18.0 ([#235](https://github.com/algolia/create-instantsearch-app/issues/235)) ([ea3ab43](https://github.com/algolia/create-instantsearch-app/commit/ea3ab43))
+- **deps:** update dependency commander to v2.19.0 ([#288](https://github.com/algolia/create-instantsearch-app/issues/288)) ([4ab3fd3](https://github.com/algolia/create-instantsearch-app/commit/4ab3fd3))
+- **deps:** update dependency expo to v29.0.1 ([#249](https://github.com/algolia/create-instantsearch-app/issues/249)) ([9eed507](https://github.com/algolia/create-instantsearch-app/commit/9eed507))
+- **deps:** update dependency expo to v30 ([#241](https://github.com/algolia/create-instantsearch-app/issues/241)) ([45b7ae5](https://github.com/algolia/create-instantsearch-app/commit/45b7ae5))
+- **deps:** update dependency load-json-file to v5.1.0 ([#270](https://github.com/algolia/create-instantsearch-app/issues/270)) ([2c16283](https://github.com/algolia/create-instantsearch-app/commit/2c16283))
+- **deps:** update dependency metalsmith-ignore to v1 ([#242](https://github.com/algolia/create-instantsearch-app/issues/242)) ([2352281](https://github.com/algolia/create-instantsearch-app/commit/2352281))
+- **deps:** update dependency rxjs to v6.3.2 ([#236](https://github.com/algolia/create-instantsearch-app/issues/236)) ([950a737](https://github.com/algolia/create-instantsearch-app/commit/950a737))
+- **deps:** update dependency rxjs to v6.3.3 ([#271](https://github.com/algolia/create-instantsearch-app/issues/271)) ([a13c192](https://github.com/algolia/create-instantsearch-app/commit/a13c192))
+- **deps:** update dependency vue to v2.5.17 ([#176](https://github.com/algolia/create-instantsearch-app/issues/176)) ([99fd4c1](https://github.com/algolia/create-instantsearch-app/commit/99fd4c1))
+- **deps:** update react monorepo to v16.5.0 ([#238](https://github.com/algolia/create-instantsearch-app/issues/238)) ([cf5d036](https://github.com/algolia/create-instantsearch-app/commit/cf5d036))
+- **deps:** update react monorepo to v16.5.1 ([#251](https://github.com/algolia/create-instantsearch-app/issues/251)) ([0086764](https://github.com/algolia/create-instantsearch-app/commit/0086764))
+- **deps:** update react monorepo to v16.5.2 ([#272](https://github.com/algolia/create-instantsearch-app/issues/272)) ([8401d1b](https://github.com/algolia/create-instantsearch-app/commit/8401d1b))
+- **InstantSearch:** disable autofocus ([#257](https://github.com/algolia/create-instantsearch-app/issues/257)) ([ed1d98a](https://github.com/algolia/create-instantsearch-app/commit/ed1d98a))
+- **templates:** Add Vue ESLint config ([#240](https://github.com/algolia/create-instantsearch-app/issues/240)) ([c1a5ecf](https://github.com/algolia/create-instantsearch-app/commit/c1a5ecf))
 
 ### Features
 
-* **cli:** add default Algolia credentials ([#291](https://github.com/algolia/create-instantsearch-app/issues/291)) ([b3dc47f](https://github.com/algolia/create-instantsearch-app/commit/b3dc47f))
-* **react:** upgrade to react-scripts@2 ([#300](https://github.com/algolia/create-instantsearch-app/issues/300)) ([f8ac929](https://github.com/algolia/create-instantsearch-app/commit/f8ac929))
-
+- **cli:** add default Algolia credentials ([#291](https://github.com/algolia/create-instantsearch-app/issues/291)) ([b3dc47f](https://github.com/algolia/create-instantsearch-app/commit/b3dc47f))
+- **react:** upgrade to react-scripts@2 ([#300](https://github.com/algolia/create-instantsearch-app/issues/300)) ([f8ac929](https://github.com/algolia/create-instantsearch-app/commit/f8ac929))
 
 ### Reverts
 
-* fix(deps): update dependency react-native to v0.57.1 ([#250](https://github.com/algolia/create-instantsearch-app/issues/250)) ([24b1935](https://github.com/algolia/create-instantsearch-app/commit/24b1935))
-
-
+- fix(deps): update dependency react-native to v0.57.1 ([#250](https://github.com/algolia/create-instantsearch-app/issues/250)) ([24b1935](https://github.com/algolia/create-instantsearch-app/commit/24b1935))
 
 <a name="4.0.0"></a>
-# [4.0.0](https://github.com/algolia/create-instantsearch-app/compare/3.3.0...4.0.0) (2018-09-03)
 
+# [4.0.0](https://github.com/algolia/create-instantsearch-app/compare/3.3.0...4.0.0) (2018-09-03)
 
 ### Bug Fixes
 
-* **cli:** Update question for "Attribute to display" ([#149](https://github.com/algolia/create-instantsearch-app/issues/149)) ([1ccd5b9](https://github.com/algolia/create-instantsearch-app/commit/1ccd5b9))
-* **deps:** update dependency algoliasearch to v3.30.0 ([#174](https://github.com/algolia/create-instantsearch-app/issues/174)) ([1e9a2a1](https://github.com/algolia/create-instantsearch-app/commit/1e9a2a1))
-* **deps:** update dependency commander to v2.17.0 ([#175](https://github.com/algolia/create-instantsearch-app/issues/175)) ([08819c5](https://github.com/algolia/create-instantsearch-app/commit/08819c5))
-* **deps:** update dependency commander to v2.17.1 ([#191](https://github.com/algolia/create-instantsearch-app/issues/191)) ([f0beb2e](https://github.com/algolia/create-instantsearch-app/commit/f0beb2e))
-* **deps:** update dependency expo to v27.1.1 ([#163](https://github.com/algolia/create-instantsearch-app/issues/163)) ([4fbba69](https://github.com/algolia/create-instantsearch-app/commit/4fbba69))
-* **deps:** update dependency expo to v29 ([#155](https://github.com/algolia/create-instantsearch-app/issues/155)) ([53b63bb](https://github.com/algolia/create-instantsearch-app/commit/53b63bb))
-* **deps:** update dependency inquirer to v6.1.0 ([#192](https://github.com/algolia/create-instantsearch-app/issues/192)) ([493185e](https://github.com/algolia/create-instantsearch-app/commit/493185e))
-* **deps:** update dependency inquirer to v6.2.0 ([#217](https://github.com/algolia/create-instantsearch-app/issues/217)) ([08ee151](https://github.com/algolia/create-instantsearch-app/commit/08ee151))
-* **deps:** update dependency react-native to v0.56.0 ([#193](https://github.com/algolia/create-instantsearch-app/issues/193)) ([2826658](https://github.com/algolia/create-instantsearch-app/commit/2826658))
-* **deps:** update dependency react-scripts to v1.1.5 ([#218](https://github.com/algolia/create-instantsearch-app/issues/218)) ([4ca0ab9](https://github.com/algolia/create-instantsearch-app/commit/4ca0ab9))
-* **deps:** update dependency rxjs to v6.3.1 ([#228](https://github.com/algolia/create-instantsearch-app/issues/228)) ([5eb3149](https://github.com/algolia/create-instantsearch-app/commit/5eb3149))
-* **deps:** update react monorepo to v16.4.2 ([#177](https://github.com/algolia/create-instantsearch-app/issues/177)) ([c9cdb13](https://github.com/algolia/create-instantsearch-app/commit/c9cdb13))
-
+- **cli:** Update question for "Attribute to display" ([#149](https://github.com/algolia/create-instantsearch-app/issues/149)) ([1ccd5b9](https://github.com/algolia/create-instantsearch-app/commit/1ccd5b9))
+- **deps:** update dependency algoliasearch to v3.30.0 ([#174](https://github.com/algolia/create-instantsearch-app/issues/174)) ([1e9a2a1](https://github.com/algolia/create-instantsearch-app/commit/1e9a2a1))
+- **deps:** update dependency commander to v2.17.0 ([#175](https://github.com/algolia/create-instantsearch-app/issues/175)) ([08819c5](https://github.com/algolia/create-instantsearch-app/commit/08819c5))
+- **deps:** update dependency commander to v2.17.1 ([#191](https://github.com/algolia/create-instantsearch-app/issues/191)) ([f0beb2e](https://github.com/algolia/create-instantsearch-app/commit/f0beb2e))
+- **deps:** update dependency expo to v27.1.1 ([#163](https://github.com/algolia/create-instantsearch-app/issues/163)) ([4fbba69](https://github.com/algolia/create-instantsearch-app/commit/4fbba69))
+- **deps:** update dependency expo to v29 ([#155](https://github.com/algolia/create-instantsearch-app/issues/155)) ([53b63bb](https://github.com/algolia/create-instantsearch-app/commit/53b63bb))
+- **deps:** update dependency inquirer to v6.1.0 ([#192](https://github.com/algolia/create-instantsearch-app/issues/192)) ([493185e](https://github.com/algolia/create-instantsearch-app/commit/493185e))
+- **deps:** update dependency inquirer to v6.2.0 ([#217](https://github.com/algolia/create-instantsearch-app/issues/217)) ([08ee151](https://github.com/algolia/create-instantsearch-app/commit/08ee151))
+- **deps:** update dependency react-native to v0.56.0 ([#193](https://github.com/algolia/create-instantsearch-app/issues/193)) ([2826658](https://github.com/algolia/create-instantsearch-app/commit/2826658))
+- **deps:** update dependency react-scripts to v1.1.5 ([#218](https://github.com/algolia/create-instantsearch-app/issues/218)) ([4ca0ab9](https://github.com/algolia/create-instantsearch-app/commit/4ca0ab9))
+- **deps:** update dependency rxjs to v6.3.1 ([#228](https://github.com/algolia/create-instantsearch-app/issues/228)) ([5eb3149](https://github.com/algolia/create-instantsearch-app/commit/5eb3149))
+- **deps:** update react monorepo to v16.4.2 ([#177](https://github.com/algolia/create-instantsearch-app/issues/177)) ([c9cdb13](https://github.com/algolia/create-instantsearch-app/commit/c9cdb13))
 
 ### Features
 
-* **cli:** Accept multiple attributes to display ([#153](https://github.com/algolia/create-instantsearch-app/issues/153)) ([0b93202](https://github.com/algolia/create-instantsearch-app/commit/0b93202)), closes [#151](https://github.com/algolia/create-instantsearch-app/issues/151)
-
+- **cli:** Accept multiple attributes to display ([#153](https://github.com/algolia/create-instantsearch-app/issues/153)) ([0b93202](https://github.com/algolia/create-instantsearch-app/commit/0b93202)), closes [#151](https://github.com/algolia/create-instantsearch-app/issues/151)
 
 ### Reverts
 
-* fix(deps): update dependency react-native to v0.56.0 ([#193](https://github.com/algolia/create-instantsearch-app/issues/193)) ([#229](https://github.com/algolia/create-instantsearch-app/issues/229)) ([14d2e58](https://github.com/algolia/create-instantsearch-app/commit/14d2e58))
-
+- fix(deps): update dependency react-native to v0.56.0 ([#193](https://github.com/algolia/create-instantsearch-app/issues/193)) ([#229](https://github.com/algolia/create-instantsearch-app/issues/229)) ([14d2e58](https://github.com/algolia/create-instantsearch-app/commit/14d2e58))
 
 ### BREAKING CHANGES
 
-* **cli:** The option `mainAttribute` has been renamed `attributesToDisplay` and now accepts multiple attributes.
-
-
+- **cli:** The option `mainAttribute` has been renamed `attributesToDisplay` and now accepts multiple attributes.
 
 <a name="3.3.0"></a>
+
 # [3.3.0](https://github.com/algolia/create-instantsearch-app/compare/3.2.0...3.3.0) (2018-07-24)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency metalsmith-in-place to v4.2.0 ([#146](https://github.com/algolia/create-instantsearch-app/issues/146)) ([a7dc371](https://github.com/algolia/create-instantsearch-app/commit/a7dc371))
-
+- **deps:** update dependency metalsmith-in-place to v4.2.0 ([#146](https://github.com/algolia/create-instantsearch-app/issues/146)) ([a7dc371](https://github.com/algolia/create-instantsearch-app/commit/a7dc371))
 
 ### Features
 
-* **templates:** Update InstantSearch.js to 2.9.0 ([b36ce30](https://github.com/algolia/create-instantsearch-app/commit/b36ce30))
-
-
+- **templates:** Update InstantSearch.js to 2.9.0 ([b36ce30](https://github.com/algolia/create-instantsearch-app/commit/b36ce30))
 
 <a name="3.2.0"></a>
-# [3.2.0](https://github.com/algolia/create-instantsearch-app/compare/3.1.0...3.2.0) (2018-07-19)
 
+# [3.2.0](https://github.com/algolia/create-instantsearch-app/compare/3.1.0...3.2.0) (2018-07-19)
 
 ### Bug Fixes
 
-* **deps:** update dependency algoliasearch to v3.29.0 ([#106](https://github.com/algolia/create-instantsearch-app/issues/106)) ([73f64f3](https://github.com/algolia/create-instantsearch-app/commit/73f64f3))
-* **deps:** update dependency commander to v2.16.0 ([#107](https://github.com/algolia/create-instantsearch-app/issues/107)) ([6c31090](https://github.com/algolia/create-instantsearch-app/commit/6c31090))
-* **deps:** update dependency inquirer to v6 ([#127](https://github.com/algolia/create-instantsearch-app/issues/127)) ([185c2a3](https://github.com/algolia/create-instantsearch-app/commit/185c2a3))
-* **deps:** update dependency react to v16.4.1 ([#133](https://github.com/algolia/create-instantsearch-app/issues/133)) ([fe5090f](https://github.com/algolia/create-instantsearch-app/commit/fe5090f))
-* **deps:** update dependency react-native to v0.56.0 ([#134](https://github.com/algolia/create-instantsearch-app/issues/134)) ([c578859](https://github.com/algolia/create-instantsearch-app/commit/c578859))
-* **deps:** update dependency rxjs to v6.2.2 ([#135](https://github.com/algolia/create-instantsearch-app/issues/135)) ([15429d6](https://github.com/algolia/create-instantsearch-app/commit/15429d6))
-* **templates:** Fix failing default tests in Angular ([#138](https://github.com/algolia/create-instantsearch-app/issues/138)) ([2974e98](https://github.com/algolia/create-instantsearch-app/commit/2974e98))
-* **templates:** Use single quotes in Angular ([#137](https://github.com/algolia/create-instantsearch-app/issues/137)) ([b461f86](https://github.com/algolia/create-instantsearch-app/commit/b461f86))
-
+- **deps:** update dependency algoliasearch to v3.29.0 ([#106](https://github.com/algolia/create-instantsearch-app/issues/106)) ([73f64f3](https://github.com/algolia/create-instantsearch-app/commit/73f64f3))
+- **deps:** update dependency commander to v2.16.0 ([#107](https://github.com/algolia/create-instantsearch-app/issues/107)) ([6c31090](https://github.com/algolia/create-instantsearch-app/commit/6c31090))
+- **deps:** update dependency inquirer to v6 ([#127](https://github.com/algolia/create-instantsearch-app/issues/127)) ([185c2a3](https://github.com/algolia/create-instantsearch-app/commit/185c2a3))
+- **deps:** update dependency react to v16.4.1 ([#133](https://github.com/algolia/create-instantsearch-app/issues/133)) ([fe5090f](https://github.com/algolia/create-instantsearch-app/commit/fe5090f))
+- **deps:** update dependency react-native to v0.56.0 ([#134](https://github.com/algolia/create-instantsearch-app/issues/134)) ([c578859](https://github.com/algolia/create-instantsearch-app/commit/c578859))
+- **deps:** update dependency rxjs to v6.2.2 ([#135](https://github.com/algolia/create-instantsearch-app/issues/135)) ([15429d6](https://github.com/algolia/create-instantsearch-app/commit/15429d6))
+- **templates:** Fix failing default tests in Angular ([#138](https://github.com/algolia/create-instantsearch-app/issues/138)) ([2974e98](https://github.com/algolia/create-instantsearch-app/commit/2974e98))
+- **templates:** Use single quotes in Angular ([#137](https://github.com/algolia/create-instantsearch-app/issues/137)) ([b461f86](https://github.com/algolia/create-instantsearch-app/commit/b461f86))
 
 ### Features
 
-* **templates:** Add types for AlgoliaSearch in Angular ([#116](https://github.com/algolia/create-instantsearch-app/issues/116)) ([63ab3c1](https://github.com/algolia/create-instantsearch-app/commit/63ab3c1))
-* **templates:** Reorder Angular `devDependencies` ([#115](https://github.com/algolia/create-instantsearch-app/issues/115)) ([2fd585a](https://github.com/algolia/create-instantsearch-app/commit/2fd585a))
-* **templates:** Use `searchClient` in Angular ([#114](https://github.com/algolia/create-instantsearch-app/issues/114)) ([6b6cb2f](https://github.com/algolia/create-instantsearch-app/commit/6b6cb2f))
-* **templates:** Use `searchClient` in React ([#113](https://github.com/algolia/create-instantsearch-app/issues/113)) ([33e646c](https://github.com/algolia/create-instantsearch-app/commit/33e646c))
-
+- **templates:** Add types for AlgoliaSearch in Angular ([#116](https://github.com/algolia/create-instantsearch-app/issues/116)) ([63ab3c1](https://github.com/algolia/create-instantsearch-app/commit/63ab3c1))
+- **templates:** Reorder Angular `devDependencies` ([#115](https://github.com/algolia/create-instantsearch-app/issues/115)) ([2fd585a](https://github.com/algolia/create-instantsearch-app/commit/2fd585a))
+- **templates:** Use `searchClient` in Angular ([#114](https://github.com/algolia/create-instantsearch-app/issues/114)) ([6b6cb2f](https://github.com/algolia/create-instantsearch-app/commit/6b6cb2f))
+- **templates:** Use `searchClient` in React ([#113](https://github.com/algolia/create-instantsearch-app/issues/113)) ([33e646c](https://github.com/algolia/create-instantsearch-app/commit/33e646c))
 
 ### Reverts
 
-* chore(deps): update dependency typescript to v2.9.2 ([#132](https://github.com/algolia/create-instantsearch-app/issues/132)) ([1c0819b](https://github.com/algolia/create-instantsearch-app/commit/1c0819b))
-
-
+- chore(deps): update dependency typescript to v2.9.2 ([#132](https://github.com/algolia/create-instantsearch-app/issues/132)) ([1c0819b](https://github.com/algolia/create-instantsearch-app/commit/1c0819b))
 
 <a name="3.1.0"></a>
+
 # [3.1.0](https://github.com/algolia/create-instantsearch-app/compare/3.0.0...3.1.0) (2018-07-05)
 
-
 ### Bug Fixes
 
-* **cli:** Remove command shortcuts ([#67](https://github.com/algolia/create-instantsearch-app/issues/67)) ([4bc6ba1](https://github.com/algolia/create-instantsearch-app/commit/4bc6ba1))
-* **ios:** run pod repo update before install ([#72](https://github.com/algolia/create-instantsearch-app/issues/72)) ([1d10805](https://github.com/algolia/create-instantsearch-app/commit/1d10805))
-* **templates:** Pin library dependencies ([#79](https://github.com/algolia/create-instantsearch-app/issues/79)) ([8ea5a77](https://github.com/algolia/create-instantsearch-app/commit/8ea5a77))
-
+- **cli:** Remove command shortcuts ([#67](https://github.com/algolia/create-instantsearch-app/issues/67)) ([4bc6ba1](https://github.com/algolia/create-instantsearch-app/commit/4bc6ba1))
+- **ios:** run pod repo update before install ([#72](https://github.com/algolia/create-instantsearch-app/issues/72)) ([1d10805](https://github.com/algolia/create-instantsearch-app/commit/1d10805))
+- **templates:** Pin library dependencies ([#79](https://github.com/algolia/create-instantsearch-app/issues/79)) ([8ea5a77](https://github.com/algolia/create-instantsearch-app/commit/8ea5a77))
 
 ### Features
 
-* **cli:**  Add template categories ([#76](https://github.com/algolia/create-instantsearch-app/issues/76)) ([a04e9c6](https://github.com/algolia/create-instantsearch-app/commit/a04e9c6))
-* **cli:** Add empty lines before intro line ([b4b4fcc](https://github.com/algolia/create-instantsearch-app/commit/b4b4fcc))
-* **templates:** Add Android template ([#73](https://github.com/algolia/create-instantsearch-app/issues/73)) ([d35e9c9](https://github.com/algolia/create-instantsearch-app/commit/d35e9c9))
-* **templates:** Add Autocomplete.js template ([#80](https://github.com/algolia/create-instantsearch-app/issues/80)) ([fe9a51c](https://github.com/algolia/create-instantsearch-app/commit/fe9a51c))
-* **templates:** Add iOS template ([#69](https://github.com/algolia/create-instantsearch-app/issues/69)) ([aa061f8](https://github.com/algolia/create-instantsearch-app/commit/aa061f8))
-* **templates:** Add JavaScript Client template ([#77](https://github.com/algolia/create-instantsearch-app/issues/77)) ([1dc0d03](https://github.com/algolia/create-instantsearch-app/commit/1dc0d03))
-* **templates:** Add JavaScript Helper template ([#78](https://github.com/algolia/create-instantsearch-app/issues/78)) ([34d0e94](https://github.com/algolia/create-instantsearch-app/commit/34d0e94))
-
-
+- **cli:** Add template categories ([#76](https://github.com/algolia/create-instantsearch-app/issues/76)) ([a04e9c6](https://github.com/algolia/create-instantsearch-app/commit/a04e9c6))
+- **cli:** Add empty lines before intro line ([b4b4fcc](https://github.com/algolia/create-instantsearch-app/commit/b4b4fcc))
+- **templates:** Add Android template ([#73](https://github.com/algolia/create-instantsearch-app/issues/73)) ([d35e9c9](https://github.com/algolia/create-instantsearch-app/commit/d35e9c9))
+- **templates:** Add Autocomplete.js template ([#80](https://github.com/algolia/create-instantsearch-app/issues/80)) ([fe9a51c](https://github.com/algolia/create-instantsearch-app/commit/fe9a51c))
+- **templates:** Add iOS template ([#69](https://github.com/algolia/create-instantsearch-app/issues/69)) ([aa061f8](https://github.com/algolia/create-instantsearch-app/commit/aa061f8))
+- **templates:** Add JavaScript Client template ([#77](https://github.com/algolia/create-instantsearch-app/issues/77)) ([1dc0d03](https://github.com/algolia/create-instantsearch-app/commit/1dc0d03))
+- **templates:** Add JavaScript Helper template ([#78](https://github.com/algolia/create-instantsearch-app/issues/78)) ([34d0e94](https://github.com/algolia/create-instantsearch-app/commit/34d0e94))
 
 <a name="3.0.0"></a>
+
 # [3.0.0](https://github.com/algolia/create-instantsearch-app/compare/3.0.0-beta.5...3.0.0) (2018-06-18)
 
-
 ### Bug Fixes
 
-* **cli:** Use latest version when stable unavailable ([#57](https://github.com/algolia/create-instantsearch-app/issues/57)) ([e764cd5](https://github.com/algolia/create-instantsearch-app/commit/e764cd5))
-
-
+- **cli:** Use latest version when stable unavailable ([#57](https://github.com/algolia/create-instantsearch-app/issues/57)) ([e764cd5](https://github.com/algolia/create-instantsearch-app/commit/e764cd5))
 
 <a name="3.0.0-beta.5"></a>
+
 # [3.0.0-beta.5](https://github.com/algolia/create-instantsearch-app/compare/3.0.0-beta.4...3.0.0-beta.5) (2018-06-15)
 
-
 ### Features
 
-* **templates:** Update Parcel on InstantSearch.js template ([2f9d529](https://github.com/algolia/create-instantsearch-app/commit/2f9d529))
-
-
+- **templates:** Update Parcel on InstantSearch.js template ([2f9d529](https://github.com/algolia/create-instantsearch-app/commit/2f9d529))
 
 <a name="3.0.0-beta.4"></a>
+
 # [3.0.0-beta.4](https://github.com/algolia/create-instantsearch-app/compare/3.0.0-beta.3...3.0.0-beta.4) (2018-06-15)
 
-
 ### Bug Fixes
 
-* **cli:** Fallback on latest version when stable unavailable ([#50](https://github.com/algolia/create-instantsearch-app/issues/50)) ([0bd64a2](https://github.com/algolia/create-instantsearch-app/commit/0bd64a2))
-
+- **cli:** Fallback on latest version when stable unavailable ([#50](https://github.com/algolia/create-instantsearch-app/issues/50)) ([0bd64a2](https://github.com/algolia/create-instantsearch-app/commit/0bd64a2))
 
 ### Features
 
-* **cli:** Print relative cd path ([#45](https://github.com/algolia/create-instantsearch-app/issues/45)) ([37907e1](https://github.com/algolia/create-instantsearch-app/commit/37907e1))
-* **cli:** Recommend attributes to display in hits ([#43](https://github.com/algolia/create-instantsearch-app/issues/43)) ([0d9cb6a](https://github.com/algolia/create-instantsearch-app/commit/0d9cb6a))
-* **task:** Ignore error log when user aborts during installation ([#42](https://github.com/algolia/create-instantsearch-app/issues/42)) ([9e99aad](https://github.com/algolia/create-instantsearch-app/commit/9e99aad))
-* **template:** Use default IS import from jsDelivr ([#46](https://github.com/algolia/create-instantsearch-app/issues/46)) ([8e0c54b](https://github.com/algolia/create-instantsearch-app/commit/8e0c54b))
-* **templates:** Add React Native template ([#53](https://github.com/algolia/create-instantsearch-app/issues/53)) ([8b14d31](https://github.com/algolia/create-instantsearch-app/commit/8b14d31))
-* **templates:** Warn facets usage with React Native template ([#56](https://github.com/algolia/create-instantsearch-app/issues/56)) ([6502feb](https://github.com/algolia/create-instantsearch-app/commit/6502feb))
-
-
+- **cli:** Print relative cd path ([#45](https://github.com/algolia/create-instantsearch-app/issues/45)) ([37907e1](https://github.com/algolia/create-instantsearch-app/commit/37907e1))
+- **cli:** Recommend attributes to display in hits ([#43](https://github.com/algolia/create-instantsearch-app/issues/43)) ([0d9cb6a](https://github.com/algolia/create-instantsearch-app/commit/0d9cb6a))
+- **task:** Ignore error log when user aborts during installation ([#42](https://github.com/algolia/create-instantsearch-app/issues/42)) ([9e99aad](https://github.com/algolia/create-instantsearch-app/commit/9e99aad))
+- **template:** Use default IS import from jsDelivr ([#46](https://github.com/algolia/create-instantsearch-app/issues/46)) ([8e0c54b](https://github.com/algolia/create-instantsearch-app/commit/8e0c54b))
+- **templates:** Add React Native template ([#53](https://github.com/algolia/create-instantsearch-app/issues/53)) ([8b14d31](https://github.com/algolia/create-instantsearch-app/commit/8b14d31))
+- **templates:** Warn facets usage with React Native template ([#56](https://github.com/algolia/create-instantsearch-app/issues/56)) ([6502feb](https://github.com/algolia/create-instantsearch-app/commit/6502feb))
 
 <a name="3.0.0-beta.3"></a>
+
 # [3.0.0-beta.3](https://github.com/algolia/create-instantsearch-app/compare/3.0.0-beta.1...3.0.0-beta.3) (2018-06-11)
 
-
 ### Bug Fixes
 
-* **templates:** Remove empty div when no facets ([#38](https://github.com/algolia/create-instantsearch-app/issues/38)) ([f860c2c](https://github.com/algolia/create-instantsearch-app/commit/f860c2c))
-
+- **templates:** Remove empty div when no facets ([#38](https://github.com/algolia/create-instantsearch-app/issues/38)) ([f860c2c](https://github.com/algolia/create-instantsearch-app/commit/f860c2c))
 
 ### Features
 
-* **release:** Set up `release-it` for releasing ([#40](https://github.com/algolia/create-instantsearch-app/issues/40)) ([054a755](https://github.com/algolia/create-instantsearch-app/commit/054a755))
-* **templates:** Add config files ([#39](https://github.com/algolia/create-instantsearch-app/issues/39)) ([b34b49b](https://github.com/algolia/create-instantsearch-app/commit/b34b49b)), closes [#34](https://github.com/algolia/create-instantsearch-app/issues/34)
-
-
+- **release:** Set up `release-it` for releasing ([#40](https://github.com/algolia/create-instantsearch-app/issues/40)) ([054a755](https://github.com/algolia/create-instantsearch-app/commit/054a755))
+- **templates:** Add config files ([#39](https://github.com/algolia/create-instantsearch-app/issues/39)) ([b34b49b](https://github.com/algolia/create-instantsearch-app/commit/b34b49b)), closes [#34](https://github.com/algolia/create-instantsearch-app/issues/34)
 
 <a name="3.0.0-beta.1"></a>
+
 # [3.0.0-beta.1](https://github.com/algolia/create-instantsearch-app/compare/3.0.0-beta.0...3.0.0-beta.1) (2018-06-05)
 
-
 ### Features
 
-* **cli:** Move hashbang to `index.js` ([fd70338](https://github.com/algolia/create-instantsearch-app/commit/fd70338))
-
-
+- **cli:** Move hashbang to `index.js` ([fd70338](https://github.com/algolia/create-instantsearch-app/commit/fd70338))
 
 <a name="3.0.0-beta.0"></a>
-# [3.0.0-beta.0](https://github.com/algolia/create-instantsearch-app/compare/2.3.0...3.0.0-beta.0) (2018-06-05)
 
+# [3.0.0-beta.0](https://github.com/algolia/create-instantsearch-app/compare/2.3.0...3.0.0-beta.0) (2018-06-05)
 
 ### Features
 
-* **api:** Create InstantSearch App v3 ([#10](https://github.com/algolia/create-instantsearch-app/issues/10)) ([8833cfb](https://github.com/algolia/create-instantsearch-app/commit/8833cfb)), closes [#9](https://github.com/algolia/create-instantsearch-app/issues/9) [#30](https://github.com/algolia/create-instantsearch-app/issues/30) [#14](https://github.com/algolia/create-instantsearch-app/issues/14) [#22](https://github.com/algolia/create-instantsearch-app/issues/22) [#26](https://github.com/algolia/create-instantsearch-app/issues/26) [#27](https://github.com/algolia/create-instantsearch-app/issues/27) [#28](https://github.com/algolia/create-instantsearch-app/issues/28)
-
-
+- **api:** Create InstantSearch App v3 ([#10](https://github.com/algolia/create-instantsearch-app/issues/10)) ([8833cfb](https://github.com/algolia/create-instantsearch-app/commit/8833cfb)), closes [#9](https://github.com/algolia/create-instantsearch-app/issues/9) [#30](https://github.com/algolia/create-instantsearch-app/issues/30) [#14](https://github.com/algolia/create-instantsearch-app/issues/14) [#22](https://github.com/algolia/create-instantsearch-app/issues/22) [#26](https://github.com/algolia/create-instantsearch-app/issues/26) [#27](https://github.com/algolia/create-instantsearch-app/issues/27) [#28](https://github.com/algolia/create-instantsearch-app/issues/28)
 
 <a name="2.3.0"></a>
-# [2.3.0](https://github.com/algolia/create-instantsearch-app/compare/2.2.0...2.3.0) (2018-02-01)
 
+# [2.3.0](https://github.com/algolia/create-instantsearch-app/compare/2.2.0...2.3.0) (2018-02-01)
 
 ### Bug Fixes
 
-* **boilerplate:** minor HTML fixes ([#6](https://github.com/algolia/create-instantsearch-app/issues/6)) ([51c00a4](https://github.com/algolia/create-instantsearch-app/commit/51c00a4))
-
+- **boilerplate:** minor HTML fixes ([#6](https://github.com/algolia/create-instantsearch-app/issues/6)) ([51c00a4](https://github.com/algolia/create-instantsearch-app/commit/51c00a4))
 
 ### Features
 
-* **version:** add dynamic versioning ([#8](https://github.com/algolia/create-instantsearch-app/issues/8)) ([decf54c](https://github.com/algolia/create-instantsearch-app/commit/decf54c)), closes [#1](https://github.com/algolia/create-instantsearch-app/issues/1)
-
-
+- **version:** add dynamic versioning ([#8](https://github.com/algolia/create-instantsearch-app/issues/8)) ([decf54c](https://github.com/algolia/create-instantsearch-app/commit/decf54c)), closes [#1](https://github.com/algolia/create-instantsearch-app/issues/1)
 
 <a name="2.2.0"></a>
-# [2.2.0](https://github.com/algolia/create-instantsearch-app/compare/d7693d6...2.2.0) (2017-09-01)
 
+# [2.2.0](https://github.com/algolia/create-instantsearch-app/compare/d7693d6...2.2.0) (2017-09-01)
 
 ### Features
 
-* can create new basic instantsearch.js projects ([d7693d6](https://github.com/algolia/create-instantsearch-app/commit/d7693d6))
-* **boilerplate:** add server to vanilla instantsearch.js ([02eb820](https://github.com/algolia/create-instantsearch-app/commit/02eb820))
-* **boilerplate:** configuration of the new app by the script ([da6758c](https://github.com/algolia/create-instantsearch-app/commit/da6758c))
-* **cli:** added config handling ([00d0a40](https://github.com/algolia/create-instantsearch-app/commit/00d0a40))
+- can create new basic instantsearch.js projects ([d7693d6](https://github.com/algolia/create-instantsearch-app/commit/d7693d6))
+- **boilerplate:** add server to vanilla instantsearch.js ([02eb820](https://github.com/algolia/create-instantsearch-app/commit/02eb820))
+- **boilerplate:** configuration of the new app by the script ([da6758c](https://github.com/algolia/create-instantsearch-app/commit/da6758c))
+- **cli:** added config handling ([00d0a40](https://github.com/algolia/create-instantsearch-app/commit/00d0a40))

--- a/packages/create-instantsearch-app/README.md
+++ b/packages/create-instantsearch-app/README.md
@@ -16,7 +16,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Get started](#get-started)
 - [Usage](#usage)
 - [API](#api)
@@ -180,7 +179,7 @@ Create InstantSearch App is [MIT licensed](LICENSE).
 [version-svg]: https://img.shields.io/npm/v/create-instantsearch-app.svg?style=flat-square
 [package-url]: https://npmjs.org/package/create-instantsearch-app
 [ci-svg]: https://img.shields.io/circleci/project/github/algolia/create-instantsearch-app.svg?style=flat-square
-[ci-url]: https://circleci.com/gh/algolia/instantsearch.js
+[ci-url]: https://circleci.com/gh/algolia/instantsearch
 [license-image]: https://img.shields.io/badge/license-MIT-green.svg?style=flat-square
 [license-url]: LICENSE
 

--- a/packages/instantsearch.css/CHANGELOG.md
+++ b/packages/instantsearch.css/CHANGELOG.md
@@ -1,16 +1,11 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [8.0.0](https://github.com/algolia/instantsearch.js/compare/instantsearch.css@7.4.5...instantsearch.css@8.0.0) (2023-01-03)
+## [8.0.0](https://github.com/algolia/instantsearch/compare/instantsearch.css@7.4.5...instantsearch.css@8.0.0) (2023-01-03)
 
 ### BREAKING CHANGES
 
-* Vendor prefixes are updated to reflect latest browser usage
-
-
-
-
+- Vendor prefixes are updated to reflect latest browser usage
 
 See [previous releases](https://github.com/algolia/instantsearch-specs/releases).

--- a/packages/instantsearch.css/README.md
+++ b/packages/instantsearch.css/README.md
@@ -1,7 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Getting started](#getting-started)
 - [Installation](#installation)
 - [Available themes](#available-themes)
@@ -90,7 +89,7 @@ To start contributing to code, you need to:
 1.  [Clone the repository](https://help.github.com/articles/cloning-a-repository/)
 1.  Install the dependencies: `yarn`
 
-Please read [our contribution process](https://github.com/algolia/instantsearch.js/blob/master/CONTRIBUTING.md) to learn more.
+Please read [our contribution process](https://github.com/algolia/instantsearch/blob/master/CONTRIBUTING.md) to learn more.
 
 ## License
 
@@ -100,8 +99,8 @@ InstantSearch.css is [MIT licensed][license-url].
 
 [version-svg]: https://img.shields.io/npm/v/instantsearch.css.svg?style=flat-square
 [package-url]: https://npmjs.org/package/instantsearch.css
-[ci-svg]: https://img.shields.io/circleci/project/github/algolia/instantsearch.js.svg?style=flat-square
-[ci-url]: https://circleci.com/gh/algolia/instantsearch.js
+[ci-svg]: https://img.shields.io/circleci/project/github/algolia/instantsearch.svg?style=flat-square
+[ci-url]: https://circleci.com/gh/algolia/instantsearch
 [license-image]: http://img.shields.io/badge/license-MIT-green.svg?style=flat-square
 [website-svg]: https://img.shields.io/badge/website-instantsearchjs.netlify.app/specs-yellow?style=flat-square
 [website-url]: https://instantsearchjs.netlify.app/specs/
@@ -109,9 +108,9 @@ InstantSearch.css is [MIT licensed][license-url].
 
 <!-- Links -->
 
-[contributing-bugreport]: https://github.com/algolia/instantsearch.js/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20InstantSearch.css
-[contributing-featurerequest]: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage,Library%3A%20InstantSearch.css&title=Feature%20request%3A%20
-[contributing-newissue]: https://github.com/algolia/instantsearch.js/issues/new?labels=triage,Library%3A%20InstantSearch.css
-[contributing-label-easy]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20InstantSearch.css%22
-[contributing-label-bug]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20InstantSearch.css%22
-[contributing-label-chore]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20InstantSearch.css%22
+[contributing-bugreport]: https://github.com/algolia/instantsearch/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20InstantSearch.css
+[contributing-featurerequest]: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage,Library%3A%20InstantSearch.css&title=Feature%20request%3A%20
+[contributing-newissue]: https://github.com/algolia/instantsearch/issues/new?labels=triage,Library%3A%20InstantSearch.css
+[contributing-label-easy]: https://github.com/algolia/instantsearch/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20InstantSearch.css%22
+[contributing-label-bug]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20InstantSearch.css%22
+[contributing-label-chore]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20InstantSearch.css%22

--- a/packages/instantsearch.css/package.json
+++ b/packages/instantsearch.css/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/algolia/instantsearch.js"
+    "url": "https://github.com/algolia/instantsearch"
   },
   "license": "MIT",
   "author": "Algolia <support@algolia.com>",

--- a/packages/instantsearch.js/.storybook/config.ts
+++ b/packages/instantsearch.js/.storybook/config.ts
@@ -19,7 +19,7 @@ addParameters({
     theme: create({
       base: 'light',
       brandTitle: 'InstantSearch.js',
-      brandUrl: 'https://github.com/algolia/instantsearch.js',
+      brandUrl: 'https://github.com/algolia/instantsearch',
     }),
     panelPosition: 'bottom',
     storySort(a: any[], b: any[]) {
@@ -38,7 +38,7 @@ addParameters({
 const req = require.context('../stories', true, /.stories.(js|ts|tsx)$/);
 
 function loadStories() {
-  req.keys().forEach(filename => req(filename));
+  req.keys().forEach((filename) => req(filename));
 }
 
 configure(loadStories, module);

--- a/packages/instantsearch.js/CHANGELOG.md
+++ b/packages/instantsearch.js/CHANGELOG.md
@@ -1,1452 +1,1005 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [4.56.10](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.56.9...instantsearch.js@4.56.10) (2023-09-05)
-
+## [4.56.10](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.9...instantsearch.js@4.56.10) (2023-09-05)
 
 ### Bug Fixes
 
-* **server:** allow detached index (no rootIndexName) in SSR ([#5832](https://github.com/algolia/instantsearch.js/issues/5832)) ([bed6c5f](https://github.com/algolia/instantsearch.js/commit/bed6c5fd003da7ba85618cd5f2fb4ff1e60c50f9)), closes [#5831](https://github.com/algolia/instantsearch.js/issues/5831)
+- **server:** allow detached index (no rootIndexName) in SSR ([#5832](https://github.com/algolia/instantsearch/issues/5832)) ([bed6c5f](https://github.com/algolia/instantsearch/commit/bed6c5fd003da7ba85618cd5f2fb4ff1e60c50f9)), closes [#5831](https://github.com/algolia/instantsearch/issues/5831)
 
+## [4.56.9](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.8...instantsearch.js@4.56.9) (2023-08-08)
 
-
-
-
-## [4.56.9](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.56.8...instantsearch.js@4.56.9) (2023-08-08)
-
+## [4.56.9](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.8...instantsearch.js@4.56.9) (2023-08-08)
 
 ### Bug Fixes
 
-* **pagination:** correctly use 1-based pagination in createURL ([#5798](https://github.com/algolia/instantsearch.js/issues/5798)) ([69ec7de](https://github.com/algolia/instantsearch.js/commit/69ec7deba05a60a223b833c6a117d5a0f2e83012))
+- **pagination:** correctly use 1-based pagination in createURL ([#5798](https://github.com/algolia/instantsearch/issues/5798)) ([69ec7de](https://github.com/algolia/instantsearch/commit/69ec7deba05a60a223b833c6a117d5a0f2e83012))
 
-
-## [4.56.8](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.56.7...instantsearch.js@4.56.8) (2023-07-25)
+## [4.56.8](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.7...instantsearch.js@4.56.8) (2023-07-25)
 
 **Note:** Version bump only for package instantsearch.js
 
-
-
-
-
-## [4.56.7](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.56.6...instantsearch.js@4.56.7) (2023-07-19)
-
+## [4.56.7](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.6...instantsearch.js@4.56.7) (2023-07-19)
 
 ### Bug Fixes
 
-* **instantsearch:** keep algoliasearch-helper as external dependency during build ([#5765](https://github.com/algolia/instantsearch.js/issues/5765)) ([550fefa](https://github.com/algolia/instantsearch.js/commit/550fefa1401773f38dedc20322513ae662faa25d))
+- **instantsearch:** keep algoliasearch-helper as external dependency during build ([#5765](https://github.com/algolia/instantsearch/issues/5765)) ([550fefa](https://github.com/algolia/instantsearch/commit/550fefa1401773f38dedc20322513ae662faa25d))
 
-
-
-
-
-## [4.56.6](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.56.5...instantsearch.js@4.56.6) (2023-07-18)
+## [4.56.6](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.5...instantsearch.js@4.56.6) (2023-07-18)
 
 **Note:** Version bump only for package instantsearch.js
 
-
-
-
-
-## [4.56.5](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.56.4...instantsearch.js@4.56.5) (2023-07-10)
-
+## [4.56.5](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.4...instantsearch.js@4.56.5) (2023-07-10)
 
 ### Bug Fixes
 
-* **url:** base createURL on UiState instead of SearchParameters ([#5696](https://github.com/algolia/instantsearch.js/issues/5696)) ([7e2c8a2](https://github.com/algolia/instantsearch.js/commit/7e2c8a295a6fc5ba36d9482f645ef55b422d5e75)), closes [#5694](https://github.com/algolia/instantsearch.js/issues/5694)
+- **url:** base createURL on UiState instead of SearchParameters ([#5696](https://github.com/algolia/instantsearch/issues/5696)) ([7e2c8a2](https://github.com/algolia/instantsearch/commit/7e2c8a295a6fc5ba36d9482f645ef55b422d5e75)), closes [#5694](https://github.com/algolia/instantsearch/issues/5694)
 
-
-
-
-
-## [4.56.4](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.56.3...instantsearch.js@4.56.4) (2023-07-04)
-
+## [4.56.4](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.3...instantsearch.js@4.56.4) (2023-07-04)
 
 ### Bug Fixes
 
-* **router:** do not update ui state if there are no widgets ([#5692](https://github.com/algolia/instantsearch.js/issues/5692)) ([ba8199f](https://github.com/algolia/instantsearch.js/commit/ba8199fe8deed9539619c6f7d65d299358979c49))
+- **router:** do not update ui state if there are no widgets ([#5692](https://github.com/algolia/instantsearch/issues/5692)) ([ba8199f](https://github.com/algolia/instantsearch/commit/ba8199fe8deed9539619c6f7d65d299358979c49))
 
-
-
-
-
-## [4.56.3](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.56.2...instantsearch.js@4.56.3) (2023-06-20)
-
+## [4.56.3](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.2...instantsearch.js@4.56.3) (2023-06-20)
 
 ### Bug Fixes
 
-* **dependencies:** update helper requirement ([#5676](https://github.com/algolia/instantsearch.js/issues/5676)) ([c289120](https://github.com/algolia/instantsearch.js/commit/c2891205c1125b1203b3b3db946d57e0fc4e4687)), closes [#5658](https://github.com/algolia/instantsearch.js/issues/5658)
-* **insights:** delay usertoken updates if received after init ([#5681](https://github.com/algolia/instantsearch.js/issues/5681)) ([0fe653e](https://github.com/algolia/instantsearch.js/commit/0fe653eab2403f39879886b7d77b52a7214f528d))
+- **dependencies:** update helper requirement ([#5676](https://github.com/algolia/instantsearch/issues/5676)) ([c289120](https://github.com/algolia/instantsearch/commit/c2891205c1125b1203b3b3db946d57e0fc4e4687)), closes [#5658](https://github.com/algolia/instantsearch/issues/5658)
+- **insights:** delay usertoken updates if received after init ([#5681](https://github.com/algolia/instantsearch/issues/5681)) ([0fe653e](https://github.com/algolia/instantsearch/commit/0fe653eab2403f39879886b7d77b52a7214f528d))
 
-
-
-
-
-## [4.56.2](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.56.1...instantsearch.js@4.56.2) (2023-06-13)
-
+## [4.56.2](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.1...instantsearch.js@4.56.2) (2023-06-13)
 
 ### Bug Fixes
 
-* **infiniteHits:** correctly avoid writing to cache when dynamicWidgets has no facets in the results ([#5669](https://github.com/algolia/instantsearch.js/issues/5669)) ([2eec37e](https://github.com/algolia/instantsearch.js/commit/2eec37e2bf70c4745577883fb1716dfe6ddce936)), closes [#5620](https://github.com/algolia/instantsearch.js/issues/5620)
+- **infiniteHits:** correctly avoid writing to cache when dynamicWidgets has no facets in the results ([#5669](https://github.com/algolia/instantsearch/issues/5669)) ([2eec37e](https://github.com/algolia/instantsearch/commit/2eec37e2bf70c4745577883fb1716dfe6ddce936)), closes [#5620](https://github.com/algolia/instantsearch/issues/5620)
 
-
-
-
-
-## [4.56.1](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.56.0...instantsearch.js@4.56.1) (2023-05-30)
-
+## [4.56.1](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.56.0...instantsearch.js@4.56.1) (2023-05-30)
 
 ### Bug Fixes
 
-* **insights:** send default click event when using auxiliary pointer button ([#5634](https://github.com/algolia/instantsearch.js/issues/5634)) ([7e4a216](https://github.com/algolia/instantsearch.js/commit/7e4a2162f87596a384b35c97efa51db9bb6f8973))
+- **insights:** send default click event when using auxiliary pointer button ([#5634](https://github.com/algolia/instantsearch/issues/5634)) ([7e4a216](https://github.com/algolia/instantsearch/commit/7e4a2162f87596a384b35c97efa51db9bb6f8973))
 
-
-
-
-
-# [4.56.0](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.55.0...instantsearch.js@4.56.0) (2023-05-16)
-
+# [4.56.0](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.55.0...instantsearch.js@4.56.0) (2023-05-16)
 
 ### Bug Fixes
 
-* **infinite-hits:** do not write cache with incomplete state caused by dynamic widgets ([#5620](https://github.com/algolia/instantsearch.js/issues/5620)) ([30edccd](https://github.com/algolia/instantsearch.js/commit/30edccdaf0607695a6e621d7a71dd36f0f719d0b))
-* **rangeinput:** allow input of numbers with precision ([#5541](https://github.com/algolia/instantsearch.js/issues/5541)) ([fb48951](https://github.com/algolia/instantsearch.js/commit/fb489513a8550528f3e2867be30fb380229ad188))
-* **this:** ensure all functions are able to be destructured ([#5611](https://github.com/algolia/instantsearch.js/issues/5611)) ([a8b5c1e](https://github.com/algolia/instantsearch.js/commit/a8b5c1e5bbd6afac39fce523f7d7c2ec02f51153)), closes [#5589](https://github.com/algolia/instantsearch.js/issues/5589)
-
+- **infinite-hits:** do not write cache with incomplete state caused by dynamic widgets ([#5620](https://github.com/algolia/instantsearch/issues/5620)) ([30edccd](https://github.com/algolia/instantsearch/commit/30edccdaf0607695a6e621d7a71dd36f0f719d0b))
+- **rangeinput:** allow input of numbers with precision ([#5541](https://github.com/algolia/instantsearch/issues/5541)) ([fb48951](https://github.com/algolia/instantsearch/commit/fb489513a8550528f3e2867be30fb380229ad188))
+- **this:** ensure all functions are able to be destructured ([#5611](https://github.com/algolia/instantsearch/issues/5611)) ([a8b5c1e](https://github.com/algolia/instantsearch/commit/a8b5c1e5bbd6afac39fce523f7d7c2ec02f51153)), closes [#5589](https://github.com/algolia/instantsearch/issues/5589)
 
 ### Features
 
-* **history:** warn when `createURL` does not return an absolute URL ([#5613](https://github.com/algolia/instantsearch.js/issues/5613)) ([f45e0fa](https://github.com/algolia/instantsearch.js/commit/f45e0faede3461678cb05170887f3b7bc02dad50))
-* **instantsearch:** make root indexName optional ([#5590](https://github.com/algolia/instantsearch.js/issues/5590)) ([80f309e](https://github.com/algolia/instantsearch.js/commit/80f309ed69b61534ca118b60c9c88691e0148fca))
+- **history:** warn when `createURL` does not return an absolute URL ([#5613](https://github.com/algolia/instantsearch/issues/5613)) ([f45e0fa](https://github.com/algolia/instantsearch/commit/f45e0faede3461678cb05170887f3b7bc02dad50))
+- **instantsearch:** make root indexName optional ([#5590](https://github.com/algolia/instantsearch/issues/5590)) ([80f309e](https://github.com/algolia/instantsearch/commit/80f309ed69b61534ca118b60c9c88691e0148fca))
 
-
-
-
-
-# [4.55.0](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.54.1...instantsearch.js@4.55.0) (2023-04-24)
-
-
+# [4.55.0](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.54.1...instantsearch.js@4.55.0) (2023-04-24)
 
 ### Features
 
-* **insights:** add insights option to InstantSearch ([#5488](https://github.com/algolia/instantsearch.js/issues/5488)) ([9031573](https://github.com/algolia/instantsearch.js/commit/9031573807fa6803dcfae9f33d61b8f111f68423)) ([#5578](https://github.com/algolia/instantsearch.js/issues/5578)) ([8fb517f](https://github.com/algolia/instantsearch.js/commit/8fb517f15381ecb32ea00cf4b01a0fd5e70e1d17)) ([#5545](https://github.com/algolia/instantsearch.js/issues/5545)) ([99a0972](https://github.com/algolia/instantsearch.js/commit/99a0972663b8f3284cac3b5621571ced7a33908f)) ([#5493](https://github.com/algolia/instantsearch.js/issues/5493)) ([cff723f](https://github.com/algolia/instantsearch.js/commit/cff723fc95a90ebb2ed14c46c51ab05764835a47))
-* **insights:** always pass Algolia credentials locally ([#5554](https://github.com/algolia/instantsearch.js/issues/5554)) ([654ab81](https://github.com/algolia/instantsearch.js/commit/654ab81e1669354c249710b6756610fba35d54b4)) ([#5558](https://github.com/algolia/instantsearch.js/issues/5558)) ([82144c0](https://github.com/algolia/instantsearch.js/commit/82144c0a0b18e6b47d6f508e5c670a9de274c121)) ([#5529](https://github.com/algolia/instantsearch.js/issues/5529)) ([8537f8f](https://github.com/algolia/instantsearch.js/commit/8537f8f7a10bcaf053ff62180c082e077b1b052d))
-* **insights:** annotate events with algoliaSource ([#5580](https://github.com/algolia/instantsearch.js/issues/5580)) ([c419307](https://github.com/algolia/instantsearch.js/commit/c419307a5f7fe46d5032c9437a17c8e3dad57fe5))
-* **insights:** automatically load search-insights if not passed ([#5484](https://github.com/algolia/instantsearch.js/issues/5484)) ([a85797b](https://github.com/algolia/instantsearch.js/commit/a85797b503edc94e001c5bfb3b754db6cb556943))
-* **insights:** enable default click events on hits and infinite hits ([#5522](https://github.com/algolia/instantsearch.js/issues/5522)) ([271bd12](https://github.com/algolia/instantsearch.js/commit/271bd12e34bc55656976bb53c90282193083eb86)) ([#5527](https://github.com/algolia/instantsearch.js/issues/5527)) ([0e55821](https://github.com/algolia/instantsearch.js/commit/0e558213c807cd17d592fadec052f3d1fc692e6c))
-* **insights:** prevent potential errors ([#5487](https://github.com/algolia/instantsearch.js/issues/5487)) ([33fe510](https://github.com/algolia/instantsearch.js/commit/33fe510307e4b382a5ba1153a0eaf160420acd11)) ([#5606](https://github.com/algolia/instantsearch.js/issues/5606)) ([bdd9290](https://github.com/algolia/instantsearch.js/commit/bdd92901b59ae4e5d7311eadfbf53ed656bbaf4a)) ([#5512](https://github.com/algolia/instantsearch.js/issues/5512)) ([85dfbc9](https://github.com/algolia/instantsearch.js/commit/85dfbc9ebd722fbe6a7e1bd056950fdbcc16d8d9))
-* **metadata:** register metadata around middleware ([#5492](https://github.com/algolia/instantsearch.js/issues/5492)) ([3e72ec8](https://github.com/algolia/instantsearch.js/commit/3e72ec82894a05a071328a4802d2f764233fe005))
+- **insights:** add insights option to InstantSearch ([#5488](https://github.com/algolia/instantsearch/issues/5488)) ([9031573](https://github.com/algolia/instantsearch/commit/9031573807fa6803dcfae9f33d61b8f111f68423)) ([#5578](https://github.com/algolia/instantsearch/issues/5578)) ([8fb517f](https://github.com/algolia/instantsearch/commit/8fb517f15381ecb32ea00cf4b01a0fd5e70e1d17)) ([#5545](https://github.com/algolia/instantsearch/issues/5545)) ([99a0972](https://github.com/algolia/instantsearch/commit/99a0972663b8f3284cac3b5621571ced7a33908f)) ([#5493](https://github.com/algolia/instantsearch/issues/5493)) ([cff723f](https://github.com/algolia/instantsearch/commit/cff723fc95a90ebb2ed14c46c51ab05764835a47))
+- **insights:** always pass Algolia credentials locally ([#5554](https://github.com/algolia/instantsearch/issues/5554)) ([654ab81](https://github.com/algolia/instantsearch/commit/654ab81e1669354c249710b6756610fba35d54b4)) ([#5558](https://github.com/algolia/instantsearch/issues/5558)) ([82144c0](https://github.com/algolia/instantsearch/commit/82144c0a0b18e6b47d6f508e5c670a9de274c121)) ([#5529](https://github.com/algolia/instantsearch/issues/5529)) ([8537f8f](https://github.com/algolia/instantsearch/commit/8537f8f7a10bcaf053ff62180c082e077b1b052d))
+- **insights:** annotate events with algoliaSource ([#5580](https://github.com/algolia/instantsearch/issues/5580)) ([c419307](https://github.com/algolia/instantsearch/commit/c419307a5f7fe46d5032c9437a17c8e3dad57fe5))
+- **insights:** automatically load search-insights if not passed ([#5484](https://github.com/algolia/instantsearch/issues/5484)) ([a85797b](https://github.com/algolia/instantsearch/commit/a85797b503edc94e001c5bfb3b754db6cb556943))
+- **insights:** enable default click events on hits and infinite hits ([#5522](https://github.com/algolia/instantsearch/issues/5522)) ([271bd12](https://github.com/algolia/instantsearch/commit/271bd12e34bc55656976bb53c90282193083eb86)) ([#5527](https://github.com/algolia/instantsearch/issues/5527)) ([0e55821](https://github.com/algolia/instantsearch/commit/0e558213c807cd17d592fadec052f3d1fc692e6c))
+- **insights:** prevent potential errors ([#5487](https://github.com/algolia/instantsearch/issues/5487)) ([33fe510](https://github.com/algolia/instantsearch/commit/33fe510307e4b382a5ba1153a0eaf160420acd11)) ([#5606](https://github.com/algolia/instantsearch/issues/5606)) ([bdd9290](https://github.com/algolia/instantsearch/commit/bdd92901b59ae4e5d7311eadfbf53ed656bbaf4a)) ([#5512](https://github.com/algolia/instantsearch/issues/5512)) ([85dfbc9](https://github.com/algolia/instantsearch/commit/85dfbc9ebd722fbe6a7e1bd056950fdbcc16d8d9))
+- **metadata:** register metadata around middleware ([#5492](https://github.com/algolia/instantsearch/issues/5492)) ([3e72ec8](https://github.com/algolia/instantsearch/commit/3e72ec82894a05a071328a4802d2f764233fe005))
 
-
-
-
-
-## [4.54.1](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.54.0...instantsearch.js@4.54.1) (2023-04-11)
-
+## [4.54.1](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.54.0...instantsearch.js@4.54.1) (2023-04-11)
 
 ### Bug Fixes
 
-* **helpers:** deprecate highlight helpers ([09817fb](https://github.com/algolia/instantsearch.js/commit/09817fb1e9231cb60d91f1c08e918fec18b08fcf))
-* **pagination:** use real template ([6783408](https://github.com/algolia/instantsearch.js/commit/678340856f690e1ebaa94c407d4d2e7644f6c1d1))
-* **panel:** use undefined templates by default ([dcef813](https://github.com/algolia/instantsearch.js/commit/dcef813020a5f9b2d3a128fe79653df52efb097d))
-* **Template:** easier to debug warning when string template is used ([f285942](https://github.com/algolia/instantsearch.js/commit/f2859424526b65f969e0bf69e0c358c433bf5b32))
+- **helpers:** deprecate highlight helpers ([09817fb](https://github.com/algolia/instantsearch/commit/09817fb1e9231cb60d91f1c08e918fec18b08fcf))
+- **pagination:** use real template ([6783408](https://github.com/algolia/instantsearch/commit/678340856f690e1ebaa94c407d4d2e7644f6c1d1))
+- **panel:** use undefined templates by default ([dcef813](https://github.com/algolia/instantsearch/commit/dcef813020a5f9b2d3a128fe79653df52efb097d))
+- **Template:** easier to debug warning when string template is used ([f285942](https://github.com/algolia/instantsearch/commit/f2859424526b65f969e0bf69e0c358c433bf5b32))
 
-
-
-
-
-# [4.54.0](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.53.0...instantsearch.js@4.54.0) (2023-03-28)
-
+# [4.54.0](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.53.0...instantsearch.js@4.54.0) (2023-03-28)
 
 ### Features
 
-* warn if same attribute is used for different faceting type ([#5553](https://github.com/algolia/instantsearch.js/issues/5553)) ([2b3da9b](https://github.com/algolia/instantsearch.js/commit/2b3da9b398fcf081bdefc5cf7887f0a9a2dd2409))
+- warn if same attribute is used for different faceting type ([#5553](https://github.com/algolia/instantsearch/issues/5553)) ([2b3da9b](https://github.com/algolia/instantsearch/commit/2b3da9b398fcf081bdefc5cf7887f0a9a2dd2409))
 
 ### Bug Fixes
 
-* **places**: don't require package to be installed ([#5574](https://github.com/algolia/instantsearch/pull/5574)) ([f5ed576](https://github.com/algolia/instantsearch/commit/f5ed576129e7e81c37d985b19dff54acff893b1b))
+- **places**: don't require package to be installed ([#5574](https://github.com/algolia/instantsearch/pull/5574)) ([f5ed576](https://github.com/algolia/instantsearch/commit/f5ed576129e7e81c37d985b19dff54acff893b1b))
 
-
-
-
-
-# [4.53.0](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.52.0...instantsearch.js@4.53.0) (2023-03-21)
-
+# [4.53.0](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.52.0...instantsearch.js@4.53.0) (2023-03-21)
 
 ### Bug Fixes
 
-* **searchbox:** add aria-hidden to svg icons ([#5547](https://github.com/algolia/instantsearch.js/issues/5547)) ([50344e3](https://github.com/algolia/instantsearch.js/commit/50344e3b14c22c886415c0e7d799aca778dc39ab)), closes [#5546](https://github.com/algolia/instantsearch.js/issues/5546)
-* **svg:** don't style width/height in attributes with unit ([#5550](https://github.com/algolia/instantsearch.js/issues/5550)) ([31b85a6](https://github.com/algolia/instantsearch.js/commit/31b85a6ad56993455adb201f88ab1d1ae2d96683))
-
+- **searchbox:** add aria-hidden to svg icons ([#5547](https://github.com/algolia/instantsearch/issues/5547)) ([50344e3](https://github.com/algolia/instantsearch/commit/50344e3b14c22c886415c0e7d799aca778dc39ab)), closes [#5546](https://github.com/algolia/instantsearch/issues/5546)
+- **svg:** don't style width/height in attributes with unit ([#5550](https://github.com/algolia/instantsearch/issues/5550)) ([31b85a6](https://github.com/algolia/instantsearch/commit/31b85a6ad56993455adb201f88ab1d1ae2d96683))
 
 ### Features
 
-* **current-refinements:** provide indexId of refinements in transformItems ([#5546](https://github.com/algolia/instantsearch.js/issues/5546)) ([89781db](https://github.com/algolia/instantsearch.js/commit/89781db6cb1d2b8ebbc116e9bcd8a10f646e7baf))
+- **current-refinements:** provide indexId of refinements in transformItems ([#5546](https://github.com/algolia/instantsearch/issues/5546)) ([89781db](https://github.com/algolia/instantsearch/commit/89781db6cb1d2b8ebbc116e9bcd8a10f646e7baf))
 
-
-
-
-
-# [4.52.0](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.51.1...instantsearch.js@4.52.0) (2023-03-07)
-
+# [4.52.0](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.51.1...instantsearch.js@4.52.0) (2023-03-07)
 
 ### Bug Fixes
 
-* **core:** deprecate searchFunction ([#5494](https://github.com/algolia/instantsearch.js/issues/5494)) ([6a98ae0](https://github.com/algolia/instantsearch.js/commit/6a98ae065802b6c6c599aa7ce37af52b2c3b26fb))
-* **infinitehits/hits:** correctly deprecate __hitIndex ([#5495](https://github.com/algolia/instantsearch.js/issues/5495)) ([2e3d1f3](https://github.com/algolia/instantsearch.js/commit/2e3d1f3f999428bbf688b0f16a1f4a422dbab87b))
-* **instantsearch**: allow dispose before start ([#5533](https://github.com/algolia/instantsearch.js/issues/5533)) ([ab1b872](https://github.com/algolia/instantsearch.js/commit/ab1b872969f08266ea8a67cb04cdd3aa7aa5431f))
-* **routing**: allow writing when InstantSearch restarts ([#5534](https://github.com/algolia/instantsearch.js/issues/5534)) ([2c7c3ed](https://github.com/algolia/instantsearch.js/commit/2c7c3ed07e45fd4ddc71d493edc824449d195407))
-
+- **core:** deprecate searchFunction ([#5494](https://github.com/algolia/instantsearch/issues/5494)) ([6a98ae0](https://github.com/algolia/instantsearch/commit/6a98ae065802b6c6c599aa7ce37af52b2c3b26fb))
+- **infinitehits/hits:** correctly deprecate \_\_hitIndex ([#5495](https://github.com/algolia/instantsearch/issues/5495)) ([2e3d1f3](https://github.com/algolia/instantsearch/commit/2e3d1f3f999428bbf688b0f16a1f4a422dbab87b))
+- **instantsearch**: allow dispose before start ([#5533](https://github.com/algolia/instantsearch/issues/5533)) ([ab1b872](https://github.com/algolia/instantsearch/commit/ab1b872969f08266ea8a67cb04cdd3aa7aa5431f))
+- **routing**: allow writing when InstantSearch restarts ([#5534](https://github.com/algolia/instantsearch/issues/5534)) ([2c7c3ed](https://github.com/algolia/instantsearch/commit/2c7c3ed07e45fd4ddc71d493edc824449d195407))
 
 ### Features
 
-* **index:** introduce setIndexUiState ([#5504](https://github.com/algolia/instantsearch.js/issues/5504)) ([c199feb](https://github.com/algolia/instantsearch.js/commit/c199febbc3381df574afbb2504edd7373b32904a))
+- **index:** introduce setIndexUiState ([#5504](https://github.com/algolia/instantsearch/issues/5504)) ([c199feb](https://github.com/algolia/instantsearch/commit/c199febbc3381df574afbb2504edd7373b32904a))
 
-
-
-
-
-## [4.51.2](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.51.1...instantsearch.js@4.51.2) (2023-02-28)
-
+## [4.51.2](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.51.1...instantsearch.js@4.51.2) (2023-02-28)
 
 ### Bug Fixes
 
-* **core:** deprecate searchFunction ([#5494](https://github.com/algolia/instantsearch.js/issues/5494)) ([6a98ae0](https://github.com/algolia/instantsearch.js/commit/6a98ae065802b6c6c599aa7ce37af52b2c3b26fb))
+- **core:** deprecate searchFunction ([#5494](https://github.com/algolia/instantsearch/issues/5494)) ([6a98ae0](https://github.com/algolia/instantsearch/commit/6a98ae065802b6c6c599aa7ce37af52b2c3b26fb))
 
-
-
-
-
-## [4.51.1](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.51.0...instantsearch.js@4.51.1) (2023-02-21)
-
+## [4.51.1](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.51.0...instantsearch.js@4.51.1) (2023-02-21)
 
 ### Bug Fixes
 
-* **breadcrumb:** guard against undefined facets ([#5482](https://github.com/algolia/instantsearch.js/issues/5482)) ([3159afe](https://github.com/algolia/instantsearch.js/commit/3159afe57472fe2b669dceb5f1ee638b658f7f52))
+- **breadcrumb:** guard against undefined facets ([#5482](https://github.com/algolia/instantsearch/issues/5482)) ([3159afe](https://github.com/algolia/instantsearch/commit/3159afe57472fe2b669dceb5f1ee638b658f7f52))
 
-
-
-
-
-# [4.51.0](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.50.3...instantsearch.js@4.51.0) (2023-02-14)
-
+# [4.51.0](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.50.3...instantsearch.js@4.51.0) (2023-02-14)
 
 ### Features
 
-* expose callbacks for advanced routers in historyRouter ([#5432](https://github.com/algolia/instantsearch.js/issues/5432)) ([39b5859](https://github.com/algolia/instantsearch.js/commit/39b5859ba78a5e8472a80e357a35ba900c963b61))
+- expose callbacks for advanced routers in historyRouter ([#5432](https://github.com/algolia/instantsearch/issues/5432)) ([39b5859](https://github.com/algolia/instantsearch/commit/39b5859ba78a5e8472a80e357a35ba900c963b61))
 
-
-
-
-
-## [4.50.3](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.50.2...instantsearch.js@4.50.3) (2023-02-07)
-
+## [4.50.3](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.50.2...instantsearch.js@4.50.3) (2023-02-07)
 
 ### Bug Fixes
 
-* **types:** expose InstantSearchStatus ([#5463](https://github.com/algolia/instantsearch.js/issues/5463)) ([2253d9e](https://github.com/algolia/instantsearch.js/commit/2253d9ed16dbe7dcd820ae3903b54b01119f2b21))
+- **types:** expose InstantSearchStatus ([#5463](https://github.com/algolia/instantsearch/issues/5463)) ([2253d9e](https://github.com/algolia/instantsearch/commit/2253d9ed16dbe7dcd820ae3903b54b01119f2b21))
 
-
-
-
-
-## [4.50.2](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.50.1...instantsearch.js@4.50.2) (2023-01-30)
-
+## [4.50.2](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.50.1...instantsearch.js@4.50.2) (2023-01-30)
 
 ### Bug Fixes
 
-* **infiniteHits:** read cache correctly when search is loading ([#5461](https://github.com/algolia/instantsearch.js/issues/5461)) ([bfabe00](https://github.com/algolia/instantsearch.js/commit/bfabe002a26e15e13b33200c355379f4e3c60f21))
+- **infiniteHits:** read cache correctly when search is loading ([#5461](https://github.com/algolia/instantsearch/issues/5461)) ([bfabe00](https://github.com/algolia/instantsearch/commit/bfabe002a26e15e13b33200c355379f4e3c60f21))
 
-
-
-
-
-## [4.50.1](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.50.0...instantsearch.js@4.50.1) (2023-01-26)
-
+## [4.50.1](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.50.0...instantsearch.js@4.50.1) (2023-01-26)
 
 ### Bug Fixes
 
-* **dependencies:** update typescript ([#5454](https://github.com/algolia/instantsearch.js/issues/5454)) ([0e6bb48](https://github.com/algolia/instantsearch.js/commit/0e6bb485a31cd3294436ac9902c2c2662dfcdf8b))
-* **insights:** pass correct sendEvent to html template ([#5457](https://github.com/algolia/instantsearch.js/issues/5457)) ([11a8473](https://github.com/algolia/instantsearch.js/commit/11a8473e52f535ec1cb54b24187f2e5899c772e3)), closes [/github.com/algolia/instantsearch/discussions/5447#discussioncomment-4779169](https://github.com//github.com/algolia/instantsearch/discussions/5447/issues/discussioncomment-4779169)
+- **dependencies:** update typescript ([#5454](https://github.com/algolia/instantsearch/issues/5454)) ([0e6bb48](https://github.com/algolia/instantsearch/commit/0e6bb485a31cd3294436ac9902c2c2662dfcdf8b))
+- **insights:** pass correct sendEvent to html template ([#5457](https://github.com/algolia/instantsearch/issues/5457)) ([11a8473](https://github.com/algolia/instantsearch/commit/11a8473e52f535ec1cb54b24187f2e5899c772e3)), closes [/github.com/algolia/instantsearch/discussions/5447#discussioncomment-4779169](https://github.com//github.com/algolia/instantsearch/discussions/5447/issues/discussioncomment-4779169)
 
-
-
-
-
-# [4.50.0](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.49.4...instantsearch.js@4.50.0) (2023-01-25)
-
+# [4.50.0](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.49.4...instantsearch.js@4.50.0) (2023-01-25)
 
 ### Bug Fixes
 
-* **bindEvent:** skip view event if search isn't stable ([#5439](https://github.com/algolia/instantsearch.js/issues/5439)) ([b0ea594](https://github.com/algolia/instantsearch.js/commit/b0ea59404faff40c975bfa63f98ca411ddef27cb))
-* **sendEvent:**  correct types in template ([#5449](https://github.com/algolia/instantsearch.js/issues/5449)) ([68152d0](https://github.com/algolia/instantsearch.js/commit/68152d0665ad67954ab7351069798e6fd530aa4b))
-
+- **bindEvent:** skip view event if search isn't stable ([#5439](https://github.com/algolia/instantsearch/issues/5439)) ([b0ea594](https://github.com/algolia/instantsearch/commit/b0ea59404faff40c975bfa63f98ca411ddef27cb))
+- **sendEvent:** correct types in template ([#5449](https://github.com/algolia/instantsearch/issues/5449)) ([68152d0](https://github.com/algolia/instantsearch/commit/68152d0665ad67954ab7351069798e6fd530aa4b))
 
 ### Features
 
-* **rendering:** always render with current state ([#5429](https://github.com/algolia/instantsearch.js/issues/5429)) ([920e951](https://github.com/algolia/instantsearch.js/commit/920e951f03aada0e6a1ce16bc389a82a2f00b202))
-* **rendering:** revert search state on error ([#5438](https://github.com/algolia/instantsearch.js/issues/5438)) ([732fcac](https://github.com/algolia/instantsearch.js/commit/732fcac79ea1f51b19f62d5c4bf1fdf22619fa73))
+- **rendering:** always render with current state ([#5429](https://github.com/algolia/instantsearch/issues/5429)) ([920e951](https://github.com/algolia/instantsearch/commit/920e951f03aada0e6a1ce16bc389a82a2f00b202))
+- **rendering:** revert search state on error ([#5438](https://github.com/algolia/instantsearch/issues/5438)) ([732fcac](https://github.com/algolia/instantsearch/commit/732fcac79ea1f51b19f62d5c4bf1fdf22619fa73))
 
-
-
-
-
-## [4.49.4](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.49.3...instantsearch.js@4.49.4) (2023-01-09)
-
+## [4.49.4](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.49.3...instantsearch.js@4.49.4) (2023-01-09)
 
 ### Bug Fixes
 
-* **dependencies:** update helper requirement for minor PP vulnerability ([#5417](https://github.com/algolia/instantsearch.js/issues/5417)) ([254ef00](https://github.com/algolia/instantsearch.js/commit/254ef00439a9af48be15f22b4fd9902899610226))
+- **dependencies:** update helper requirement for minor PP vulnerability ([#5417](https://github.com/algolia/instantsearch/issues/5417)) ([254ef00](https://github.com/algolia/instantsearch/commit/254ef00439a9af48be15f22b4fd9902899610226))
 
-
-
-
-
-# [4.49.3](https://github.com/algolia/instantsearch.js/compare/instantsearch.js@4.49.2...instantsearch.js@4.49.3) (2023-01-03)
-
+# [4.49.3](https://github.com/algolia/instantsearch/compare/instantsearch.js@4.49.2...instantsearch.js@4.49.3) (2023-01-03)
 
 ### Bug Fixes
 
-* simple state mapping `routeToState` function throw an error when state is `null` ([#5177](https://github.com/algolia/instantsearch.js/issues/5177)) ([8e61c4c](https://github.com/algolia/instantsearch.js/commit/8e61c4ca32d8f9649f24721a7c682e517919e55e))
-
-
-
-
+- simple state mapping `routeToState` function throw an error when state is `null` ([#5177](https://github.com/algolia/instantsearch/issues/5177)) ([8e61c4c](https://github.com/algolia/instantsearch/commit/8e61c4ca32d8f9649f24721a7c682e517919e55e))
 
 ## 4.49.2 (2022-12-13)
 
 ### Bug Fixes
 
-* **answers:** mark as deprecated ([#5157](https://github.com/algolia/instantsearch.js/pull/5157)) ([d7b62eda](https://github.com/algolia/instantsearch.js/commit/d7b62eda77d894a3677a0967a05a2a357e7e5a94))
+- **answers:** mark as deprecated ([#5157](https://github.com/algolia/instantsearch/pull/5157)) ([d7b62eda](https://github.com/algolia/instantsearch/commit/d7b62eda77d894a3677a0967a05a2a357e7e5a94))
 
-
-
-
-
-## [4.49.1](https://github.com/algolia/instantsearch.js/compare/v4.49.0...v4.49.1) (2022-11-01)
-
+## [4.49.1](https://github.com/algolia/instantsearch/compare/v4.49.0...v4.49.1) (2022-11-01)
 
 ### Bug Fixes
 
-* **insights:** check before usage of `document` ([#5149](https://github.com/algolia/instantsearch.js/issues/5149)) ([6733dea](https://github.com/algolia/instantsearch.js/commit/6733dea1091a3a6c8ec9049eba652a7f06e9c501))
+- **insights:** check before usage of `document` ([#5149](https://github.com/algolia/instantsearch/issues/5149)) ([6733dea](https://github.com/algolia/instantsearch/commit/6733dea1091a3a6c8ec9049eba652a7f06e9c501))
 
-
-
-# [4.49.0](https://github.com/algolia/instantsearch.js/compare/v4.48.1...v4.49.0) (2022-10-25)
-
+# [4.49.0](https://github.com/algolia/instantsearch/compare/v4.48.1...v4.49.0) (2022-10-25)
 
 ### Features
 
-* **poweredBy:** update component logo ([#5145](https://github.com/algolia/instantsearch.js/issues/5145)) ([7df7816](https://github.com/algolia/instantsearch.js/commit/7df7816eac1bb3d2eafee5da7b6f4f59611468b2))
+- **poweredBy:** update component logo ([#5145](https://github.com/algolia/instantsearch/issues/5145)) ([7df7816](https://github.com/algolia/instantsearch/commit/7df7816eac1bb3d2eafee5da7b6f4f59611468b2))
 
-
-
-## [4.48.1](https://github.com/algolia/instantsearch.js/compare/v4.48.0...v4.48.1) (2022-10-18)
-
+## [4.48.1](https://github.com/algolia/instantsearch/compare/v4.48.0...v4.48.1) (2022-10-18)
 
 ### Bug Fixes
 
-* **bundlesize:** consolidate usage of "classnames" helper ([#5138](https://github.com/algolia/instantsearch.js/issues/5138)) ([f1ec288](https://github.com/algolia/instantsearch.js/commit/f1ec28889be5c2f906dd398f37d072587e29cf3a))
-* **currentRefinements:** reset page number on refine ([#5136](https://github.com/algolia/instantsearch.js/issues/5136)) ([407b576](https://github.com/algolia/instantsearch.js/commit/407b5767b51c26d5f471071a92f2e32762898f24))
-* **events:** prevent warning on low number of listeners ([#5143](https://github.com/algolia/instantsearch.js/issues/5143)) ([432aa70](https://github.com/algolia/instantsearch.js/commit/432aa7006e7d8eefd1c8c382f59ea2d2974a19da))
+- **bundlesize:** consolidate usage of "classnames" helper ([#5138](https://github.com/algolia/instantsearch/issues/5138)) ([f1ec288](https://github.com/algolia/instantsearch/commit/f1ec28889be5c2f906dd398f37d072587e29cf3a))
+- **currentRefinements:** reset page number on refine ([#5136](https://github.com/algolia/instantsearch/issues/5136)) ([407b576](https://github.com/algolia/instantsearch/commit/407b5767b51c26d5f471071a92f2e32762898f24))
+- **events:** prevent warning on low number of listeners ([#5143](https://github.com/algolia/instantsearch/issues/5143)) ([432aa70](https://github.com/algolia/instantsearch/commit/432aa7006e7d8eefd1c8c382f59ea2d2974a19da))
 
-
-
-# [4.48.0](https://github.com/algolia/instantsearch.js/compare/v4.47.0...v4.48.0) (2022-10-10)
-
+# [4.48.0](https://github.com/algolia/instantsearch/compare/v4.47.0...v4.48.0) (2022-10-10)
 
 ### Bug Fixes
 
-* **insightsMiddleware:** infer type of insightsClient for onEvent ([#5130](https://github.com/algolia/instantsearch.js/issues/5130)) ([dd5fca4](https://github.com/algolia/instantsearch.js/commit/dd5fca4c185c66f1e31ebe9c0568bcad48e062f3)), closes [#5129](https://github.com/algolia/instantsearch.js/issues/5129)
-
+- **insightsMiddleware:** infer type of insightsClient for onEvent ([#5130](https://github.com/algolia/instantsearch/issues/5130)) ([dd5fca4](https://github.com/algolia/instantsearch/commit/dd5fca4c185c66f1e31ebe9c0568bcad48e062f3)), closes [#5129](https://github.com/algolia/instantsearch/issues/5129)
 
 ### Features
 
-* **routing:** include repeated indexId in URL correctly ([#5134](https://github.com/algolia/instantsearch.js/issues/5134)) ([679f5da](https://github.com/algolia/instantsearch.js/commit/679f5dad839536def6ae9c3a18416296d40ed49a))
+- **routing:** include repeated indexId in URL correctly ([#5134](https://github.com/algolia/instantsearch/issues/5134)) ([679f5da](https://github.com/algolia/instantsearch/commit/679f5dad839536def6ae9c3a18416296d40ed49a))
 
-
-
-# [4.47.0](https://github.com/algolia/instantsearch.js/compare/v4.46.3...v4.47.0) (2022-10-03)
-
+# [4.47.0](https://github.com/algolia/instantsearch/compare/v4.46.3...v4.47.0) (2022-10-03)
 
 ### Bug Fixes
 
-* **hierarchicalMenu:** pass correct attribute name to Insights ([#5124](https://github.com/algolia/instantsearch.js/issues/5124)) ([fe18a16](https://github.com/algolia/instantsearch.js/commit/fe18a168b1b195d067298770b55fd29a7fdb6edb))
-
+- **hierarchicalMenu:** pass correct attribute name to Insights ([#5124](https://github.com/algolia/instantsearch/issues/5124)) ([fe18a16](https://github.com/algolia/instantsearch/commit/fe18a168b1b195d067298770b55fd29a7fdb6edb))
 
 ### Features
 
-* **status:** introduce status in InstantSearch class ([#5115](https://github.com/algolia/instantsearch.js/issues/5115)) ([21f3147](https://github.com/algolia/instantsearch.js/commit/21f31476e75e162b38b002d5439f231f3990e785))
-* **hierarchicalMenu**: introduce `ais-HierarchicalMenu-item--selected` class ([#5125](https://github.com/algolia/instantsearch.js/issues/5125)) ([4ebb828](https://github.com/algolia/instantsearch.js/commit/4ebb828c93afabfd8083246dfe7edfd33932d5fd))
+- **status:** introduce status in InstantSearch class ([#5115](https://github.com/algolia/instantsearch/issues/5115)) ([21f3147](https://github.com/algolia/instantsearch/commit/21f31476e75e162b38b002d5439f231f3990e785))
+- **hierarchicalMenu**: introduce `ais-HierarchicalMenu-item--selected` class ([#5125](https://github.com/algolia/instantsearch/issues/5125)) ([4ebb828](https://github.com/algolia/instantsearch/commit/4ebb828c93afabfd8083246dfe7edfd33932d5fd))
 
-
-## [4.46.3](https://github.com/algolia/instantsearch.js/compare/v4.46.2...v4.46.3) (2022-09-27)
-
+## [4.46.3](https://github.com/algolia/instantsearch/compare/v4.46.2...v4.46.3) (2022-09-27)
 
 ### Bug Fixes
 
-* **currentRefinements:** implement noRefinementRoot modifier class ([#5114](https://github.com/algolia/instantsearch.js/issues/5114)) ([cb66830](https://github.com/algolia/instantsearch.js/commit/cb668305af26bf919841c25bd4cc8493fcdf8cf9))
+- **currentRefinements:** implement noRefinementRoot modifier class ([#5114](https://github.com/algolia/instantsearch/issues/5114)) ([cb66830](https://github.com/algolia/instantsearch/commit/cb668305af26bf919841c25bd4cc8493fcdf8cf9))
 
-
-
-## [4.46.2](https://github.com/algolia/instantsearch.js/compare/v4.46.1...v4.46.2) (2022-09-22)
-
+## [4.46.2](https://github.com/algolia/instantsearch/compare/v4.46.1...v4.46.2) (2022-09-22)
 
 ### Bug Fixes
 
-* **build:** remove jsx pragma comments from build output ([#5112](https://github.com/algolia/instantsearch.js/issues/5112)) ([6582083](https://github.com/algolia/instantsearch.js/commit/65820831b7d7e14867f13a2947795491730b8442))
-* **imports:** split out templating from ./utils ([#5111](https://github.com/algolia/instantsearch.js/issues/5111)) ([fc765f3](https://github.com/algolia/instantsearch.js/commit/fc765f35ddd85068237edc81c66932b098e3b55a)), closes [#5109](https://github.com/algolia/instantsearch.js/issues/5109)
+- **build:** remove jsx pragma comments from build output ([#5112](https://github.com/algolia/instantsearch/issues/5112)) ([6582083](https://github.com/algolia/instantsearch/commit/65820831b7d7e14867f13a2947795491730b8442))
+- **imports:** split out templating from ./utils ([#5111](https://github.com/algolia/instantsearch/issues/5111)) ([fc765f3](https://github.com/algolia/instantsearch/commit/fc765f35ddd85068237edc81c66932b098e3b55a)), closes [#5109](https://github.com/algolia/instantsearch/issues/5109)
 
-
-
-## [4.46.1](https://github.com/algolia/instantsearch.js/compare/v4.46.0...v4.46.1) (2022-09-15)
-
+## [4.46.1](https://github.com/algolia/instantsearch/compare/v4.46.0...v4.46.1) (2022-09-15)
 
 ### Bug Fixes
 
-* **hierarchicalMenu:** use existing facet filters in multi queries for parent facet values ([#5105](https://github.com/algolia/instantsearch.js/issues/5105)) ([10a83f1](https://github.com/algolia/instantsearch.js/commit/10a83f146f714d9f97bb8edca2499f16df4ca22d))
-* **insights:** make sure change in userToken can't reset the search parameters ([#5101](https://github.com/algolia/instantsearch.js/issues/5101)) ([b20c8dc](https://github.com/algolia/instantsearch.js/commit/b20c8dc70e34c1f234dc10eb7fc69296f30986a4))
-* **setUiState**: call onStateChange handler ([#5104](https://github.com/algolia/instantsearch.js/issues/5104)) ([231853d](https://github.com/algolia/instantsearch.js/commit/231853dab731189a33ee480cdb196789c7336fda)))
+- **hierarchicalMenu:** use existing facet filters in multi queries for parent facet values ([#5105](https://github.com/algolia/instantsearch/issues/5105)) ([10a83f1](https://github.com/algolia/instantsearch/commit/10a83f146f714d9f97bb8edca2499f16df4ca22d))
+- **insights:** make sure change in userToken can't reset the search parameters ([#5101](https://github.com/algolia/instantsearch/issues/5101)) ([b20c8dc](https://github.com/algolia/instantsearch/commit/b20c8dc70e34c1f234dc10eb7fc69296f30986a4))
+- **setUiState**: call onStateChange handler ([#5104](https://github.com/algolia/instantsearch/issues/5104)) ([231853d](https://github.com/algolia/instantsearch/commit/231853dab731189a33ee480cdb196789c7336fda)))
 
-
-
-## [4.46.0](https://github.com/algolia/instantsearch.js/compare/v4.45.1...v4.46.0) (2022-09-12)
-
+## [4.46.0](https://github.com/algolia/instantsearch/compare/v4.45.1...v4.46.0) (2022-09-12)
 
 ### Features
 
-* **html:** deprecate Hogan.js and string-based templates ([#5095](https://github.com/algolia/instantsearch.js/issues/5095)) ([a06ddf5](https://github.com/algolia/instantsearch.js/commit/a06ddf55f1ffd1a93cddab2fcf95d2be3220a423))
-* **html:** introduce `html` templating ([#5081](https://github.com/algolia/instantsearch.js/issues/5081)) ([e55e224](https://github.com/algolia/instantsearch.js/commit/e55e2245256193d27f2c85f24b8aab7c9048c554))
+- **html:** deprecate Hogan.js and string-based templates ([#5095](https://github.com/algolia/instantsearch/issues/5095)) ([a06ddf5](https://github.com/algolia/instantsearch/commit/a06ddf55f1ffd1a93cddab2fcf95d2be3220a423))
+- **html:** introduce `html` templating ([#5081](https://github.com/algolia/instantsearch/issues/5081)) ([e55e224](https://github.com/algolia/instantsearch/commit/e55e2245256193d27f2c85f24b8aab7c9048c554))
 
-
-
-## [4.45.1](https://github.com/algolia/instantsearch.js/compare/v4.45.0...v4.45.1) (2022-09-06)
-
+## [4.45.1](https://github.com/algolia/instantsearch/compare/v4.45.0...v4.45.1) (2022-09-06)
 
 ### Bug Fixes
 
-* **ratingMenu:** fix `undefined` facet values error when `disjunctiveFacets` is empty ([#5096](https://github.com/algolia/instantsearch.js/issues/5096)) ([dd870d5](https://github.com/algolia/instantsearch.js/commit/dd870d5a658ce42b068eadf34f9b69772291aa20))
+- **ratingMenu:** fix `undefined` facet values error when `disjunctiveFacets` is empty ([#5096](https://github.com/algolia/instantsearch/issues/5096)) ([dd870d5](https://github.com/algolia/instantsearch/commit/dd870d5a658ce42b068eadf34f9b69772291aa20))
 
-
-
-# [4.45.0](https://github.com/algolia/instantsearch.js/compare/v4.44.1...v4.45.0) (2022-08-29)
-
+# [4.45.0](https://github.com/algolia/instantsearch/compare/v4.44.1...v4.45.0) (2022-08-29)
 
 ### Features
 
-* **connectors:** deprecate `hasNoResults` in favor of `canRefine` ([#5091](https://github.com/algolia/instantsearch.js/issues/5091)) ([1749a4e](https://github.com/algolia/instantsearch.js/commit/1749a4eb9a2f28fa4a8d442163e3b10acbde7c22))
+- **connectors:** deprecate `hasNoResults` in favor of `canRefine` ([#5091](https://github.com/algolia/instantsearch/issues/5091)) ([1749a4e](https://github.com/algolia/instantsearch/commit/1749a4eb9a2f28fa4a8d442163e3b10acbde7c22))
 
-
-
-## [4.44.1](https://github.com/algolia/instantsearch.js/compare/v4.44.0...v4.44.1) (2022-08-25)
-
+## [4.44.1](https://github.com/algolia/instantsearch/compare/v4.44.0...v4.44.1) (2022-08-25)
 
 ### Bug Fixes
 
-* **connectNumericMenu + connectRange:** stop sending invalid clickedFilters event ([#5085](https://github.com/algolia/instantsearch.js/issues/5085)) ([20996c7](https://github.com/algolia/instantsearch.js/commit/20996c7a159988c58e00ff24d2d2dc98af8b980f))
+- **connectNumericMenu + connectRange:** stop sending invalid clickedFilters event ([#5085](https://github.com/algolia/instantsearch/issues/5085)) ([20996c7](https://github.com/algolia/instantsearch/commit/20996c7a159988c58e00ff24d2d2dc98af8b980f))
 
-
-
-# [4.44.0](https://github.com/algolia/instantsearch.js/compare/v4.43.1...v4.44.0) (2022-08-08)
-
+# [4.44.0](https://github.com/algolia/instantsearch/compare/v4.43.1...v4.44.0) (2022-08-08)
 
 ### Features
 
-* **geo-search:** make `GeoHit` type generic ([#5083](https://github.com/algolia/instantsearch.js/issues/5083)) ([3d3c7b2](https://github.com/algolia/instantsearch.js/commit/3d3c7b298b74effe9bb722a04fbb47dc39a4bd95))
+- **geo-search:** make `GeoHit` type generic ([#5083](https://github.com/algolia/instantsearch/issues/5083)) ([3d3c7b2](https://github.com/algolia/instantsearch/commit/3d3c7b298b74effe9bb722a04fbb47dc39a4bd95))
 
-
-
-## [4.43.1](https://github.com/algolia/instantsearch.js/compare/v4.43.0...v4.43.1) (2022-07-11)
-
+## [4.43.1](https://github.com/algolia/instantsearch/compare/v4.43.0...v4.43.1) (2022-07-11)
 
 ### Bug Fixes
 
-* **errors:** rethrow error as error if it's an object ([#5075](https://github.com/algolia/instantsearch.js/issues/5075)) ([34132bb](https://github.com/algolia/instantsearch.js/commit/34132bba38c05fa2f5e4e54c6889e9335e62e4f4))
-* **ratingMenu:** don't warn if results are artificial ([#5073](https://github.com/algolia/instantsearch.js/issues/5073)) ([d747d23](https://github.com/algolia/instantsearch.js/commit/d747d23b28c380fe82a40eeab06c57359af8004a))
-* **types:** use correct case for _geoloc property ([#5074](https://github.com/algolia/instantsearch.js/issues/5074)) ([6fed7d8](https://github.com/algolia/instantsearch.js/commit/6fed7d870c3607980776d33a3697f8e2789aa08b))
+- **errors:** rethrow error as error if it's an object ([#5075](https://github.com/algolia/instantsearch/issues/5075)) ([34132bb](https://github.com/algolia/instantsearch/commit/34132bba38c05fa2f5e4e54c6889e9335e62e4f4))
+- **ratingMenu:** don't warn if results are artificial ([#5073](https://github.com/algolia/instantsearch/issues/5073)) ([d747d23](https://github.com/algolia/instantsearch/commit/d747d23b28c380fe82a40eeab06c57359af8004a))
+- **types:** use correct case for \_geoloc property ([#5074](https://github.com/algolia/instantsearch/issues/5074)) ([6fed7d8](https://github.com/algolia/instantsearch/commit/6fed7d870c3607980776d33a3697f8e2789aa08b))
 
-
-
-# [4.43.0](https://github.com/algolia/instantsearch.js/compare/v4.42.0...v4.43.0) (2022-06-28)
-
+# [4.43.0](https://github.com/algolia/instantsearch/compare/v4.42.0...v4.43.0) (2022-06-28)
 
 ### Features
 
-* **types:** support algoliasearch v5 ([#5066](https://github.com/algolia/instantsearch.js/issues/5066)) ([3eb4dc7](https://github.com/algolia/instantsearch.js/commit/3eb4dc75a5935f2ee4fead8787f39af0150b24c4))
+- **types:** support algoliasearch v5 ([#5066](https://github.com/algolia/instantsearch/issues/5066)) ([3eb4dc7](https://github.com/algolia/instantsearch/commit/3eb4dc75a5935f2ee4fead8787f39af0150b24c4))
 
-
-
-# [4.42.0](https://github.com/algolia/instantsearch.js/compare/v4.41.2...v4.42.0) (2022-06-21)
-
+# [4.42.0](https://github.com/algolia/instantsearch/compare/v4.41.2...v4.42.0) (2022-06-21)
 
 ### Bug Fixes
 
-* **es:** update import path for `infiniteHitsCache` in depreciation message ([#5068](https://github.com/algolia/instantsearch.js/issues/5068)) ([545cbaf](https://github.com/algolia/instantsearch.js/commit/545cbafd748bb8be32bff66ac60b5f3f9133a5b4))
-
+- **es:** update import path for `infiniteHitsCache` in depreciation message ([#5068](https://github.com/algolia/instantsearch/issues/5068)) ([545cbaf](https://github.com/algolia/instantsearch/commit/545cbafd748bb8be32bff66ac60b5f3f9133a5b4))
 
 ### Features
 
-* **core:** sort parameters & support client.search for sffv ([#5069](https://github.com/algolia/instantsearch.js/issues/5069)) ([34e2b00](https://github.com/algolia/instantsearch.js/commit/34e2b00cbc93f1bc86ee0abaec6b6e132bd18354))
+- **core:** sort parameters & support client.search for sffv ([#5069](https://github.com/algolia/instantsearch/issues/5069)) ([34e2b00](https://github.com/algolia/instantsearch/commit/34e2b00cbc93f1bc86ee0abaec6b6e132bd18354))
 
-
-
-## [4.41.2](https://github.com/algolia/instantsearch.js/compare/v4.41.1...v4.41.2) (2022-06-15)
-
+## [4.41.2](https://github.com/algolia/instantsearch/compare/v4.41.1...v4.41.2) (2022-06-15)
 
 ### Bug Fixes
 
-* **hierarchicalMenu:** show full hierarchical parent values ([#5063](https://github.com/algolia/instantsearch.js/issues/5063)) ([cd1db34](https://github.com/algolia/instantsearch.js/commit/cd1db34815f92acb3d2d0cec6c1ae7865d14fb13))
+- **hierarchicalMenu:** show full hierarchical parent values ([#5063](https://github.com/algolia/instantsearch/issues/5063)) ([cd1db34](https://github.com/algolia/instantsearch/commit/cd1db34815f92acb3d2d0cec6c1ae7865d14fb13))
 
-
-
-## [4.41.1](https://github.com/algolia/instantsearch.js/compare/v4.41.0...v4.41.1) (2022-06-14)
-
+## [4.41.1](https://github.com/algolia/instantsearch/compare/v4.41.0...v4.41.1) (2022-06-14)
 
 ### Bug Fixes
 
-* **insights:** don't send view event if search is stalled ([#5058](https://github.com/algolia/instantsearch.js/issues/5058)) ([1686dfb](https://github.com/algolia/instantsearch.js/commit/1686dfb096cfce062e268feda7956e3b160bf2da)), closes [/github.com/algolia/instantsearch.js/blob/99f6fe1dc51e4815e5b9efcfb30e3e2f3127e763/src/lib/utils/createSendEventForHits.ts#L168](https://github.com//github.com/algolia/instantsearch.js/blob/99f6fe1dc51e4815e5b9efcfb30e3e2f3127e763/src/lib/utils/createSendEventForHits.ts/issues/L168) [/github.com/algolia/instantsearch.js/blob/55313e4ea4105b777f3f102e9f48a7e440496d25/src/middlewares/createInsightsMiddleware.ts#L144](https://github.com//github.com/algolia/instantsearch.js/blob/55313e4ea4105b777f3f102e9f48a7e440496d25/src/middlewares/createInsightsMiddleware.ts/issues/L144)
-* **types:** avoid inferring UiState type from initialUiState ([#5061](https://github.com/algolia/instantsearch.js/issues/5061)) ([80ca07e](https://github.com/algolia/instantsearch.js/commit/80ca07e29064357343ee997be94ef10beadba637)), closes [/github.com/Microsoft/TypeScript/issues/14829#issuecomment-504042546](https://github.com//github.com/Microsoft/TypeScript/issues/14829/issues/issuecomment-504042546) [#5060](https://github.com/algolia/instantsearch.js/issues/5060)
-* **types:** make all usages of UiState in InstantSearch generic ([#5060](https://github.com/algolia/instantsearch.js/issues/5060)) ([2b9e76b](https://github.com/algolia/instantsearch.js/commit/2b9e76b568fb4d4cc5bd49c384ee583d84d6f39a))
+- **insights:** don't send view event if search is stalled ([#5058](https://github.com/algolia/instantsearch/issues/5058)) ([1686dfb](https://github.com/algolia/instantsearch/commit/1686dfb096cfce062e268feda7956e3b160bf2da)), closes [/github.com/algolia/instantsearch/blob/99f6fe1dc51e4815e5b9efcfb30e3e2f3127e763/src/lib/utils/createSendEventForHits.ts#L168](https://github.com//github.com/algolia/instantsearch/blob/99f6fe1dc51e4815e5b9efcfb30e3e2f3127e763/src/lib/utils/createSendEventForHits.ts/issues/L168) [/github.com/algolia/instantsearch/blob/55313e4ea4105b777f3f102e9f48a7e440496d25/src/middlewares/createInsightsMiddleware.ts#L144](https://github.com//github.com/algolia/instantsearch/blob/55313e4ea4105b777f3f102e9f48a7e440496d25/src/middlewares/createInsightsMiddleware.ts/issues/L144)
+- **types:** avoid inferring UiState type from initialUiState ([#5061](https://github.com/algolia/instantsearch/issues/5061)) ([80ca07e](https://github.com/algolia/instantsearch/commit/80ca07e29064357343ee997be94ef10beadba637)), closes [/github.com/Microsoft/TypeScript/issues/14829#issuecomment-504042546](https://github.com//github.com/Microsoft/TypeScript/issues/14829/issues/issuecomment-504042546) [#5060](https://github.com/algolia/instantsearch/issues/5060)
+- **types:** make all usages of UiState in InstantSearch generic ([#5060](https://github.com/algolia/instantsearch/issues/5060)) ([2b9e76b](https://github.com/algolia/instantsearch/commit/2b9e76b568fb4d4cc5bd49c384ee583d84d6f39a))
 
-
-
-# [4.41.0](https://github.com/algolia/instantsearch.js/compare/v4.40.6...v4.41.0) (2022-06-01)
-
+# [4.41.0](https://github.com/algolia/instantsearch/compare/v4.40.6...v4.41.0) (2022-06-01)
 
 ### Features
 
-* **core:** don't schedule search without widgets ([#5056](https://github.com/algolia/instantsearch.js/issues/5056)) ([ea3d6d9](https://github.com/algolia/instantsearch.js/commit/ea3d6d9c6ae1fe2f90bf5643d4bdcbb89507e9bc))
+- **core:** don't schedule search without widgets ([#5056](https://github.com/algolia/instantsearch/issues/5056)) ([ea3d6d9](https://github.com/algolia/instantsearch/commit/ea3d6d9c6ae1fe2f90bf5643d4bdcbb89507e9bc))
 
-
-
-## [4.40.6](https://github.com/algolia/instantsearch.js/compare/v4.40.5...v4.40.6) (2022-05-24)
-
+## [4.40.6](https://github.com/algolia/instantsearch/compare/v4.40.5...v4.40.6) (2022-05-24)
 
 ### Bug Fixes
 
-* **types:** only allow `null` for parent in `getWidgetRenderState` if widget is an index ([#5052](https://github.com/algolia/instantsearch.js/issues/5052)) ([fe0fce0](https://github.com/algolia/instantsearch.js/commit/fe0fce0641ffff9af1d1303b7ee71d77ba08f8bd))
+- **types:** only allow `null` for parent in `getWidgetRenderState` if widget is an index ([#5052](https://github.com/algolia/instantsearch/issues/5052)) ([fe0fce0](https://github.com/algolia/instantsearch/commit/fe0fce0641ffff9af1d1303b7ee71d77ba08f8bd))
 
-
-
-## [4.40.5](https://github.com/algolia/instantsearch.js/compare/v4.40.4...v4.40.5) (2022-04-26)
-
+## [4.40.5](https://github.com/algolia/instantsearch/compare/v4.40.4...v4.40.5) (2022-04-26)
 
 ### Bug Fixes
 
-* **routing:** prevent writing the same URL twice ([#5045](https://github.com/algolia/instantsearch.js/issues/5045)) ([5d79d92](https://github.com/algolia/instantsearch.js/commit/5d79d92b30e188e5206dcb5fe86fcac058c3f09b))
+- **routing:** prevent writing the same URL twice ([#5045](https://github.com/algolia/instantsearch/issues/5045)) ([5d79d92](https://github.com/algolia/instantsearch/commit/5d79d92b30e188e5206dcb5fe86fcac058c3f09b))
 
-
-
-## [4.40.4](https://github.com/algolia/instantsearch.js/compare/v4.40.3...v4.40.4) (2022-04-13)
-
+## [4.40.4](https://github.com/algolia/instantsearch/compare/v4.40.3...v4.40.4) (2022-04-13)
 
 ### Bug Fixes
 
-* **currentRefinements:** correctly show and allow for refining escaped values ([#5041](https://github.com/algolia/instantsearch.js/issues/5041)) ([277f4df](https://github.com/algolia/instantsearch.js/commit/277f4dff21fb7eeaeb41a8c49aaaf707f880ee58))
+- **currentRefinements:** correctly show and allow for refining escaped values ([#5041](https://github.com/algolia/instantsearch/issues/5041)) ([277f4df](https://github.com/algolia/instantsearch/commit/277f4dff21fb7eeaeb41a8c49aaaf707f880ee58))
 
-
-
-## [4.40.3](https://github.com/algolia/instantsearch.js/compare/v4.40.2...v4.40.3) (2022-04-04)
-
+## [4.40.3](https://github.com/algolia/instantsearch/compare/v4.40.2...v4.40.3) (2022-04-04)
 
 ### Bug Fixes
 
-* **refinements:** escape facet values starting with "-" ([#5039](https://github.com/algolia/instantsearch.js/issues/5039)) ([6b6f4e8](https://github.com/algolia/instantsearch.js/commit/6b6f4e86550a3c9dd02f3a8400d832cef64cb45d))
+- **refinements:** escape facet values starting with "-" ([#5039](https://github.com/algolia/instantsearch/issues/5039)) ([6b6f4e8](https://github.com/algolia/instantsearch/commit/6b6f4e86550a3c9dd02f3a8400d832cef64cb45d))
 
-
-
-## [4.40.2](https://github.com/algolia/instantsearch.js/compare/v4.40.1...v4.40.2) (2022-03-29)
-
+## [4.40.2](https://github.com/algolia/instantsearch/compare/v4.40.1...v4.40.2) (2022-03-29)
 
 ### Bug Fixes
 
-* **currentRefinements:** more detailed type for item.type ([#5034](https://github.com/algolia/instantsearch.js/issues/5034)) ([773e2c6](https://github.com/algolia/instantsearch.js/commit/773e2c65840f86881eb3dd8825c8c4ad9c73aec9))
+- **currentRefinements:** more detailed type for item.type ([#5034](https://github.com/algolia/instantsearch/issues/5034)) ([773e2c6](https://github.com/algolia/instantsearch/commit/773e2c65840f86881eb3dd8825c8c4ad9c73aec9))
 
-
-
-## [4.40.1](https://github.com/algolia/instantsearch.js/compare/v4.40.0...v4.40.1) (2022-03-21)
-
+## [4.40.1](https://github.com/algolia/instantsearch/compare/v4.40.0...v4.40.1) (2022-03-21)
 
 ### Bug Fixes
 
-* **types:** update to latest algoliasearch-helper ([6bbe790](https://github.com/algolia/instantsearch.js/commit/6bbe790a99320b4237b81614472c048ffe4426d8))
+- **types:** update to latest algoliasearch-helper ([6bbe790](https://github.com/algolia/instantsearch/commit/6bbe790a99320b4237b81614472c048ffe4426d8))
 
-
-
-# [4.40.0](https://github.com/algolia/instantsearch.js/compare/v4.39.2...v4.40.0) (2022-03-21)
-
+# [4.40.0](https://github.com/algolia/instantsearch/compare/v4.39.2...v4.40.0) (2022-03-21)
 
 ### Features
 
-* **infiniteHits:** avoid caching artificial results ([#5023](https://github.com/algolia/instantsearch.js/issues/5023)) ([e8c0145](https://github.com/algolia/instantsearch.js/commit/e8c01452ebe77b82b8a107c5d4fc026abf5645d8))
+- **infiniteHits:** avoid caching artificial results ([#5023](https://github.com/algolia/instantsearch/issues/5023)) ([e8c0145](https://github.com/algolia/instantsearch/commit/e8c01452ebe77b82b8a107c5d4fc026abf5645d8))
 
-
-
-## [4.39.2](https://github.com/algolia/instantsearch.js/compare/v4.39.1...v4.39.2) (2022-03-14)
-
+## [4.39.2](https://github.com/algolia/instantsearch/compare/v4.39.1...v4.39.2) (2022-03-14)
 
 ### Bug Fixes
 
-* fix types of `sortBy` option ([#5024](https://github.com/algolia/instantsearch.js/issues/5024)) ([3f7ea32](https://github.com/algolia/instantsearch.js/commit/3f7ea32374e0e409ebf27b07d28cf3871a5b33b3))
+- fix types of `sortBy` option ([#5024](https://github.com/algolia/instantsearch/issues/5024)) ([3f7ea32](https://github.com/algolia/instantsearch/commit/3f7ea32374e0e409ebf27b07d28cf3871a5b33b3))
 
-
-
-## [4.39.1](https://github.com/algolia/instantsearch.js/compare/v4.39.0...v4.39.1) (2022-03-01)
-
+## [4.39.1](https://github.com/algolia/instantsearch/compare/v4.39.0...v4.39.1) (2022-03-01)
 
 ### Bug Fixes
 
-* **insights:** send view events after rendering ([#5014](https://github.com/algolia/instantsearch.js/issues/5014)) ([e952abc](https://github.com/algolia/instantsearch.js/commit/e952abc64043a55e06c9c46a656bc98ad45d1502))
+- **insights:** send view events after rendering ([#5014](https://github.com/algolia/instantsearch/issues/5014)) ([e952abc](https://github.com/algolia/instantsearch/commit/e952abc64043a55e06c9c46a656bc98ad45d1502))
 
-
-
-# [4.39.0](https://github.com/algolia/instantsearch.js/compare/v4.38.1...v4.39.0) (2022-02-23)
-
+# [4.39.0](https://github.com/algolia/instantsearch/compare/v4.38.1...v4.39.0) (2022-02-23)
 
 ### Features
 
-* **ts:** allow Hits related connectors to be generic ([#5019](https://github.com/algolia/instantsearch.js/issues/5019)) ([e986f7e](https://github.com/algolia/instantsearch.js/commit/e986f7e46d57173da4d3d6c3c23fbdf3f9c0f78c))
+- **ts:** allow Hits related connectors to be generic ([#5019](https://github.com/algolia/instantsearch/issues/5019)) ([e986f7e](https://github.com/algolia/instantsearch/commit/e986f7e46d57173da4d3d6c3c23fbdf3f9c0f78c))
 
-
-
-## [4.38.1](https://github.com/algolia/instantsearch.js/compare/v4.38.0...v4.38.1) (2022-02-08)
-
+## [4.38.1](https://github.com/algolia/instantsearch/compare/v4.38.0...v4.38.1) (2022-02-08)
 
 ### Bug Fixes
 
-* **routing:** fix history router based on history length ([#5004](https://github.com/algolia/instantsearch.js/issues/5004)) ([40541af](https://github.com/algolia/instantsearch.js/commit/40541af5c8face0e32a1ec3a4665a8387d89c626))
-* **metadata:** ensure safe user agent detection ([#5009](https://github.com/algolia/instantsearch.js/pull/5009) [15a6a9d](https://github.com/algolia/instantsearch.js/commit/15a6a9d10ee512fab6884696bc59bedea13bd1b3))
+- **routing:** fix history router based on history length ([#5004](https://github.com/algolia/instantsearch/issues/5004)) ([40541af](https://github.com/algolia/instantsearch/commit/40541af5c8face0e32a1ec3a4665a8387d89c626))
+- **metadata:** ensure safe user agent detection ([#5009](https://github.com/algolia/instantsearch/pull/5009) [15a6a9d](https://github.com/algolia/instantsearch/commit/15a6a9d10ee512fab6884696bc59bedea13bd1b3))
 
-
-# [4.38.0](https://github.com/algolia/instantsearch.js/compare/v4.37.3...v4.38.0) (2022-01-28)
-
+# [4.38.0](https://github.com/algolia/instantsearch/compare/v4.37.3...v4.38.0) (2022-01-28)
 
 ### Bug Fixes
 
-* **typescript:** remove non-existing UMD type definition ([#5001](https://github.com/algolia/instantsearch.js/issues/5001)) ([c234374](https://github.com/algolia/instantsearch.js/commit/c234374a1f5333f6625980c45fa0833a8c130257))
-
+- **typescript:** remove non-existing UMD type definition ([#5001](https://github.com/algolia/instantsearch/issues/5001)) ([c234374](https://github.com/algolia/instantsearch/commit/c234374a1f5333f6625980c45fa0833a8c130257))
 
 ### Features
 
-* **connectors:** expose search results to `transformItems` when available ([#5000](https://github.com/algolia/instantsearch.js/issues/5000)) ([58c2651](https://github.com/algolia/instantsearch.js/commit/58c26517aad916ce49b474458e3411ff7ef5497a))
+- **connectors:** expose search results to `transformItems` when available ([#5000](https://github.com/algolia/instantsearch/issues/5000)) ([58c2651](https://github.com/algolia/instantsearch/commit/58c26517aad916ce49b474458e3411ff7ef5497a))
 
-
-
-## [4.37.3](https://github.com/algolia/instantsearch.js/compare/v4.37.2...v4.37.3) (2022-01-25)
-
+## [4.37.3](https://github.com/algolia/instantsearch/compare/v4.37.2...v4.37.3) (2022-01-25)
 
 ### Bug Fixes
 
-* **helpers:** display warning if attribute cannot be highlighted/snippeted ([#4996](https://github.com/algolia/instantsearch.js/issues/4996)) ([e81bf59](https://github.com/algolia/instantsearch.js/commit/e81bf59f0f28eb7b9f54f7d4424c60546b9a4d8c))
+- **helpers:** display warning if attribute cannot be highlighted/snippeted ([#4996](https://github.com/algolia/instantsearch/issues/4996)) ([e81bf59](https://github.com/algolia/instantsearch/commit/e81bf59f0f28eb7b9f54f7d4424c60546b9a4d8c))
 
-
-
-## [4.37.2](https://github.com/algolia/instantsearch.js/compare/v4.37.1...v4.37.2) (2022-01-10)
-
+## [4.37.2](https://github.com/algolia/instantsearch/compare/v4.37.1...v4.37.2) (2022-01-10)
 
 ### Bug Fixes
 
-* **searchbox:** make sure setting query to the initial doesn't cause a stale state ([#4990](https://github.com/algolia/instantsearch.js/issues/4990)) ([3faca01](https://github.com/algolia/instantsearch.js/commit/3faca014aad08145c3b4cc66a5e841da3a0f64b8))
+- **searchbox:** make sure setting query to the initial doesn't cause a stale state ([#4990](https://github.com/algolia/instantsearch/issues/4990)) ([3faca01](https://github.com/algolia/instantsearch/commit/3faca014aad08145c3b4cc66a5e841da3a0f64b8))
 
-
-
-## [4.37.1](https://github.com/algolia/instantsearch.js/compare/v4.37.0...v4.37.1) (2022-01-05)
-
+## [4.37.1](https://github.com/algolia/instantsearch/compare/v4.37.0...v4.37.1) (2022-01-05)
 
 ### Bug Fixes
 
-* **connectBreadcrumb:** returns an empty array if no hierarchicalFacets exist ([#4980](https://github.com/algolia/instantsearch.js/issues/4980)) ([3ea9b91](https://github.com/algolia/instantsearch.js/commit/3ea9b918f85c686a07b06cfc12b8c59b80181f28))
-* **es:** mark inner package.json as side-effect free ([#4984](https://github.com/algolia/instantsearch.js/issues/4984)) ([74f56f3](https://github.com/algolia/instantsearch.js/commit/74f56f35b7ccc78904592edfc40e782e40847986)), closes [#4971](https://github.com/algolia/instantsearch.js/issues/4971)
-* **events:** emit error as typeof Error ([#4983](https://github.com/algolia/instantsearch.js/issues/4983)) ([4adfaf2](https://github.com/algolia/instantsearch.js/commit/4adfaf2eba40fffa7f4800664dc89e0edf2d819e))
+- **connectBreadcrumb:** returns an empty array if no hierarchicalFacets exist ([#4980](https://github.com/algolia/instantsearch/issues/4980)) ([3ea9b91](https://github.com/algolia/instantsearch/commit/3ea9b918f85c686a07b06cfc12b8c59b80181f28))
+- **es:** mark inner package.json as side-effect free ([#4984](https://github.com/algolia/instantsearch/issues/4984)) ([74f56f3](https://github.com/algolia/instantsearch/commit/74f56f35b7ccc78904592edfc40e782e40847986)), closes [#4971](https://github.com/algolia/instantsearch/issues/4971)
+- **events:** emit error as typeof Error ([#4983](https://github.com/algolia/instantsearch/issues/4983)) ([4adfaf2](https://github.com/algolia/instantsearch/commit/4adfaf2eba40fffa7f4800664dc89e0edf2d819e))
 
-
-
-# [4.37.0](https://github.com/algolia/instantsearch.js/compare/v4.36.0...v4.37.0) (2022-01-04)
-
+# [4.37.0](https://github.com/algolia/instantsearch/compare/v4.36.0...v4.37.0) (2022-01-04)
 
 ### Features
 
-* **build:** expose `/es` as a real ES module ([#4971](https://github.com/algolia/instantsearch.js/issues/4971)) ([e5b3434](https://github.com/algolia/instantsearch.js/commit/e5b343490921f70736e11a7758bdc7a3aeed6d69))
+- **build:** expose `/es` as a real ES module ([#4971](https://github.com/algolia/instantsearch/issues/4971)) ([e5b3434](https://github.com/algolia/instantsearch/commit/e5b343490921f70736e11a7758bdc7a3aeed6d69))
 
-
-
-# [4.36.0](https://github.com/algolia/instantsearch.js/compare/v4.35.0...v4.36.0) (2021-12-16)
-
+# [4.36.0](https://github.com/algolia/instantsearch/compare/v4.35.0...v4.36.0) (2021-12-16)
 
 ### Features
 
-* **dynamicWidgets:** send facets * and maxValuesPerFacet by default ([#4968](https://github.com/algolia/instantsearch.js/issues/4968)) ([969ae89](https://github.com/algolia/instantsearch.js/commit/969ae8980f7c8a055bb4c6c5967d04744644f555))
-* **DynamicWidgets:** throw when transformItems returns anything that isn't an array ([#4975](https://github.com/algolia/instantsearch.js/issues/4975)) ([5c328c8](https://github.com/algolia/instantsearch.js/commit/5c328c85428eb9a5c1450fd01154751f4e0ea2fa))
+- **dynamicWidgets:** send facets \* and maxValuesPerFacet by default ([#4968](https://github.com/algolia/instantsearch/issues/4968)) ([969ae89](https://github.com/algolia/instantsearch/commit/969ae8980f7c8a055bb4c6c5967d04744644f555))
+- **DynamicWidgets:** throw when transformItems returns anything that isn't an array ([#4975](https://github.com/algolia/instantsearch/issues/4975)) ([5c328c8](https://github.com/algolia/instantsearch/commit/5c328c85428eb9a5c1450fd01154751f4e0ea2fa))
 
-
-
-# [4.35.0](https://github.com/algolia/instantsearch.js/compare/v4.34.0...v4.35.0) (2021-12-13)
-
+# [4.35.0](https://github.com/algolia/instantsearch/compare/v4.34.0...v4.35.0) (2021-12-13)
 
 ### Features
 
-* **events:** move to @algolia/events ([#4961](https://github.com/algolia/instantsearch.js/issues/4961)) ([1c56726](https://github.com/algolia/instantsearch.js/commit/1c5672640c65d7ed6f6e381a3162e508bdda44f3))
+- **events:** move to @algolia/events ([#4961](https://github.com/algolia/instantsearch/issues/4961)) ([1c56726](https://github.com/algolia/instantsearch/commit/1c5672640c65d7ed6f6e381a3162e508bdda44f3))
 
 ### Bug Fixes
 
-* **deps:** Add missing peer dependency ([#4950](https://github.com/algolia/instantsearch.js/issues/4950)) ([468578da9](https://github.com/algolia/instantsearch.js/commit/468578da948a12224c892fd12cba4c880aa7b25f))
+- **deps:** Add missing peer dependency ([#4950](https://github.com/algolia/instantsearch/issues/4950)) ([468578da9](https://github.com/algolia/instantsearch/commit/468578da948a12224c892fd12cba4c880aa7b25f))
 
-
-
-# [4.34.0](https://github.com/algolia/instantsearch.js/compare/v4.33.2...v4.34.0) (2021-12-07)
-
+# [4.34.0](https://github.com/algolia/instantsearch/compare/v4.33.2...v4.34.0) (2021-12-07)
 
 ### Features
 
-* rely on `state` in `getWidgetRenderState` ([#4960](https://github.com/algolia/instantsearch.js/issues/4960)) ([5006841](https://github.com/algolia/instantsearch.js/commit/50068417e5e7211802bc717b582946f6e630d7ac))
-* support initial results (experimental) ([#4967](https://github.com/algolia/instantsearch.js/issues/4967)) ([db11c13](https://github.com/algolia/instantsearch.js/commit/db11c13ea55433491f5e924633bff12a303c1bc6))
+- rely on `state` in `getWidgetRenderState` ([#4960](https://github.com/algolia/instantsearch/issues/4960)) ([5006841](https://github.com/algolia/instantsearch/commit/50068417e5e7211802bc717b582946f6e630d7ac))
+- support initial results (experimental) ([#4967](https://github.com/algolia/instantsearch/issues/4967)) ([db11c13](https://github.com/algolia/instantsearch/commit/db11c13ea55433491f5e924633bff12a303c1bc6))
 
-
-
-## [4.33.2](https://github.com/algolia/instantsearch.js/compare/v4.33.1...v4.33.2) (2021-11-16)
-
+## [4.33.2](https://github.com/algolia/instantsearch/compare/v4.33.1...v4.33.2) (2021-11-16)
 
 ### Bug Fixes
 
-* **connectNumericMenu:** allow option for same start/end values ([#4951](https://github.com/algolia/instantsearch.js/issues/4951)) ([18da714](https://github.com/algolia/instantsearch.js/commit/18da714574fa98957d29014add3123e9c377551f))
+- **connectNumericMenu:** allow option for same start/end values ([#4951](https://github.com/algolia/instantsearch/issues/4951)) ([18da714](https://github.com/algolia/instantsearch/commit/18da714574fa98957d29014add3123e9c377551f))
 
-
-
-## [4.33.1](https://github.com/algolia/instantsearch.js/compare/v4.33.0...v4.33.1) (2021-11-02)
-
+## [4.33.1](https://github.com/algolia/instantsearch/compare/v4.33.0...v4.33.1) (2021-11-02)
 
 ### Bug Fixes
 
-* **getUiState:** support `initialUiState` ([#4948](https://github.com/algolia/instantsearch.js/issues/4948)) ([532474d](https://github.com/algolia/instantsearch.js/commit/532474dfaf49446ab59a2a27424ca220947dd5bd))
+- **getUiState:** support `initialUiState` ([#4948](https://github.com/algolia/instantsearch/issues/4948)) ([532474d](https://github.com/algolia/instantsearch/commit/532474dfaf49446ab59a2a27424ca220947dd5bd))
 
-
-
-# [4.33.0](https://github.com/algolia/instantsearch.js/compare/v4.32.0...v4.33.0) (2021-10-26)
-
+# [4.33.0](https://github.com/algolia/instantsearch/compare/v4.32.0...v4.33.0) (2021-10-26)
 
 ### Bug Fixes
 
-* **router:** skip history push on browser back and forward actions ([#4933](https://github.com/algolia/instantsearch.js/issues/4933)) ([7909da4](https://github.com/algolia/instantsearch.js/commit/7909da4903eb1aee885811e280b909a3bda488be))
-* **setUiState:** reset UI state with empty object ([#4944](https://github.com/algolia/instantsearch.js/issues/4944)) ([5faae4a](https://github.com/algolia/instantsearch.js/commit/5faae4ac44ac5ad2f8086ad2a306bcfaa14bc754))
-
+- **router:** skip history push on browser back and forward actions ([#4933](https://github.com/algolia/instantsearch/issues/4933)) ([7909da4](https://github.com/algolia/instantsearch/commit/7909da4903eb1aee885811e280b909a3bda488be))
+- **setUiState:** reset UI state with empty object ([#4944](https://github.com/algolia/instantsearch/issues/4944)) ([5faae4a](https://github.com/algolia/instantsearch/commit/5faae4ac44ac5ad2f8086ad2a306bcfaa14bc754))
 
 ### Features
 
-* **router:** support server environments ([#4940](https://github.com/algolia/instantsearch.js/issues/4940)) ([a002962](https://github.com/algolia/instantsearch.js/commit/a002962df0e7683b29bef8bfaaddb494fa551a14))
+- **router:** support server environments ([#4940](https://github.com/algolia/instantsearch/issues/4940)) ([a002962](https://github.com/algolia/instantsearch/commit/a002962df0e7683b29bef8bfaaddb494fa551a14))
 
-
-
-# [4.32.0](https://github.com/algolia/instantsearch.js/compare/v4.31.1...v4.32.0) (2021-10-20)
-
+# [4.32.0](https://github.com/algolia/instantsearch/compare/v4.31.1...v4.32.0) (2021-10-20)
 
 ### Features
 
-* **dependencies:** update algoliasearch-helper ([#4936](https://github.com/algolia/instantsearch.js/issues/4936)) ([014a413](https://github.com/algolia/instantsearch.js/commit/014a413f14dded3861a9c288ea618f1602bcd66d))
+- **dependencies:** update algoliasearch-helper ([#4936](https://github.com/algolia/instantsearch/issues/4936)) ([014a413](https://github.com/algolia/instantsearch/commit/014a413f14dded3861a9c288ea618f1602bcd66d))
 
-
-
-## [4.31.1](https://github.com/algolia/instantsearch.js/compare/v4.31.0...v4.31.1) (2021-10-19)
-
+## [4.31.1](https://github.com/algolia/instantsearch/compare/v4.31.0...v4.31.1) (2021-10-19)
 
 ### Bug Fixes
 
-* **types:** export correct types from search-insights ([#4930](https://github.com/algolia/instantsearch.js/issues/4930)) ([5ae7a5b](https://github.com/algolia/instantsearch.js/commit/5ae7a5b86ad9c042bfbdc60e505c159eebdb404f))
+- **types:** export correct types from search-insights ([#4930](https://github.com/algolia/instantsearch/issues/4930)) ([5ae7a5b](https://github.com/algolia/instantsearch/commit/5ae7a5b86ad9c042bfbdc60e505c159eebdb404f))
 
-
-
-# [4.31.0](https://github.com/algolia/instantsearch.js/compare/v4.30.3...v4.31.0) (2021-10-14)
-
+# [4.31.0](https://github.com/algolia/instantsearch/compare/v4.30.3...v4.31.0) (2021-10-14)
 
 ### Features
 
-* **InstantSearch:** defer initial search ([#4925](https://github.com/algolia/instantsearch.js/issues/4925)) ([9a88115](https://github.com/algolia/instantsearch.js/commit/9a8811534af1288e316cdfb6f6fc49df1597290e))
+- **InstantSearch:** defer initial search ([#4925](https://github.com/algolia/instantsearch/issues/4925)) ([9a88115](https://github.com/algolia/instantsearch/commit/9a8811534af1288e316cdfb6f6fc49df1597290e))
 
-
-
-## [4.30.3](https://github.com/algolia/instantsearch.js/compare/v4.30.2...v4.30.3) (2021-10-12)
-
+## [4.30.3](https://github.com/algolia/instantsearch/compare/v4.30.2...v4.30.3) (2021-10-12)
 
 ### Bug Fixes
 
-* **toggleRefinement:** don't set off value in getWidgetRenderState ([#4912](https://github.com/algolia/instantsearch.js/issues/4912)) ([69525bf](https://github.com/algolia/instantsearch.js/commit/69525bf2a3087aeb75c4f1e5ab8452012436f61f))
+- **toggleRefinement:** don't set off value in getWidgetRenderState ([#4912](https://github.com/algolia/instantsearch/issues/4912)) ([69525bf](https://github.com/algolia/instantsearch/commit/69525bf2a3087aeb75c4f1e5ab8452012436f61f))
 
-
-
-## [4.30.2](https://github.com/algolia/instantsearch.js/compare/v4.30.1...v4.30.2) (2021-09-21)
-
+## [4.30.2](https://github.com/algolia/instantsearch/compare/v4.30.1...v4.30.2) (2021-09-21)
 
 ### Bug Fixes
 
-* **es:** add warning to typescript declaration of keys to be imported from helpers ([#4908](https://github.com/algolia/instantsearch.js/issues/4908)) ([8cbd5fb](https://github.com/algolia/instantsearch.js/commit/8cbd5fb3f02427f2c7de6e818f1ff4c81485b3e1))
-* **infinite/hits:** stop saving the transformed results in cache ([#4907](https://github.com/algolia/instantsearch.js/issues/4907)) ([82dc0ae](https://github.com/algolia/instantsearch.js/commit/82dc0ae966fda37582d5324ea6ca3e0f33ef56d5)), closes [#4819](https://github.com/algolia/instantsearch.js/issues/4819)
+- **es:** add warning to typescript declaration of keys to be imported from helpers ([#4908](https://github.com/algolia/instantsearch/issues/4908)) ([8cbd5fb](https://github.com/algolia/instantsearch/commit/8cbd5fb3f02427f2c7de6e818f1ff4c81485b3e1))
+- **infinite/hits:** stop saving the transformed results in cache ([#4907](https://github.com/algolia/instantsearch/issues/4907)) ([82dc0ae](https://github.com/algolia/instantsearch/commit/82dc0ae966fda37582d5324ea6ca3e0f33ef56d5)), closes [#4819](https://github.com/algolia/instantsearch/issues/4819)
 
-
-
-## [4.30.1](https://github.com/algolia/instantsearch.js/compare/v4.30.0...v4.30.1) (2021-09-14)
-
+## [4.30.1](https://github.com/algolia/instantsearch/compare/v4.30.0...v4.30.1) (2021-09-14)
 
 ### Bug Fixes
 
-* **insightsMiddleware:** throw an error when credentials can't be extracted ([#4901](https://github.com/algolia/instantsearch.js/issues/4901)) ([55313e4](https://github.com/algolia/instantsearch.js/commit/55313e4ea4105b777f3f102e9f48a7e440496d25))
+- **insightsMiddleware:** throw an error when credentials can't be extracted ([#4901](https://github.com/algolia/instantsearch/issues/4901)) ([55313e4](https://github.com/algolia/instantsearch/commit/55313e4ea4105b777f3f102e9f48a7e440496d25))
 
-
-
-# [4.30.0](https://github.com/algolia/instantsearch.js/compare/v4.29.1...v4.30.0) (2021-09-07)
-
+# [4.30.0](https://github.com/algolia/instantsearch/compare/v4.29.1...v4.30.0) (2021-09-07)
 
 ### Bug Fixes
 
-* **insights:** handle multiple setUserToken call before search.start() ([#4897](https://github.com/algolia/instantsearch.js/issues/4897)) ([51a6f2b](https://github.com/algolia/instantsearch.js/commit/51a6f2bcd2ea312e7038e6f3208a2e9b3fed494a))
-
+- **insights:** handle multiple setUserToken call before search.start() ([#4897](https://github.com/algolia/instantsearch/issues/4897)) ([51a6f2b](https://github.com/algolia/instantsearch/commit/51a6f2bcd2ea312e7038e6f3208a2e9b3fed494a))
 
 ### Features
 
-* **dynamicWidgets:** add fallbackWidget ([#4847](https://github.com/algolia/instantsearch.js/issues/4847)) ([7d99ab9](https://github.com/algolia/instantsearch.js/commit/7d99ab95972d5886cdc82abb5794a41d38381a50))
-* **dynamicWidgets:** mark as stable ([#4899](https://github.com/algolia/instantsearch.js/issues/4899)) ([f97468f](https://github.com/algolia/instantsearch.js/commit/f97468f134d92c198433a7dad16a3b19b3779a94))
+- **dynamicWidgets:** add fallbackWidget ([#4847](https://github.com/algolia/instantsearch/issues/4847)) ([7d99ab9](https://github.com/algolia/instantsearch/commit/7d99ab95972d5886cdc82abb5794a41d38381a50))
+- **dynamicWidgets:** mark as stable ([#4899](https://github.com/algolia/instantsearch/issues/4899)) ([f97468f](https://github.com/algolia/instantsearch/commit/f97468f134d92c198433a7dad16a3b19b3779a94))
 
-
-
-## [4.29.1](https://github.com/algolia/instantsearch.js/compare/v4.29.0...v4.29.1) (2021-09-02)
-
+## [4.29.1](https://github.com/algolia/instantsearch/compare/v4.29.0...v4.29.1) (2021-09-02)
 
 ### Bug Fixes
 
-* **middleware:** subscribe middleware before initializing main index ([#4849](https://github.com/algolia/instantsearch.js/issues/4849)) ([0fc8f73](https://github.com/algolia/instantsearch.js/commit/0fc8f7322f8521f934ed871e8125707ba2ec0bfd))
+- **middleware:** subscribe middleware before initializing main index ([#4849](https://github.com/algolia/instantsearch/issues/4849)) ([0fc8f73](https://github.com/algolia/instantsearch/commit/0fc8f7322f8521f934ed871e8125707ba2ec0bfd))
 
-
-
-# [4.29.0](https://github.com/algolia/instantsearch.js/compare/v4.28.0...v4.29.0) (2021-08-31)
-
+# [4.29.0](https://github.com/algolia/instantsearch/compare/v4.28.0...v4.29.0) (2021-08-31)
 
 ### Features
 
-* **panel:** render templates on init with render state ([#4845](https://github.com/algolia/instantsearch.js/issues/4845)) ([0e151a9](https://github.com/algolia/instantsearch.js/commit/0e151a9552092807ecbc6993f3f6193fef621f44))
+- **panel:** render templates on init with render state ([#4845](https://github.com/algolia/instantsearch/issues/4845)) ([0e151a9](https://github.com/algolia/instantsearch/commit/0e151a9552092807ecbc6993f3f6193fef621f44))
 
-
-
-# [4.28.0](https://github.com/algolia/instantsearch.js/compare/v4.27.2...v4.28.0) (2021-08-24)
-
+# [4.28.0](https://github.com/algolia/instantsearch/compare/v4.27.2...v4.28.0) (2021-08-24)
 
 ### Bug Fixes
 
-* **sendEvent:** split > 20 objects in multiple calls ([#4841](https://github.com/algolia/instantsearch.js/issues/4841)) ([44574bc](https://github.com/algolia/instantsearch.js/commit/44574bcf03ac05e22274099622e6a1839599ca7e))
-* **svg:** remove xmlns ([#4839](https://github.com/algolia/instantsearch.js/issues/4839)) ([932ae3a](https://github.com/algolia/instantsearch.js/commit/932ae3a868340a32ccaacb276c862921fee41a93))
-
+- **sendEvent:** split > 20 objects in multiple calls ([#4841](https://github.com/algolia/instantsearch/issues/4841)) ([44574bc](https://github.com/algolia/instantsearch/commit/44574bcf03ac05e22274099622e6a1839599ca7e))
+- **svg:** remove xmlns ([#4839](https://github.com/algolia/instantsearch/issues/4839)) ([932ae3a](https://github.com/algolia/instantsearch/commit/932ae3a868340a32ccaacb276c862921fee41a93))
 
 ### Features
 
-* **ts:** expose built files in umd ([#4844](https://github.com/algolia/instantsearch.js/issues/4844)) ([8578ae3](https://github.com/algolia/instantsearch.js/commit/8578ae30a915db49acaa0292faba2ec6ccd52b73))
+- **ts:** expose built files in umd ([#4844](https://github.com/algolia/instantsearch/issues/4844)) ([8578ae3](https://github.com/algolia/instantsearch/commit/8578ae30a915db49acaa0292faba2ec6ccd52b73))
 
-
-
-## [4.27.2](https://github.com/algolia/instantsearch.js/compare/v4.27.1...v4.27.2) (2021-08-18)
-
+## [4.27.2](https://github.com/algolia/instantsearch/compare/v4.27.1...v4.27.2) (2021-08-18)
 
 ### Bug Fixes
 
-* **types:** export all types as "type" to avoid exporting in .js ([#4837](https://github.com/algolia/instantsearch.js/issues/4837)) ([dcbbd88](https://github.com/algolia/instantsearch.js/commit/dcbbd8804b4b6471d24820b42826b57388974c27))
+- **types:** export all types as "type" to avoid exporting in .js ([#4837](https://github.com/algolia/instantsearch/issues/4837)) ([dcbbd88](https://github.com/algolia/instantsearch/commit/dcbbd8804b4b6471d24820b42826b57388974c27))
 
-
-
-## [4.27.1](https://github.com/algolia/instantsearch.js/compare/v4.27.0...v4.27.1) (2021-08-17)
-
+## [4.27.1](https://github.com/algolia/instantsearch/compare/v4.27.0...v4.27.1) (2021-08-17)
 
 ### Bug Fixes
 
-* **ts:** export types from entry point ([#4834](https://github.com/algolia/instantsearch.js/issues/4834)) ([3014e84](https://github.com/algolia/instantsearch.js/commit/3014e8481e401db62fff41d6867580c04adeaf6b))
+- **ts:** export types from entry point ([#4834](https://github.com/algolia/instantsearch/issues/4834)) ([3014e84](https://github.com/algolia/instantsearch/commit/3014e8481e401db62fff41d6867580c04adeaf6b))
 
-
-
-# [4.27.0](https://github.com/algolia/instantsearch.js/compare/v4.26.0...v4.27.0) (2021-08-17)
-
+# [4.27.0](https://github.com/algolia/instantsearch/compare/v4.26.0...v4.27.0) (2021-08-17)
 
 ### Bug Fixes
 
-* **ts:** correct entry point ([#4829](https://github.com/algolia/instantsearch.js/issues/4829)) ([24a45f9](https://github.com/algolia/instantsearch.js/commit/24a45f9a9fb3c8f62003d2aa37b3456c11af2985))
-* **ts:** export PaginationConnector ([d201322](https://github.com/algolia/instantsearch.js/commit/d201322de0d09a664b762422fdc0a51e2bd566bc))
-
+- **ts:** correct entry point ([#4829](https://github.com/algolia/instantsearch/issues/4829)) ([24a45f9](https://github.com/algolia/instantsearch/commit/24a45f9a9fb3c8f62003d2aa37b3456c11af2985))
+- **ts:** export PaginationConnector ([d201322](https://github.com/algolia/instantsearch/commit/d201322de0d09a664b762422fdc0a51e2bd566bc))
 
 ### Features
 
-* **typescript:** expose types at regular build ([#4832](https://github.com/algolia/instantsearch.js/issues/4832)) ([4bea07b](https://github.com/algolia/instantsearch.js/commit/4bea07b99f492441eb94e483378e0778f90c5b43))
+- **typescript:** expose types at regular build ([#4832](https://github.com/algolia/instantsearch/issues/4832)) ([4bea07b](https://github.com/algolia/instantsearch/commit/4bea07b99f492441eb94e483378e0778f90c5b43))
 
 If you were using typescript via the `experimental-typescript` tag, you can now use regular InstantSearch.js.
 
-# [4.26.0](https://github.com/algolia/instantsearch.js/compare/v4.25.3...v4.26.0) (2021-08-10)
-
-
-### Features
-
-* **ts:** allow custom ui state and route state in routing ([#4816](https://github.com/algolia/instantsearch.js/issues/4816)) ([5f8ba5d](https://github.com/algolia/instantsearch.js/commit/5f8ba5ddcf5e32fd3cecf39ea667d8266dab35f8))
-* **types:** allow typed access to properties added to entry ([#4814](https://github.com/algolia/instantsearch.js/issues/4814)) ([9000f16](https://github.com/algolia/instantsearch.js/commit/9000f16c3e0ff53eda4ca21281a87d8ff9b9154d))
-
-
-
-## [4.25.3](https://github.com/algolia/instantsearch.js/compare/v4.25.2...v4.25.3) (2021-08-03)
-
-
-### Bug Fixes
-
-* **types:** fix hits and results types in connectHits and connectInfiniteHits ([#4820](https://github.com/algolia/instantsearch.js/issues/4820)) ([2bf987e](https://github.com/algolia/instantsearch.js/commit/2bf987e8b2728a8e65a88a49d46eadf6c0172660))
-
-
-
-## [4.25.2](https://github.com/algolia/instantsearch.js/compare/v4.25.1...v4.25.2) (2021-07-20)
-
-
-### Bug Fixes
-
-* **build:** ensure build fails when types building fails ([#4812](https://github.com/algolia/instantsearch.js/issues/4812)) ([b37e23b](https://github.com/algolia/instantsearch.js/commit/b37e23b5819abbc03049124bc3a29120f91aeb8c))
-* **types:** export widget's types ([#4813](https://github.com/algolia/instantsearch.js/issues/4813)) ([e9764e9](https://github.com/algolia/instantsearch.js/commit/e9764e9273e5b7bacd86f8d1cb751e87bd75eb75))
-
-
-
-## [4.25.1](https://github.com/algolia/instantsearch.js/compare/v4.25.0...v4.25.1) (2021-07-13)
-
-
-### Bug Fixes
-
-* **deps:** force a lower version of qs ([#4805](https://github.com/algolia/instantsearch.js/issues/4805)) ([07b7e08](https://github.com/algolia/instantsearch.js/commit/07b7e086282f8cc6a17aee822902d97204c1d2da))
-
-
-
-# [4.25.0](https://github.com/algolia/instantsearch.js/compare/v4.24.3...v4.25.0) (2021-07-06)
-
+# [4.26.0](https://github.com/algolia/instantsearch/compare/v4.25.3...v4.26.0) (2021-08-10)
 
 ### Features
 
-* **facets:** apply result from facet ordering ([#4784](https://github.com/algolia/instantsearch.js/issues/4784)) ([9e9d839](https://github.com/algolia/instantsearch.js/commit/9e9d8394067bec35425b7d66f94fcce504faee7f))
+- **ts:** allow custom ui state and route state in routing ([#4816](https://github.com/algolia/instantsearch/issues/4816)) ([5f8ba5d](https://github.com/algolia/instantsearch/commit/5f8ba5ddcf5e32fd3cecf39ea667d8266dab35f8))
+- **types:** allow typed access to properties added to entry ([#4814](https://github.com/algolia/instantsearch/issues/4814)) ([9000f16](https://github.com/algolia/instantsearch/commit/9000f16c3e0ff53eda4ca21281a87d8ff9b9154d))
 
-
-
-## [4.24.3](https://github.com/algolia/instantsearch.js/compare/v4.24.2...v4.24.3) (2021-07-05)
-
+## [4.25.3](https://github.com/algolia/instantsearch/compare/v4.25.2...v4.25.3) (2021-08-03)
 
 ### Bug Fixes
 
-* **dynamicWidgets:** read from facetOrdering.facets ([42d6c6c](https://github.com/algolia/instantsearch.js/commit/42d6c6cefc5f009a3cfc63ab3d628ed2811f1700))
-* **ts:** make template types consistent ([#4785](https://github.com/algolia/instantsearch.js/issues/4785)) ([e0fbd55](https://github.com/algolia/instantsearch.js/commit/e0fbd55b6b98dd64301f113fd394dce57552d94c))
+- **types:** fix hits and results types in connectHits and connectInfiniteHits ([#4820](https://github.com/algolia/instantsearch/issues/4820)) ([2bf987e](https://github.com/algolia/instantsearch/commit/2bf987e8b2728a8e65a88a49d46eadf6c0172660))
 
-
-
-## [4.24.2](https://github.com/algolia/instantsearch.js/compare/v4.24.1...v4.24.2) (2021-06-29)
-
+## [4.25.2](https://github.com/algolia/instantsearch/compare/v4.25.1...v4.25.2) (2021-07-20)
 
 ### Bug Fixes
 
-* **index:** export `IndexWidgetParams` type ([#4793](https://github.com/algolia/instantsearch.js/issues/4793)) ([91bdea1](https://github.com/algolia/instantsearch.js/commit/91bdea18f3768265937e2d3aca4acaa05c24e426))
-* **onStateChange:** propagate change to middleware ([#4796](https://github.com/algolia/instantsearch.js/issues/4796)) ([57c32c0](https://github.com/algolia/instantsearch.js/commit/57c32c0a43bd2c6cbdd3f8ea7eac8109e3024f2a))
-* **relevantSort:** export `RelevantSortWidgetParams` type ([#4794](https://github.com/algolia/instantsearch.js/issues/4794)) ([1a10b59](https://github.com/algolia/instantsearch.js/commit/1a10b59938c6121f58510726b67ee6dfa1aa1b7c))
-* **sortBy:** do not write the default state ([#4798](https://github.com/algolia/instantsearch.js/issues/4798)) ([1d8a40e](https://github.com/algolia/instantsearch.js/commit/1d8a40ecc8e6e48746113ec3ec0d975e14bec1ea))
+- **build:** ensure build fails when types building fails ([#4812](https://github.com/algolia/instantsearch/issues/4812)) ([b37e23b](https://github.com/algolia/instantsearch/commit/b37e23b5819abbc03049124bc3a29120f91aeb8c))
+- **types:** export widget's types ([#4813](https://github.com/algolia/instantsearch/issues/4813)) ([e9764e9](https://github.com/algolia/instantsearch/commit/e9764e9273e5b7bacd86f8d1cb751e87bd75eb75))
 
-
-
-## [4.24.1](https://github.com/algolia/instantsearch.js/compare/v4.24.0...v4.24.1) (2021-06-23)
-
+## [4.25.1](https://github.com/algolia/instantsearch/compare/v4.25.0...v4.25.1) (2021-07-13)
 
 ### Bug Fixes
 
-* **mainHelper:** allow a mainHelper to be set before start ([#4790](https://github.com/algolia/instantsearch.js/issues/4790)) ([e8329ae](https://github.com/algolia/instantsearch.js/commit/e8329aecb386755a039cf10850e394d0d71f29f4))
+- **deps:** force a lower version of qs ([#4805](https://github.com/algolia/instantsearch/issues/4805)) ([07b7e08](https://github.com/algolia/instantsearch/commit/07b7e086282f8cc6a17aee822902d97204c1d2da))
 
-
-
-# [4.24.0](https://github.com/algolia/instantsearch.js/compare/v4.23.0...v4.24.0) (2021-06-15)
-
-
-### Bug Fixes
-
-* **clearRefinements:** do not throw when widgetParams is not given ([#4778](https://github.com/algolia/instantsearch.js/issues/4778)) ([6b1a375](https://github.com/algolia/instantsearch.js/commit/6b1a375ed7139c0b98993c0cb7ab40838e1f2288))
-* **ts:** make `CSSClasses` types consistent ([#4774](https://github.com/algolia/instantsearch.js/issues/4774)) ([99008a9](https://github.com/algolia/instantsearch.js/commit/99008a985ddc61ce197200df51fdcf385914064d))
-
+# [4.25.0](https://github.com/algolia/instantsearch/compare/v4.24.3...v4.25.0) (2021-07-06)
 
 ### Features
 
-* **dynamicWidgets:** add default attributesToRender & transformItems ([#4776](https://github.com/algolia/instantsearch.js/issues/4776)) ([44dab44](https://github.com/algolia/instantsearch.js/commit/44dab44282da58b36a707ad80aff4c18477abccd))
-* **ts:** convert pagination widget and component ([#4765](https://github.com/algolia/instantsearch.js/issues/4765)) ([34eb950](https://github.com/algolia/instantsearch.js/commit/34eb9500a2d7072814fd715e1c2217ed22de30d1))
-* **ts:** convert rangeInput widget and component ([#4766](https://github.com/algolia/instantsearch.js/issues/4766)) ([40b1a82](https://github.com/algolia/instantsearch.js/commit/40b1a82f9df4b16708fceefbba77a8fb49c7dc41))
+- **facets:** apply result from facet ordering ([#4784](https://github.com/algolia/instantsearch/issues/4784)) ([9e9d839](https://github.com/algolia/instantsearch/commit/9e9d8394067bec35425b7d66f94fcce504faee7f))
 
-
-
-# [4.23.0](https://github.com/algolia/instantsearch.js/compare/v4.22.0...v4.23.0) (2021-05-25)
-
+## [4.24.3](https://github.com/algolia/instantsearch/compare/v4.24.2...v4.24.3) (2021-07-05)
 
 ### Bug Fixes
 
-* **range:** reset the page on refine ([#4760](https://github.com/algolia/instantsearch.js/issues/4760)) ([24e3b34](https://github.com/algolia/instantsearch.js/commit/24e3b34c944ec32b414e845550e9c6c02b39cb92)), closes [#4759](https://github.com/algolia/instantsearch.js/issues/4759)
+- **dynamicWidgets:** read from facetOrdering.facets ([42d6c6c](https://github.com/algolia/instantsearch/commit/42d6c6cefc5f009a3cfc63ab3d628ed2811f1700))
+- **ts:** make template types consistent ([#4785](https://github.com/algolia/instantsearch/issues/4785)) ([e0fbd55](https://github.com/algolia/instantsearch/commit/e0fbd55b6b98dd64301f113fd394dce57552d94c))
 
+## [4.24.2](https://github.com/algolia/instantsearch/compare/v4.24.1...v4.24.2) (2021-06-29)
+
+### Bug Fixes
+
+- **index:** export `IndexWidgetParams` type ([#4793](https://github.com/algolia/instantsearch/issues/4793)) ([91bdea1](https://github.com/algolia/instantsearch/commit/91bdea18f3768265937e2d3aca4acaa05c24e426))
+- **onStateChange:** propagate change to middleware ([#4796](https://github.com/algolia/instantsearch/issues/4796)) ([57c32c0](https://github.com/algolia/instantsearch/commit/57c32c0a43bd2c6cbdd3f8ea7eac8109e3024f2a))
+- **relevantSort:** export `RelevantSortWidgetParams` type ([#4794](https://github.com/algolia/instantsearch/issues/4794)) ([1a10b59](https://github.com/algolia/instantsearch/commit/1a10b59938c6121f58510726b67ee6dfa1aa1b7c))
+- **sortBy:** do not write the default state ([#4798](https://github.com/algolia/instantsearch/issues/4798)) ([1d8a40e](https://github.com/algolia/instantsearch/commit/1d8a40ecc8e6e48746113ec3ec0d975e14bec1ea))
+
+## [4.24.1](https://github.com/algolia/instantsearch/compare/v4.24.0...v4.24.1) (2021-06-23)
+
+### Bug Fixes
+
+- **mainHelper:** allow a mainHelper to be set before start ([#4790](https://github.com/algolia/instantsearch/issues/4790)) ([e8329ae](https://github.com/algolia/instantsearch/commit/e8329aecb386755a039cf10850e394d0d71f29f4))
+
+# [4.24.0](https://github.com/algolia/instantsearch/compare/v4.23.0...v4.24.0) (2021-06-15)
+
+### Bug Fixes
+
+- **clearRefinements:** do not throw when widgetParams is not given ([#4778](https://github.com/algolia/instantsearch/issues/4778)) ([6b1a375](https://github.com/algolia/instantsearch/commit/6b1a375ed7139c0b98993c0cb7ab40838e1f2288))
+- **ts:** make `CSSClasses` types consistent ([#4774](https://github.com/algolia/instantsearch/issues/4774)) ([99008a9](https://github.com/algolia/instantsearch/commit/99008a985ddc61ce197200df51fdcf385914064d))
 
 ### Features
 
-* **ts:** convert poweredBy widget ([#4756](https://github.com/algolia/instantsearch.js/issues/4756)) ([142660a](https://github.com/algolia/instantsearch.js/commit/142660a2bc0ab7212265a9ff6dadf7a7f1081c69))
+- **dynamicWidgets:** add default attributesToRender & transformItems ([#4776](https://github.com/algolia/instantsearch/issues/4776)) ([44dab44](https://github.com/algolia/instantsearch/commit/44dab44282da58b36a707ad80aff4c18477abccd))
+- **ts:** convert pagination widget and component ([#4765](https://github.com/algolia/instantsearch/issues/4765)) ([34eb950](https://github.com/algolia/instantsearch/commit/34eb9500a2d7072814fd715e1c2217ed22de30d1))
+- **ts:** convert rangeInput widget and component ([#4766](https://github.com/algolia/instantsearch/issues/4766)) ([40b1a82](https://github.com/algolia/instantsearch/commit/40b1a82f9df4b16708fceefbba77a8fb49c7dc41))
 
-
-
-# [4.22.0](https://github.com/algolia/instantsearch.js/compare/v4.21.0...v4.22.0) (2021-05-05)
-
+# [4.23.0](https://github.com/algolia/instantsearch/compare/v4.22.0...v4.23.0) (2021-05-25)
 
 ### Bug Fixes
 
-* **insights:** do not throw when userToken is not given ([#4724](https://github.com/algolia/instantsearch.js/issues/4724)) ([8241b29](https://github.com/algolia/instantsearch.js/commit/8241b2909c981a6bb52e9f4f9b6bacb7bc60263b))
-* **insights:** use getUserToken method instead of _get ([#4744](https://github.com/algolia/instantsearch.js/issues/4744)) ([05d05a9](https://github.com/algolia/instantsearch.js/commit/05d05a9a8ad79e4ec8b183a3d17c2360430c302e))
-* **relevantSort:** remove "relevantSort" nesting, since there's only one property ([#4735](https://github.com/algolia/instantsearch.js/issues/4735)) ([f742083](https://github.com/algolia/instantsearch.js/commit/f74208396159524086341be4acf84d2af2b44135))
-* **connectToggleRefinement:** nest getRenderState per attribute ([#4743](https://github.com/algolia/instantsearch.js/issues/4743)) ([b9c884d](https://github.com/algolia/instantsearch.js/commit/b9c884daa406e1be63482ed198674b2ba22e66f2))
-* **connectToggleRefinement:** remove search parameters from render state ([#4743](https://github.com/algolia/instantsearch.js/issues/4743)) ([b9c884d](https://github.com/algolia/instantsearch.js/commit/b9c884daa406e1be63482ed198674b2ba22e66f2))
-
+- **range:** reset the page on refine ([#4760](https://github.com/algolia/instantsearch/issues/4760)) ([24e3b34](https://github.com/algolia/instantsearch/commit/24e3b34c944ec32b414e845550e9c6c02b39cb92)), closes [#4759](https://github.com/algolia/instantsearch/issues/4759)
 
 ### Features
 
-* **core:** add getUiState function ([#4750](https://github.com/algolia/instantsearch.js/issues/4750)) ([adce212](https://github.com/algolia/instantsearch.js/commit/adce2127de6c652ee6364e889a525d9d0ff6efdd))
-* **dynamicWidgets:** implementation ([#4687](https://github.com/algolia/instantsearch.js/issues/4687)) ([2e7ccc9](https://github.com/algolia/instantsearch.js/commit/2e7ccc91c8d2e4aa50c82a186cce057907042ed4))
-* **ts:** migrate toggleRefinement & connectToggleRefinement ([#4743](https://github.com/algolia/instantsearch.js/issues/4743)) ([b9c884d](https://github.com/algolia/instantsearch.js/commit/b9c884daa406e1be63482ed198674b2ba22e66f2))
-* **widget:** add access to "parent" in dispose ([#4745](https://github.com/algolia/instantsearch.js/issues/4745)) ([3fca986](https://github.com/algolia/instantsearch.js/commit/3fca986542e8b18312a6c6be810bf5fb986804a4))
+- **ts:** convert poweredBy widget ([#4756](https://github.com/algolia/instantsearch/issues/4756)) ([142660a](https://github.com/algolia/instantsearch/commit/142660a2bc0ab7212265a9ff6dadf7a7f1081c69))
 
-
-
-# [4.21.0](https://github.com/algolia/instantsearch.js/compare/v4.20.0...v4.21.0) (2021-04-12)
-
+# [4.22.0](https://github.com/algolia/instantsearch/compare/v4.21.0...v4.22.0) (2021-05-05)
 
 ### Bug Fixes
 
-* **infiniteHits:** fix wrong behavior of showPrevious regarding cachedHits ([#4725](https://github.com/algolia/instantsearch.js/issues/4725)) ([40b27b6](https://github.com/algolia/instantsearch.js/commit/40b27b668ec1dcb8608b299c941e0003b43911d3))
-* **ratingMenu:** use url in default template ([#4728](https://github.com/algolia/instantsearch.js/issues/4728)) ([31d9c50](https://github.com/algolia/instantsearch.js/commit/31d9c50344818cd4f4e62993a981ec3616d8b88e))
-
+- **insights:** do not throw when userToken is not given ([#4724](https://github.com/algolia/instantsearch/issues/4724)) ([8241b29](https://github.com/algolia/instantsearch/commit/8241b2909c981a6bb52e9f4f9b6bacb7bc60263b))
+- **insights:** use getUserToken method instead of \_get ([#4744](https://github.com/algolia/instantsearch/issues/4744)) ([05d05a9](https://github.com/algolia/instantsearch/commit/05d05a9a8ad79e4ec8b183a3d17c2360430c302e))
+- **relevantSort:** remove "relevantSort" nesting, since there's only one property ([#4735](https://github.com/algolia/instantsearch/issues/4735)) ([f742083](https://github.com/algolia/instantsearch/commit/f74208396159524086341be4acf84d2af2b44135))
+- **connectToggleRefinement:** nest getRenderState per attribute ([#4743](https://github.com/algolia/instantsearch/issues/4743)) ([b9c884d](https://github.com/algolia/instantsearch/commit/b9c884daa406e1be63482ed198674b2ba22e66f2))
+- **connectToggleRefinement:** remove search parameters from render state ([#4743](https://github.com/algolia/instantsearch/issues/4743)) ([b9c884d](https://github.com/algolia/instantsearch/commit/b9c884daa406e1be63482ed198674b2ba22e66f2))
 
 ### Features
 
-* **middleware:** accept partial methods ([#4673](https://github.com/algolia/instantsearch.js/issues/4673)) ([8f2aad2](https://github.com/algolia/instantsearch.js/commit/8f2aad2f0465cc883681143f350a11c24ce694e2))
-* **ts:** convert hierarchical-menu to TypeScript ([#4711](https://github.com/algolia/instantsearch.js/issues/4711)) ([870e2f7](https://github.com/algolia/instantsearch.js/commit/870e2f7285d58c48196356cd88fb4aca66feb7aa))
-* **ts:** convert RefinementList component to TypeScript ([#4702](https://github.com/algolia/instantsearch.js/issues/4702)) ([fd562de](https://github.com/algolia/instantsearch.js/commit/fd562de5e50e3889abaa9ef8151faa1b5179d7f6))
-* **ts:** convert search-box to TypeScript ([#4710](https://github.com/algolia/instantsearch.js/issues/4710)) ([e73257a](https://github.com/algolia/instantsearch.js/commit/e73257a466082207c0289f22bad523334d101aae))
+- **core:** add getUiState function ([#4750](https://github.com/algolia/instantsearch/issues/4750)) ([adce212](https://github.com/algolia/instantsearch/commit/adce2127de6c652ee6364e889a525d9d0ff6efdd))
+- **dynamicWidgets:** implementation ([#4687](https://github.com/algolia/instantsearch/issues/4687)) ([2e7ccc9](https://github.com/algolia/instantsearch/commit/2e7ccc91c8d2e4aa50c82a186cce057907042ed4))
+- **ts:** migrate toggleRefinement & connectToggleRefinement ([#4743](https://github.com/algolia/instantsearch/issues/4743)) ([b9c884d](https://github.com/algolia/instantsearch/commit/b9c884daa406e1be63482ed198674b2ba22e66f2))
+- **widget:** add access to "parent" in dispose ([#4745](https://github.com/algolia/instantsearch/issues/4745)) ([3fca986](https://github.com/algolia/instantsearch/commit/3fca986542e8b18312a6c6be810bf5fb986804a4))
 
+# [4.21.0](https://github.com/algolia/instantsearch/compare/v4.20.0...v4.21.0) (2021-04-12)
 
+### Bug Fixes
 
-# [4.20.0](https://github.com/algolia/instantsearch.js/compare/v4.19.0...v4.20.0) (2021-04-06)
-
+- **infiniteHits:** fix wrong behavior of showPrevious regarding cachedHits ([#4725](https://github.com/algolia/instantsearch/issues/4725)) ([40b27b6](https://github.com/algolia/instantsearch/commit/40b27b668ec1dcb8608b299c941e0003b43911d3))
+- **ratingMenu:** use url in default template ([#4728](https://github.com/algolia/instantsearch/issues/4728)) ([31d9c50](https://github.com/algolia/instantsearch/commit/31d9c50344818cd4f4e62993a981ec3616d8b88e))
 
 ### Features
 
-* **clearRefinements:** implement canRefine ([#4684](https://github.com/algolia/instantsearch.js/issues/4684)) ([a898f09](https://github.com/algolia/instantsearch.js/commit/a898f09bddca5db1f6782104375df3873d49c688))
-* **currentRefinements:** implement canRefine ([#4697](https://github.com/algolia/instantsearch.js/issues/4697)) ([4db75ba](https://github.com/algolia/instantsearch.js/commit/4db75baa9ff2e18f871547511d8f1234eea9d41b))
-* **hierarchicalMenu:** implement canRefine ([#4685](https://github.com/algolia/instantsearch.js/issues/4685)) ([0d2e450](https://github.com/algolia/instantsearch.js/commit/0d2e450aed2aaac72ae7ff7f1bb322ce6992c8ba))
-* **middleware:** add unuse method ([#4708](https://github.com/algolia/instantsearch.js/issues/4708)) ([8e3c406](https://github.com/algolia/instantsearch.js/commit/8e3c406c8f29bcae56d2f82f07cbd087043346fe))
-* **pagination:** implement canRefine ([#4683](https://github.com/algolia/instantsearch.js/issues/4683)) ([3ae51e6](https://github.com/algolia/instantsearch.js/commit/3ae51e60543984463a13b25e64aa2f879c91313e))
-* **range:** implement canRefine ([#4686](https://github.com/algolia/instantsearch.js/issues/4686)) ([a99ab6f](https://github.com/algolia/instantsearch.js/commit/a99ab6f968b791ffa31cd17dda598c293e73b88e))
-* **ratingMenu:** implement canRefine ([#4691](https://github.com/algolia/instantsearch.js/issues/4691)) ([42191a0](https://github.com/algolia/instantsearch.js/commit/42191a097a048a325234dd3f40f7799145628cd6))
-* **toggleRefinement:** implement canRefine ([#4689](https://github.com/algolia/instantsearch.js/issues/4689)) ([48dc7f8](https://github.com/algolia/instantsearch.js/commit/48dc7f8423c92b21bcd59856bf2fc685ae4aba69))
-* **ts:** convert rating-menu to TypeScript ([#4701](https://github.com/algolia/instantsearch.js/issues/4701)) ([f14ca08](https://github.com/algolia/instantsearch.js/commit/f14ca0891237a7a49b09d881cddedb93efc3a266))
-* **ts:** convert Template component to TypeScript ([#4703](https://github.com/algolia/instantsearch.js/issues/4703)) ([0688571](https://github.com/algolia/instantsearch.js/commit/068857137b85d1065bc5997514461d72fe595130))
+- **middleware:** accept partial methods ([#4673](https://github.com/algolia/instantsearch/issues/4673)) ([8f2aad2](https://github.com/algolia/instantsearch/commit/8f2aad2f0465cc883681143f350a11c24ce694e2))
+- **ts:** convert hierarchical-menu to TypeScript ([#4711](https://github.com/algolia/instantsearch/issues/4711)) ([870e2f7](https://github.com/algolia/instantsearch/commit/870e2f7285d58c48196356cd88fb4aca66feb7aa))
+- **ts:** convert RefinementList component to TypeScript ([#4702](https://github.com/algolia/instantsearch/issues/4702)) ([fd562de](https://github.com/algolia/instantsearch/commit/fd562de5e50e3889abaa9ef8151faa1b5179d7f6))
+- **ts:** convert search-box to TypeScript ([#4710](https://github.com/algolia/instantsearch/issues/4710)) ([e73257a](https://github.com/algolia/instantsearch/commit/e73257a466082207c0289f22bad523334d101aae))
 
-
-
-# [4.19.0](https://github.com/algolia/instantsearch.js/compare/v4.18.0...v4.19.0) (2021-03-30)
-
-
-### Bug Fixes
-
-* **setUiState:** make sure previous ui state is stored ([#4699](https://github.com/algolia/instantsearch.js/issues/4699)) ([0f5d688](https://github.com/algolia/instantsearch.js/commit/0f5d6888c5e77c750d264ed19be3418d920266af))
-
+# [4.20.0](https://github.com/algolia/instantsearch/compare/v4.19.0...v4.20.0) (2021-04-06)
 
 ### Features
 
-* **relevantSort:** implement canRefine ([#4693](https://github.com/algolia/instantsearch.js/issues/4693)) ([24d9ded](https://github.com/algolia/instantsearch.js/commit/24d9ded0c0e3246b91fe16ab1d1d579c17d68731))
-* **currentRefinements:** implement canRefine ([#4690](https://github.com/algolia/instantsearch.js/issues/4690)) ([f02416c](https://github.com/algolia/instantsearch.js/commit/f02416cf226ec3f7c2238b3e0902ec6f78381515))
-* **ts:** convert sortBy, connectSortBy ([#4700](https://github.com/algolia/instantsearch.js/issues/4700)) ([86de1e0](https://github.com/algolia/instantsearch.js/commit/86de1e0a675c91b75e72463e6b11df62739d69b5))
+- **clearRefinements:** implement canRefine ([#4684](https://github.com/algolia/instantsearch/issues/4684)) ([a898f09](https://github.com/algolia/instantsearch/commit/a898f09bddca5db1f6782104375df3873d49c688))
+- **currentRefinements:** implement canRefine ([#4697](https://github.com/algolia/instantsearch/issues/4697)) ([4db75ba](https://github.com/algolia/instantsearch/commit/4db75baa9ff2e18f871547511d8f1234eea9d41b))
+- **hierarchicalMenu:** implement canRefine ([#4685](https://github.com/algolia/instantsearch/issues/4685)) ([0d2e450](https://github.com/algolia/instantsearch/commit/0d2e450aed2aaac72ae7ff7f1bb322ce6992c8ba))
+- **middleware:** add unuse method ([#4708](https://github.com/algolia/instantsearch/issues/4708)) ([8e3c406](https://github.com/algolia/instantsearch/commit/8e3c406c8f29bcae56d2f82f07cbd087043346fe))
+- **pagination:** implement canRefine ([#4683](https://github.com/algolia/instantsearch/issues/4683)) ([3ae51e6](https://github.com/algolia/instantsearch/commit/3ae51e60543984463a13b25e64aa2f879c91313e))
+- **range:** implement canRefine ([#4686](https://github.com/algolia/instantsearch/issues/4686)) ([a99ab6f](https://github.com/algolia/instantsearch/commit/a99ab6f968b791ffa31cd17dda598c293e73b88e))
+- **ratingMenu:** implement canRefine ([#4691](https://github.com/algolia/instantsearch/issues/4691)) ([42191a0](https://github.com/algolia/instantsearch/commit/42191a097a048a325234dd3f40f7799145628cd6))
+- **toggleRefinement:** implement canRefine ([#4689](https://github.com/algolia/instantsearch/issues/4689)) ([48dc7f8](https://github.com/algolia/instantsearch/commit/48dc7f8423c92b21bcd59856bf2fc685ae4aba69))
+- **ts:** convert rating-menu to TypeScript ([#4701](https://github.com/algolia/instantsearch/issues/4701)) ([f14ca08](https://github.com/algolia/instantsearch/commit/f14ca0891237a7a49b09d881cddedb93efc3a266))
+- **ts:** convert Template component to TypeScript ([#4703](https://github.com/algolia/instantsearch/issues/4703)) ([0688571](https://github.com/algolia/instantsearch/commit/068857137b85d1065bc5997514461d72fe595130))
 
-
-
-# [4.18.0](https://github.com/algolia/instantsearch.js/compare/v4.17.0...v4.18.0) (2021-03-24)
-
+# [4.19.0](https://github.com/algolia/instantsearch/compare/v4.18.0...v4.19.0) (2021-03-30)
 
 ### Bug Fixes
 
-* **createURL:** correctly remove page in state ([#4679](https://github.com/algolia/instantsearch.js/issues/4679)) ([48c080e](https://github.com/algolia/instantsearch.js/commit/48c080ef85b974e68e1c80ceffea7a0138407a1e))
-* **utils:** circular dependency in createSendEventForHits ([#4680](https://github.com/algolia/instantsearch.js/issues/4680)) ([045f33b](https://github.com/algolia/instantsearch.js/commit/045f33bc6184fb04501e39a5a97e1e969095389a))
-
+- **setUiState:** make sure previous ui state is stored ([#4699](https://github.com/algolia/instantsearch/issues/4699)) ([0f5d688](https://github.com/algolia/instantsearch/commit/0f5d6888c5e77c750d264ed19be3418d920266af))
 
 ### Features
 
-* **metadata:** expose client's algolia agent ([#4694](https://github.com/algolia/instantsearch.js/issues/4694)) ([3d0cb5b](https://github.com/algolia/instantsearch.js/commit/3d0cb5b69056674246efb1acf33e143ac7ae4915))
-* **ts:** convert connectRefinementList, refinementList ([#4658](https://github.com/algolia/instantsearch.js/issues/4658)) ([794b2d3](https://github.com/algolia/instantsearch.js/commit/794b2d3316ae7ee79cfa0643565b65e5bec5c7c1))
-* **ts:** convert stats, connectStats ([#4681](https://github.com/algolia/instantsearch.js/issues/4681)) ([37bbd01](https://github.com/algolia/instantsearch.js/commit/37bbd016a83d5cb66d1f78c0865f7677fa7098fb))
-* **ts:** update to typescript 4 ([#4654](https://github.com/algolia/instantsearch.js/issues/4654)) ([638e437](https://github.com/algolia/instantsearch.js/commit/638e437fdd80af0cfd38818f9da37a50f8f4343f))
+- **relevantSort:** implement canRefine ([#4693](https://github.com/algolia/instantsearch/issues/4693)) ([24d9ded](https://github.com/algolia/instantsearch/commit/24d9ded0c0e3246b91fe16ab1d1d579c17d68731))
+- **currentRefinements:** implement canRefine ([#4690](https://github.com/algolia/instantsearch/issues/4690)) ([f02416c](https://github.com/algolia/instantsearch/commit/f02416cf226ec3f7c2238b3e0902ec6f78381515))
+- **ts:** convert sortBy, connectSortBy ([#4700](https://github.com/algolia/instantsearch/issues/4700)) ([86de1e0](https://github.com/algolia/instantsearch/commit/86de1e0a675c91b75e72463e6b11df62739d69b5))
 
-
-
-# [4.17.0](https://github.com/algolia/instantsearch.js/compare/v4.16.1...v4.17.0) (2021-03-09)
-
+# [4.18.0](https://github.com/algolia/instantsearch/compare/v4.17.0...v4.18.0) (2021-03-24)
 
 ### Bug Fixes
 
-* **bindEvent:** escape payload correctly ([#4670](https://github.com/algolia/instantsearch.js/issues/4670)) ([c1cbaf4](https://github.com/algolia/instantsearch.js/commit/c1cbaf49f6af9784535df80d024cdad56f3ddb84))
-
+- **createURL:** correctly remove page in state ([#4679](https://github.com/algolia/instantsearch/issues/4679)) ([48c080e](https://github.com/algolia/instantsearch/commit/48c080ef85b974e68e1c80ceffea7a0138407a1e))
+- **utils:** circular dependency in createSendEventForHits ([#4680](https://github.com/algolia/instantsearch/issues/4680)) ([045f33b](https://github.com/algolia/instantsearch/commit/045f33bc6184fb04501e39a5a97e1e969095389a))
 
 ### Features
 
-* **insights:** add hits and attributes to InsightsEvent ([#4667](https://github.com/algolia/instantsearch.js/issues/4667)) ([17ef71c](https://github.com/algolia/instantsearch.js/commit/17ef71c32586d0a93bb3905696b6ff7c7be1f3f9))
+- **metadata:** expose client's algolia agent ([#4694](https://github.com/algolia/instantsearch/issues/4694)) ([3d0cb5b](https://github.com/algolia/instantsearch/commit/3d0cb5b69056674246efb1acf33e143ac7ae4915))
+- **ts:** convert connectRefinementList, refinementList ([#4658](https://github.com/algolia/instantsearch/issues/4658)) ([794b2d3](https://github.com/algolia/instantsearch/commit/794b2d3316ae7ee79cfa0643565b65e5bec5c7c1))
+- **ts:** convert stats, connectStats ([#4681](https://github.com/algolia/instantsearch/issues/4681)) ([37bbd01](https://github.com/algolia/instantsearch/commit/37bbd016a83d5cb66d1f78c0865f7677fa7098fb))
+- **ts:** update to typescript 4 ([#4654](https://github.com/algolia/instantsearch/issues/4654)) ([638e437](https://github.com/algolia/instantsearch/commit/638e437fdd80af0cfd38818f9da37a50f8f4343f))
 
-
-
-## [4.16.1](https://github.com/algolia/instantsearch.js/compare/v4.16.0...v4.16.1) (2021-03-03)
-
-
-### Bug Fixes
-
-* **relevantSort:** rename smartSort to relevantSort ([#4668](https://github.com/algolia/instantsearch.js/issues/4668)) ([579eee8](https://github.com/algolia/instantsearch.js/commit/579eee8d38effe067407a269e493400c460eb842))
-
-
-
-# [4.16.0](https://github.com/algolia/instantsearch.js/compare/v4.15.0...v4.16.0) (2021-03-01)
-
+# [4.17.0](https://github.com/algolia/instantsearch/compare/v4.16.1...v4.17.0) (2021-03-09)
 
 ### Bug Fixes
 
-* **relevantSort:** export the widget and the connector ([#4663](https://github.com/algolia/instantsearch.js/issues/4663)) ([e7aaa8c](https://github.com/algolia/instantsearch.js/commit/e7aaa8ceb47b8cafc3a3a323ebe47f45f3841ba4))
-
+- **bindEvent:** escape payload correctly ([#4670](https://github.com/algolia/instantsearch/issues/4670)) ([c1cbaf4](https://github.com/algolia/instantsearch/commit/c1cbaf49f6af9784535df80d024cdad56f3ddb84))
 
 ### Features
 
-* **answers:** add `EXPERIMENTAL_answers` widget ([#4581](https://github.com/algolia/instantsearch.js/issues/4581)) ([e4c9070](https://github.com/algolia/instantsearch.js/commit/e4c9070250779d7d3afabe7f9a19644717bc12c8)), closes [#4635](https://github.com/algolia/instantsearch.js/issues/4635)
+- **insights:** add hits and attributes to InsightsEvent ([#4667](https://github.com/algolia/instantsearch/issues/4667)) ([17ef71c](https://github.com/algolia/instantsearch/commit/17ef71c32586d0a93bb3905696b6ff7c7be1f3f9))
 
+## [4.16.1](https://github.com/algolia/instantsearch/compare/v4.16.0...v4.16.1) (2021-03-03)
 
+### Bug Fixes
 
-# [4.15.0](https://github.com/algolia/instantsearch.js/compare/v4.14.2...v4.15.0) (2021-02-23)
+- **relevantSort:** rename smartSort to relevantSort ([#4668](https://github.com/algolia/instantsearch/issues/4668)) ([579eee8](https://github.com/algolia/instantsearch/commit/579eee8d38effe067407a269e493400c460eb842))
 
+# [4.16.0](https://github.com/algolia/instantsearch/compare/v4.15.0...v4.16.0) (2021-03-01)
+
+### Bug Fixes
+
+- **relevantSort:** export the widget and the connector ([#4663](https://github.com/algolia/instantsearch/issues/4663)) ([e7aaa8c](https://github.com/algolia/instantsearch/commit/e7aaa8ceb47b8cafc3a3a323ebe47f45f3841ba4))
 
 ### Features
 
-* **relevantSort:** add widget ([#4648](https://github.com/algolia/instantsearch.js/issues/4648)) ([89c6e86](https://github.com/algolia/instantsearch.js/commit/89c6e868f490e9b6e507dd70c215e962f4c69ccb))
-* **stats:** apply nbSortedHits ([#4649](https://github.com/algolia/instantsearch.js/issues/4649)) ([34478c1](https://github.com/algolia/instantsearch.js/commit/34478c198dcafbd45fd101db0cd2fbe6328272b8))
-* **ts:** convert menu ([#4652](https://github.com/algolia/instantsearch.js/issues/4652)) ([2271b43](https://github.com/algolia/instantsearch.js/commit/2271b4379918e865a1b0cea09c139e517df97bc5))
+- **answers:** add `EXPERIMENTAL_answers` widget ([#4581](https://github.com/algolia/instantsearch/issues/4581)) ([e4c9070](https://github.com/algolia/instantsearch/commit/e4c9070250779d7d3afabe7f9a19644717bc12c8)), closes [#4635](https://github.com/algolia/instantsearch/issues/4635)
 
-
-
-## [4.14.2](https://github.com/algolia/instantsearch.js/compare/v4.14.1...v4.14.2) (2021-02-17)
-
-
-### Bug Fixes
-
-* **insights:** don't reset page ([#4655](https://github.com/algolia/instantsearch.js/issues/4655)) ([2b31250](https://github.com/algolia/instantsearch.js/commit/2b312508e8be59284180e7f490ce0aac80f9c2b6))
-
-
-
-## [4.14.1](https://github.com/algolia/instantsearch.js/compare/v4.14.0...v4.14.1) (2021-02-16)
-
-
-### Bug Fixes
-
-* **compat:** remove references to window ([#4651](https://github.com/algolia/instantsearch.js/issues/4651)) ([1ede1ae](https://github.com/algolia/instantsearch.js/commit/1ede1ae392d3a12f5b0fe29075ffeb05e572a874)), closes [#4650](https://github.com/algolia/instantsearch.js/issues/4650)
-
-
-
-# [4.14.0](https://github.com/algolia/instantsearch.js/compare/v4.13.2...v4.14.0) (2021-02-09)
-
+# [4.15.0](https://github.com/algolia/instantsearch/compare/v4.14.2...v4.15.0) (2021-02-23)
 
 ### Features
 
-* **queryRuleContext:** allow to make refinements based on query ([#4638](https://github.com/algolia/instantsearch.js/issues/4638)) ([dd033fc](https://github.com/algolia/instantsearch.js/commit/dd033fc58ff11027e4f4b6157aedf0aea0326af3))
+- **relevantSort:** add widget ([#4648](https://github.com/algolia/instantsearch/issues/4648)) ([89c6e86](https://github.com/algolia/instantsearch/commit/89c6e868f490e9b6e507dd70c215e962f4c69ccb))
+- **stats:** apply nbSortedHits ([#4649](https://github.com/algolia/instantsearch/issues/4649)) ([34478c1](https://github.com/algolia/instantsearch/commit/34478c198dcafbd45fd101db0cd2fbe6328272b8))
+- **ts:** convert menu ([#4652](https://github.com/algolia/instantsearch/issues/4652)) ([2271b43](https://github.com/algolia/instantsearch/commit/2271b4379918e865a1b0cea09c139e517df97bc5))
 
-
-
-## [4.13.2](https://github.com/algolia/instantsearch.js/compare/v4.13.1...v4.13.2) (2021-02-03)
-
-
-### Bug Fixes
-
-* **range:** don't go out of bounds with min or max given ([#4627](https://github.com/algolia/instantsearch.js/issues/4627)) ([8327ec0](https://github.com/algolia/instantsearch.js/commit/8327ec01c3940dfc20f5f1c8e3e0fc85f29af690))
-
-
-
-## [4.13.1](https://github.com/algolia/instantsearch.js/compare/v4.13.0...v4.13.1) (2021-01-26)
-
+## [4.14.2](https://github.com/algolia/instantsearch/compare/v4.14.1...v4.14.2) (2021-02-17)
 
 ### Bug Fixes
 
-* **index:** only set listeners on init once ([#4634](https://github.com/algolia/instantsearch.js/issues/4634)) ([730b49d](https://github.com/algolia/instantsearch.js/commit/730b49d43782b98c5119a5d3dbfec09073bde1d0))
+- **insights:** don't reset page ([#4655](https://github.com/algolia/instantsearch/issues/4655)) ([2b31250](https://github.com/algolia/instantsearch/commit/2b312508e8be59284180e7f490ce0aac80f9c2b6))
 
+## [4.14.1](https://github.com/algolia/instantsearch/compare/v4.14.0...v4.14.1) (2021-02-16)
 
+### Bug Fixes
 
-# [4.13.0](https://github.com/algolia/instantsearch.js/compare/v4.12.0...v4.13.0) (2021-01-26)
+- **compat:** remove references to window ([#4651](https://github.com/algolia/instantsearch/issues/4651)) ([1ede1ae](https://github.com/algolia/instantsearch/commit/1ede1ae392d3a12f5b0fe29075ffeb05e572a874)), closes [#4650](https://github.com/algolia/instantsearch/issues/4650)
 
+# [4.14.0](https://github.com/algolia/instantsearch/compare/v4.13.2...v4.14.0) (2021-02-09)
 
 ### Features
 
-* **ratingMenu:** Add support for floats in values ([#4611](https://github.com/algolia/instantsearch.js/issues/4611)) ([3f52784](https://github.com/algolia/instantsearch.js/commit/3f52784862b72ef59acfc0735fe482cbfa6ad1f5))
+- **queryRuleContext:** allow to make refinements based on query ([#4638](https://github.com/algolia/instantsearch/issues/4638)) ([dd033fc](https://github.com/algolia/instantsearch/commit/dd033fc58ff11027e4f4b6157aedf0aea0326af3))
 
+## [4.13.2](https://github.com/algolia/instantsearch/compare/v4.13.1...v4.13.2) (2021-02-03)
 
+### Bug Fixes
 
-# [4.12.0](https://github.com/algolia/instantsearch.js/compare/v4.11.0...v4.12.0) (2021-01-20)
+- **range:** don't go out of bounds with min or max given ([#4627](https://github.com/algolia/instantsearch/issues/4627)) ([8327ec0](https://github.com/algolia/instantsearch/commit/8327ec01c3940dfc20f5f1c8e3e0fc85f29af690))
 
+## [4.13.1](https://github.com/algolia/instantsearch/compare/v4.13.0...v4.13.1) (2021-01-26)
+
+### Bug Fixes
+
+- **index:** only set listeners on init once ([#4634](https://github.com/algolia/instantsearch/issues/4634)) ([730b49d](https://github.com/algolia/instantsearch/commit/730b49d43782b98c5119a5d3dbfec09073bde1d0))
+
+# [4.13.0](https://github.com/algolia/instantsearch/compare/v4.12.0...v4.13.0) (2021-01-26)
+
+### Features
+
+- **ratingMenu:** Add support for floats in values ([#4611](https://github.com/algolia/instantsearch/issues/4611)) ([3f52784](https://github.com/algolia/instantsearch/commit/3f52784862b72ef59acfc0735fe482cbfa6ad1f5))
+
+# [4.12.0](https://github.com/algolia/instantsearch/compare/v4.11.0...v4.12.0) (2021-01-20)
 
 ### Code Refactoring
 
-* rename all references to widgetOptions as widgetParams ([#4612](https://github.com/algolia/instantsearch.js/issues/4612)) ([ff9a18d](https://github.com/algolia/instantsearch.js/commit/ff9a18d31635013ee4bc242291f121c8e5827f38))
-
+- rename all references to widgetOptions as widgetParams ([#4612](https://github.com/algolia/instantsearch/issues/4612)) ([ff9a18d](https://github.com/algolia/instantsearch/commit/ff9a18d31635013ee4bc242291f121c8e5827f38))
 
 ### Features
 
-* **core:** expose metadata of widgets ([#4604](https://github.com/algolia/instantsearch.js/issues/4604)) ([1fcf716](https://github.com/algolia/instantsearch.js/commit/1fcf71657b176b14067df36765a38e32d2a6dd9b))
-* **widgets:** annotate widget instances with $$widgetType ([#4624](https://github.com/algolia/instantsearch.js/issues/4624)) ([df3f478](https://github.com/algolia/instantsearch.js/commit/df3f47867e65a2e56c6da968d7a154471172adce))
-
+- **core:** expose metadata of widgets ([#4604](https://github.com/algolia/instantsearch/issues/4604)) ([1fcf716](https://github.com/algolia/instantsearch/commit/1fcf71657b176b14067df36765a38e32d2a6dd9b))
+- **widgets:** annotate widget instances with $$widgetType ([#4624](https://github.com/algolia/instantsearch/issues/4624)) ([df3f478](https://github.com/algolia/instantsearch/commit/df3f47867e65a2e56c6da968d7a154471172adce))
 
 ### BREAKING CHANGES
 
-* if you're using experimental-typescript and importing a type of the form `...WidgetOptions`, this now becomes `...WidgetParams` (eg. replace `HitsWidgetOptions` with `HitsWidgetParams`)
+- if you're using experimental-typescript and importing a type of the form `...WidgetOptions`, this now becomes `...WidgetParams` (eg. replace `HitsWidgetOptions` with `HitsWidgetParams`)
 
-
-
-# [4.11.0](https://github.com/algolia/instantsearch.js/compare/v4.10.0...v4.11.0) (2021-01-14)
-
+# [4.11.0](https://github.com/algolia/instantsearch/compare/v4.10.0...v4.11.0) (2021-01-14)
 
 ### Bug Fixes
 
-* **index:** do not warn for nested index widget ([#4620](https://github.com/algolia/instantsearch.js/issues/4620)) ([7502744](https://github.com/algolia/instantsearch.js/commit/7502744cd546181ec4429cd6b8144200ba2a8f82))
-* **insights:** don't quote values ([#4619](https://github.com/algolia/instantsearch.js/issues/4619)) ([ac2444c](https://github.com/algolia/instantsearch.js/commit/ac2444c36c6f41e35ed6d1a6d045479b35416576))
-
+- **index:** do not warn for nested index widget ([#4620](https://github.com/algolia/instantsearch/issues/4620)) ([7502744](https://github.com/algolia/instantsearch/commit/7502744cd546181ec4429cd6b8144200ba2a8f82))
+- **insights:** don't quote values ([#4619](https://github.com/algolia/instantsearch/issues/4619)) ([ac2444c](https://github.com/algolia/instantsearch/commit/ac2444c36c6f41e35ed6d1a6d045479b35416576))
 
 ### Features
 
-* **insights:** accept initParams for insightsClient ([#4608](https://github.com/algolia/instantsearch.js/issues/4608)) ([0a0ae2b](https://github.com/algolia/instantsearch.js/commit/0a0ae2bf10a4e210373b8fde635949a56c86e52e))
+- **insights:** accept initParams for insightsClient ([#4608](https://github.com/algolia/instantsearch/issues/4608)) ([0a0ae2b](https://github.com/algolia/instantsearch/commit/0a0ae2bf10a4e210373b8fde635949a56c86e52e))
 
-
-
-# [4.10.0](https://github.com/algolia/instantsearch.js/compare/v4.9.2...v4.10.0) (2021-01-05)
-
+# [4.10.0](https://github.com/algolia/instantsearch/compare/v4.9.2...v4.10.0) (2021-01-05)
 
 ### Features
 
-* **index:** expose createURL ([#4603](https://github.com/algolia/instantsearch.js/issues/4603)) ([f57e9c5](https://github.com/algolia/instantsearch.js/commit/f57e9c5a46e927b8dd38f167ee5c467151334a08))
-* **index:** expose scoped results getter ([#4609](https://github.com/algolia/instantsearch.js/issues/4609)) ([a41b1e4](https://github.com/algolia/instantsearch.js/commit/a41b1e46bb195e6ef1f9bdbdde64d9300246c22f))
-* **reverseHighlight/reverseSnippet:** Implements reverseHighlight and reverseSnippet ([#4592](https://github.com/algolia/instantsearch.js/issues/4592)) ([718bf45](https://github.com/algolia/instantsearch.js/commit/718bf458152bb55bab1efb542adb8e31298c0c3c))
+- **index:** expose createURL ([#4603](https://github.com/algolia/instantsearch/issues/4603)) ([f57e9c5](https://github.com/algolia/instantsearch/commit/f57e9c5a46e927b8dd38f167ee5c467151334a08))
+- **index:** expose scoped results getter ([#4609](https://github.com/algolia/instantsearch/issues/4609)) ([a41b1e4](https://github.com/algolia/instantsearch/commit/a41b1e46bb195e6ef1f9bdbdde64d9300246c22f))
+- **reverseHighlight/reverseSnippet:** Implements reverseHighlight and reverseSnippet ([#4592](https://github.com/algolia/instantsearch/issues/4592)) ([718bf45](https://github.com/algolia/instantsearch/commit/718bf458152bb55bab1efb542adb8e31298c0c3c))
 
-
-
-## [4.9.2](https://github.com/algolia/instantsearch.js/compare/v4.9.1...v4.9.2) (2020-12-15)
-
+## [4.9.2](https://github.com/algolia/instantsearch/compare/v4.9.1...v4.9.2) (2020-12-15)
 
 ### Bug Fixes
 
-* warn about invalid userToken ([#4605](https://github.com/algolia/instantsearch.js/issues/4605)) ([5fce769](https://github.com/algolia/instantsearch.js/commit/5fce769f42fe5b44f73eb68f3858a6ea1ec2d854))
-* **types:** correct type for queryHook return ([#4602](https://github.com/algolia/instantsearch.js/issues/4602)) ([acff8db](https://github.com/algolia/instantsearch.js/commit/acff8db3a2238edf40da1ee6b44e93a94e090698))
+- warn about invalid userToken ([#4605](https://github.com/algolia/instantsearch/issues/4605)) ([5fce769](https://github.com/algolia/instantsearch/commit/5fce769f42fe5b44f73eb68f3858a6ea1ec2d854))
+- **types:** correct type for queryHook return ([#4602](https://github.com/algolia/instantsearch/issues/4602)) ([acff8db](https://github.com/algolia/instantsearch/commit/acff8db3a2238edf40da1ee6b44e93a94e090698))
 
-
-
-## [4.9.1](https://github.com/algolia/instantsearch.js/compare/v4.9.0...v4.9.1) (2020-12-08)
-
+## [4.9.1](https://github.com/algolia/instantsearch/compare/v4.9.0...v4.9.1) (2020-12-08)
 
 ### Bug Fixes
 
-* **range:** consistently convert min & max to numbers ([#4587](https://github.com/algolia/instantsearch.js/issues/4587)) ([ccf159e](https://github.com/algolia/instantsearch.js/commit/ccf159efcb94e9c8c04c558fcb69e2e3d8d79729))
+- **range:** consistently convert min & max to numbers ([#4587](https://github.com/algolia/instantsearch/issues/4587)) ([ccf159e](https://github.com/algolia/instantsearch/commit/ccf159efcb94e9c8c04c558fcb69e2e3d8d79729))
 
-
-
-# [4.9.0](https://github.com/algolia/instantsearch.js/compare/v4.8.7...v4.9.0) (2020-12-01)
-
+# [4.9.0](https://github.com/algolia/instantsearch/compare/v4.8.7...v4.9.0) (2020-12-01)
 
 ### Bug Fixes
 
-* remove a warning about insights that is not relevant anymore ([#4593](https://github.com/algolia/instantsearch.js/issues/4593)) ([b5f6a47](https://github.com/algolia/instantsearch.js/commit/b5f6a479ff1b9b692c733f51e39eade724ff3413))
-
+- remove a warning about insights that is not relevant anymore ([#4593](https://github.com/algolia/instantsearch/issues/4593)) ([b5f6a47](https://github.com/algolia/instantsearch/commit/b5f6a479ff1b9b692c733f51e39eade724ff3413))
 
 ### Features
 
-* **autocomplete:** implement `getWidgetRenderState` ([#4466](https://github.com/algolia/instantsearch.js/issues/4466)) ([c215836](https://github.com/algolia/instantsearch.js/commit/c2158364a63d0f05bb820f802871a2f093e041ec))
-* **breadcrumb:** implement `getWidgetRenderState` ([#4467](https://github.com/algolia/instantsearch.js/issues/4467)) ([80b348e](https://github.com/algolia/instantsearch.js/commit/80b348ef1a6a29b1897f5ee1d680dcbaba5fa4fe))
-* **clearRefinements:** implement `getWidgetRenderState` ([#4468](https://github.com/algolia/instantsearch.js/issues/4468)) ([2b3117c](https://github.com/algolia/instantsearch.js/commit/2b3117c34207514967ff453b6f5d8275a6b0b0ec))
-* **configure:** getRenderState for multiple configure widgets ([#4582](https://github.com/algolia/instantsearch.js/issues/4582)) ([5432af1](https://github.com/algolia/instantsearch.js/commit/5432af1df3c1ee4e62b87ede76acda7b749f38dd))
-* **configure:** implement `getWidgetRenderState` ([#4469](https://github.com/algolia/instantsearch.js/issues/4469)) ([3a1b325](https://github.com/algolia/instantsearch.js/commit/3a1b32556f3d5a6a3330b404688e06d5815a2390))
-* **connectPagination:** add getWidgetRenderState & refactor to TS ([#4574](https://github.com/algolia/instantsearch.js/issues/4574)) ([1553aa3](https://github.com/algolia/instantsearch.js/commit/1553aa36c8bb8664b5e74fd2378ea2ef45a52acf))
-* **core:** introduce `getWidgetRenderState` (2/n) ([#4457](https://github.com/algolia/instantsearch.js/issues/4457)) ([4839bb6](https://github.com/algolia/instantsearch.js/commit/4839bb61e4c8ee6083710195d5db5684c7b0889f))
-* **core:** introduce `getWidgetUiState` lifecycle hook (1/n) ([#4454](https://github.com/algolia/instantsearch.js/issues/4454)) ([cf21ea4](https://github.com/algolia/instantsearch.js/commit/cf21ea4cb580ed523828c926b7ba724c46eed8a4))
-* **currentRefinements:** implement `getWidgetRenderState` ([#4470](https://github.com/algolia/instantsearch.js/issues/4470)) ([b8df824](https://github.com/algolia/instantsearch.js/commit/b8df824e26a164280d9da9b3c3ce41ad56962439))
-* **connectQueryRules:** getWidgetRenderState ([#4572](https://github.com/algolia/instantsearch.js/issues/4572)) ([edcc4a4](https://github.com/algolia/instantsearch.js/commit/edcc4a463d32af21bb73acbca879d4982ae9006f))
-* **connectGeoSearch:** support getWidgetRenderState ([#4564](https://github.com/algolia/instantsearch.js/issues/4564)) ([8d06fba](https://github.com/algolia/instantsearch.js/commit/8d06fba40be0392daa1b48f235d93d92bb6b5e93))
-* **hierarchicalMenu:** implement `getWidgetRenderState` ([#4471](https://github.com/algolia/instantsearch.js/issues/4471)) ([9fd3cd0](https://github.com/algolia/instantsearch.js/commit/9fd3cd06dfc3b5302c00ee1820ff58be2a37c3b7))
-* **highlight:** accept array for attribute ([#4588](https://github.com/algolia/instantsearch.js/issues/4588)) ([b0c3a3a](https://github.com/algolia/instantsearch.js/commit/b0c3a3a960646bff22b2d28e21aa2675484a354b))
-* **hits:** implement `getWidgetRenderState` ([#4525](https://github.com/algolia/instantsearch.js/issues/4525)) ([3391ff7](https://github.com/algolia/instantsearch.js/commit/3391ff7bac8b406ab474e712408bda2be69934c9))
-* **hitsPerPage:** implement `getRenderState` and `getWidgetRenderState` ([#4532](https://github.com/algolia/instantsearch.js/issues/4532)) ([7ad10ea](https://github.com/algolia/instantsearch.js/commit/7ad10ea648f48766061153994da90920a5194103))
-* **infinite-hits:** implement `getRenderState` and `getWidgetRenderState` ([#4535](https://github.com/algolia/instantsearch.js/issues/4535)) ([98c70d9](https://github.com/algolia/instantsearch.js/commit/98c70d980bc1036057a2dd99dc6aeee8343e4472))
-* **menu:** implement `getRenderState` and `getWidgetRenderState` ([#4540](https://github.com/algolia/instantsearch.js/issues/4540)) ([239906c](https://github.com/algolia/instantsearch.js/commit/239906c7fdb36c691b9a9aca343802a8ccc616c8))
-* **panel:** spread widgetRenderState in the options in panel ([#4527](https://github.com/algolia/instantsearch.js/issues/4527)) ([8f82eaa](https://github.com/algolia/instantsearch.js/commit/8f82eaa34e7abe9070e404a5a45d352af61d940a)), closes [#4558](https://github.com/algolia/instantsearch.js/issues/4558)
-* **poweredBy:** getWidgetRenderState ([#4551](https://github.com/algolia/instantsearch.js/issues/4551)) ([cd816a4](https://github.com/algolia/instantsearch.js/commit/cd816a41afe0704eab3cbd1f019fc660ca5d255e))
-* **range:** implement `getRenderState` and `getWidgetRenderState` ([#4536](https://github.com/algolia/instantsearch.js/issues/4536)) ([d67bfcd](https://github.com/algolia/instantsearch.js/commit/d67bfcdb828cc8b35a5c959e54823b6d3c37b087))
-* **rating-menu:** implement `getRenderState` and `getWidgetRenderState` ([#4548](https://github.com/algolia/instantsearch.js/issues/4548)) ([166a96c](https://github.com/algolia/instantsearch.js/commit/166a96c170c137e78b3fe3b9f69f73744f4fcb8b))
-* **refinement-list:** implement `getRenderState` and `getWidgetRenderState` ([#4549](https://github.com/algolia/instantsearch.js/issues/4549)) ([c824bd0](https://github.com/algolia/instantsearch.js/commit/c824bd074d388e44e99b53592167cffcacae3377))
-* **numeric-menu:** add `getRenderState` ([#4550](https://github.com/algolia/instantsearch.js/issues/4550)) ([5385edf](https://github.com/algolia/instantsearch.js/commit/5385edf39d3ac1515845b5e20ce179a2869ab86d))
-* **sortBy:** implement `getRenderState` and `getWidgetRenderState` ([#4568](https://github.com/algolia/instantsearch.js/issues/4568)) ([fd249f7](https://github.com/algolia/instantsearch.js/commit/fd249f700854d1f11e97cb5dac2c1b3964c59e29))
-* **stats:** implement `getRenderState` and `getWidgetRenderState` ([#4565](https://github.com/algolia/instantsearch.js/issues/4565)) ([b8dfd6d](https://github.com/algolia/instantsearch.js/commit/b8dfd6dbb8c462b0d0571e9f0499df6e4dda7745))
-* **toggleRefinement:** implement `getRenderState` and `getWidgetRenderState` ([#4569](https://github.com/algolia/instantsearch.js/issues/4569)) ([f2c9a10](https://github.com/algolia/instantsearch.js/commit/f2c9a102cba9abe21ed08b18e979713156e10901))
-* **voice-search:** implement `getRenderState` and `getWidgetRenderState` ([#4557](https://github.com/algolia/instantsearch.js/issues/4557)) ([d308da1](https://github.com/algolia/instantsearch.js/commit/d308da1ab892cc5185616cd5b8a4a3f488e708c4))
+- **autocomplete:** implement `getWidgetRenderState` ([#4466](https://github.com/algolia/instantsearch/issues/4466)) ([c215836](https://github.com/algolia/instantsearch/commit/c2158364a63d0f05bb820f802871a2f093e041ec))
+- **breadcrumb:** implement `getWidgetRenderState` ([#4467](https://github.com/algolia/instantsearch/issues/4467)) ([80b348e](https://github.com/algolia/instantsearch/commit/80b348ef1a6a29b1897f5ee1d680dcbaba5fa4fe))
+- **clearRefinements:** implement `getWidgetRenderState` ([#4468](https://github.com/algolia/instantsearch/issues/4468)) ([2b3117c](https://github.com/algolia/instantsearch/commit/2b3117c34207514967ff453b6f5d8275a6b0b0ec))
+- **configure:** getRenderState for multiple configure widgets ([#4582](https://github.com/algolia/instantsearch/issues/4582)) ([5432af1](https://github.com/algolia/instantsearch/commit/5432af1df3c1ee4e62b87ede76acda7b749f38dd))
+- **configure:** implement `getWidgetRenderState` ([#4469](https://github.com/algolia/instantsearch/issues/4469)) ([3a1b325](https://github.com/algolia/instantsearch/commit/3a1b32556f3d5a6a3330b404688e06d5815a2390))
+- **connectPagination:** add getWidgetRenderState & refactor to TS ([#4574](https://github.com/algolia/instantsearch/issues/4574)) ([1553aa3](https://github.com/algolia/instantsearch/commit/1553aa36c8bb8664b5e74fd2378ea2ef45a52acf))
+- **core:** introduce `getWidgetRenderState` (2/n) ([#4457](https://github.com/algolia/instantsearch/issues/4457)) ([4839bb6](https://github.com/algolia/instantsearch/commit/4839bb61e4c8ee6083710195d5db5684c7b0889f))
+- **core:** introduce `getWidgetUiState` lifecycle hook (1/n) ([#4454](https://github.com/algolia/instantsearch/issues/4454)) ([cf21ea4](https://github.com/algolia/instantsearch/commit/cf21ea4cb580ed523828c926b7ba724c46eed8a4))
+- **currentRefinements:** implement `getWidgetRenderState` ([#4470](https://github.com/algolia/instantsearch/issues/4470)) ([b8df824](https://github.com/algolia/instantsearch/commit/b8df824e26a164280d9da9b3c3ce41ad56962439))
+- **connectQueryRules:** getWidgetRenderState ([#4572](https://github.com/algolia/instantsearch/issues/4572)) ([edcc4a4](https://github.com/algolia/instantsearch/commit/edcc4a463d32af21bb73acbca879d4982ae9006f))
+- **connectGeoSearch:** support getWidgetRenderState ([#4564](https://github.com/algolia/instantsearch/issues/4564)) ([8d06fba](https://github.com/algolia/instantsearch/commit/8d06fba40be0392daa1b48f235d93d92bb6b5e93))
+- **hierarchicalMenu:** implement `getWidgetRenderState` ([#4471](https://github.com/algolia/instantsearch/issues/4471)) ([9fd3cd0](https://github.com/algolia/instantsearch/commit/9fd3cd06dfc3b5302c00ee1820ff58be2a37c3b7))
+- **highlight:** accept array for attribute ([#4588](https://github.com/algolia/instantsearch/issues/4588)) ([b0c3a3a](https://github.com/algolia/instantsearch/commit/b0c3a3a960646bff22b2d28e21aa2675484a354b))
+- **hits:** implement `getWidgetRenderState` ([#4525](https://github.com/algolia/instantsearch/issues/4525)) ([3391ff7](https://github.com/algolia/instantsearch/commit/3391ff7bac8b406ab474e712408bda2be69934c9))
+- **hitsPerPage:** implement `getRenderState` and `getWidgetRenderState` ([#4532](https://github.com/algolia/instantsearch/issues/4532)) ([7ad10ea](https://github.com/algolia/instantsearch/commit/7ad10ea648f48766061153994da90920a5194103))
+- **infinite-hits:** implement `getRenderState` and `getWidgetRenderState` ([#4535](https://github.com/algolia/instantsearch/issues/4535)) ([98c70d9](https://github.com/algolia/instantsearch/commit/98c70d980bc1036057a2dd99dc6aeee8343e4472))
+- **menu:** implement `getRenderState` and `getWidgetRenderState` ([#4540](https://github.com/algolia/instantsearch/issues/4540)) ([239906c](https://github.com/algolia/instantsearch/commit/239906c7fdb36c691b9a9aca343802a8ccc616c8))
+- **panel:** spread widgetRenderState in the options in panel ([#4527](https://github.com/algolia/instantsearch/issues/4527)) ([8f82eaa](https://github.com/algolia/instantsearch/commit/8f82eaa34e7abe9070e404a5a45d352af61d940a)), closes [#4558](https://github.com/algolia/instantsearch/issues/4558)
+- **poweredBy:** getWidgetRenderState ([#4551](https://github.com/algolia/instantsearch/issues/4551)) ([cd816a4](https://github.com/algolia/instantsearch/commit/cd816a41afe0704eab3cbd1f019fc660ca5d255e))
+- **range:** implement `getRenderState` and `getWidgetRenderState` ([#4536](https://github.com/algolia/instantsearch/issues/4536)) ([d67bfcd](https://github.com/algolia/instantsearch/commit/d67bfcdb828cc8b35a5c959e54823b6d3c37b087))
+- **rating-menu:** implement `getRenderState` and `getWidgetRenderState` ([#4548](https://github.com/algolia/instantsearch/issues/4548)) ([166a96c](https://github.com/algolia/instantsearch/commit/166a96c170c137e78b3fe3b9f69f73744f4fcb8b))
+- **refinement-list:** implement `getRenderState` and `getWidgetRenderState` ([#4549](https://github.com/algolia/instantsearch/issues/4549)) ([c824bd0](https://github.com/algolia/instantsearch/commit/c824bd074d388e44e99b53592167cffcacae3377))
+- **numeric-menu:** add `getRenderState` ([#4550](https://github.com/algolia/instantsearch/issues/4550)) ([5385edf](https://github.com/algolia/instantsearch/commit/5385edf39d3ac1515845b5e20ce179a2869ab86d))
+- **sortBy:** implement `getRenderState` and `getWidgetRenderState` ([#4568](https://github.com/algolia/instantsearch/issues/4568)) ([fd249f7](https://github.com/algolia/instantsearch/commit/fd249f700854d1f11e97cb5dac2c1b3964c59e29))
+- **stats:** implement `getRenderState` and `getWidgetRenderState` ([#4565](https://github.com/algolia/instantsearch/issues/4565)) ([b8dfd6d](https://github.com/algolia/instantsearch/commit/b8dfd6dbb8c462b0d0571e9f0499df6e4dda7745))
+- **toggleRefinement:** implement `getRenderState` and `getWidgetRenderState` ([#4569](https://github.com/algolia/instantsearch/issues/4569)) ([f2c9a10](https://github.com/algolia/instantsearch/commit/f2c9a102cba9abe21ed08b18e979713156e10901))
+- **voice-search:** implement `getRenderState` and `getWidgetRenderState` ([#4557](https://github.com/algolia/instantsearch/issues/4557)) ([d308da1](https://github.com/algolia/instantsearch/commit/d308da1ab892cc5185616cd5b8a4a3f488e708c4))
 
-
-
-## [4.8.7](https://github.com/algolia/instantsearch.js/compare/v4.8.6...v4.8.7) (2020-11-19)
-
+## [4.8.7](https://github.com/algolia/instantsearch/compare/v4.8.6...v4.8.7) (2020-11-19)
 
 ### Bug Fixes
 
-* **insights:** use internal `find` util method ([#4580](https://github.com/algolia/instantsearch.js/issues/4580)) ([61b855b](https://github.com/algolia/instantsearch.js/commit/61b855b28282992a55795db88f8bfef2e5825cb3))
+- **insights:** use internal `find` util method ([#4580](https://github.com/algolia/instantsearch/issues/4580)) ([61b855b](https://github.com/algolia/instantsearch/commit/61b855b28282992a55795db88f8bfef2e5825cb3))
 
-
-
-## [4.8.6](https://github.com/algolia/instantsearch.js/compare/v4.8.5...v4.8.6) (2020-11-17)
-
+## [4.8.6](https://github.com/algolia/instantsearch/compare/v4.8.5...v4.8.6) (2020-11-17)
 
 ### Bug Fixes
 
-* **insights:** do not throw when sending event right after creating insights middleware ([#4575](https://github.com/algolia/instantsearch.js/issues/4575)) ([d963f8d](https://github.com/algolia/instantsearch.js/commit/d963f8d6155e6bb56f852e00528ed10dc9bcc461))
+- **insights:** do not throw when sending event right after creating insights middleware ([#4575](https://github.com/algolia/instantsearch/issues/4575)) ([d963f8d](https://github.com/algolia/instantsearch/commit/d963f8d6155e6bb56f852e00528ed10dc9bcc461))
 
-
-
-## [4.8.5](https://github.com/algolia/instantsearch.js/compare/v4.8.4...v4.8.5) (2020-11-10)
-
+## [4.8.5](https://github.com/algolia/instantsearch/compare/v4.8.4...v4.8.5) (2020-11-10)
 
 ### Bug Fixes
 
-* **configure:** pass the latest state to onStateChange ([#4555](https://github.com/algolia/instantsearch.js/issues/4555)) ([6ab76e8](https://github.com/algolia/instantsearch.js/commit/6ab76e82f93e8c7bb2bfdde267b6d7f4f9b333ff))
+- **configure:** pass the latest state to onStateChange ([#4555](https://github.com/algolia/instantsearch/issues/4555)) ([6ab76e8](https://github.com/algolia/instantsearch/commit/6ab76e82f93e8c7bb2bfdde267b6d7f4f9b333ff))
 
-
-
-## [4.8.4](https://github.com/algolia/instantsearch.js/compare/v4.8.3...v4.8.4) (2020-10-27)
-
+## [4.8.4](https://github.com/algolia/instantsearch/compare/v4.8.3...v4.8.4) (2020-10-27)
 
 ### Bug Fixes
 
-* **infiniteHits:** do not cache the cached hits inside the connector ([#4534](https://github.com/algolia/instantsearch.js/issues/4534)) ([c97395e](https://github.com/algolia/instantsearch.js/commit/c97395e2d3443651e628617f0974703a100a988e))
-* **insights:** show deprecation warnings for old insights related properties and functions ([#4524](https://github.com/algolia/instantsearch.js/issues/4524)) ([c93e1cf](https://github.com/algolia/instantsearch.js/commit/c93e1cfcad06b327066078088410eb7d51972790))
+- **infiniteHits:** do not cache the cached hits inside the connector ([#4534](https://github.com/algolia/instantsearch/issues/4534)) ([c97395e](https://github.com/algolia/instantsearch/commit/c97395e2d3443651e628617f0974703a100a988e))
+- **insights:** show deprecation warnings for old insights related properties and functions ([#4524](https://github.com/algolia/instantsearch/issues/4524)) ([c93e1cf](https://github.com/algolia/instantsearch/commit/c93e1cfcad06b327066078088410eb7d51972790))
 
-
-
-## [4.8.3](https://github.com/algolia/instantsearch.js/compare/v4.8.2...v4.8.3) (2020-09-29)
-
+## [4.8.3](https://github.com/algolia/instantsearch/compare/v4.8.2...v4.8.3) (2020-09-29)
 
 ### Bug Fixes
 
-* **middleware:** rename EXPERIMENTAL_use to use ([#4450](https://github.com/algolia/instantsearch.js/issues/4450)) ([87ecb99](https://github.com/algolia/instantsearch.js/commit/87ecb99f33ab4930d8ec1996ddba9db0a9d07da4))
-* **refinementList:** cap `maxFacetHits` to 100 for SFFV ([#4523](https://github.com/algolia/instantsearch.js/issues/4523)) ([baf1f02](https://github.com/algolia/instantsearch.js/commit/baf1f027fc2436e86536fffbee11a595cfd7dac0))
+- **middleware:** rename EXPERIMENTAL_use to use ([#4450](https://github.com/algolia/instantsearch/issues/4450)) ([87ecb99](https://github.com/algolia/instantsearch/commit/87ecb99f33ab4930d8ec1996ddba9db0a9d07da4))
+- **refinementList:** cap `maxFacetHits` to 100 for SFFV ([#4523](https://github.com/algolia/instantsearch/issues/4523)) ([baf1f02](https://github.com/algolia/instantsearch/commit/baf1f027fc2436e86536fffbee11a595cfd7dac0))
 
-
-
-## [4.8.2](https://github.com/algolia/instantsearch.js/compare/v4.8.1...v4.8.2) (2020-09-22)
-
+## [4.8.2](https://github.com/algolia/instantsearch/compare/v4.8.1...v4.8.2) (2020-09-22)
 
 ### Bug Fixes
 
-* **insights:** fix the regression that it didn't send events with instantsearch.insights() ([#4519](https://github.com/algolia/instantsearch.js/issues/4519)) ([10e38df](https://github.com/algolia/instantsearch.js/commit/10e38df02608071cd7272e829b6748be41b9c2c0))
+- **insights:** fix the regression that it didn't send events with instantsearch.insights() ([#4519](https://github.com/algolia/instantsearch/issues/4519)) ([10e38df](https://github.com/algolia/instantsearch/commit/10e38df02608071cd7272e829b6748be41b9c2c0))
 
-
-
-## [4.8.1](https://github.com/algolia/instantsearch.js/compare/v4.8.0...v4.8.1) (2020-09-15)
-
+## [4.8.1](https://github.com/algolia/instantsearch/compare/v4.8.0...v4.8.1) (2020-09-15)
 
 ### Bug Fixes
 
-* **hitsPerPage:** update link to hitsPerPage widget ([#4513](https://github.com/algolia/instantsearch.js/issues/4513)) ([daa4bb9](https://github.com/algolia/instantsearch.js/commit/daa4bb944065dede46d716308325039c3602d9dc))
-* **infiniteHits:** compute `isLastPage` based on cached pages ([#4509](https://github.com/algolia/instantsearch.js/issues/4509)) ([b6fb1ab](https://github.com/algolia/instantsearch.js/commit/b6fb1abcf5ac456dc39adaeb97945665cad8fa11))
+- **hitsPerPage:** update link to hitsPerPage widget ([#4513](https://github.com/algolia/instantsearch/issues/4513)) ([daa4bb9](https://github.com/algolia/instantsearch/commit/daa4bb944065dede46d716308325039c3602d9dc))
+- **infiniteHits:** compute `isLastPage` based on cached pages ([#4509](https://github.com/algolia/instantsearch/issues/4509)) ([b6fb1ab](https://github.com/algolia/instantsearch/commit/b6fb1abcf5ac456dc39adaeb97945665cad8fa11))
 
-
-
-# [4.8.0](https://github.com/algolia/instantsearch.js/compare/v4.7.2...v4.8.0) (2020-09-08)
-
+# [4.8.0](https://github.com/algolia/instantsearch/compare/v4.7.2...v4.8.0) (2020-09-08)
 
 ### Features
 
-* **insights:** introduce `insights` middleware ([#4446](https://github.com/algolia/instantsearch.js/issues/4446)) ([9bc6359](https://github.com/algolia/instantsearch.js/commit/9bc635986097736272aac8c5d3380a255488fdb7))
+- **insights:** introduce `insights` middleware ([#4446](https://github.com/algolia/instantsearch/issues/4446)) ([9bc6359](https://github.com/algolia/instantsearch/commit/9bc635986097736272aac8c5d3380a255488fdb7))
 
-
-
-## [4.7.2](https://github.com/algolia/instantsearch.js/compare/v4.7.1...v4.7.2) (2020-08-31)
-
+## [4.7.2](https://github.com/algolia/instantsearch/compare/v4.7.1...v4.7.2) (2020-08-31)
 
 ### Bug Fixes
 
-* **bundlesize:** remove prop-type imports ([#4491](https://github.com/algolia/instantsearch.js/issues/4491)) ([8361cd6](https://github.com/algolia/instantsearch.js/commit/8361cd63b3bac15eb6250e9f509fb15c1fc57f48))
-* **router:** skip router write on duplicate entries ([#4487](https://github.com/algolia/instantsearch.js/issues/4487)) ([9296022](https://github.com/algolia/instantsearch.js/commit/9296022fecadfbf82f15e837c215a1356eac4bc5))
-* **searchBox:** pass "spellcheck" property correctly to input ([#4483](https://github.com/algolia/instantsearch.js/issues/4483)) ([3cf43c7](https://github.com/algolia/instantsearch.js/commit/3cf43c7187841cf961a0280307af1a5f7a4e8da7))
+- **bundlesize:** remove prop-type imports ([#4491](https://github.com/algolia/instantsearch/issues/4491)) ([8361cd6](https://github.com/algolia/instantsearch/commit/8361cd63b3bac15eb6250e9f509fb15c1fc57f48))
+- **router:** skip router write on duplicate entries ([#4487](https://github.com/algolia/instantsearch/issues/4487)) ([9296022](https://github.com/algolia/instantsearch/commit/9296022fecadfbf82f15e837c215a1356eac4bc5))
+- **searchBox:** pass "spellcheck" property correctly to input ([#4483](https://github.com/algolia/instantsearch/issues/4483)) ([3cf43c7](https://github.com/algolia/instantsearch/commit/3cf43c7187841cf961a0280307af1a5f7a4e8da7))
 
-
-
-# [4.7.1](https://github.com/algolia/instantsearch.js/compare/v4.7.0...v4.7.1) (2020-08-19)
-
+# [4.7.1](https://github.com/algolia/instantsearch/compare/v4.7.0...v4.7.1) (2020-08-19)
 
 ### Bug Fixes
 
-* **configureRelatedItems:** support nested attributes ([#4480](https://github.com/algolia/instantsearch.js/issues/4480)) ([2266004](https://github.com/algolia/instantsearch.js/commit/2266004f274138b45640f000a5da8aa14e419e6c))
-* **connectToggleRefinement:** fix onFacetValue/offFacetValue on render when using arrays for on/off ([#4449](https://github.com/algolia/instantsearch.js/issues/4449)) ([fd3e83f](https://github.com/algolia/instantsearch.js/commit/fd3e83f2cf2e5b44b7d29eb4c67526e55c18d708))
-* **index:** don't show a development warning for inconsistent UI state in `connectRange` ([#4440](https://github.com/algolia/instantsearch.js/issues/4440)) ([eb8c8b3](https://github.com/algolia/instantsearch.js/commit/eb8c8b3494cb66dbef1d03e7d74374dc49059345)), closes [#4437](https://github.com/algolia/instantsearch.js/issues/4437)
-* **infiniteHits:** work with controlled mode ([#4435](https://github.com/algolia/instantsearch.js/issues/4435)) ([68b20f4](https://github.com/algolia/instantsearch.js/commit/68b20f487fcd54fd7dec11b4c494b6aa94a18516))
-* **typescript:** correct dummy v4 client ([#4459](https://github.com/algolia/instantsearch.js/issues/4459)) ([ca0c394](https://github.com/algolia/instantsearch.js/commit/ca0c3946608bb8ec5dcf5378d8d382d809a4d86f))
-* **typescript:** jsDoc comments which conform to Connector definition ([#4458](https://github.com/algolia/instantsearch.js/issues/4458)) ([5209bdb](https://github.com/algolia/instantsearch.js/commit/5209bdb9189e7cbbf9514b62fde55f923b2b3273))
-* **typescript:** export correct types ([#4476](https://github.com/algolia/instantsearch.js/issues/4476)) ([5fb4c5b](https://github.com/algolia/instantsearch.js/commit/5fb4c5b9d6ac75636e94514598ef5d5a86affafd))
+- **configureRelatedItems:** support nested attributes ([#4480](https://github.com/algolia/instantsearch/issues/4480)) ([2266004](https://github.com/algolia/instantsearch/commit/2266004f274138b45640f000a5da8aa14e419e6c))
+- **connectToggleRefinement:** fix onFacetValue/offFacetValue on render when using arrays for on/off ([#4449](https://github.com/algolia/instantsearch/issues/4449)) ([fd3e83f](https://github.com/algolia/instantsearch/commit/fd3e83f2cf2e5b44b7d29eb4c67526e55c18d708))
+- **index:** don't show a development warning for inconsistent UI state in `connectRange` ([#4440](https://github.com/algolia/instantsearch/issues/4440)) ([eb8c8b3](https://github.com/algolia/instantsearch/commit/eb8c8b3494cb66dbef1d03e7d74374dc49059345)), closes [#4437](https://github.com/algolia/instantsearch/issues/4437)
+- **infiniteHits:** work with controlled mode ([#4435](https://github.com/algolia/instantsearch/issues/4435)) ([68b20f4](https://github.com/algolia/instantsearch/commit/68b20f487fcd54fd7dec11b4c494b6aa94a18516))
+- **typescript:** correct dummy v4 client ([#4459](https://github.com/algolia/instantsearch/issues/4459)) ([ca0c394](https://github.com/algolia/instantsearch/commit/ca0c3946608bb8ec5dcf5378d8d382d809a4d86f))
+- **typescript:** jsDoc comments which conform to Connector definition ([#4458](https://github.com/algolia/instantsearch/issues/4458)) ([5209bdb](https://github.com/algolia/instantsearch/commit/5209bdb9189e7cbbf9514b62fde55f923b2b3273))
+- **typescript:** export correct types ([#4476](https://github.com/algolia/instantsearch/issues/4476)) ([5fb4c5b](https://github.com/algolia/instantsearch/commit/5fb4c5b9d6ac75636e94514598ef5d5a86affafd))
 
-
-
-# [4.7.0](https://github.com/algolia/instantsearch.js/compare/v4.6.0...v4.7.0) (2020-06-15)
-
+# [4.7.0](https://github.com/algolia/instantsearch/compare/v4.6.0...v4.7.0) (2020-06-15)
 
 ### Bug Fixes
 
-* **rangeInput:** clear input when refinement is cleared ([#4429](https://github.com/algolia/instantsearch.js/issues/4429)) ([a2c7663](https://github.com/algolia/instantsearch.js/commit/a2c7663424c5cd59e17ed841e12abaa19e524b14))
-
+- **rangeInput:** clear input when refinement is cleared ([#4429](https://github.com/algolia/instantsearch/issues/4429)) ([a2c7663](https://github.com/algolia/instantsearch/commit/a2c7663424c5cd59e17ed841e12abaa19e524b14))
 
 ### Features
 
-* **infiniteHits:** support cache ([#4431](https://github.com/algolia/instantsearch.js/issues/4431)) ([008c01c](https://github.com/algolia/instantsearch.js/commit/008c01c7cd09e4fcecdf53a4b299960de2b7a026))
+- **infiniteHits:** support cache ([#4431](https://github.com/algolia/instantsearch/issues/4431)) ([008c01c](https://github.com/algolia/instantsearch/commit/008c01c7cd09e4fcecdf53a4b299960de2b7a026))
 
-
-
-# [4.6.0](https://github.com/algolia/instantsearch.js/compare/v4.5.0...v4.6.0) (2020-06-08)
-
+# [4.6.0](https://github.com/algolia/instantsearch/compare/v4.5.0...v4.6.0) (2020-06-08)
 
 ### Bug Fixes
 
-* **connectPagination:** set `isLastPage` to `true` when no results ([#4422](https://github.com/algolia/instantsearch.js/issues/4422)) ([92bcc02](https://github.com/algolia/instantsearch.js/commit/92bcc0271927f0239083366fff920530977e32cd))
-* **rangeInput:** support typing float numbers ([#4418](https://github.com/algolia/instantsearch.js/issues/4418)) ([61b19b8](https://github.com/algolia/instantsearch.js/commit/61b19b87ae3afdabde8ef355e3b727059ae59911))
-
+- **connectPagination:** set `isLastPage` to `true` when no results ([#4422](https://github.com/algolia/instantsearch/issues/4422)) ([92bcc02](https://github.com/algolia/instantsearch/commit/92bcc0271927f0239083366fff920530977e32cd))
+- **rangeInput:** support typing float numbers ([#4418](https://github.com/algolia/instantsearch/issues/4418)) ([61b19b8](https://github.com/algolia/instantsearch/commit/61b19b87ae3afdabde8ef355e3b727059ae59911))
 
 ### Features
 
-* **connectToggleRefinement:** add support for array values ([#4420](https://github.com/algolia/instantsearch.js/issues/4420)) ([fe1fbee](https://github.com/algolia/instantsearch.js/commit/fe1fbee4ad59c5f24831ed38a419906bbd7d2c15))
+- **connectToggleRefinement:** add support for array values ([#4420](https://github.com/algolia/instantsearch/issues/4420)) ([fe1fbee](https://github.com/algolia/instantsearch/commit/fe1fbee4ad59c5f24831ed38a419906bbd7d2c15))
 
-
-
-# [4.5.0](https://github.com/algolia/instantsearch.js/compare/v4.4.1...v4.5.0) (2020-05-13)
-
+# [4.5.0](https://github.com/algolia/instantsearch/compare/v4.4.1...v4.5.0) (2020-05-13)
 
 ### Bug Fixes
 
-* **middleware:** subscribe middleware after `init` ([#4322](https://github.com/algolia/instantsearch.js/issues/4322)) ([f61fc4d](https://github.com/algolia/instantsearch.js/commit/f61fc4d133c118cfe8f2a2ba2e02d037a21cf8e0))
-
+- **middleware:** subscribe middleware after `init` ([#4322](https://github.com/algolia/instantsearch/issues/4322)) ([f61fc4d](https://github.com/algolia/instantsearch/commit/f61fc4d133c118cfe8f2a2ba2e02d037a21cf8e0))
 
 ### Features
 
-* **index:** support adding index widget with initial UI state ([#4359](https://github.com/algolia/instantsearch.js/issues/4359)) ([5ff4c83](https://github.com/algolia/instantsearch.js/commit/5ff4c8307c2be7bde7fb53aa9935a243e6532fe2))
-* **voice:** allow custom voice helper ([#4363](https://github.com/algolia/instantsearch.js/issues/4363)) ([4a00fa6](https://github.com/algolia/instantsearch.js/commit/4a00fa607354aefaae468735b590e237a2d46f9b))
+- **index:** support adding index widget with initial UI state ([#4359](https://github.com/algolia/instantsearch/issues/4359)) ([5ff4c83](https://github.com/algolia/instantsearch/commit/5ff4c8307c2be7bde7fb53aa9935a243e6532fe2))
+- **voice:** allow custom voice helper ([#4363](https://github.com/algolia/instantsearch/issues/4363)) ([4a00fa6](https://github.com/algolia/instantsearch/commit/4a00fa607354aefaae468735b590e237a2d46f9b))
 
-
-
-## [4.4.1](https://github.com/algolia/instantsearch.js/compare/v4.4.0...v4.4.1) (2020-04-29)
-
+## [4.4.1](https://github.com/algolia/instantsearch/compare/v4.4.0...v4.4.1) (2020-04-29)
 
 ### Bug Fixes
 
-* **range:** fix range calculation when step is set ([#4398](https://github.com/algolia/instantsearch.js/issues/4398)) ([a36b4e0](https://github.com/algolia/instantsearch.js/commit/a36b4e0a64afaa9dfa3048c802d010d569c821a9))
-* **router:** don't write an existing URL ([#4392](https://github.com/algolia/instantsearch.js/issues/4392)) ([ee6a9c6](https://github.com/algolia/instantsearch.js/commit/ee6a9c657c97adebba9fb9404eae454c3996b86d))
+- **range:** fix range calculation when step is set ([#4398](https://github.com/algolia/instantsearch/issues/4398)) ([a36b4e0](https://github.com/algolia/instantsearch/commit/a36b4e0a64afaa9dfa3048c802d010d569c821a9))
+- **router:** don't write an existing URL ([#4392](https://github.com/algolia/instantsearch/issues/4392)) ([ee6a9c6](https://github.com/algolia/instantsearch/commit/ee6a9c657c97adebba9fb9404eae454c3996b86d))
 
-
-
-# [4.4.0](https://github.com/algolia/instantsearch.js/compare/v4.3.1...v4.4.0) (2020-04-08)
-
+# [4.4.0](https://github.com/algolia/instantsearch/compare/v4.3.1...v4.4.0) (2020-04-08)
 
 ### Features
 
-* introduce controlled mode APIs with `onStateChange` and `setUiState` ([#4362](https://github.com/algolia/instantsearch.js/issues/4362)) ([4953324](https://github.com/algolia/instantsearch.js/commit/4953324ac8a3af4c6a8be411ca9e7cc673ee6561))
+- introduce controlled mode APIs with `onStateChange` and `setUiState` ([#4362](https://github.com/algolia/instantsearch/issues/4362)) ([4953324](https://github.com/algolia/instantsearch/commit/4953324ac8a3af4c6a8be411ca9e7cc673ee6561))
 
+## [4.3.1](https://github.com/algolia/instantsearch/compare/v4.3.0...v4.3.1) (2020-03-06)
 
-
-## [4.3.1](https://github.com/algolia/instantsearch.js/compare/v4.3.0...v4.3.1) (2020-03-06)
-
-This versions fixes a [Cross-Site Scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) (XSS) vulnerability ([#4344](https://github.com/algolia/instantsearch.js/issues/4344)) when using the [`refinementList`](https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/) widget when relying on its default [`item`](https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/#widget-param-item) template and [routing](https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/#widget-param-routing). **We recommend all users to upgrade to this version**. We now escape the `refinementList` `item` template by default, which avoids HTML to be injected. If ever you were relying on this behavior, **which we do not recommend**, you can copy the [previous `item` template](https://github.com/algolia/instantsearch.js/blob/933d9ffb3c0a396a047eeb4b44733b17aa31d081/src/widgets/refinement-list/defaultTemplates.js#L2-L9) into your widget.
+This versions fixes a [Cross-Site Scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) (XSS) vulnerability ([#4344](https://github.com/algolia/instantsearch/issues/4344)) when using the [`refinementList`](https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/) widget when relying on its default [`item`](https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/#widget-param-item) template and [routing](https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/#widget-param-routing). **We recommend all users to upgrade to this version**. We now escape the `refinementList` `item` template by default, which avoids HTML to be injected. If ever you were relying on this behavior, **which we do not recommend**, you can copy the [previous `item` template](https://github.com/algolia/instantsearch/blob/933d9ffb3c0a396a047eeb4b44733b17aa31d081/src/widgets/refinement-list/defaultTemplates.js#L2-L9) into your widget.
 
 You were not vulnerable to this XSS if:
 
@@ -1454,94 +1007,73 @@ You were not vulnerable to this XSS if:
 - You didn't use use the [`refinementList`](https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/) widget ([`connectRefinementList`](https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/#connector) is not subject to this issue)
 - You used a custom `item` template for your [`refinementList`](https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/) widget that does not rely on the triple-brace Hogan.js syntax (e.g., `{{{highlighted}}}`)
 
+### Bug Fixes
+
+- **refinementList:** prevent XSS via routing ([#4344](https://github.com/algolia/instantsearch/issues/4344)) ([8552221](https://github.com/algolia/instantsearch/commit/8552221eff17a4ae5ba9c454054b0eb6e002934d))
+
+# [4.3.0](https://github.com/algolia/instantsearch/compare/v4.2.0...v4.3.0) (2020-02-25)
 
 ### Bug Fixes
 
-* **refinementList:** prevent XSS via routing ([#4344](https://github.com/algolia/instantsearch.js/issues/4344)) ([8552221](https://github.com/algolia/instantsearch.js/commit/8552221eff17a4ae5ba9c454054b0eb6e002934d))
+- **deps:** update dependency algoliasearch-helper to v3.1.1 that fixes a case where refinements for a facet with a name that matches a substring of another facet could be cleared by mistake ([algolia/algoliasearch-helper-js/pull/760](https://github.com/algolia/algoliasearch-helper-js/pull/760)) ([#4335](https://github.com/algolia/instantsearch/issues/4335)) ([9bc66cf](https://github.com/algolia/instantsearch/commit/381cda05c9c51dc9d3245a6d926e3c919245b723))
 
+### Features
 
+- **highlight:** add cssClasses to snippet & highlight helper ([#4306](https://github.com/algolia/instantsearch/issues/4306)) ([ece0aa6](https://github.com/algolia/instantsearch/commit/ece0aa60f05c2c687a23f9219d62ace0d5b866f9))
 
-# [4.3.0](https://github.com/algolia/instantsearch.js/compare/v4.2.0...v4.3.0) (2020-02-25)
+# [4.2.0](https://github.com/algolia/instantsearch/compare/v4.1.1...v4.2.0) (2020-01-23)
 
+### Features
+
+- **algoliasearch:** add support for algoliasearch v4 ([#4294](https://github.com/algolia/instantsearch/issues/4294)) ([73f1584](https://github.com/algolia/instantsearch/commit/73f158428c7d4de1e3d1bc40bf4342362f275829))
+- **insights:** add getInsightsAnonymousUserToken helper ([#4279](https://github.com/algolia/instantsearch/issues/4279)) ([4653f95](https://github.com/algolia/instantsearch/commit/4653f95b436a0715ce1489e0b83c00a87e4a02f0))
+
+## [4.1.1](https://github.com/algolia/instantsearch/compare/v4.1.0...v4.1.1) (2019-12-20)
 
 ### Bug Fixes
 
-* **deps:** update dependency algoliasearch-helper to v3.1.1 that fixes a case where refinements for a facet with a name that matches a substring of another facet could be cleared by mistake ([algolia/algoliasearch-helper-js/pull/760](https://github.com/algolia/algoliasearch-helper-js/pull/760)) ([#4335](https://github.com/algolia/instantsearch.js/issues/4335)) ([9bc66cf](https://github.com/algolia/instantsearch.js/commit/381cda05c9c51dc9d3245a6d926e3c919245b723))
-
-
-### Features
-
-* **highlight:** add cssClasses to snippet & highlight helper ([#4306](https://github.com/algolia/instantsearch.js/issues/4306)) ([ece0aa6](https://github.com/algolia/instantsearch.js/commit/ece0aa60f05c2c687a23f9219d62ace0d5b866f9))
-
-
-# [4.2.0](https://github.com/algolia/instantsearch.js/compare/v4.1.1...v4.2.0) (2020-01-23)
-
+- **configureRelatedItems:** use `facetFilters` to exclude `obje… ([#4264](https://github.com/algolia/instantsearch/issues/4264)) ([9bc66cf](https://github.com/algolia/instantsearch/commit/9bc66cfb8b13a44840c687a1631696c85e45845f))
+- **index:** fix warning for widgets sharing connectors ([#4260](https://github.com/algolia/instantsearch/issues/4260)) ([ec97b4a](https://github.com/algolia/instantsearch/commit/ec97b4a07e5d1f9a967f5ee5925ebd3b447e1b02))
+- **insights:** export Insights helper in the ESM build ([#4261](https://github.com/algolia/instantsearch/issues/4261)) ([20649af](https://github.com/algolia/instantsearch/commit/20649aff54a3150050866038cd3718d6010c353b))
+- **insights:** move 'insightsClient not provided error' to wrapper level ([#4254](https://github.com/algolia/instantsearch/issues/4254)) ([15d38dd](https://github.com/algolia/instantsearch/commit/15d38ddb87fbd6323f350d42f791c4d7a1505eeb))
 
 ### Features
 
-* **algoliasearch:** add support for algoliasearch v4 ([#4294](https://github.com/algolia/instantsearch.js/issues/4294)) ([73f1584](https://github.com/algolia/instantsearch.js/commit/73f158428c7d4de1e3d1bc40bf4342362f275829))
-* **insights:** add getInsightsAnonymousUserToken helper ([#4279](https://github.com/algolia/instantsearch.js/issues/4279)) ([4653f95](https://github.com/algolia/instantsearch.js/commit/4653f95b436a0715ce1489e0b83c00a87e4a02f0))
+- **insights:** add hogan helper ([#4253](https://github.com/algolia/instantsearch/issues/4253)) ([85739d7](https://github.com/algolia/instantsearch/commit/85739d782ae1fad3b87612e4a410eada0ca4fe54))
 
-
-
-## [4.1.1](https://github.com/algolia/instantsearch.js/compare/v4.1.0...v4.1.1) (2019-12-20)
-
-
-### Bug Fixes
-
-* **configureRelatedItems:** use `facetFilters` to exclude `obje… ([#4264](https://github.com/algolia/instantsearch.js/issues/4264)) ([9bc66cf](https://github.com/algolia/instantsearch.js/commit/9bc66cfb8b13a44840c687a1631696c85e45845f))
-* **index:** fix warning for widgets sharing connectors ([#4260](https://github.com/algolia/instantsearch.js/issues/4260)) ([ec97b4a](https://github.com/algolia/instantsearch.js/commit/ec97b4a07e5d1f9a967f5ee5925ebd3b447e1b02))
-* **insights:** export Insights helper in the ESM build ([#4261](https://github.com/algolia/instantsearch.js/issues/4261)) ([20649af](https://github.com/algolia/instantsearch.js/commit/20649aff54a3150050866038cd3718d6010c353b))
-* **insights:** move 'insightsClient not provided error' to wrapper level ([#4254](https://github.com/algolia/instantsearch.js/issues/4254)) ([15d38dd](https://github.com/algolia/instantsearch.js/commit/15d38ddb87fbd6323f350d42f791c4d7a1505eeb))
-
-
-### Features
-
-* **insights:** add hogan helper ([#4253](https://github.com/algolia/instantsearch.js/issues/4253)) ([85739d7](https://github.com/algolia/instantsearch.js/commit/85739d782ae1fad3b87612e4a410eada0ca4fe54))
-
-
-
-# [4.1.0](https://github.com/algolia/instantsearch.js/compare/v4.0.1...v4.1.0) (2019-12-10)
+# [4.1.0](https://github.com/algolia/instantsearch/compare/v4.0.1...v4.1.0) (2019-12-10)
 
 The [4.0.1](#4.0.1) release contained experimental TypeScript definitions in the ESM build by accident. We rolled this back in 4.1.0 because types will first be released on an experimental tag: `experimental-typescript`.
 
-
 ### Bug Fixes
 
-* **core:** display correct object types in messages ([#4249](https://github.com/algolia/instantsearch.js/issues/4249)) ([fb2c3c9](https://github.com/algolia/instantsearch.js/commit/fb2c3c9c37fd8d28cd4712486c5c637e237fe83b))
-* **insights:** detect clicks on children of `[data-insights]` HTML elements ([#4197](https://github.com/algolia/instantsearch.js/issues/4197)) ([9cac5a3](https://github.com/algolia/instantsearch.js/commit/9cac5a3aa4af616ec7913c17ed7388134c5e7f0a))
-* **insights:** display docs URL when missing ([#4231](https://github.com/algolia/instantsearch.js/issues/4231)) ([9df1e7f](https://github.com/algolia/instantsearch.js/commit/9df1e7f762333bd31b5840b35378d56605fe4844))
-* **widgets:** override connectors' `$$type` ([#4227](https://github.com/algolia/instantsearch.js/issues/4227)) ([50f4af3](https://github.com/algolia/instantsearch.js/commit/50f4af3006a44cd08dd99b3a72bd410340c2e48a))
-
+- **core:** display correct object types in messages ([#4249](https://github.com/algolia/instantsearch/issues/4249)) ([fb2c3c9](https://github.com/algolia/instantsearch/commit/fb2c3c9c37fd8d28cd4712486c5c637e237fe83b))
+- **insights:** detect clicks on children of `[data-insights]` HTML elements ([#4197](https://github.com/algolia/instantsearch/issues/4197)) ([9cac5a3](https://github.com/algolia/instantsearch/commit/9cac5a3aa4af616ec7913c17ed7388134c5e7f0a))
+- **insights:** display docs URL when missing ([#4231](https://github.com/algolia/instantsearch/issues/4231)) ([9df1e7f](https://github.com/algolia/instantsearch/commit/9df1e7f762333bd31b5840b35378d56605fe4844))
+- **widgets:** override connectors' `$$type` ([#4227](https://github.com/algolia/instantsearch/issues/4227)) ([50f4af3](https://github.com/algolia/instantsearch/commit/50f4af3006a44cd08dd99b3a72bd410340c2e48a))
 
 ### Features
 
-* **middleware:** introduce `EXPERIMENTAL_use` to plug middleware into InstantSearch ([#4224](https://github.com/algolia/instantsearch.js/issues/4224)) ([9d1f7be](https://github.com/algolia/instantsearch.js/commit/9d1f7be9df304a4bc2d07dbd253a73580a0593c3))
-* **router:** plug router as a middleware ([#4224](https://github.com/algolia/instantsearch.js/issues/4224)) ([9d1f7be](https://github.com/algolia/instantsearch.js/commit/9d1f7be9df304a4bc2d07dbd253a73580a0593c3))
-* **insights:** detect window.aa when available on global scope and a function ([#4191](https://github.com/algolia/instantsearch.js/issues/4191)) ([d6df5af](https://github.com/algolia/instantsearch.js/commit/d6df5affc4111aaf2c82f847ffe877793faac86c))
-* **typescript:** add declaration files (experimental) ([#4220](https://github.com/algolia/instantsearch.js/issues/4220)) ([ebacfe5](https://github.com/algolia/instantsearch.js/commit/ebacfe55bc0fddf9ca217eca8c8a207b220ab93d))
-* **widgets:** introduce Related Items widgets as experimental (`EXPERIMENTAL_configureRelatedItems` and `EXPERIMENTAL_connectConfigureRelatedItems`) ([#4233](https://github.com/algolia/instantsearch.js/issues/4233)) ([f811f4e](https://github.com/algolia/instantsearch.js/commit/f811f4efa3e58a2b868d11ec338248715a7596c9))
+- **middleware:** introduce `EXPERIMENTAL_use` to plug middleware into InstantSearch ([#4224](https://github.com/algolia/instantsearch/issues/4224)) ([9d1f7be](https://github.com/algolia/instantsearch/commit/9d1f7be9df304a4bc2d07dbd253a73580a0593c3))
+- **router:** plug router as a middleware ([#4224](https://github.com/algolia/instantsearch/issues/4224)) ([9d1f7be](https://github.com/algolia/instantsearch/commit/9d1f7be9df304a4bc2d07dbd253a73580a0593c3))
+- **insights:** detect window.aa when available on global scope and a function ([#4191](https://github.com/algolia/instantsearch/issues/4191)) ([d6df5af](https://github.com/algolia/instantsearch/commit/d6df5affc4111aaf2c82f847ffe877793faac86c))
+- **typescript:** add declaration files (experimental) ([#4220](https://github.com/algolia/instantsearch/issues/4220)) ([ebacfe5](https://github.com/algolia/instantsearch/commit/ebacfe55bc0fddf9ca217eca8c8a207b220ab93d))
+- **widgets:** introduce Related Items widgets as experimental (`EXPERIMENTAL_configureRelatedItems` and `EXPERIMENTAL_connectConfigureRelatedItems`) ([#4233](https://github.com/algolia/instantsearch/issues/4233)) ([f811f4e](https://github.com/algolia/instantsearch/commit/f811f4efa3e58a2b868d11ec338248715a7596c9))
 
-
-
-## [4.0.1](https://github.com/algolia/instantsearch.js/compare/v4.0.0...v4.0.1) (2019-11-28)
-
+## [4.0.1](https://github.com/algolia/instantsearch/compare/v4.0.0...v4.0.1) (2019-11-28)
 
 ### Bug Fixes
 
-* widget name in documentation link for index ([#4172](https://github.com/algolia/instantsearch.js/issues/4172)) ([fe7e588](https://github.com/algolia/instantsearch.js/commit/fe7e588d252ad6bd7de2f49d52ca022099f3e959))
-* **helper:** rely on stable version of algoliasearch-helper ([#4200](https://github.com/algolia/instantsearch.js/issues/4200)) ([ff11731](https://github.com/algolia/instantsearch.js/commit/ff117314d786c4509edabcb1ddbac73f55930511))
-* **infiniteHits:** correct widget options types ([#4222](https://github.com/algolia/instantsearch.js/issues/4222)) ([bb1b327](https://github.com/algolia/instantsearch.js/commit/bb1b327e26b5faad3358a00d174dc48fd4b73356))
-* **queryHook:** restore behaviour of queryHook ([#4202](https://github.com/algolia/instantsearch.js/issues/4202)) ([7bf96cb](https://github.com/algolia/instantsearch.js/commit/7bf96cb6eafd5349cdf2f32114d5e6ef5dde1328)), closes [/github.com/algolia/instantsearch.js/commit/c073a9acb51fff3c15278fcd563e47fec55c8365#diff-530222e0c4597f2110dc6ba173a306b0L98](https://github.com//github.com/algolia/instantsearch.js/commit/c073a9acb51fff3c15278fcd563e47fec55c8365/issues/diff-530222e0c4597f2110dc6ba173a306b0L98)
-
+- widget name in documentation link for index ([#4172](https://github.com/algolia/instantsearch/issues/4172)) ([fe7e588](https://github.com/algolia/instantsearch/commit/fe7e588d252ad6bd7de2f49d52ca022099f3e959))
+- **helper:** rely on stable version of algoliasearch-helper ([#4200](https://github.com/algolia/instantsearch/issues/4200)) ([ff11731](https://github.com/algolia/instantsearch/commit/ff117314d786c4509edabcb1ddbac73f55930511))
+- **infiniteHits:** correct widget options types ([#4222](https://github.com/algolia/instantsearch/issues/4222)) ([bb1b327](https://github.com/algolia/instantsearch/commit/bb1b327e26b5faad3358a00d174dc48fd4b73356))
+- **queryHook:** restore behaviour of queryHook ([#4202](https://github.com/algolia/instantsearch/issues/4202)) ([7bf96cb](https://github.com/algolia/instantsearch/commit/7bf96cb6eafd5349cdf2f32114d5e6ef5dde1328)), closes [/github.com/algolia/instantsearch/commit/c073a9acb51fff3c15278fcd563e47fec55c8365#diff-530222e0c4597f2110dc6ba173a306b0L98](https://github.com//github.com/algolia/instantsearch/commit/c073a9acb51fff3c15278fcd563e47fec55c8365/issues/diff-530222e0c4597f2110dc6ba173a306b0L98)
 
 ### Features
 
-* **transformers:** add tests ([#4153](https://github.com/algolia/instantsearch.js/issues/4153)) ([5a28415](https://github.com/algolia/instantsearch.js/commit/5a28415c39bf5a3a65c61d8f0d444ea6f4e0e17a))
+- **transformers:** add tests ([#4153](https://github.com/algolia/instantsearch/issues/4153)) ([5a28415](https://github.com/algolia/instantsearch/commit/5a28415c39bf5a3a65c61d8f0d444ea6f4e0e17a))
 
-
-
-# [4.0.0](https://github.com/algolia/instantsearch.js/compare/v3.7.0...v4.0.0) (2019-10-23)
+# [4.0.0](https://github.com/algolia/instantsearch/compare/v3.7.0...v4.0.0) (2019-10-23)
 
 This release is focused on two main features: Federated search, and bundle size reduction.
 
@@ -1557,2436 +1089,2046 @@ Note, if you are using the [places.js](https://github.com/algolia/places) Instan
 
 ### Bug Fixes
 
-* **configure:** merge with the previous parameters ([#4085](https://github.com/algolia/instantsearch.js/issues/4085)) ([a215d0c](https://github.com/algolia/instantsearch.js/commit/a215d0c))
-* **configure:** update lifecycle state ([#3994](https://github.com/algolia/instantsearch.js/issues/3994)) ([3d8d967](https://github.com/algolia/instantsearch.js/commit/3d8d967))
-* **connectInfiniteHits:** fix page state when adding or removing widgets ([#4104](https://github.com/algolia/instantsearch.js/issues/4104)) ([1077340](https://github.com/algolia/instantsearch.js/commit/1077340))
-* **connectInfiniteHits:** fix state when navigating or adding/removing widgets ([#4123](https://github.com/algolia/instantsearch.js/issues/4123)) ([9cbd24a](https://github.com/algolia/instantsearch.js/commit/9cbd24a))
-* **createURL:** support multi-index ([#4082](https://github.com/algolia/instantsearch.js/issues/4082)) ([179a6e5](https://github.com/algolia/instantsearch.js/commit/179a6e5))
-* **defer:** recover from error ([#3933](https://github.com/algolia/instantsearch.js/issues/3933)) ([f22b9e2](https://github.com/algolia/instantsearch.js/commit/f22b9e2))
-* **helper:** expose .lastResults to .helper ([#4170](https://github.com/algolia/instantsearch.js/issues/4170)) ([236eb7b](https://github.com/algolia/instantsearch.js/commit/236eb7b))
-* **history:** avoid empty query string ([#4130](https://github.com/algolia/instantsearch.js/issues/4130)) ([18fee7c](https://github.com/algolia/instantsearch.js/commit/18fee7c))
-* **hits:** update lifecycle state ([#3977](https://github.com/algolia/instantsearch.js/issues/3977)) ([6e55ba6](https://github.com/algolia/instantsearch.js/commit/6e55ba6))
-* **hitsPerPage:** avoid sync default value ([#4086](https://github.com/algolia/instantsearch.js/issues/4086)) ([3f8b958](https://github.com/algolia/instantsearch.js/commit/3f8b958))
-* **hitsPerPage:** update lifecycle state ([#3978](https://github.com/algolia/instantsearch.js/issues/3978)) ([d21d620](https://github.com/algolia/instantsearch.js/commit/d21d620))
-* **index:** ensure that we always use the index set by widgets ([#4125](https://github.com/algolia/instantsearch.js/issues/4125)) ([952dc70](https://github.com/algolia/instantsearch.js/commit/952dc70)), closes [/github.com/algolia/algoliasearch-helper-js/blob/5a0352aa233c5ea932df6b054a16989c8d302404/src/algoliasearch.helper.js#L124](https://github.com//github.com/algolia/algoliasearch-helper-js/blob/5a0352aa233c5ea932df6b054a16989c8d302404/src/algoliasearch.helper.js/issues/L124)
-* **index:** prevent render without results ([#3932](https://github.com/algolia/instantsearch.js/issues/3932)) ([1b9b5f4](https://github.com/algolia/instantsearch.js/commit/1b9b5f4))
-* **index:** subscribe to state change only after init for uiState ([#4003](https://github.com/algolia/instantsearch.js/issues/4003)) ([9490ca9](https://github.com/algolia/instantsearch.js/commit/9490ca9))
-* **index:** support custom UI params in UI state warning ([#4165](https://github.com/algolia/instantsearch.js/issues/4165)) ([80d32fc](https://github.com/algolia/instantsearch.js/commit/80d32fc))
-* **index:** warn for inconsistent UI state in development mode ([#4140](https://github.com/algolia/instantsearch.js/issues/4140)) ([7e277dc](https://github.com/algolia/instantsearch.js/commit/7e277dc))
-* **infiniteHits:** update lifecycle state ([#3983](https://github.com/algolia/instantsearch.js/issues/3983)) ([4b8bee5](https://github.com/algolia/instantsearch.js/commit/4b8bee5))
-* **instantsearch:** return instance in widgets methods ([#4143](https://github.com/algolia/instantsearch.js/issues/4143)) ([77ffb93](https://github.com/algolia/instantsearch.js/commit/77ffb93))
-* **InstantSearch:** cancel scheduled operations ([#3930](https://github.com/algolia/instantsearch.js/issues/3930)) ([3aafbad](https://github.com/algolia/instantsearch.js/commit/3aafbad))
-* **InstantSearch:** fix initialUIState when refinements are already present in the route ([#4103](https://github.com/algolia/instantsearch.js/issues/4103)) ([079db57](https://github.com/algolia/instantsearch.js/commit/079db57))
-* **InstantSearch:** remove useless walk/duplicate request ([#4127](https://github.com/algolia/instantsearch.js/issues/4127)) ([70163a8](https://github.com/algolia/instantsearch.js/commit/70163a8))
-* **menu:** apply & remove refinement ([#4027](https://github.com/algolia/instantsearch.js/issues/4027)) ([85de2cf](https://github.com/algolia/instantsearch.js/commit/85de2cf))
-* **menu:** prevent error on stale search ([#3934](https://github.com/algolia/instantsearch.js/issues/3934)) ([5f9e138](https://github.com/algolia/instantsearch.js/commit/5f9e138))
-* **numericMenu:** take array into account for empty state ([#4084](https://github.com/algolia/instantsearch.js/issues/4084)) ([2c05a01](https://github.com/algolia/instantsearch.js/commit/2c05a01))
-* **pagination:** update lifecycle state ([#3979](https://github.com/algolia/instantsearch.js/issues/3979)) ([2b08344](https://github.com/algolia/instantsearch.js/commit/2b08344))
-* **pagination:** update no refinement behavior ([#4124](https://github.com/algolia/instantsearch.js/issues/4124)) ([8d222ad](https://github.com/algolia/instantsearch.js/commit/8d222ad))
-* **range:** clear widget state on empty refinements ([#4157](https://github.com/algolia/instantsearch.js/issues/4157)) ([23cd112](https://github.com/algolia/instantsearch.js/commit/23cd112))
-* **ratingMenu:** update lifecycle state ([#3987](https://github.com/algolia/instantsearch.js/issues/3987)) ([ffadf64](https://github.com/algolia/instantsearch.js/commit/ffadf64))
-* **RefinementList:** remove root css class on sublists ([#4117](https://github.com/algolia/instantsearch.js/issues/4117)) ([ceddd42](https://github.com/algolia/instantsearch.js/commit/ceddd42)), closes [/github.com/algolia/instantsearch.js/blob/v2/src/decorators/headerFooter.js#L22](https://github.com//github.com/algolia/instantsearch.js/blob/v2/src/decorators/headerFooter.js/issues/L22)
-* **searchBox:** update lifecycle state ([#3981](https://github.com/algolia/instantsearch.js/issues/3981)) ([0ea4950](https://github.com/algolia/instantsearch.js/commit/0ea4950))
-* **sortBy:** ensure a return value for getWidgetSearchParameters ([#4126](https://github.com/algolia/instantsearch.js/issues/4126)) ([569d573](https://github.com/algolia/instantsearch.js/commit/569d573))
-* **sortBy:** read initial index name from parent index ([#4079](https://github.com/algolia/instantsearch.js/issues/4079)) ([fe23c55](https://github.com/algolia/instantsearch.js/commit/fe23c55))
-* display warnings only in development ([#4150](https://github.com/algolia/instantsearch.js/issues/4150)) ([44f69a0](https://github.com/algolia/instantsearch.js/commit/44f69a0))
-* remove useless types  ([#3958](https://github.com/algolia/instantsearch.js/issues/3958)) ([ddebf53](https://github.com/algolia/instantsearch.js/commit/ddebf53))
-* **stories:** hide Places ([#4152](https://github.com/algolia/instantsearch.js/issues/4152)) ([7ff843f](https://github.com/algolia/instantsearch.js/commit/7ff843f))
-* **toggleRefinement:** update lifecycle state ([#3993](https://github.com/algolia/instantsearch.js/issues/3993)) ([f1beff6](https://github.com/algolia/instantsearch.js/commit/f1beff6))
-* **voiceSearch:** update lifecycle state ([#3982](https://github.com/algolia/instantsearch.js/issues/3982)) ([798e3c1](https://github.com/algolia/instantsearch.js/commit/798e3c1))
-* **warnings:** remove v3 warnings ([#4134](https://github.com/algolia/instantsearch.js/issues/4134)) ([7eb6810](https://github.com/algolia/instantsearch.js/commit/7eb6810))
-
-
-### Features
-
-* **autocomplete:** leverage scoped results ([#3975](https://github.com/algolia/instantsearch.js/issues/3975)) ([8f05968](https://github.com/algolia/instantsearch.js/commit/8f05968))
-* **autocomplete:** participate in routing ([#4029](https://github.com/algolia/instantsearch.js/issues/4029)) ([a9ca0c5](https://github.com/algolia/instantsearch.js/commit/a9ca0c5))
-* **autocomplete:** provide indexId ([#4142](https://github.com/algolia/instantsearch.js/issues/4142)) ([b641e23](https://github.com/algolia/instantsearch.js/commit/b641e23))
-* **clearRefinements:** support multiple indices ([#4036](https://github.com/algolia/instantsearch.js/issues/4036)) ([3611b11](https://github.com/algolia/instantsearch.js/commit/3611b11))
-* **connectAutocomplete:** add default value on getConfiguration ([#3836](https://github.com/algolia/instantsearch.js/issues/3836)) ([724b83f](https://github.com/algolia/instantsearch.js/commit/724b83f))
-* **connectAutocomplete:** clear the state on dispose ([#3815](https://github.com/algolia/instantsearch.js/issues/3815)) ([8ae87d8](https://github.com/algolia/instantsearch.js/commit/8ae87d8))
-* **connectHierarchicalMenu:** update getWidgetSearchParameters ([#4053](https://github.com/algolia/instantsearch.js/issues/4053)) ([c99f822](https://github.com/algolia/instantsearch.js/commit/c99f822))
-* **connectHits:** clear the state on dispose ([#3816](https://github.com/algolia/instantsearch.js/issues/3816)) ([c4de730](https://github.com/algolia/instantsearch.js/commit/c4de730))
-* **connectHits:** implement getWidgetSearchParameters ([#4001](https://github.com/algolia/instantsearch.js/issues/4001)) ([c77cf66](https://github.com/algolia/instantsearch.js/commit/c77cf66))
-* **connectHitsPerPage:** clear the state on dispose ([#3818](https://github.com/algolia/instantsearch.js/issues/3818)) ([d7a5c89](https://github.com/algolia/instantsearch.js/commit/d7a5c89))
-* **connectInfiniteHits:** add default value on getConfiguration ([#3837](https://github.com/algolia/instantsearch.js/issues/3837)) ([8c65249](https://github.com/algolia/instantsearch.js/commit/8c65249))
-* **connectInfiniteHits:** clear the state on dispose ([#3819](https://github.com/algolia/instantsearch.js/issues/3819)) ([60ce151](https://github.com/algolia/instantsearch.js/commit/60ce151))
-* **connectMenu:** update getWidgetSearchParameters ([#4054](https://github.com/algolia/instantsearch.js/issues/4054)) ([7d001e7](https://github.com/algolia/instantsearch.js/commit/7d001e7))
-* **connectNumericMenu:** update state lifecycle  ([#4013](https://github.com/algolia/instantsearch.js/issues/4013)) ([2620c90](https://github.com/algolia/instantsearch.js/commit/2620c90))
-* **connectPagination:** add default value on getConfiguration ([#3838](https://github.com/algolia/instantsearch.js/issues/3838)) ([aa4602c](https://github.com/algolia/instantsearch.js/commit/aa4602c))
-* **connectPagination:** clear the state on dispose ([#3821](https://github.com/algolia/instantsearch.js/issues/3821)) ([5b8ef49](https://github.com/algolia/instantsearch.js/commit/5b8ef49))
-* **connectPagination:** update getWidgetSearchParameters ([#4004](https://github.com/algolia/instantsearch.js/issues/4004)) ([eed7e77](https://github.com/algolia/instantsearch.js/commit/eed7e77))
-* **connectRange:** default `precision` to 0 ([#3953](https://github.com/algolia/instantsearch.js/issues/3953)) ([632e06b](https://github.com/algolia/instantsearch.js/commit/632e06b))
-* **connectRatingMenu:** update getWidgetSearchParameters  ([#4008](https://github.com/algolia/instantsearch.js/issues/4008)) ([d3c96bf](https://github.com/algolia/instantsearch.js/commit/d3c96bf))
-* **connectRefinementList:** update getWidgetSearchParameters  ([#4010](https://github.com/algolia/instantsearch.js/issues/4010)) ([ddc8fc4](https://github.com/algolia/instantsearch.js/commit/ddc8fc4))
-* **connectSearchBox:** clear the state on dispose ([#3822](https://github.com/algolia/instantsearch.js/issues/3822)) ([940522c](https://github.com/algolia/instantsearch.js/commit/940522c))
-* **connectSearchBox:** mount with a default query ([#3840](https://github.com/algolia/instantsearch.js/issues/3840)) ([c3a7d69](https://github.com/algolia/instantsearch.js/commit/c3a7d69))
-* **connectSearchBox:** update getWidgetSearchParameters ([#4002](https://github.com/algolia/instantsearch.js/issues/4002)) ([5c6fcd8](https://github.com/algolia/instantsearch.js/commit/5c6fcd8))
-* **connectVoiceSearch:** add default value on getConfiguration ([#3841](https://github.com/algolia/instantsearch.js/issues/3841)) ([fb70363](https://github.com/algolia/instantsearch.js/commit/fb70363))
-* **connectVoiceSearch:** clear the state on dispose ([#3823](https://github.com/algolia/instantsearch.js/issues/3823)) ([705b3e6](https://github.com/algolia/instantsearch.js/commit/705b3e6))
-* **connectVoiceSearch:** update getWidgetSearchParameters ([#4055](https://github.com/algolia/instantsearch.js/issues/4055)) ([b8c669f](https://github.com/algolia/instantsearch.js/commit/b8c669f))
-* **core:** deprecate addWidget & removeWidget ([#4131](https://github.com/algolia/instantsearch.js/issues/4131)) ([e5dafef](https://github.com/algolia/instantsearch.js/commit/e5dafef))
-* **currentRefinements:** support multiple indices ([#4012](https://github.com/algolia/instantsearch.js/issues/4012)) ([e997728](https://github.com/algolia/instantsearch.js/commit/e997728))
-* **defer:** implement cancellable callback ([#3916](https://github.com/algolia/instantsearch.js/issues/3916)) ([43a0bf8](https://github.com/algolia/instantsearch.js/commit/43a0bf8))
-* **federated:** keep a consistent state in the RefinementList life cycle ([#3976](https://github.com/algolia/instantsearch.js/issues/3976)) ([31d0fd6](https://github.com/algolia/instantsearch.js/commit/31d0fd6))
-* **hitsPerPage:** support new routing system ([#4038](https://github.com/algolia/instantsearch.js/issues/4038)) ([02502cb](https://github.com/algolia/instantsearch.js/commit/02502cb)), closes [#4069](https://github.com/algolia/instantsearch.js/issues/4069)
-* **index:** accept indexId ([#4070](https://github.com/algolia/instantsearch.js/issues/4070)) ([b74f8e3](https://github.com/algolia/instantsearch.js/commit/b74f8e3))
-* **index:** add mergeSearchParameters function ([#3917](https://github.com/algolia/instantsearch.js/issues/3917)) ([c0fe7bb](https://github.com/algolia/instantsearch.js/commit/c0fe7bb))
-* **index:** add widget ([dbbda0f](https://github.com/algolia/instantsearch.js/commit/dbbda0f)), closes [#3892](https://github.com/algolia/instantsearch.js/issues/3892) [#3893](https://github.com/algolia/instantsearch.js/issues/3893) [#3914](https://github.com/algolia/instantsearch.js/issues/3914)
-* **index:** compute local uiState ([#3997](https://github.com/algolia/instantsearch.js/issues/3997)) ([997c0f4](https://github.com/algolia/instantsearch.js/commit/997c0f4))
-* **index:** merge `ruleContexts` search parameter ([#3944](https://github.com/algolia/instantsearch.js/issues/3944)) ([e94752d](https://github.com/algolia/instantsearch.js/commit/e94752d))
-* **index:** provide scoped results to render hook ([#3964](https://github.com/algolia/instantsearch.js/issues/3964)) ([37c6aad](https://github.com/algolia/instantsearch.js/commit/37c6aad))
-* **index:** replicate searchFunction hack ([#4078](https://github.com/algolia/instantsearch.js/issues/4078)) ([1d2a816](https://github.com/algolia/instantsearch.js/commit/1d2a816)), closes [/github.com/algolia/instantsearch.js/blob/509513c0feafaad522f6f18d87a441559f4aa050/src/lib/RoutingManager.ts#L113-L130](https://github.com//github.com/algolia/instantsearch.js/blob/509513c0feafaad522f6f18d87a441559f4aa050/src/lib/RoutingManager.ts/issues/L113-L130)
-* **index:** reset page of child indexes ([#3962](https://github.com/algolia/instantsearch.js/issues/3962)) ([131b1ce](https://github.com/algolia/instantsearch.js/commit/131b1ce))
-* **index:** resolve parent SearchParameters ([#3937](https://github.com/algolia/instantsearch.js/issues/3937)) ([2611da5](https://github.com/algolia/instantsearch.js/commit/2611da5))
-* **index:** use uiState driven SearchParameters ([#4059](https://github.com/algolia/instantsearch.js/issues/4059)) ([b12bb9f](https://github.com/algolia/instantsearch.js/commit/b12bb9f))
-* **infiniteHits:** support new routing system ([#4040](https://github.com/algolia/instantsearch.js/issues/4040)) ([49315cf](https://github.com/algolia/instantsearch.js/commit/49315cf))
-* **instantsearch:** add onStateChange method ([#4080](https://github.com/algolia/instantsearch.js/issues/4080)) ([9f68da5](https://github.com/algolia/instantsearch.js/commit/9f68da5))
-* **InstantSearch:** switch to DerivedHelper only ([#3885](https://github.com/algolia/instantsearch.js/issues/3885)) ([d6fc317](https://github.com/algolia/instantsearch.js/commit/d6fc317))
-* **places:** add Places widget ([#4167](https://github.com/algolia/instantsearch.js/issues/4167)) ([1d754d1](https://github.com/algolia/instantsearch.js/commit/1d754d1))
-* drop support of searchParameters for initialUiState ([#4081](https://github.com/algolia/instantsearch.js/issues/4081)) ([571efeb](https://github.com/algolia/instantsearch.js/commit/571efeb))
-* **range:** support new routing system ([#4039](https://github.com/algolia/instantsearch.js/issues/4039)) ([8cba05a](https://github.com/algolia/instantsearch.js/commit/8cba05a))
-* **routing:** add a "single index" compatibility mode ([#4087](https://github.com/algolia/instantsearch.js/issues/4087)) ([842eb0f](https://github.com/algolia/instantsearch.js/commit/842eb0f))
-* **RoutingManager:** update state on route update ([#4100](https://github.com/algolia/instantsearch.js/issues/4100)) ([88f2615](https://github.com/algolia/instantsearch.js/commit/88f2615))
-* **toggleRefinement:** support new routing system ([#4037](https://github.com/algolia/instantsearch.js/issues/4037)) ([6a9d99f](https://github.com/algolia/instantsearch.js/commit/6a9d99f))
-* **types:** DerivedHelper ([#3887](https://github.com/algolia/instantsearch.js/issues/3887)) ([0f38b4a](https://github.com/algolia/instantsearch.js/commit/0f38b4a))
-* **types:** rename RenderOptions -> RendererOptions ([#3867](https://github.com/algolia/instantsearch.js/issues/3867)) ([05c6f72](https://github.com/algolia/instantsearch.js/commit/05c6f72))
-* **utils:** implement defer ([#3882](https://github.com/algolia/instantsearch.js/issues/3882)) ([8af470e](https://github.com/algolia/instantsearch.js/commit/8af470e))
-* **voice:** add additional query parameters ([#3738](https://github.com/algolia/instantsearch.js/issues/3738)) ([c555255](https://github.com/algolia/instantsearch.js/commit/c555255))
-* drop suppot for onHistoryChange ([#3941](https://github.com/algolia/instantsearch.js/issues/3941)) ([697f609](https://github.com/algolia/instantsearch.js/commit/697f609))
-* introduce initialUiState option ([#4074](https://github.com/algolia/instantsearch.js/issues/4074)) ([de00707](https://github.com/algolia/instantsearch.js/commit/de00707))
-* update UiState definition ([#4075](https://github.com/algolia/instantsearch.js/issues/4075)) ([9e7d3d8](https://github.com/algolia/instantsearch.js/commit/9e7d3d8))
-* **widgets:** add `$$type` to widgets definition ([#3960](https://github.com/algolia/instantsearch.js/issues/3960)) ([344d1b7](https://github.com/algolia/instantsearch.js/commit/344d1b7))
-
-
-
-# [3.7.0](https://github.com/algolia/instantsearch.js/compare/v3.5.4...v3.7.0) (2019-10-08)
-
-
-### Bug Fixes
-
-* **clearRefinements:** reset page to 0 ([#3936](https://github.com/algolia/instantsearch.js/issues/3936)) ([7378a0a](https://github.com/algolia/instantsearch.js/commit/7378a0a))
-* **connectSortBy:** never update the initial index ([#4015](https://github.com/algolia/instantsearch.js/issues/4015)) ([bc0f9e2](https://github.com/algolia/instantsearch.js/commit/bc0f9e2))
-* **deps:** update dependency instantsearch.js to v3.5.4 ([#3929](https://github.com/algolia/instantsearch.js/issues/3929)) ([eff84c5](https://github.com/algolia/instantsearch.js/commit/eff84c5))
-* **deps:** update dependency instantsearch.js to v3.6.0 ([#4021](https://github.com/algolia/instantsearch.js/issues/4021)) ([7719bba](https://github.com/algolia/instantsearch.js/commit/7719bba))
-* **enhanceConfiguration:** deduplicate the hierarchicalFacets ([#3966](https://github.com/algolia/instantsearch.js/issues/3966)) ([baf8a35](https://github.com/algolia/instantsearch.js/commit/baf8a35))
-* **examples:** fix IE11 compatibility for e-commerce demo ([#4049](https://github.com/algolia/instantsearch.js/issues/4049)) ([dc6f350](https://github.com/algolia/instantsearch.js/commit/dc6f350))
-* **examples:** fix missing polyfill in e-commerce demo ([#4076](https://github.com/algolia/instantsearch.js/issues/4076)) ([4bf3ab3](https://github.com/algolia/instantsearch.js/commit/4bf3ab3))
-* **hierarchicalFacets:** prevent different rootPath on same attribute ([#3965](https://github.com/algolia/instantsearch.js/issues/3965)) ([5ee79fa](https://github.com/algolia/instantsearch.js/commit/5ee79fa))
-* **instantsearch:** warn deprecated usage of `searchParameters` ([#4151](https://github.com/algolia/instantsearch.js/issues/4151)) ([18e1c36](https://github.com/algolia/instantsearch.js/commit/18e1c36))
-* **menuSelect:** unmount component ([#3911](https://github.com/algolia/instantsearch.js/issues/3911)) ([f6debce](https://github.com/algolia/instantsearch.js/commit/f6debce))
-* **rangeInput:** unmount component ([#3910](https://github.com/algolia/instantsearch.js/issues/3910)) ([f6c29e8](https://github.com/algolia/instantsearch.js/commit/f6c29e8))
-* **refinementList:** fix showMore button to work after search ([#3082](https://github.com/algolia/instantsearch.js/issues/3082)) ([23e46b6](https://github.com/algolia/instantsearch.js/commit/23e46b6))
-* pass noop as default value to unmountFn at connectors ([#3955](https://github.com/algolia/instantsearch.js/issues/3955)) ([7c38744](https://github.com/algolia/instantsearch.js/commit/7c38744))
-
-
-
-# [3.6.0](https://github.com/algolia/instantsearch.js/compare/v3.5.4...v3.6.0) (2019-07-30)
-
-
-### Bug Fixes
-
-* **clearRefinements:** reset page to 0 ([#3936](https://github.com/algolia/instantsearch.js/issues/3936)) ([7378a0a](https://github.com/algolia/instantsearch.js/commit/7378a0a))
-* pass noop as default value to unmountFn at connectors ([#3955](https://github.com/algolia/instantsearch.js/issues/3955)) ([7c38744](https://github.com/algolia/instantsearch.js/commit/7c38744))
-* **enhanceConfiguration:** deduplicate the hierarchicalFacets ([#3966](https://github.com/algolia/instantsearch.js/issues/3966)) ([baf8a35](https://github.com/algolia/instantsearch.js/commit/baf8a35))
-* **hierarchicalFacets:** prevent different rootPath on same attribute ([#3965](https://github.com/algolia/instantsearch.js/issues/3965)) ([5ee79fa](https://github.com/algolia/instantsearch.js/commit/5ee79fa))
-* **menuSelect:** unmount component ([#3911](https://github.com/algolia/instantsearch.js/issues/3911)) ([f6debce](https://github.com/algolia/instantsearch.js/commit/f6debce))
-* **rangeInput:** unmount component ([#3910](https://github.com/algolia/instantsearch.js/issues/3910)) ([f6c29e8](https://github.com/algolia/instantsearch.js/commit/f6c29e8))
-* **refinementList:** fix showMore button to work after search ([#3082](https://github.com/algolia/instantsearch.js/issues/3082)) ([23e46b6](https://github.com/algolia/instantsearch.js/commit/23e46b6))
-
-
-
-## [3.5.4](https://github.com/algolia/instantsearch.js/compare/v3.5.3...v3.5.4) (2019-07-01)
-
-
-### Bug Fixes
-
-* **connectSortBy:** do not throw with wrong indexes ([#3824](https://github.com/algolia/instantsearch.js/issues/3824)) ([2a84ee2](https://github.com/algolia/instantsearch.js/commit/2a84ee2))
-* **deps:** update dependency instantsearch.js to v3.5.3 ([#3877](https://github.com/algolia/instantsearch.js/issues/3877)) ([463f3bb](https://github.com/algolia/instantsearch.js/commit/463f3bb))
-* **escape:** make sure that __escaped does not get removed ([#3830](https://github.com/algolia/instantsearch.js/issues/3830)) ([fbafd22](https://github.com/algolia/instantsearch.js/commit/fbafd22))
-* **getRefinements:** check for facet before accessing its data ([#3842](https://github.com/algolia/instantsearch.js/issues/3842)) ([aadc769](https://github.com/algolia/instantsearch.js/commit/aadc769))
-* **panel:** return value from dispose ([#3895](https://github.com/algolia/instantsearch.js/issues/3895)) ([bceb78f](https://github.com/algolia/instantsearch.js/commit/bceb78f))
-* **voiceSearch:** remove event listeners on stop ([#3845](https://github.com/algolia/instantsearch.js/issues/3845)) ([688e36a](https://github.com/algolia/instantsearch.js/commit/688e36a))
-
-
-
-## [3.5.3](https://github.com/algolia/instantsearch.js/compare/v3.5.1...v3.5.3) (2019-05-28)
-
-
-### Bug Fixes
-
-* **voiceSearch:** let the connector handle the default value of searchAsYouSpeak when it's not given ([#3817](https://github.com/algolia/instantsearch.js/issues/3817)) ([9d3e91b](https://github.com/algolia/instantsearch.js/commit/9d3e91b))
-* **getTag:** use object version of toString ([#3820](https://github.com/algolia/instantsearch.js/issues/3820)) ([a7348ea](https://github.com/algolia/instantsearch.js/commit/a7348ea))
-* **types:** fix cssClasses of voiceSearch ([#3783](https://github.com/algolia/instantsearch.js/issues/3783)) ([f016326](https://github.com/algolia/instantsearch.js/commit/f016326))
-
-
-
-# [3.5.1](https://github.com/algolia/instantsearch.js/compare/v3.4.0...v3.5.1) (2019-05-20)
-
-
-### Bug Fixes
-
-* **types:** improve types for voiceSearch ([#3778](https://github.com/algolia/instantsearch.js/issues/3778)) ([ed2d61a](https://github.com/algolia/instantsearch.js/commit/ed2d61a))
-* **types:** update UiState type ([#3777](https://github.com/algolia/instantsearch.js/issues/3777)) ([36e3a3d](https://github.com/algolia/instantsearch.js/commit/36e3a3d))
-* **voiceSearch:** remove event listeners on dispose ([#3779](https://github.com/algolia/instantsearch.js/issues/3779)) ([0e988cc](https://github.com/algolia/instantsearch.js/commit/0e988cc))
-* **hitsPerPage:** improve warning for missing state value ([#3707](https://github.com/algolia/instantsearch.js/issues/3707)) ([93d8432](https://github.com/algolia/instantsearch.js/commit/93d8432))
-* **numericMenu:** prevent refinement reset on checked radio click ([#3749](https://github.com/algolia/instantsearch.js/issues/3749)) ([e4a6e75](https://github.com/algolia/instantsearch.js/commit/e4a6e75))
-* **rangeSlider:** round the slider pit value ([#3758](https://github.com/algolia/instantsearch.js/issues/3758)) ([6edee3e](https://github.com/algolia/instantsearch.js/commit/6edee3e)), closes [#2904](https://github.com/algolia/instantsearch.js/issues/2904)
-* **types:** improve UiState types ([#3763](https://github.com/algolia/instantsearch.js/issues/3763)) ([e8ea57b](https://github.com/algolia/instantsearch.js/commit/e8ea57b))
-* **voice:** import correct noop ([#3766](https://github.com/algolia/instantsearch.js/issues/3766)) ([6a80422](https://github.com/algolia/instantsearch.js/commit/6a80422))
-
+- **configure:** merge with the previous parameters ([#4085](https://github.com/algolia/instantsearch/issues/4085)) ([a215d0c](https://github.com/algolia/instantsearch/commit/a215d0c))
+- **configure:** update lifecycle state ([#3994](https://github.com/algolia/instantsearch/issues/3994)) ([3d8d967](https://github.com/algolia/instantsearch/commit/3d8d967))
+- **connectInfiniteHits:** fix page state when adding or removing widgets ([#4104](https://github.com/algolia/instantsearch/issues/4104)) ([1077340](https://github.com/algolia/instantsearch/commit/1077340))
+- **connectInfiniteHits:** fix state when navigating or adding/removing widgets ([#4123](https://github.com/algolia/instantsearch/issues/4123)) ([9cbd24a](https://github.com/algolia/instantsearch/commit/9cbd24a))
+- **createURL:** support multi-index ([#4082](https://github.com/algolia/instantsearch/issues/4082)) ([179a6e5](https://github.com/algolia/instantsearch/commit/179a6e5))
+- **defer:** recover from error ([#3933](https://github.com/algolia/instantsearch/issues/3933)) ([f22b9e2](https://github.com/algolia/instantsearch/commit/f22b9e2))
+- **helper:** expose .lastResults to .helper ([#4170](https://github.com/algolia/instantsearch/issues/4170)) ([236eb7b](https://github.com/algolia/instantsearch/commit/236eb7b))
+- **history:** avoid empty query string ([#4130](https://github.com/algolia/instantsearch/issues/4130)) ([18fee7c](https://github.com/algolia/instantsearch/commit/18fee7c))
+- **hits:** update lifecycle state ([#3977](https://github.com/algolia/instantsearch/issues/3977)) ([6e55ba6](https://github.com/algolia/instantsearch/commit/6e55ba6))
+- **hitsPerPage:** avoid sync default value ([#4086](https://github.com/algolia/instantsearch/issues/4086)) ([3f8b958](https://github.com/algolia/instantsearch/commit/3f8b958))
+- **hitsPerPage:** update lifecycle state ([#3978](https://github.com/algolia/instantsearch/issues/3978)) ([d21d620](https://github.com/algolia/instantsearch/commit/d21d620))
+- **index:** ensure that we always use the index set by widgets ([#4125](https://github.com/algolia/instantsearch/issues/4125)) ([952dc70](https://github.com/algolia/instantsearch/commit/952dc70)), closes [/github.com/algolia/algoliasearch-helper-js/blob/5a0352aa233c5ea932df6b054a16989c8d302404/src/algoliasearch.helper.js#L124](https://github.com//github.com/algolia/algoliasearch-helper-js/blob/5a0352aa233c5ea932df6b054a16989c8d302404/src/algoliasearch.helper.js/issues/L124)
+- **index:** prevent render without results ([#3932](https://github.com/algolia/instantsearch/issues/3932)) ([1b9b5f4](https://github.com/algolia/instantsearch/commit/1b9b5f4))
+- **index:** subscribe to state change only after init for uiState ([#4003](https://github.com/algolia/instantsearch/issues/4003)) ([9490ca9](https://github.com/algolia/instantsearch/commit/9490ca9))
+- **index:** support custom UI params in UI state warning ([#4165](https://github.com/algolia/instantsearch/issues/4165)) ([80d32fc](https://github.com/algolia/instantsearch/commit/80d32fc))
+- **index:** warn for inconsistent UI state in development mode ([#4140](https://github.com/algolia/instantsearch/issues/4140)) ([7e277dc](https://github.com/algolia/instantsearch/commit/7e277dc))
+- **infiniteHits:** update lifecycle state ([#3983](https://github.com/algolia/instantsearch/issues/3983)) ([4b8bee5](https://github.com/algolia/instantsearch/commit/4b8bee5))
+- **instantsearch:** return instance in widgets methods ([#4143](https://github.com/algolia/instantsearch/issues/4143)) ([77ffb93](https://github.com/algolia/instantsearch/commit/77ffb93))
+- **InstantSearch:** cancel scheduled operations ([#3930](https://github.com/algolia/instantsearch/issues/3930)) ([3aafbad](https://github.com/algolia/instantsearch/commit/3aafbad))
+- **InstantSearch:** fix initialUIState when refinements are already present in the route ([#4103](https://github.com/algolia/instantsearch/issues/4103)) ([079db57](https://github.com/algolia/instantsearch/commit/079db57))
+- **InstantSearch:** remove useless walk/duplicate request ([#4127](https://github.com/algolia/instantsearch/issues/4127)) ([70163a8](https://github.com/algolia/instantsearch/commit/70163a8))
+- **menu:** apply & remove refinement ([#4027](https://github.com/algolia/instantsearch/issues/4027)) ([85de2cf](https://github.com/algolia/instantsearch/commit/85de2cf))
+- **menu:** prevent error on stale search ([#3934](https://github.com/algolia/instantsearch/issues/3934)) ([5f9e138](https://github.com/algolia/instantsearch/commit/5f9e138))
+- **numericMenu:** take array into account for empty state ([#4084](https://github.com/algolia/instantsearch/issues/4084)) ([2c05a01](https://github.com/algolia/instantsearch/commit/2c05a01))
+- **pagination:** update lifecycle state ([#3979](https://github.com/algolia/instantsearch/issues/3979)) ([2b08344](https://github.com/algolia/instantsearch/commit/2b08344))
+- **pagination:** update no refinement behavior ([#4124](https://github.com/algolia/instantsearch/issues/4124)) ([8d222ad](https://github.com/algolia/instantsearch/commit/8d222ad))
+- **range:** clear widget state on empty refinements ([#4157](https://github.com/algolia/instantsearch/issues/4157)) ([23cd112](https://github.com/algolia/instantsearch/commit/23cd112))
+- **ratingMenu:** update lifecycle state ([#3987](https://github.com/algolia/instantsearch/issues/3987)) ([ffadf64](https://github.com/algolia/instantsearch/commit/ffadf64))
+- **RefinementList:** remove root css class on sublists ([#4117](https://github.com/algolia/instantsearch/issues/4117)) ([ceddd42](https://github.com/algolia/instantsearch/commit/ceddd42)), closes [/github.com/algolia/instantsearch/blob/v2/src/decorators/headerFooter.js#L22](https://github.com//github.com/algolia/instantsearch/blob/v2/src/decorators/headerFooter.js/issues/L22)
+- **searchBox:** update lifecycle state ([#3981](https://github.com/algolia/instantsearch/issues/3981)) ([0ea4950](https://github.com/algolia/instantsearch/commit/0ea4950))
+- **sortBy:** ensure a return value for getWidgetSearchParameters ([#4126](https://github.com/algolia/instantsearch/issues/4126)) ([569d573](https://github.com/algolia/instantsearch/commit/569d573))
+- **sortBy:** read initial index name from parent index ([#4079](https://github.com/algolia/instantsearch/issues/4079)) ([fe23c55](https://github.com/algolia/instantsearch/commit/fe23c55))
+- display warnings only in development ([#4150](https://github.com/algolia/instantsearch/issues/4150)) ([44f69a0](https://github.com/algolia/instantsearch/commit/44f69a0))
+- remove useless types ([#3958](https://github.com/algolia/instantsearch/issues/3958)) ([ddebf53](https://github.com/algolia/instantsearch/commit/ddebf53))
+- **stories:** hide Places ([#4152](https://github.com/algolia/instantsearch/issues/4152)) ([7ff843f](https://github.com/algolia/instantsearch/commit/7ff843f))
+- **toggleRefinement:** update lifecycle state ([#3993](https://github.com/algolia/instantsearch/issues/3993)) ([f1beff6](https://github.com/algolia/instantsearch/commit/f1beff6))
+- **voiceSearch:** update lifecycle state ([#3982](https://github.com/algolia/instantsearch/issues/3982)) ([798e3c1](https://github.com/algolia/instantsearch/commit/798e3c1))
+- **warnings:** remove v3 warnings ([#4134](https://github.com/algolia/instantsearch/issues/4134)) ([7eb6810](https://github.com/algolia/instantsearch/commit/7eb6810))
 
 ### Features
 
-* **voiceSearch:** add connector and widget ([#3601](https://github.com/algolia/instantsearch.js/issues/3601)) ([21e4d81](https://github.com/algolia/instantsearch.js/commit/21e4d81))
+- **autocomplete:** leverage scoped results ([#3975](https://github.com/algolia/instantsearch/issues/3975)) ([8f05968](https://github.com/algolia/instantsearch/commit/8f05968))
+- **autocomplete:** participate in routing ([#4029](https://github.com/algolia/instantsearch/issues/4029)) ([a9ca0c5](https://github.com/algolia/instantsearch/commit/a9ca0c5))
+- **autocomplete:** provide indexId ([#4142](https://github.com/algolia/instantsearch/issues/4142)) ([b641e23](https://github.com/algolia/instantsearch/commit/b641e23))
+- **clearRefinements:** support multiple indices ([#4036](https://github.com/algolia/instantsearch/issues/4036)) ([3611b11](https://github.com/algolia/instantsearch/commit/3611b11))
+- **connectAutocomplete:** add default value on getConfiguration ([#3836](https://github.com/algolia/instantsearch/issues/3836)) ([724b83f](https://github.com/algolia/instantsearch/commit/724b83f))
+- **connectAutocomplete:** clear the state on dispose ([#3815](https://github.com/algolia/instantsearch/issues/3815)) ([8ae87d8](https://github.com/algolia/instantsearch/commit/8ae87d8))
+- **connectHierarchicalMenu:** update getWidgetSearchParameters ([#4053](https://github.com/algolia/instantsearch/issues/4053)) ([c99f822](https://github.com/algolia/instantsearch/commit/c99f822))
+- **connectHits:** clear the state on dispose ([#3816](https://github.com/algolia/instantsearch/issues/3816)) ([c4de730](https://github.com/algolia/instantsearch/commit/c4de730))
+- **connectHits:** implement getWidgetSearchParameters ([#4001](https://github.com/algolia/instantsearch/issues/4001)) ([c77cf66](https://github.com/algolia/instantsearch/commit/c77cf66))
+- **connectHitsPerPage:** clear the state on dispose ([#3818](https://github.com/algolia/instantsearch/issues/3818)) ([d7a5c89](https://github.com/algolia/instantsearch/commit/d7a5c89))
+- **connectInfiniteHits:** add default value on getConfiguration ([#3837](https://github.com/algolia/instantsearch/issues/3837)) ([8c65249](https://github.com/algolia/instantsearch/commit/8c65249))
+- **connectInfiniteHits:** clear the state on dispose ([#3819](https://github.com/algolia/instantsearch/issues/3819)) ([60ce151](https://github.com/algolia/instantsearch/commit/60ce151))
+- **connectMenu:** update getWidgetSearchParameters ([#4054](https://github.com/algolia/instantsearch/issues/4054)) ([7d001e7](https://github.com/algolia/instantsearch/commit/7d001e7))
+- **connectNumericMenu:** update state lifecycle ([#4013](https://github.com/algolia/instantsearch/issues/4013)) ([2620c90](https://github.com/algolia/instantsearch/commit/2620c90))
+- **connectPagination:** add default value on getConfiguration ([#3838](https://github.com/algolia/instantsearch/issues/3838)) ([aa4602c](https://github.com/algolia/instantsearch/commit/aa4602c))
+- **connectPagination:** clear the state on dispose ([#3821](https://github.com/algolia/instantsearch/issues/3821)) ([5b8ef49](https://github.com/algolia/instantsearch/commit/5b8ef49))
+- **connectPagination:** update getWidgetSearchParameters ([#4004](https://github.com/algolia/instantsearch/issues/4004)) ([eed7e77](https://github.com/algolia/instantsearch/commit/eed7e77))
+- **connectRange:** default `precision` to 0 ([#3953](https://github.com/algolia/instantsearch/issues/3953)) ([632e06b](https://github.com/algolia/instantsearch/commit/632e06b))
+- **connectRatingMenu:** update getWidgetSearchParameters ([#4008](https://github.com/algolia/instantsearch/issues/4008)) ([d3c96bf](https://github.com/algolia/instantsearch/commit/d3c96bf))
+- **connectRefinementList:** update getWidgetSearchParameters ([#4010](https://github.com/algolia/instantsearch/issues/4010)) ([ddc8fc4](https://github.com/algolia/instantsearch/commit/ddc8fc4))
+- **connectSearchBox:** clear the state on dispose ([#3822](https://github.com/algolia/instantsearch/issues/3822)) ([940522c](https://github.com/algolia/instantsearch/commit/940522c))
+- **connectSearchBox:** mount with a default query ([#3840](https://github.com/algolia/instantsearch/issues/3840)) ([c3a7d69](https://github.com/algolia/instantsearch/commit/c3a7d69))
+- **connectSearchBox:** update getWidgetSearchParameters ([#4002](https://github.com/algolia/instantsearch/issues/4002)) ([5c6fcd8](https://github.com/algolia/instantsearch/commit/5c6fcd8))
+- **connectVoiceSearch:** add default value on getConfiguration ([#3841](https://github.com/algolia/instantsearch/issues/3841)) ([fb70363](https://github.com/algolia/instantsearch/commit/fb70363))
+- **connectVoiceSearch:** clear the state on dispose ([#3823](https://github.com/algolia/instantsearch/issues/3823)) ([705b3e6](https://github.com/algolia/instantsearch/commit/705b3e6))
+- **connectVoiceSearch:** update getWidgetSearchParameters ([#4055](https://github.com/algolia/instantsearch/issues/4055)) ([b8c669f](https://github.com/algolia/instantsearch/commit/b8c669f))
+- **core:** deprecate addWidget & removeWidget ([#4131](https://github.com/algolia/instantsearch/issues/4131)) ([e5dafef](https://github.com/algolia/instantsearch/commit/e5dafef))
+- **currentRefinements:** support multiple indices ([#4012](https://github.com/algolia/instantsearch/issues/4012)) ([e997728](https://github.com/algolia/instantsearch/commit/e997728))
+- **defer:** implement cancellable callback ([#3916](https://github.com/algolia/instantsearch/issues/3916)) ([43a0bf8](https://github.com/algolia/instantsearch/commit/43a0bf8))
+- **federated:** keep a consistent state in the RefinementList life cycle ([#3976](https://github.com/algolia/instantsearch/issues/3976)) ([31d0fd6](https://github.com/algolia/instantsearch/commit/31d0fd6))
+- **hitsPerPage:** support new routing system ([#4038](https://github.com/algolia/instantsearch/issues/4038)) ([02502cb](https://github.com/algolia/instantsearch/commit/02502cb)), closes [#4069](https://github.com/algolia/instantsearch/issues/4069)
+- **index:** accept indexId ([#4070](https://github.com/algolia/instantsearch/issues/4070)) ([b74f8e3](https://github.com/algolia/instantsearch/commit/b74f8e3))
+- **index:** add mergeSearchParameters function ([#3917](https://github.com/algolia/instantsearch/issues/3917)) ([c0fe7bb](https://github.com/algolia/instantsearch/commit/c0fe7bb))
+- **index:** add widget ([dbbda0f](https://github.com/algolia/instantsearch/commit/dbbda0f)), closes [#3892](https://github.com/algolia/instantsearch/issues/3892) [#3893](https://github.com/algolia/instantsearch/issues/3893) [#3914](https://github.com/algolia/instantsearch/issues/3914)
+- **index:** compute local uiState ([#3997](https://github.com/algolia/instantsearch/issues/3997)) ([997c0f4](https://github.com/algolia/instantsearch/commit/997c0f4))
+- **index:** merge `ruleContexts` search parameter ([#3944](https://github.com/algolia/instantsearch/issues/3944)) ([e94752d](https://github.com/algolia/instantsearch/commit/e94752d))
+- **index:** provide scoped results to render hook ([#3964](https://github.com/algolia/instantsearch/issues/3964)) ([37c6aad](https://github.com/algolia/instantsearch/commit/37c6aad))
+- **index:** replicate searchFunction hack ([#4078](https://github.com/algolia/instantsearch/issues/4078)) ([1d2a816](https://github.com/algolia/instantsearch/commit/1d2a816)), closes [/github.com/algolia/instantsearch/blob/509513c0feafaad522f6f18d87a441559f4aa050/src/lib/RoutingManager.ts#L113-L130](https://github.com//github.com/algolia/instantsearch/blob/509513c0feafaad522f6f18d87a441559f4aa050/src/lib/RoutingManager.ts/issues/L113-L130)
+- **index:** reset page of child indexes ([#3962](https://github.com/algolia/instantsearch/issues/3962)) ([131b1ce](https://github.com/algolia/instantsearch/commit/131b1ce))
+- **index:** resolve parent SearchParameters ([#3937](https://github.com/algolia/instantsearch/issues/3937)) ([2611da5](https://github.com/algolia/instantsearch/commit/2611da5))
+- **index:** use uiState driven SearchParameters ([#4059](https://github.com/algolia/instantsearch/issues/4059)) ([b12bb9f](https://github.com/algolia/instantsearch/commit/b12bb9f))
+- **infiniteHits:** support new routing system ([#4040](https://github.com/algolia/instantsearch/issues/4040)) ([49315cf](https://github.com/algolia/instantsearch/commit/49315cf))
+- **instantsearch:** add onStateChange method ([#4080](https://github.com/algolia/instantsearch/issues/4080)) ([9f68da5](https://github.com/algolia/instantsearch/commit/9f68da5))
+- **InstantSearch:** switch to DerivedHelper only ([#3885](https://github.com/algolia/instantsearch/issues/3885)) ([d6fc317](https://github.com/algolia/instantsearch/commit/d6fc317))
+- **places:** add Places widget ([#4167](https://github.com/algolia/instantsearch/issues/4167)) ([1d754d1](https://github.com/algolia/instantsearch/commit/1d754d1))
+- drop support of searchParameters for initialUiState ([#4081](https://github.com/algolia/instantsearch/issues/4081)) ([571efeb](https://github.com/algolia/instantsearch/commit/571efeb))
+- **range:** support new routing system ([#4039](https://github.com/algolia/instantsearch/issues/4039)) ([8cba05a](https://github.com/algolia/instantsearch/commit/8cba05a))
+- **routing:** add a "single index" compatibility mode ([#4087](https://github.com/algolia/instantsearch/issues/4087)) ([842eb0f](https://github.com/algolia/instantsearch/commit/842eb0f))
+- **RoutingManager:** update state on route update ([#4100](https://github.com/algolia/instantsearch/issues/4100)) ([88f2615](https://github.com/algolia/instantsearch/commit/88f2615))
+- **toggleRefinement:** support new routing system ([#4037](https://github.com/algolia/instantsearch/issues/4037)) ([6a9d99f](https://github.com/algolia/instantsearch/commit/6a9d99f))
+- **types:** DerivedHelper ([#3887](https://github.com/algolia/instantsearch/issues/3887)) ([0f38b4a](https://github.com/algolia/instantsearch/commit/0f38b4a))
+- **types:** rename RenderOptions -> RendererOptions ([#3867](https://github.com/algolia/instantsearch/issues/3867)) ([05c6f72](https://github.com/algolia/instantsearch/commit/05c6f72))
+- **utils:** implement defer ([#3882](https://github.com/algolia/instantsearch/issues/3882)) ([8af470e](https://github.com/algolia/instantsearch/commit/8af470e))
+- **voice:** add additional query parameters ([#3738](https://github.com/algolia/instantsearch/issues/3738)) ([c555255](https://github.com/algolia/instantsearch/commit/c555255))
+- drop suppot for onHistoryChange ([#3941](https://github.com/algolia/instantsearch/issues/3941)) ([697f609](https://github.com/algolia/instantsearch/commit/697f609))
+- introduce initialUiState option ([#4074](https://github.com/algolia/instantsearch/issues/4074)) ([de00707](https://github.com/algolia/instantsearch/commit/de00707))
+- update UiState definition ([#4075](https://github.com/algolia/instantsearch/issues/4075)) ([9e7d3d8](https://github.com/algolia/instantsearch/commit/9e7d3d8))
+- **widgets:** add `$$type` to widgets definition ([#3960](https://github.com/algolia/instantsearch/issues/3960)) ([344d1b7](https://github.com/algolia/instantsearch/commit/344d1b7))
 
+# [3.7.0](https://github.com/algolia/instantsearch/compare/v3.5.4...v3.7.0) (2019-10-08)
+
+### Bug Fixes
+
+- **clearRefinements:** reset page to 0 ([#3936](https://github.com/algolia/instantsearch/issues/3936)) ([7378a0a](https://github.com/algolia/instantsearch/commit/7378a0a))
+- **connectSortBy:** never update the initial index ([#4015](https://github.com/algolia/instantsearch/issues/4015)) ([bc0f9e2](https://github.com/algolia/instantsearch/commit/bc0f9e2))
+- **deps:** update dependency instantsearch.js to v3.5.4 ([#3929](https://github.com/algolia/instantsearch/issues/3929)) ([eff84c5](https://github.com/algolia/instantsearch/commit/eff84c5))
+- **deps:** update dependency instantsearch.js to v3.6.0 ([#4021](https://github.com/algolia/instantsearch/issues/4021)) ([7719bba](https://github.com/algolia/instantsearch/commit/7719bba))
+- **enhanceConfiguration:** deduplicate the hierarchicalFacets ([#3966](https://github.com/algolia/instantsearch/issues/3966)) ([baf8a35](https://github.com/algolia/instantsearch/commit/baf8a35))
+- **examples:** fix IE11 compatibility for e-commerce demo ([#4049](https://github.com/algolia/instantsearch/issues/4049)) ([dc6f350](https://github.com/algolia/instantsearch/commit/dc6f350))
+- **examples:** fix missing polyfill in e-commerce demo ([#4076](https://github.com/algolia/instantsearch/issues/4076)) ([4bf3ab3](https://github.com/algolia/instantsearch/commit/4bf3ab3))
+- **hierarchicalFacets:** prevent different rootPath on same attribute ([#3965](https://github.com/algolia/instantsearch/issues/3965)) ([5ee79fa](https://github.com/algolia/instantsearch/commit/5ee79fa))
+- **instantsearch:** warn deprecated usage of `searchParameters` ([#4151](https://github.com/algolia/instantsearch/issues/4151)) ([18e1c36](https://github.com/algolia/instantsearch/commit/18e1c36))
+- **menuSelect:** unmount component ([#3911](https://github.com/algolia/instantsearch/issues/3911)) ([f6debce](https://github.com/algolia/instantsearch/commit/f6debce))
+- **rangeInput:** unmount component ([#3910](https://github.com/algolia/instantsearch/issues/3910)) ([f6c29e8](https://github.com/algolia/instantsearch/commit/f6c29e8))
+- **refinementList:** fix showMore button to work after search ([#3082](https://github.com/algolia/instantsearch/issues/3082)) ([23e46b6](https://github.com/algolia/instantsearch/commit/23e46b6))
+- pass noop as default value to unmountFn at connectors ([#3955](https://github.com/algolia/instantsearch/issues/3955)) ([7c38744](https://github.com/algolia/instantsearch/commit/7c38744))
+
+# [3.6.0](https://github.com/algolia/instantsearch/compare/v3.5.4...v3.6.0) (2019-07-30)
+
+### Bug Fixes
+
+- **clearRefinements:** reset page to 0 ([#3936](https://github.com/algolia/instantsearch/issues/3936)) ([7378a0a](https://github.com/algolia/instantsearch/commit/7378a0a))
+- pass noop as default value to unmountFn at connectors ([#3955](https://github.com/algolia/instantsearch/issues/3955)) ([7c38744](https://github.com/algolia/instantsearch/commit/7c38744))
+- **enhanceConfiguration:** deduplicate the hierarchicalFacets ([#3966](https://github.com/algolia/instantsearch/issues/3966)) ([baf8a35](https://github.com/algolia/instantsearch/commit/baf8a35))
+- **hierarchicalFacets:** prevent different rootPath on same attribute ([#3965](https://github.com/algolia/instantsearch/issues/3965)) ([5ee79fa](https://github.com/algolia/instantsearch/commit/5ee79fa))
+- **menuSelect:** unmount component ([#3911](https://github.com/algolia/instantsearch/issues/3911)) ([f6debce](https://github.com/algolia/instantsearch/commit/f6debce))
+- **rangeInput:** unmount component ([#3910](https://github.com/algolia/instantsearch/issues/3910)) ([f6c29e8](https://github.com/algolia/instantsearch/commit/f6c29e8))
+- **refinementList:** fix showMore button to work after search ([#3082](https://github.com/algolia/instantsearch/issues/3082)) ([23e46b6](https://github.com/algolia/instantsearch/commit/23e46b6))
+
+## [3.5.4](https://github.com/algolia/instantsearch/compare/v3.5.3...v3.5.4) (2019-07-01)
+
+### Bug Fixes
+
+- **connectSortBy:** do not throw with wrong indexes ([#3824](https://github.com/algolia/instantsearch/issues/3824)) ([2a84ee2](https://github.com/algolia/instantsearch/commit/2a84ee2))
+- **deps:** update dependency instantsearch.js to v3.5.3 ([#3877](https://github.com/algolia/instantsearch/issues/3877)) ([463f3bb](https://github.com/algolia/instantsearch/commit/463f3bb))
+- **escape:** make sure that \_\_escaped does not get removed ([#3830](https://github.com/algolia/instantsearch/issues/3830)) ([fbafd22](https://github.com/algolia/instantsearch/commit/fbafd22))
+- **getRefinements:** check for facet before accessing its data ([#3842](https://github.com/algolia/instantsearch/issues/3842)) ([aadc769](https://github.com/algolia/instantsearch/commit/aadc769))
+- **panel:** return value from dispose ([#3895](https://github.com/algolia/instantsearch/issues/3895)) ([bceb78f](https://github.com/algolia/instantsearch/commit/bceb78f))
+- **voiceSearch:** remove event listeners on stop ([#3845](https://github.com/algolia/instantsearch/issues/3845)) ([688e36a](https://github.com/algolia/instantsearch/commit/688e36a))
+
+## [3.5.3](https://github.com/algolia/instantsearch/compare/v3.5.1...v3.5.3) (2019-05-28)
+
+### Bug Fixes
+
+- **voiceSearch:** let the connector handle the default value of searchAsYouSpeak when it's not given ([#3817](https://github.com/algolia/instantsearch/issues/3817)) ([9d3e91b](https://github.com/algolia/instantsearch/commit/9d3e91b))
+- **getTag:** use object version of toString ([#3820](https://github.com/algolia/instantsearch/issues/3820)) ([a7348ea](https://github.com/algolia/instantsearch/commit/a7348ea))
+- **types:** fix cssClasses of voiceSearch ([#3783](https://github.com/algolia/instantsearch/issues/3783)) ([f016326](https://github.com/algolia/instantsearch/commit/f016326))
+
+# [3.5.1](https://github.com/algolia/instantsearch/compare/v3.4.0...v3.5.1) (2019-05-20)
+
+### Bug Fixes
+
+- **types:** improve types for voiceSearch ([#3778](https://github.com/algolia/instantsearch/issues/3778)) ([ed2d61a](https://github.com/algolia/instantsearch/commit/ed2d61a))
+- **types:** update UiState type ([#3777](https://github.com/algolia/instantsearch/issues/3777)) ([36e3a3d](https://github.com/algolia/instantsearch/commit/36e3a3d))
+- **voiceSearch:** remove event listeners on dispose ([#3779](https://github.com/algolia/instantsearch/issues/3779)) ([0e988cc](https://github.com/algolia/instantsearch/commit/0e988cc))
+- **hitsPerPage:** improve warning for missing state value ([#3707](https://github.com/algolia/instantsearch/issues/3707)) ([93d8432](https://github.com/algolia/instantsearch/commit/93d8432))
+- **numericMenu:** prevent refinement reset on checked radio click ([#3749](https://github.com/algolia/instantsearch/issues/3749)) ([e4a6e75](https://github.com/algolia/instantsearch/commit/e4a6e75))
+- **rangeSlider:** round the slider pit value ([#3758](https://github.com/algolia/instantsearch/issues/3758)) ([6edee3e](https://github.com/algolia/instantsearch/commit/6edee3e)), closes [#2904](https://github.com/algolia/instantsearch/issues/2904)
+- **types:** improve UiState types ([#3763](https://github.com/algolia/instantsearch/issues/3763)) ([e8ea57b](https://github.com/algolia/instantsearch/commit/e8ea57b))
+- **voice:** import correct noop ([#3766](https://github.com/algolia/instantsearch/issues/3766)) ([6a80422](https://github.com/algolia/instantsearch/commit/6a80422))
+
+### Features
+
+- **voiceSearch:** add connector and widget ([#3601](https://github.com/algolia/instantsearch/issues/3601)) ([21e4d81](https://github.com/algolia/instantsearch/commit/21e4d81))
 
 ### Reverts
 
-* chore(build): remove PropTypes from builds ([#3697](https://github.com/algolia/instantsearch.js/issues/3697)) ([#3776](https://github.com/algolia/instantsearch.js/issues/3776)) ([1e6be79](https://github.com/algolia/instantsearch.js/commit/1e6be79))
+- chore(build): remove PropTypes from builds ([#3697](https://github.com/algolia/instantsearch/issues/3697)) ([#3776](https://github.com/algolia/instantsearch/issues/3776)) ([1e6be79](https://github.com/algolia/instantsearch/commit/1e6be79))
 
-
-# [3.4.0](https://github.com/algolia/instantsearch.js/compare/v3.3.0...v3.4.0) (2019-04-17)
-
+# [3.4.0](https://github.com/algolia/instantsearch/compare/v3.3.0...v3.4.0) (2019-04-17)
 
 ### Bug Fixes
 
-* **storybook:** fix Hierarchical menu separator in Breadcrumb story ([#3695](https://github.com/algolia/instantsearch.js/issues/3695)) ([b3bf8ac](https://github.com/algolia/instantsearch.js/commit/b3bf8ac))
-* **tools:** use commonjs in bump-package-version.js ([#3699](https://github.com/algolia/instantsearch.js/issues/3699)) ([6a6dbe1](https://github.com/algolia/instantsearch.js/commit/6a6dbe1))
-* **types:** fix wrong typing in getWidgetState ([#3693](https://github.com/algolia/instantsearch.js/issues/3693)) ([b3c2154](https://github.com/algolia/instantsearch.js/commit/b3c2154))
-* **types:** remove unused Without type ([#3694](https://github.com/algolia/instantsearch.js/issues/3694)) ([656d000](https://github.com/algolia/instantsearch.js/commit/656d000))
-
+- **storybook:** fix Hierarchical menu separator in Breadcrumb story ([#3695](https://github.com/algolia/instantsearch/issues/3695)) ([b3bf8ac](https://github.com/algolia/instantsearch/commit/b3bf8ac))
+- **tools:** use commonjs in bump-package-version.js ([#3699](https://github.com/algolia/instantsearch/issues/3699)) ([6a6dbe1](https://github.com/algolia/instantsearch/commit/6a6dbe1))
+- **types:** fix wrong typing in getWidgetState ([#3693](https://github.com/algolia/instantsearch/issues/3693)) ([b3c2154](https://github.com/algolia/instantsearch/commit/b3c2154))
+- **types:** remove unused Without type ([#3694](https://github.com/algolia/instantsearch/issues/3694)) ([656d000](https://github.com/algolia/instantsearch/commit/656d000))
 
 ### Features
 
-* **infiniteHits:** add previous button ([#3675](https://github.com/algolia/instantsearch.js/issues/3675)) ([2e6137b](https://github.com/algolia/instantsearch.js/commit/2e6137b))
-* **Insights:** Insights inside Instantsearch ([#3598](https://github.com/algolia/instantsearch.js/issues/3598)) ([387f41f](https://github.com/algolia/instantsearch.js/commit/387f41f))
+- **infiniteHits:** add previous button ([#3675](https://github.com/algolia/instantsearch/issues/3675)) ([2e6137b](https://github.com/algolia/instantsearch/commit/2e6137b))
+- **Insights:** Insights inside Instantsearch ([#3598](https://github.com/algolia/instantsearch/issues/3598)) ([387f41f](https://github.com/algolia/instantsearch/commit/387f41f))
 
-
-
-# [3.3.0](https://github.com/algolia/instantsearch.js/compare/v3.2.1...v3.3.0) (2019-04-11)
-
+# [3.3.0](https://github.com/algolia/instantsearch/compare/v3.2.1...v3.3.0) (2019-04-11)
 
 ### Bug Fixes
 
-* **connectQueryRules:** improve tracked refinement type ([#3648](https://github.com/algolia/instantsearch.js/issues/3648)) ([e16ad57](https://github.com/algolia/instantsearch.js/commit/e16ad57))
-* **currentRefinements:** don't rely on `_objectSpread` ([#3672](https://github.com/algolia/instantsearch.js/issues/3672)) ([cd64bcf](https://github.com/algolia/instantsearch.js/commit/cd64bcf))
-* **queryRuleCustomData:** add default template ([#3650](https://github.com/algolia/instantsearch.js/issues/3650)) ([83e9eaa](https://github.com/algolia/instantsearch.js/commit/83e9eaa))
-* **QueryRuleCustomData:** pass data as object to templates ([#3647](https://github.com/algolia/instantsearch.js/issues/3647)) ([b8f8b4e](https://github.com/algolia/instantsearch.js/commit/b8f8b4e))
-* **queryRules:** fix types and stories ([#3670](https://github.com/algolia/instantsearch.js/issues/3670)) ([ba6e2e6](https://github.com/algolia/instantsearch.js/commit/ba6e2e6))
-* **routing:** apply windowTitle on first load ([#3669](https://github.com/algolia/instantsearch.js/issues/3669)) ([d553502](https://github.com/algolia/instantsearch.js/commit/d553502)), closes [#3667](https://github.com/algolia/instantsearch.js/issues/3667)
-* **routing:** support parsing URLs with up to 100 refinements ([#3671](https://github.com/algolia/instantsearch.js/issues/3671)) ([6ddcfb6](https://github.com/algolia/instantsearch.js/commit/6ddcfb6))
-* **RoutingManager:** avoid stale uiState ([#3630](https://github.com/algolia/instantsearch.js/issues/3630)) ([e1588aa](https://github.com/algolia/instantsearch.js/commit/e1588aa))
-* **types:** improve InstantSearch types ([#3651](https://github.com/algolia/instantsearch.js/issues/3651)) ([db9b91e](https://github.com/algolia/instantsearch.js/commit/db9b91e))
-* **ua:** Update the User-Agent to use the new format ([#3616](https://github.com/algolia/instantsearch.js/issues/3616)) ([ab84c57](https://github.com/algolia/instantsearch.js/commit/ab84c57))
-
+- **connectQueryRules:** improve tracked refinement type ([#3648](https://github.com/algolia/instantsearch/issues/3648)) ([e16ad57](https://github.com/algolia/instantsearch/commit/e16ad57))
+- **currentRefinements:** don't rely on `_objectSpread` ([#3672](https://github.com/algolia/instantsearch/issues/3672)) ([cd64bcf](https://github.com/algolia/instantsearch/commit/cd64bcf))
+- **queryRuleCustomData:** add default template ([#3650](https://github.com/algolia/instantsearch/issues/3650)) ([83e9eaa](https://github.com/algolia/instantsearch/commit/83e9eaa))
+- **QueryRuleCustomData:** pass data as object to templates ([#3647](https://github.com/algolia/instantsearch/issues/3647)) ([b8f8b4e](https://github.com/algolia/instantsearch/commit/b8f8b4e))
+- **queryRules:** fix types and stories ([#3670](https://github.com/algolia/instantsearch/issues/3670)) ([ba6e2e6](https://github.com/algolia/instantsearch/commit/ba6e2e6))
+- **routing:** apply windowTitle on first load ([#3669](https://github.com/algolia/instantsearch/issues/3669)) ([d553502](https://github.com/algolia/instantsearch/commit/d553502)), closes [#3667](https://github.com/algolia/instantsearch/issues/3667)
+- **routing:** support parsing URLs with up to 100 refinements ([#3671](https://github.com/algolia/instantsearch/issues/3671)) ([6ddcfb6](https://github.com/algolia/instantsearch/commit/6ddcfb6))
+- **RoutingManager:** avoid stale uiState ([#3630](https://github.com/algolia/instantsearch/issues/3630)) ([e1588aa](https://github.com/algolia/instantsearch/commit/e1588aa))
+- **types:** improve InstantSearch types ([#3651](https://github.com/algolia/instantsearch/issues/3651)) ([db9b91e](https://github.com/algolia/instantsearch/commit/db9b91e))
+- **ua:** Update the User-Agent to use the new format ([#3616](https://github.com/algolia/instantsearch/issues/3616)) ([ab84c57](https://github.com/algolia/instantsearch/commit/ab84c57))
 
 ### Features
 
-* **infiniteHits:** add previous button ([#3645](https://github.com/algolia/instantsearch.js/issues/3645)) ([2c9e38d](https://github.com/algolia/instantsearch.js/commit/2c9e38d))
-* **queryRules:** add connectQueryRules connector ([#3597](https://github.com/algolia/instantsearch.js/issues/3597)) ([924cd99](https://github.com/algolia/instantsearch.js/commit/924cd99)), closes [#3599](https://github.com/algolia/instantsearch.js/issues/3599) [#3600](https://github.com/algolia/instantsearch.js/issues/3600)
-* **queryRules:** add context features to Query Rules ([#3617](https://github.com/algolia/instantsearch.js/issues/3617)) ([922879e](https://github.com/algolia/instantsearch.js/commit/922879e)), closes [#3602](https://github.com/algolia/instantsearch.js/issues/3602)
-
+- **infiniteHits:** add previous button ([#3645](https://github.com/algolia/instantsearch/issues/3645)) ([2c9e38d](https://github.com/algolia/instantsearch/commit/2c9e38d))
+- **queryRules:** add connectQueryRules connector ([#3597](https://github.com/algolia/instantsearch/issues/3597)) ([924cd99](https://github.com/algolia/instantsearch/commit/924cd99)), closes [#3599](https://github.com/algolia/instantsearch/issues/3599) [#3600](https://github.com/algolia/instantsearch/issues/3600)
+- **queryRules:** add context features to Query Rules ([#3617](https://github.com/algolia/instantsearch/issues/3617)) ([922879e](https://github.com/algolia/instantsearch/commit/922879e)), closes [#3602](https://github.com/algolia/instantsearch/issues/3602)
 
 ### Reverts
 
-* feat(infiniteHits): add previous button ([214c0fc](https://github.com/algolia/instantsearch.js/commit/214c0fc))
+- feat(infiniteHits): add previous button ([214c0fc](https://github.com/algolia/instantsearch/commit/214c0fc))
 
-
-
-## [3.2.1](https://github.com/algolia/instantsearch.js/compare/v3.1.0...v3.2.1) (2019-03-18)
-
+## [3.2.1](https://github.com/algolia/instantsearch/compare/v3.1.0...v3.2.1) (2019-03-18)
 
 ### Bug Fixes
 
-* **connectToggleRefinement:** keep user provided, but falsy values ([#3526](https://github.com/algolia/instantsearch.js/issues/3526)) ([958a151](https://github.com/algolia/instantsearch.js/commit/958a151))
-* **instantsearch:** update usage errors ([#3543](https://github.com/algolia/instantsearch.js/issues/3543)) ([a2a800b](https://github.com/algolia/instantsearch.js/commit/a2a800b))
-* **panel:** append panel body as a child element ([#3561](https://github.com/algolia/instantsearch.js/issues/3561)) ([3de59a3](https://github.com/algolia/instantsearch.js/commit/3de59a3))
-* **poweredBy:** remove TypeScript extension in import ([#3530](https://github.com/algolia/instantsearch.js/issues/3530)) ([99ecc0b](https://github.com/algolia/instantsearch.js/commit/99ecc0b)), closes [#3528](https://github.com/algolia/instantsearch.js/issues/3528)
-* **release:** update doctoc script ([e07c654](https://github.com/algolia/instantsearch.js/commit/e07c654))
-* **searchbox:** unmount component on dispose ([#3563](https://github.com/algolia/instantsearch.js/issues/3563)) ([c3f0435](https://github.com/algolia/instantsearch.js/commit/c3f0435))
-* **searchBox:** add reusable SearchBox component ([#3489](https://github.com/algolia/instantsearch.js/issues/3489)) ([c073a9a](https://github.com/algolia/instantsearch.js/commit/c073a9a))
-
+- **connectToggleRefinement:** keep user provided, but falsy values ([#3526](https://github.com/algolia/instantsearch/issues/3526)) ([958a151](https://github.com/algolia/instantsearch/commit/958a151))
+- **instantsearch:** update usage errors ([#3543](https://github.com/algolia/instantsearch/issues/3543)) ([a2a800b](https://github.com/algolia/instantsearch/commit/a2a800b))
+- **panel:** append panel body as a child element ([#3561](https://github.com/algolia/instantsearch/issues/3561)) ([3de59a3](https://github.com/algolia/instantsearch/commit/3de59a3))
+- **poweredBy:** remove TypeScript extension in import ([#3530](https://github.com/algolia/instantsearch/issues/3530)) ([99ecc0b](https://github.com/algolia/instantsearch/commit/99ecc0b)), closes [#3528](https://github.com/algolia/instantsearch/issues/3528)
+- **release:** update doctoc script ([e07c654](https://github.com/algolia/instantsearch/commit/e07c654))
+- **searchbox:** unmount component on dispose ([#3563](https://github.com/algolia/instantsearch/issues/3563)) ([c3f0435](https://github.com/algolia/instantsearch/commit/c3f0435))
+- **searchBox:** add reusable SearchBox component ([#3489](https://github.com/algolia/instantsearch/issues/3489)) ([c073a9a](https://github.com/algolia/instantsearch/commit/c073a9a))
 
 ### Features
 
-* **panel:** implement collapsed feature ([#3575](https://github.com/algolia/instantsearch.js/issues/3575)) ([e84b02b](https://github.com/algolia/instantsearch.js/commit/e84b02b))
+- **panel:** implement collapsed feature ([#3575](https://github.com/algolia/instantsearch/issues/3575)) ([e84b02b](https://github.com/algolia/instantsearch/commit/e84b02b))
 
-
-
-# [3.2.0](https://github.com/algolia/instantsearch.js/compare/v3.1.0...v3.2.0) (2019-03-14)
-
+# [3.2.0](https://github.com/algolia/instantsearch/compare/v3.1.0...v3.2.0) (2019-03-14)
 
 ### Bug Fixes
 
-* **instantsearch:** update usage errors ([#3543](https://github.com/algolia/instantsearch.js/issues/3543)) ([a2a800b](https://github.com/algolia/instantsearch.js/commit/a2a800b))
-* **searchBox:** add reusable SearchBox component ([#3489](https://github.com/algolia/instantsearch.js/issues/3489)) ([c073a9a](https://github.com/algolia/instantsearch.js/commit/c073a9a))
-
+- **instantsearch:** update usage errors ([#3543](https://github.com/algolia/instantsearch/issues/3543)) ([a2a800b](https://github.com/algolia/instantsearch/commit/a2a800b))
+- **searchBox:** add reusable SearchBox component ([#3489](https://github.com/algolia/instantsearch/issues/3489)) ([c073a9a](https://github.com/algolia/instantsearch/commit/c073a9a))
 
 ### Features
 
-* **panel:** implement collapsed feature ([#3575](https://github.com/algolia/instantsearch.js/issues/3575)) ([e84b02b](https://github.com/algolia/instantsearch.js/commit/e84b02b))
-
-
+- **panel:** implement collapsed feature ([#3575](https://github.com/algolia/instantsearch/issues/3575)) ([e84b02b](https://github.com/algolia/instantsearch/commit/e84b02b))
 
 <a name="3.1.1"></a>
-## [3.1.1](https://github.com/algolia/instantsearch.js/compare/v3.1.0...v3.1.1) (2019-02-14)
 
+## [3.1.1](https://github.com/algolia/instantsearch/compare/v3.1.0...v3.1.1) (2019-02-14)
 
 ### Bug Fixes
 
-* **connectToggleRefinement:** keep user provided, but falsy values ([#3526](https://github.com/algolia/instantsearch.js/issues/3526)) ([958a151](https://github.com/algolia/instantsearch.js/commit/958a151))
-* **poweredBy:** remove TypeScript extension in import ([#3530](https://github.com/algolia/instantsearch.js/issues/3530)) ([99ecc0b](https://github.com/algolia/instantsearch.js/commit/99ecc0b)), closes [#3528](https://github.com/algolia/instantsearch.js/issues/3528)
-* **release:** update doctoc script ([e07c654](https://github.com/algolia/instantsearch.js/commit/e07c654))
-
-
+- **connectToggleRefinement:** keep user provided, but falsy values ([#3526](https://github.com/algolia/instantsearch/issues/3526)) ([958a151](https://github.com/algolia/instantsearch/commit/958a151))
+- **poweredBy:** remove TypeScript extension in import ([#3530](https://github.com/algolia/instantsearch/issues/3530)) ([99ecc0b](https://github.com/algolia/instantsearch/commit/99ecc0b)), closes [#3528](https://github.com/algolia/instantsearch/issues/3528)
+- **release:** update doctoc script ([e07c654](https://github.com/algolia/instantsearch/commit/e07c654))
 
 <a name="3.1.0"></a>
-## [3.1.0](https://github.com/algolia/instantsearch.js/compare/v3.0.0...v3.1.0) (2019-02-13)
+
+## [3.1.0](https://github.com/algolia/instantsearch/compare/v3.0.0...v3.1.0) (2019-02-13)
 
 ### Features
 
-* **connectCurrentRefinements**: add a root label ([#3515](https://github.com/algolia/instantsearch.js/pull/3515)) ([b8f774f](https://github.com/algolia/instantsearch.js/commit/b8f774f))
-* Update error messages ([#3516](https://github.com/algolia/instantsearch.js/pull/3516))
-* **InstantSearch**: remove event listeners on dispose ([#3420](https://github.com/algolia/instantsearch.js/pull/3420))
-* **InstantSearch**: set helper to `null` on dispose ([#3415](https://github.com/algolia/instantsearch.js/pull/3415))
-* **utils**: warn only in development ([#3367](https://github.com/algolia/instantsearch.js/pull/3367))
+- **connectCurrentRefinements**: add a root label ([#3515](https://github.com/algolia/instantsearch/pull/3515)) ([b8f774f](https://github.com/algolia/instantsearch/commit/b8f774f))
+- Update error messages ([#3516](https://github.com/algolia/instantsearch/pull/3516))
+- **InstantSearch**: remove event listeners on dispose ([#3420](https://github.com/algolia/instantsearch/pull/3420))
+- **InstantSearch**: set helper to `null` on dispose ([#3415](https://github.com/algolia/instantsearch/pull/3415))
+- **utils**: warn only in development ([#3367](https://github.com/algolia/instantsearch/pull/3367))
 
 ### Bug Fixes
 
-* **InstantSearch**: set helper to `null` on dispose ([#3415](https://github.com/algolia/instantsearch.js/pull/3415))
-* **utils**: warn only in development ([#3367](https://github.com/algolia/instantsearch.js/pull/3367))
+- **InstantSearch**: set helper to `null` on dispose ([#3415](https://github.com/algolia/instantsearch/pull/3415))
+- **utils**: warn only in development ([#3367](https://github.com/algolia/instantsearch/pull/3367))
 
 <a name="3.0.0"></a>
-## [3.0.0](https://github.com/algolia/instantsearch.js/compare/v2.10.3...v3.0.0) (2018-12-20)
 
-Check the [migration guide](https://github.com/algolia/instantsearch.js/blob/879aa20d3c1e2fe906bc526b05c57f6847c433be/docgen/src/guides/v3-migration.md).
+## [3.0.0](https://github.com/algolia/instantsearch/compare/v2.10.3...v3.0.0) (2018-12-20)
+
+Check the [migration guide](https://github.com/algolia/instantsearch/blob/879aa20d3c1e2fe906bc526b05c57f6847c433be/docgen/src/guides/v3-migration.md).
 
 <a name="2.10.4"></a>
-## [2.10.4](https://github.com/algolia/instantsearch.js/compare/v2.10.3...v2.10.4) (2018-10-30)
 
+## [2.10.4](https://github.com/algolia/instantsearch/compare/v2.10.3...v2.10.4) (2018-10-30)
 
 ### Bug Fixes
 
-* **getRefinements:** provide attributeName for type: query ([6a58b99](https://github.com/algolia/instantsearch.js/commit/6a58b99)), closes [#3205](https://github.com/algolia/instantsearch.js/issues/3205)
-
+- **getRefinements:** provide attributeName for type: query ([6a58b99](https://github.com/algolia/instantsearch/commit/6a58b99)), closes [#3205](https://github.com/algolia/instantsearch/issues/3205)
 
 <a name="2.10.3"></a>
-## [2.10.3](https://github.com/algolia/instantsearch.js/compare/v2.10.2...v2.10.3) (2018-10-29)
 
+## [2.10.3](https://github.com/algolia/instantsearch/compare/v2.10.2...v2.10.3) (2018-10-29)
 
 ### Bug Fixes
 
-* **deps:** unpin production dependencies ([257ecb7](https://github.com/algolia/instantsearch.js/commit/257ecb7))
-* **InstantSearch:** avoid useless search on addWidgets ([#3178](https://github.com/algolia/instantsearch.js/issues/3178)) ([961626d](https://github.com/algolia/instantsearch.js/commit/961626d))
-* **numericselector:** default value can be undefined ([#3139](https://github.com/algolia/instantsearch.js/issues/3139)) ([39d22f5](https://github.com/algolia/instantsearch.js/commit/39d22f5))
-
+- **deps:** unpin production dependencies ([257ecb7](https://github.com/algolia/instantsearch/commit/257ecb7))
+- **InstantSearch:** avoid useless search on addWidgets ([#3178](https://github.com/algolia/instantsearch/issues/3178)) ([961626d](https://github.com/algolia/instantsearch/commit/961626d))
+- **numericselector:** default value can be undefined ([#3139](https://github.com/algolia/instantsearch/issues/3139)) ([39d22f5](https://github.com/algolia/instantsearch/commit/39d22f5))
 
 ### Features
 
-* **utils:** add warn function ([#3147](https://github.com/algolia/instantsearch.js/issues/3147)) ([9de87bb](https://github.com/algolia/instantsearch.js/commit/9de87bb))
-
-
+- **utils:** add warn function ([#3147](https://github.com/algolia/instantsearch/issues/3147)) ([9de87bb](https://github.com/algolia/instantsearch/commit/9de87bb))
 
 <a name="2.10.2"></a>
-## [2.10.2](https://github.com/algolia/instantsearch.js/compare/v2.10.1...v2.10.2) (2018-09-10)
 
+## [2.10.2](https://github.com/algolia/instantsearch/compare/v2.10.1...v2.10.2) (2018-09-10)
 
 ### Bug Fixes
 
-* **searchbox:** Add missing color to searchbox input field ([#3086](https://github.com/algolia/instantsearch.js/issues/3086)) ([62b852a](https://github.com/algolia/instantsearch.js/commit/62b852a)), closes [#3075](https://github.com/algolia/instantsearch.js/issues/3075)
-* **Stats:** let the widget render on all values ([#3070](https://github.com/algolia/instantsearch.js/issues/3070)) ([cd8f17e](https://github.com/algolia/instantsearch.js/commit/cd8f17e)), closes [#3056](https://github.com/algolia/instantsearch.js/issues/3056)
-
-
+- **searchbox:** Add missing color to searchbox input field ([#3086](https://github.com/algolia/instantsearch/issues/3086)) ([62b852a](https://github.com/algolia/instantsearch/commit/62b852a)), closes [#3075](https://github.com/algolia/instantsearch/issues/3075)
+- **Stats:** let the widget render on all values ([#3070](https://github.com/algolia/instantsearch/issues/3070)) ([cd8f17e](https://github.com/algolia/instantsearch/commit/cd8f17e)), closes [#3056](https://github.com/algolia/instantsearch/issues/3056)
 
 <a name="2.10.1"></a>
-## [2.10.1](https://github.com/algolia/instantsearch.js/compare/v2.10.0...v2.10.1) (2018-08-17)
 
+## [2.10.1](https://github.com/algolia/instantsearch/compare/v2.10.0...v2.10.1) (2018-08-17)
 
 ### Bug Fixes
 
-* **connectBreadcrumb:** ensure that data is an array ([#3067](https://github.com/algolia/instantsearch.js/issues/3067)) ([759f709](https://github.com/algolia/instantsearch.js/commit/759f709))
-
-
+- **connectBreadcrumb:** ensure that data is an array ([#3067](https://github.com/algolia/instantsearch/issues/3067)) ([759f709](https://github.com/algolia/instantsearch/commit/759f709))
 
 <a name="2.10.0"></a>
-# [2.10.0](https://github.com/algolia/instantsearch.js/compare/v2.9.0...v2.10.0) (2018-08-08)
 
+# [2.10.0](https://github.com/algolia/instantsearch/compare/v2.9.0...v2.10.0) (2018-08-08)
 
 ### Bug Fixes
 
-* **release:** provide interactive TTY for npm publish ([#3053](https://github.com/algolia/instantsearch.js/issues/3053)) ([ede9460](https://github.com/algolia/instantsearch.js/commit/ede9460))
-
+- **release:** provide interactive TTY for npm publish ([#3053](https://github.com/algolia/instantsearch/issues/3053)) ([ede9460](https://github.com/algolia/instantsearch/commit/ede9460))
 
 ### Features
 
-* Implement `transformItems` API ([#3042](https://github.com/algolia/instantsearch.js/issues/3042)) ([1510a94](https://github.com/algolia/instantsearch.js/commit/1510a94))
-
-
+- Implement `transformItems` API ([#3042](https://github.com/algolia/instantsearch/issues/3042)) ([1510a94](https://github.com/algolia/instantsearch/commit/1510a94))
 
 <a name="2.9.0"></a>
-# [2.9.0](https://github.com/algolia/instantsearch.js/compare/v2.8.1...v2.9.0) (2018-07-18)
 
+# [2.9.0](https://github.com/algolia/instantsearch/compare/v2.8.1...v2.9.0) (2018-07-18)
 
 ### Features
 
-* **infiniteHits:** add showmoreButton to cssClasses ([#3026](https://github.com/algolia/instantsearch.js/issues/3026)) ([8287de0](https://github.com/algolia/instantsearch.js/commit/8287de0))
-
-
+- **infiniteHits:** add showmoreButton to cssClasses ([#3026](https://github.com/algolia/instantsearch/issues/3026)) ([8287de0](https://github.com/algolia/instantsearch/commit/8287de0))
 
 <a name="2.8.1"></a>
-## [2.8.1](https://github.com/algolia/instantsearch.js/compare/v2.8.0...v2.8.1) (2018-07-03)
 
+## [2.8.1](https://github.com/algolia/instantsearch/compare/v2.8.0...v2.8.1) (2018-07-03)
 
 ### Bug Fixes
 
-* **connectHitsPerPage:** default value should not break the API  ([#3006](https://github.com/algolia/instantsearch.js/issues/3006)) ([6635304](https://github.com/algolia/instantsearch.js/commit/6635304)), closes [#2732](https://github.com/algolia/instantsearch.js/issues/2732)
-* **connectRefinementList:** throw error with usage ([#2962](https://github.com/algolia/instantsearch.js/issues/2962)) ([f60222d](https://github.com/algolia/instantsearch.js/commit/f60222d))
-* **sourcemap:** provide good url ([#3011](https://github.com/algolia/instantsearch.js/issues/3011)) ([9632ade](https://github.com/algolia/instantsearch.js/commit/9632ade))
-* **warning:** make sure suggested import is possible ([#3014](https://github.com/algolia/instantsearch.js/issues/3014)) ([eb27152](https://github.com/algolia/instantsearch.js/commit/eb27152))
-
-
+- **connectHitsPerPage:** default value should not break the API ([#3006](https://github.com/algolia/instantsearch/issues/3006)) ([6635304](https://github.com/algolia/instantsearch/commit/6635304)), closes [#2732](https://github.com/algolia/instantsearch/issues/2732)
+- **connectRefinementList:** throw error with usage ([#2962](https://github.com/algolia/instantsearch/issues/2962)) ([f60222d](https://github.com/algolia/instantsearch/commit/f60222d))
+- **sourcemap:** provide good url ([#3011](https://github.com/algolia/instantsearch/issues/3011)) ([9632ade](https://github.com/algolia/instantsearch/commit/9632ade))
+- **warning:** make sure suggested import is possible ([#3014](https://github.com/algolia/instantsearch/issues/3014)) ([eb27152](https://github.com/algolia/instantsearch/commit/eb27152))
 
 <a name="2.8.0"></a>
-# [2.8.0](https://github.com/algolia/instantsearch.js/compare/v2.7.6...v2.8.0) (2018-05-30)
 
+# [2.8.0](https://github.com/algolia/instantsearch/compare/v2.7.6...v2.8.0) (2018-05-30)
 
 ### Features
 
-* **connectors:** add connectAutocomplete ([#2841](https://github.com/algolia/instantsearch.js/issues/2841)) ([4bec81e](https://github.com/algolia/instantsearch.js/commit/4bec81e)), closes [/github.com/algolia/instantsearch.js/pull/2841#discussion_r188383882](https://github.com//github.com/algolia/instantsearch.js/pull/2841/issues/discussion_r188383882) [#2313](https://github.com/algolia/instantsearch.js/issues/2313)
-* **search-client:** Add support for Universal Search Clients ([#2894](https://github.com/algolia/instantsearch.js/issues/2894)) ([5df3c74](https://github.com/algolia/instantsearch.js/commit/5df3c74)), closes [#2905](https://github.com/algolia/instantsearch.js/issues/2905)
-
-
+- **connectors:** add connectAutocomplete ([#2841](https://github.com/algolia/instantsearch/issues/2841)) ([4bec81e](https://github.com/algolia/instantsearch/commit/4bec81e)), closes [/github.com/algolia/instantsearch/pull/2841#discussion_r188383882](https://github.com//github.com/algolia/instantsearch/pull/2841/issues/discussion_r188383882) [#2313](https://github.com/algolia/instantsearch/issues/2313)
+- **search-client:** Add support for Universal Search Clients ([#2894](https://github.com/algolia/instantsearch/issues/2894)) ([5df3c74](https://github.com/algolia/instantsearch/commit/5df3c74)), closes [#2905](https://github.com/algolia/instantsearch/issues/2905)
 
 <a name="2.7.6"></a>
-## [2.7.6](https://github.com/algolia/instantsearch.js/compare/v2.7.5...v2.7.6) (2018-05-29)
 
+## [2.7.6](https://github.com/algolia/instantsearch/compare/v2.7.5...v2.7.6) (2018-05-29)
 
 ### Bug Fixes
 
-* **connectConfigure:** ensure we do not extend `SearchParameters` ([#2945](https://github.com/algolia/instantsearch.js/issues/2945)) ([fdb4a7a](https://github.com/algolia/instantsearch.js/commit/fdb4a7a))
-* **infinite-hits:** fix [#2543](https://github.com/algolia/instantsearch.js/issues/2543) ([#2948](https://github.com/algolia/instantsearch.js/issues/2948)) ([bbf9f8f](https://github.com/algolia/instantsearch.js/commit/bbf9f8f))
-
-
+- **connectConfigure:** ensure we do not extend `SearchParameters` ([#2945](https://github.com/algolia/instantsearch/issues/2945)) ([fdb4a7a](https://github.com/algolia/instantsearch/commit/fdb4a7a))
+- **infinite-hits:** fix [#2543](https://github.com/algolia/instantsearch/issues/2543) ([#2948](https://github.com/algolia/instantsearch/issues/2948)) ([bbf9f8f](https://github.com/algolia/instantsearch/commit/bbf9f8f))
 
 <a name="2.7.5"></a>
-## [2.7.5](https://github.com/algolia/instantsearch.js/compare/v2.7.4...v2.7.5) (2018-05-28)
 
+## [2.7.5](https://github.com/algolia/instantsearch/compare/v2.7.4...v2.7.5) (2018-05-28)
 
 ### Bug Fixes
 
-* **clear-all:** apply excludeAttribute correctly with clearsQuery ([#2935](https://github.com/algolia/instantsearch.js/issues/2935)) ([e782ab8](https://github.com/algolia/instantsearch.js/commit/e782ab8))
-* **connectInfiniteHits:** fix [#2928](https://github.com/algolia/instantsearch.js/issues/2928)  ([#2939](https://github.com/algolia/instantsearch.js/issues/2939)) ([0293a31](https://github.com/algolia/instantsearch.js/commit/0293a31))
-
-
+- **clear-all:** apply excludeAttribute correctly with clearsQuery ([#2935](https://github.com/algolia/instantsearch/issues/2935)) ([e782ab8](https://github.com/algolia/instantsearch/commit/e782ab8))
+- **connectInfiniteHits:** fix [#2928](https://github.com/algolia/instantsearch/issues/2928) ([#2939](https://github.com/algolia/instantsearch/issues/2939)) ([0293a31](https://github.com/algolia/instantsearch/commit/0293a31))
 
 <a name="2.7.4"></a>
-## [2.7.4](https://github.com/algolia/instantsearch.js/compare/v2.7.3...v2.7.4) (2018-05-03)
 
+## [2.7.4](https://github.com/algolia/instantsearch/compare/v2.7.3...v2.7.4) (2018-05-03)
 
 ### Bug Fixes
 
-* **searchFunction:** Fix unresolved returned Promise ([#2913](https://github.com/algolia/instantsearch.js/issues/2913)) ([5286c7c](https://github.com/algolia/instantsearch.js/commit/5286c7c))
-
-
+- **searchFunction:** Fix unresolved returned Promise ([#2913](https://github.com/algolia/instantsearch/issues/2913)) ([5286c7c](https://github.com/algolia/instantsearch/commit/5286c7c))
 
 <a name="2.7.3"></a>
-## [2.7.3](https://github.com/algolia/instantsearch.js/compare/v2.7.2...v2.7.3) (2018-04-26)
 
+## [2.7.3](https://github.com/algolia/instantsearch/compare/v2.7.2...v2.7.3) (2018-04-26)
 
 ### Bug Fixes
 
-* **index.es6:** avoid use of Object.assign for IE ([#2908](https://github.com/algolia/instantsearch.js/issues/2908)) ([228b02e](https://github.com/algolia/instantsearch.js/commit/228b02e))
-
-
+- **index.es6:** avoid use of Object.assign for IE ([#2908](https://github.com/algolia/instantsearch/issues/2908)) ([228b02e](https://github.com/algolia/instantsearch/commit/228b02e))
 
 <a name="2.7.2"></a>
-## [2.7.2](https://github.com/algolia/instantsearch.js/compare/v2.7.1...v2.7.2) (2018-04-18)
+
+## [2.7.2](https://github.com/algolia/instantsearch/compare/v2.7.1...v2.7.2) (2018-04-18)
 
 ### Bug Fixes
 
-* **routing:** should apply stateMapping when doing initial write ([#2892](https://github.com/algolia/instantsearch.js/issues/2892)) ([7f62e6dc](https://github.com/algolia/instantsearch.js/commit/7f62e6dc))
-* **ie:** do not rely on Object.assign ([#2885](https://github.com/algolia/instantsearch.js/issues/2885)) ([88497e56](https://github.com/algolia/instantsearch.js/commit/88497e56))
-
-
+- **routing:** should apply stateMapping when doing initial write ([#2892](https://github.com/algolia/instantsearch/issues/2892)) ([7f62e6dc](https://github.com/algolia/instantsearch/commit/7f62e6dc))
+- **ie:** do not rely on Object.assign ([#2885](https://github.com/algolia/instantsearch/issues/2885)) ([88497e56](https://github.com/algolia/instantsearch/commit/88497e56))
 
 <a name="2.7.1"></a>
-## [2.7.1](https://github.com/algolia/instantsearch.js/compare/v2.7.0...v2.7.1) (2018-04-11)
 
+## [2.7.1](https://github.com/algolia/instantsearch/compare/v2.7.0...v2.7.1) (2018-04-11)
 
 ### Bug Fixes
 
-* **history:** provide location and use named parameters ([#2877](https://github.com/algolia/instantsearch.js/issues/2877)) ([761ffa4](https://github.com/algolia/instantsearch.js/commit/761ffa4))
-
-
+- **history:** provide location and use named parameters ([#2877](https://github.com/algolia/instantsearch/issues/2877)) ([761ffa4](https://github.com/algolia/instantsearch/commit/761ffa4))
 
 <a name="2.7.0"></a>
-# [2.7.0](https://github.com/algolia/instantsearch.js/compare/v2.6.3...v2.7.0) (2018-04-09)
 
+# [2.7.0](https://github.com/algolia/instantsearch/compare/v2.6.3...v2.7.0) (2018-04-09)
 
 ### Bug Fixes
 
-* pagination padding ([#2866](https://github.com/algolia/instantsearch.js/issues/2866)) ([e8c58cc](https://github.com/algolia/instantsearch.js/commit/e8c58cc))
-* **geosearch:** avoid reset map when it already moved ([#2870](https://github.com/algolia/instantsearch.js/issues/2870)) ([f171b8a](https://github.com/algolia/instantsearch.js/commit/f171b8a))
-* **removeWidget:** check for widgets.length on next tick ([#2831](https://github.com/algolia/instantsearch.js/issues/2831)) ([7e639d6](https://github.com/algolia/instantsearch.js/commit/7e639d6))
-
+- pagination padding ([#2866](https://github.com/algolia/instantsearch/issues/2866)) ([e8c58cc](https://github.com/algolia/instantsearch/commit/e8c58cc))
+- **geosearch:** avoid reset map when it already moved ([#2870](https://github.com/algolia/instantsearch/issues/2870)) ([f171b8a](https://github.com/algolia/instantsearch/commit/f171b8a))
+- **removeWidget:** check for widgets.length on next tick ([#2831](https://github.com/algolia/instantsearch/issues/2831)) ([7e639d6](https://github.com/algolia/instantsearch/commit/7e639d6))
 
 ### Features
 
-* **connetConfigure:** add a connector to create a connector widget ([8fdf752](https://github.com/algolia/instantsearch.js/commit/8fdf752))
-* **routing:** provide a mechanism to synchronize the search ([#2829](https://github.com/algolia/instantsearch.js/issues/2829)) ([75b2ca3](https://github.com/algolia/instantsearch.js/commit/75b2ca3)), closes [#2849](https://github.com/algolia/instantsearch.js/issues/2849) [#2849](https://github.com/algolia/instantsearch.js/issues/2849)
-* **size:** add sideEffects false to package.json ([#2861](https://github.com/algolia/instantsearch.js/issues/2861)) ([f5d1ab1](https://github.com/algolia/instantsearch.js/commit/f5d1ab1)), closes [#2859](https://github.com/algolia/instantsearch.js/issues/2859)
-
-
+- **connetConfigure:** add a connector to create a connector widget ([8fdf752](https://github.com/algolia/instantsearch/commit/8fdf752))
+- **routing:** provide a mechanism to synchronize the search ([#2829](https://github.com/algolia/instantsearch/issues/2829)) ([75b2ca3](https://github.com/algolia/instantsearch/commit/75b2ca3)), closes [#2849](https://github.com/algolia/instantsearch/issues/2849) [#2849](https://github.com/algolia/instantsearch/issues/2849)
+- **size:** add sideEffects false to package.json ([#2861](https://github.com/algolia/instantsearch/issues/2861)) ([f5d1ab1](https://github.com/algolia/instantsearch/commit/f5d1ab1)), closes [#2859](https://github.com/algolia/instantsearch/issues/2859)
 
 <a name="2.6.3"></a>
-## [2.6.3](https://github.com/algolia/instantsearch.js/compare/v2.6.2...v2.6.3) (2018-03-30)
 
+## [2.6.3](https://github.com/algolia/instantsearch/compare/v2.6.2...v2.6.3) (2018-03-30)
 
 ### Bug Fixes
 
-* **rangeSlider:** handles were blocked ([#2849](https://github.com/algolia/instantsearch.js/issues/2849)) ([a2af4f0](https://github.com/algolia/instantsearch.js/commit/a2af4f0))
-
-
+- **rangeSlider:** handles were blocked ([#2849](https://github.com/algolia/instantsearch/issues/2849)) ([a2af4f0](https://github.com/algolia/instantsearch/commit/a2af4f0))
 
 <a name="2.6.2"></a>
-## [2.6.2](https://github.com/algolia/instantsearch.js/compare/v2.6.1...v2.6.2) (2018-03-29)
 
+## [2.6.2](https://github.com/algolia/instantsearch/compare/v2.6.1...v2.6.2) (2018-03-29)
 
 ### Bug Fixes
 
-* **connectGeoSearch:** correctly dispose the connector ([#2845](https://github.com/algolia/instantsearch.js/issues/2845)) ([a4eafd2](https://github.com/algolia/instantsearch.js/commit/a4eafd2))
-* **GeoSearch:** correctly unmount the widget ([#2846](https://github.com/algolia/instantsearch.js/issues/2846)) ([f31ef3c](https://github.com/algolia/instantsearch.js/commit/f31ef3c))
-
-
+- **connectGeoSearch:** correctly dispose the connector ([#2845](https://github.com/algolia/instantsearch/issues/2845)) ([a4eafd2](https://github.com/algolia/instantsearch/commit/a4eafd2))
+- **GeoSearch:** correctly unmount the widget ([#2846](https://github.com/algolia/instantsearch/issues/2846)) ([f31ef3c](https://github.com/algolia/instantsearch/commit/f31ef3c))
 
 <a name="2.6.1"></a>
-## [2.6.1](https://github.com/algolia/instantsearch.js/compare/v2.6.0...v2.6.1) (2018-03-28)
 
+## [2.6.1](https://github.com/algolia/instantsearch/compare/v2.6.0...v2.6.1) (2018-03-28)
 
 ### Bug Fixes
 
-* **connectBreadcrumb:** allow unmounting ([#2815](https://github.com/algolia/instantsearch.js/issues/2815)) ([c6c353a](https://github.com/algolia/instantsearch.js/commit/c6c353a))
-* **connectBreadcrumb:** update typo in property type items ([#2782](https://github.com/algolia/instantsearch.js/issues/2782)) ([79ebd66](https://github.com/algolia/instantsearch.js/commit/79ebd66))
-* **docgen:** pass the relatedTypes to the struct mixin in connectors layout ([#2780](https://github.com/algolia/instantsearch.js/issues/2780)) ([f7f8b05](https://github.com/algolia/instantsearch.js/commit/f7f8b05))
-* **GeoSearch:** update typo in property type cssClasses ([#2781](https://github.com/algolia/instantsearch.js/issues/2781)) ([419c2ab](https://github.com/algolia/instantsearch.js/commit/419c2ab))
-* **main:** correctly import EventEmitter ([#2814](https://github.com/algolia/instantsearch.js/issues/2814)) ([8fa3649](https://github.com/algolia/instantsearch.js/commit/8fa3649)), closes [#2730](https://github.com/algolia/instantsearch.js/issues/2730)
-
-
+- **connectBreadcrumb:** allow unmounting ([#2815](https://github.com/algolia/instantsearch/issues/2815)) ([c6c353a](https://github.com/algolia/instantsearch/commit/c6c353a))
+- **connectBreadcrumb:** update typo in property type items ([#2782](https://github.com/algolia/instantsearch/issues/2782)) ([79ebd66](https://github.com/algolia/instantsearch/commit/79ebd66))
+- **docgen:** pass the relatedTypes to the struct mixin in connectors layout ([#2780](https://github.com/algolia/instantsearch/issues/2780)) ([f7f8b05](https://github.com/algolia/instantsearch/commit/f7f8b05))
+- **GeoSearch:** update typo in property type cssClasses ([#2781](https://github.com/algolia/instantsearch/issues/2781)) ([419c2ab](https://github.com/algolia/instantsearch/commit/419c2ab))
+- **main:** correctly import EventEmitter ([#2814](https://github.com/algolia/instantsearch/issues/2814)) ([8fa3649](https://github.com/algolia/instantsearch/commit/8fa3649)), closes [#2730](https://github.com/algolia/instantsearch/issues/2730)
 
 <a name="2.6.0"></a>
-# [2.6.0](https://github.com/algolia/instantsearch.js/compare/v2.5.2...v2.6.0) (2018-03-06)
 
+# [2.6.0](https://github.com/algolia/instantsearch/compare/v2.5.2...v2.6.0) (2018-03-06)
 
 ### Bug Fixes
 
-* **GeoSearch:** add apiKey for Google Maps ([#2773](https://github.com/algolia/instantsearch.js/issues/2773)) ([6c1846f](https://github.com/algolia/instantsearch.js/commit/6c1846f))
-* **GeoSearch:** override button style ([#2772](https://github.com/algolia/instantsearch.js/issues/2772)) ([4d69b50](https://github.com/algolia/instantsearch.js/commit/4d69b50))
-
+- **GeoSearch:** add apiKey for Google Maps ([#2773](https://github.com/algolia/instantsearch/issues/2773)) ([6c1846f](https://github.com/algolia/instantsearch/commit/6c1846f))
+- **GeoSearch:** override button style ([#2772](https://github.com/algolia/instantsearch/issues/2772)) ([4d69b50](https://github.com/algolia/instantsearch/commit/4d69b50))
 
 ### Features
 
-* **configure:** add the Configure widget ([#2698](https://github.com/algolia/instantsearch.js/issues/2698)) ([94daabc](https://github.com/algolia/instantsearch.js/commit/94daabc))
-* add GeoSearch widget & connector ([#2743](https://github.com/algolia/instantsearch.js/issues/2743)) ([7fa17ff](https://github.com/algolia/instantsearch.js/commit/7fa17ff))
-
-
+- **configure:** add the Configure widget ([#2698](https://github.com/algolia/instantsearch/issues/2698)) ([94daabc](https://github.com/algolia/instantsearch/commit/94daabc))
+- add GeoSearch widget & connector ([#2743](https://github.com/algolia/instantsearch/issues/2743)) ([7fa17ff](https://github.com/algolia/instantsearch/commit/7fa17ff))
 
 <a name="2.5.2"></a>
-## [2.5.2](https://github.com/algolia/instantsearch.js/compare/v2.5.1...v2.5.2) (2018-02-26)
 
+## [2.5.2](https://github.com/algolia/instantsearch/compare/v2.5.1...v2.5.2) (2018-02-26)
 
 ### Bug Fixes
 
-* **Template:** harden Symbol checks ([#2749](https://github.com/algolia/instantsearch.js/issues/2749)) ([fab66bc](https://github.com/algolia/instantsearch.js/commit/fab66bc))
-* **yarnrc:** use empty string for save-prefix ([#2739](https://github.com/algolia/instantsearch.js/issues/2739)) ([979e0cd](https://github.com/algolia/instantsearch.js/commit/979e0cd))
-
-
+- **Template:** harden Symbol checks ([#2749](https://github.com/algolia/instantsearch/issues/2749)) ([fab66bc](https://github.com/algolia/instantsearch/commit/fab66bc))
+- **yarnrc:** use empty string for save-prefix ([#2739](https://github.com/algolia/instantsearch/issues/2739)) ([979e0cd](https://github.com/algolia/instantsearch/commit/979e0cd))
 
 <a name="2.5.1"></a>
-## [2.5.1](https://github.com/algolia/instantsearch.js/compare/v2.5.0...v2.5.1) (2018-02-13)
 
+## [2.5.1](https://github.com/algolia/instantsearch/compare/v2.5.0...v2.5.1) (2018-02-13)
 
 ### Bug Fixes
 
-* **perf:** only compute snappoints when step is provided ([#2699](https://github.com/algolia/instantsearch.js/issues/2699)) ([ce9ca19](https://github.com/algolia/instantsearch.js/commit/ce9ca19)), closes [#2662](https://github.com/algolia/instantsearch.js/issues/2662)
-
-
+- **perf:** only compute snappoints when step is provided ([#2699](https://github.com/algolia/instantsearch/issues/2699)) ([ce9ca19](https://github.com/algolia/instantsearch/commit/ce9ca19)), closes [#2662](https://github.com/algolia/instantsearch/issues/2662)
 
 <a name="2.5.0"></a>
-# [2.5.0](https://github.com/algolia/instantsearch.js/compare/v2.4.1...v2.5.0) (2018-02-06)
 
+# [2.5.0](https://github.com/algolia/instantsearch/compare/v2.4.1...v2.5.0) (2018-02-06)
 
 ### Bug Fixes
 
-* **doc:** add maximum width to images (fix [#2685](https://github.com/algolia/instantsearch.js/issues/2685)) ([#2686](https://github.com/algolia/instantsearch.js/issues/2686)) ([f4b5377](https://github.com/algolia/instantsearch.js/commit/f4b5377))
-
+- **doc:** add maximum width to images (fix [#2685](https://github.com/algolia/instantsearch/issues/2685)) ([#2686](https://github.com/algolia/instantsearch/issues/2686)) ([f4b5377](https://github.com/algolia/instantsearch/commit/f4b5377))
 
 ### Features
 
-* support for algolia insights ([#2689](https://github.com/algolia/instantsearch.js/issues/2689)) ([96b8d61](https://github.com/algolia/instantsearch.js/commit/96b8d61))
-
-
+- support for algolia insights ([#2689](https://github.com/algolia/instantsearch/issues/2689)) ([96b8d61](https://github.com/algolia/instantsearch/commit/96b8d61))
 
 <a name="2.4.1"></a>
-## [2.4.1](https://github.com/algolia/instantsearch.js/compare/v2.4.0...v2.4.1) (2018-01-04)
 
+## [2.4.1](https://github.com/algolia/instantsearch/compare/v2.4.0...v2.4.1) (2018-01-04)
 
 ### Bug Fixes
 
-* **core:** correct escape highlight for arrays and nested objects ([#2646](https://github.com/algolia/instantsearch.js/issues/2646)) ([ed0ee73](https://github.com/algolia/instantsearch.js/commit/ed0ee73))
-
-
+- **core:** correct escape highlight for arrays and nested objects ([#2646](https://github.com/algolia/instantsearch/issues/2646)) ([ed0ee73](https://github.com/algolia/instantsearch/commit/ed0ee73))
 
 <a name="2.4.0"></a>
-# [2.4.0](https://github.com/algolia/instantsearch.js/compare/v2.3.3...v2.4.0) (2018-01-02)
 
+# [2.4.0](https://github.com/algolia/instantsearch/compare/v2.3.3...v2.4.0) (2018-01-02)
 
 ### Bug Fixes
 
-* **pagination:** disable buttons if not results ([#2643](https://github.com/algolia/instantsearch.js/issues/2643)) ([9017b72](https://github.com/algolia/instantsearch.js/commit/9017b72)), closes [#2014](https://github.com/algolia/instantsearch.js/issues/2014)
-* **theme:** fix height of pagination ([#2641](https://github.com/algolia/instantsearch.js/issues/2641)) ([b3185e5](https://github.com/algolia/instantsearch.js/commit/b3185e5))
-
+- **pagination:** disable buttons if not results ([#2643](https://github.com/algolia/instantsearch/issues/2643)) ([9017b72](https://github.com/algolia/instantsearch/commit/9017b72)), closes [#2014](https://github.com/algolia/instantsearch/issues/2014)
+- **theme:** fix height of pagination ([#2641](https://github.com/algolia/instantsearch/issues/2641)) ([b3185e5](https://github.com/algolia/instantsearch/commit/b3185e5))
 
 ### Features
 
-* **core:** add a reload method on the InstantSearch component ([#2637](https://github.com/algolia/instantsearch.js/issues/2637)) ([e73ff13](https://github.com/algolia/instantsearch.js/commit/e73ff13))
-* **core:** add an error event to monitor error from Algolia ([#2642](https://github.com/algolia/instantsearch.js/issues/2642)) ([71c2d68](https://github.com/algolia/instantsearch.js/commit/71c2d68)), closes [#1585](https://github.com/algolia/instantsearch.js/issues/1585)
-* **core:** rename `reload` to `refresh` ([#2645](https://github.com/algolia/instantsearch.js/issues/2645)) ([9b8ac65](https://github.com/algolia/instantsearch.js/commit/9b8ac65))
-* **wrapWithHits:** enable async init ([#2635](https://github.com/algolia/instantsearch.js/issues/2635)) ([08a8747](https://github.com/algolia/instantsearch.js/commit/08a8747))
-
-
+- **core:** add a reload method on the InstantSearch component ([#2637](https://github.com/algolia/instantsearch/issues/2637)) ([e73ff13](https://github.com/algolia/instantsearch/commit/e73ff13))
+- **core:** add an error event to monitor error from Algolia ([#2642](https://github.com/algolia/instantsearch/issues/2642)) ([71c2d68](https://github.com/algolia/instantsearch/commit/71c2d68)), closes [#1585](https://github.com/algolia/instantsearch/issues/1585)
+- **core:** rename `reload` to `refresh` ([#2645](https://github.com/algolia/instantsearch/issues/2645)) ([9b8ac65](https://github.com/algolia/instantsearch/commit/9b8ac65))
+- **wrapWithHits:** enable async init ([#2635](https://github.com/algolia/instantsearch/issues/2635)) ([08a8747](https://github.com/algolia/instantsearch/commit/08a8747))
 
 <a name="2.3.3"></a>
-## [2.3.3](https://github.com/algolia/instantsearch.js/compare/v2.3.2...v2.3.3) (2017-12-11)
 
+## [2.3.3](https://github.com/algolia/instantsearch/compare/v2.3.2...v2.3.3) (2017-12-11)
 
 ### Bug Fixes
 
-* **core:** search is stalled at init ([#2623](https://github.com/algolia/instantsearch.js/issues/2623)) ([e3dd577](https://github.com/algolia/instantsearch.js/commit/e3dd577)), closes [#2616](https://github.com/algolia/instantsearch.js/issues/2616)
-
-
+- **core:** search is stalled at init ([#2623](https://github.com/algolia/instantsearch/issues/2623)) ([e3dd577](https://github.com/algolia/instantsearch/commit/e3dd577)), closes [#2616](https://github.com/algolia/instantsearch/issues/2616)
 
 <a name="2.3.2"></a>
-## [2.3.2](https://github.com/algolia/instantsearch.js/compare/v2.3.1...v2.3.2) (2017-12-06)
 
+## [2.3.2](https://github.com/algolia/instantsearch/compare/v2.3.1...v2.3.2) (2017-12-06)
 
 ### Bug Fixes
 
-* React reference: Breadcrumb & RangeInput components ([#2618](https://github.com/algolia/instantsearch.js/issues/2618)) ([7f32161](https://github.com/algolia/instantsearch.js/commit/7f32161))
-
-
+- React reference: Breadcrumb & RangeInput components ([#2618](https://github.com/algolia/instantsearch/issues/2618)) ([7f32161](https://github.com/algolia/instantsearch/commit/7f32161))
 
 <a name="2.3.1"></a>
-## [2.3.1](https://github.com/algolia/instantsearch.js/compare/v2.3.0...v2.3.1) (2017-12-04)
 
+## [2.3.1](https://github.com/algolia/instantsearch/compare/v2.3.0...v2.3.1) (2017-12-04)
 
 ### Bug Fixes
 
-* **connectors:** check facet is refined before removing it. hierarchicalMenu / menu ([67ae035](https://github.com/algolia/instantsearch.js/commit/67ae035))
-* **poweredBy:** minify slightly and make into correct URL ([#2615](https://github.com/algolia/instantsearch.js/issues/2615)) ([2b7d747](https://github.com/algolia/instantsearch.js/commit/2b7d747)), closes [#2613](https://github.com/algolia/instantsearch.js/issues/2613)
-
-
+- **connectors:** check facet is refined before removing it. hierarchicalMenu / menu ([67ae035](https://github.com/algolia/instantsearch/commit/67ae035))
+- **poweredBy:** minify slightly and make into correct URL ([#2615](https://github.com/algolia/instantsearch/issues/2615)) ([2b7d747](https://github.com/algolia/instantsearch/commit/2b7d747)), closes [#2613](https://github.com/algolia/instantsearch/issues/2613)
 
 <a name="2.3.0"></a>
-# [2.3.0](https://github.com/algolia/instantsearch.js/compare/v2.3.0-beta.7...v2.3.0) (2017-11-30)
 
+# [2.3.0](https://github.com/algolia/instantsearch/compare/v2.3.0-beta.7...v2.3.0) (2017-11-30)
 
 ### Bug Fixes
 
-* **InstantSearch.dispose:** dont call `getConfiguration` of URLSync widget ([#2604](https://github.com/algolia/instantsearch.js/issues/2604)) ([3234b12](https://github.com/algolia/instantsearch.js/commit/3234b12))
-* **connectors:** prefer wrappers over bind ([#2575](https://github.com/algolia/instantsearch.js/issues/2575)) ([f8e0e00](https://github.com/algolia/instantsearch.js/commit/f8e0e00))
-* **connectHierarchicalMenu:** do not return if facet not set ([#2521](https://github.com/algolia/instantsearch.js/issues/2521)) ([26e99fb](https://github.com/algolia/instantsearch.js/commit/26e99fb))
-
-
+- **InstantSearch.dispose:** dont call `getConfiguration` of URLSync widget ([#2604](https://github.com/algolia/instantsearch/issues/2604)) ([3234b12](https://github.com/algolia/instantsearch/commit/3234b12))
+- **connectors:** prefer wrappers over bind ([#2575](https://github.com/algolia/instantsearch/issues/2575)) ([f8e0e00](https://github.com/algolia/instantsearch/commit/f8e0e00))
+- **connectHierarchicalMenu:** do not return if facet not set ([#2521](https://github.com/algolia/instantsearch/issues/2521)) ([26e99fb](https://github.com/algolia/instantsearch/commit/26e99fb))
 
 ### Features
 
-* **core:** provide information about stalled search to widgets ([#2569](https://github.com/algolia/instantsearch.js/issues/2569)) ([d104be1](https://github.com/algolia/instantsearch.js/commit/d104be1))
-* **core:** InstantSearch hot remove/add widgets ([#2384](https://github.com/algolia/instantsearch.js/issues/2384)) ([cfc1710](https://github.com/algolia/instantsearch.js/commit/cfc1710))
-* **refinementList:** add escapeFacetHits parameter ([#2507](https://github.com/algolia/instantsearch.js/issues/2507)) ([9b1b7ee](https://github.com/algolia/instantsearch.js/commit/9b1b7ee))
-* **breadcrumb:** Add the breadcrumb widget ([#2451](https://github.com/algolia/instantsearch.js/issues/2451)) ([11d78f0](https://github.com/algolia/instantsearch.js/commit/11d78f0)), closes [#2299](https://github.com/algolia/instantsearch.js/issues/2299)
-* **connectRange:** round the range based on precision ([#2498](https://github.com/algolia/instantsearch.js/issues/2498)) ([d4df45d](https://github.com/algolia/instantsearch.js/commit/d4df45d))
-* **rangeInput:** add rangeInput widget ([#2440](https://github.com/algolia/instantsearch.js/issues/2440)) ([7916d16](https://github.com/algolia/instantsearch.js/commit/7916d16))
-
-
+- **core:** provide information about stalled search to widgets ([#2569](https://github.com/algolia/instantsearch/issues/2569)) ([d104be1](https://github.com/algolia/instantsearch/commit/d104be1))
+- **core:** InstantSearch hot remove/add widgets ([#2384](https://github.com/algolia/instantsearch/issues/2384)) ([cfc1710](https://github.com/algolia/instantsearch/commit/cfc1710))
+- **refinementList:** add escapeFacetHits parameter ([#2507](https://github.com/algolia/instantsearch/issues/2507)) ([9b1b7ee](https://github.com/algolia/instantsearch/commit/9b1b7ee))
+- **breadcrumb:** Add the breadcrumb widget ([#2451](https://github.com/algolia/instantsearch/issues/2451)) ([11d78f0](https://github.com/algolia/instantsearch/commit/11d78f0)), closes [#2299](https://github.com/algolia/instantsearch/issues/2299)
+- **connectRange:** round the range based on precision ([#2498](https://github.com/algolia/instantsearch/issues/2498)) ([d4df45d](https://github.com/algolia/instantsearch/commit/d4df45d))
+- **rangeInput:** add rangeInput widget ([#2440](https://github.com/algolia/instantsearch/issues/2440)) ([7916d16](https://github.com/algolia/instantsearch/commit/7916d16))
 
 <a name="2.2.5"></a>
-## [2.2.5](https://github.com/algolia/instantsearch.js/compare/v2.2.4...v2.2.5) (2017-11-20)
 
+## [2.2.5](https://github.com/algolia/instantsearch/compare/v2.2.4...v2.2.5) (2017-11-20)
 
 ### Bug Fixes
 
-* **searchbox:** fix usage of custom reset template ([#2585](https://github.com/algolia/instantsearch.js/issues/2585)) ([aad92b9](https://github.com/algolia/instantsearch.js/commit/aad92b9)), closes [#2528](https://github.com/algolia/instantsearch.js/issues/2528)
-
-
+- **searchbox:** fix usage of custom reset template ([#2585](https://github.com/algolia/instantsearch/issues/2585)) ([aad92b9](https://github.com/algolia/instantsearch/commit/aad92b9)), closes [#2528](https://github.com/algolia/instantsearch/issues/2528)
 
 <a name="2.2.4"></a>
-## [2.2.4](https://github.com/algolia/instantsearch.js/compare/v2.2.3...v2.2.4) (2017-11-13)
 
+## [2.2.4](https://github.com/algolia/instantsearch/compare/v2.2.3...v2.2.4) (2017-11-13)
 
 ### Bug Fixes
 
-* **numericSelector:** make default value possible ([#2565](https://github.com/algolia/instantsearch.js/issues/2565)) ([5664f98](https://github.com/algolia/instantsearch.js/commit/5664f98))
-
-
+- **numericSelector:** make default value possible ([#2565](https://github.com/algolia/instantsearch/issues/2565)) ([5664f98](https://github.com/algolia/instantsearch/commit/5664f98))
 
 <a name="2.2.3"></a>
-## [2.2.3](https://github.com/algolia/instantsearch.js/compare/v2.2.2...v2.2.3) (2017-11-07)
 
+## [2.2.3](https://github.com/algolia/instantsearch/compare/v2.2.2...v2.2.3) (2017-11-07)
 
 ### Bug Fixes
 
-* **connectRefinementList:** add label to searched items ([#2553](https://github.com/algolia/instantsearch.js/issues/2553)) ([ec810fa](https://github.com/algolia/instantsearch.js/commit/ec810fa))
-* **refinementList:** fix facet exhaustivity check ([#2554](https://github.com/algolia/instantsearch.js/issues/2554)) ([0f1bf08](https://github.com/algolia/instantsearch.js/commit/0f1bf08)), closes [#2552](https://github.com/algolia/instantsearch.js/issues/2552)
-* **theme:** searchbar should have normal size input ([#2545](https://github.com/algolia/instantsearch.js/issues/2545)) ([50d99f0](https://github.com/algolia/instantsearch.js/commit/50d99f0))
-
-
+- **connectRefinementList:** add label to searched items ([#2553](https://github.com/algolia/instantsearch/issues/2553)) ([ec810fa](https://github.com/algolia/instantsearch/commit/ec810fa))
+- **refinementList:** fix facet exhaustivity check ([#2554](https://github.com/algolia/instantsearch/issues/2554)) ([0f1bf08](https://github.com/algolia/instantsearch/commit/0f1bf08)), closes [#2552](https://github.com/algolia/instantsearch/issues/2552)
+- **theme:** searchbar should have normal size input ([#2545](https://github.com/algolia/instantsearch/issues/2545)) ([50d99f0](https://github.com/algolia/instantsearch/commit/50d99f0))
 
 <a name="2.2.2"></a>
-## [2.2.2](https://github.com/algolia/instantsearch.js/compare/v2.2.1...v2.2.2) (2017-10-30)
 
+## [2.2.2](https://github.com/algolia/instantsearch/compare/v2.2.1...v2.2.2) (2017-10-30)
 
 ### Bug Fixes
 
-* **connectRefinementList:** set default value for limit ([#2517](https://github.com/algolia/instantsearch.js/issues/2517)) ([32918c9](https://github.com/algolia/instantsearch.js/commit/32918c9))
-* **MenuSelect:** switch from react to preact-compat ([#2513](https://github.com/algolia/instantsearch.js/issues/2513)) ([06aa626](https://github.com/algolia/instantsearch.js/commit/06aa626))
-* **range-slider:** add option `collapsible` ([#2502](https://github.com/algolia/instantsearch.js/issues/2502)) ([e78399d](https://github.com/algolia/instantsearch.js/commit/e78399d)), closes [#2501](https://github.com/algolia/instantsearch.js/issues/2501)
-* **url-sync:** make URLSync consistent even if search is tampered ([392927e](https://github.com/algolia/instantsearch.js/commit/392927e)), closes [#2523](https://github.com/algolia/instantsearch.js/issues/2523)
-
-
+- **connectRefinementList:** set default value for limit ([#2517](https://github.com/algolia/instantsearch/issues/2517)) ([32918c9](https://github.com/algolia/instantsearch/commit/32918c9))
+- **MenuSelect:** switch from react to preact-compat ([#2513](https://github.com/algolia/instantsearch/issues/2513)) ([06aa626](https://github.com/algolia/instantsearch/commit/06aa626))
+- **range-slider:** add option `collapsible` ([#2502](https://github.com/algolia/instantsearch/issues/2502)) ([e78399d](https://github.com/algolia/instantsearch/commit/e78399d)), closes [#2501](https://github.com/algolia/instantsearch/issues/2501)
+- **url-sync:** make URLSync consistent even if search is tampered ([392927e](https://github.com/algolia/instantsearch/commit/392927e)), closes [#2523](https://github.com/algolia/instantsearch/issues/2523)
 
 <a name="2.2.1"></a>
-## [2.2.1](https://github.com/algolia/instantsearch.js/compare/v2.2.0...v2.2.1) (2017-10-16)
 
+## [2.2.1](https://github.com/algolia/instantsearch/compare/v2.2.0...v2.2.1) (2017-10-16)
 
 ### Bug Fixes
 
-* **connectRangeSlider:** only clear the refinement on the current attribute ([#2459](https://github.com/algolia/instantsearch.js/issues/2459)) ([7cebf58](https://github.com/algolia/instantsearch.js/commit/7cebf58))
-* **menuSelect:** select in userCssClasses ([#2455](https://github.com/algolia/instantsearch.js/issues/2455)) ([0eb3dc8](https://github.com/algolia/instantsearch.js/commit/0eb3dc8))
-* **menuSelect:** use preact instead of React ([#2460](https://github.com/algolia/instantsearch.js/issues/2460)) ([35ccae8](https://github.com/algolia/instantsearch.js/commit/35ccae8))
-* **test:** correctly reset the wired dependency ([#2461](https://github.com/algolia/instantsearch.js/issues/2461)) ([1f7f4ed](https://github.com/algolia/instantsearch.js/commit/1f7f4ed))
-
-
+- **connectRangeSlider:** only clear the refinement on the current attribute ([#2459](https://github.com/algolia/instantsearch/issues/2459)) ([7cebf58](https://github.com/algolia/instantsearch/commit/7cebf58))
+- **menuSelect:** select in userCssClasses ([#2455](https://github.com/algolia/instantsearch/issues/2455)) ([0eb3dc8](https://github.com/algolia/instantsearch/commit/0eb3dc8))
+- **menuSelect:** use preact instead of React ([#2460](https://github.com/algolia/instantsearch/issues/2460)) ([35ccae8](https://github.com/algolia/instantsearch/commit/35ccae8))
+- **test:** correctly reset the wired dependency ([#2461](https://github.com/algolia/instantsearch/issues/2461)) ([1f7f4ed](https://github.com/algolia/instantsearch/commit/1f7f4ed))
 
 <a name="2.2.0"></a>
-# [2.2.0](https://github.com/algolia/instantsearch.js/compare/v2.1.6...v2.2.0) (2017-10-03)
 
+# [2.2.0](https://github.com/algolia/instantsearch/compare/v2.1.6...v2.2.0) (2017-10-03)
 
 ### Bug Fixes
 
-* **build:** minify css with `csso` instead of unminify css ([#2419](https://github.com/algolia/instantsearch.js/issues/2419)) ([12f96b8](https://github.com/algolia/instantsearch.js/commit/12f96b8)), closes [#2375](https://github.com/algolia/instantsearch.js/issues/2375)
-* **clear-all:** display the query when clearsQuery is true ([#2414](https://github.com/algolia/instantsearch.js/issues/2414)) ([6921895](https://github.com/algolia/instantsearch.js/commit/6921895))
-* **range-slider:** Fix slider boundaries ([#2408](https://github.com/algolia/instantsearch.js/issues/2408)) ([bea43db](https://github.com/algolia/instantsearch.js/commit/bea43db)), closes [#2386](https://github.com/algolia/instantsearch.js/issues/2386)
-* **selector:** root classname is applied twice ([#2423](https://github.com/algolia/instantsearch.js/issues/2423)) ([44dca11](https://github.com/algolia/instantsearch.js/commit/44dca11)), closes [#2396](https://github.com/algolia/instantsearch.js/issues/2396) [#2397](https://github.com/algolia/instantsearch.js/issues/2397)
-* **webpack.dev:** sourcemaps in dev ([#2422](https://github.com/algolia/instantsearch.js/issues/2422)) ([ba6ca0a](https://github.com/algolia/instantsearch.js/commit/ba6ca0a))
-
+- **build:** minify css with `csso` instead of unminify css ([#2419](https://github.com/algolia/instantsearch/issues/2419)) ([12f96b8](https://github.com/algolia/instantsearch/commit/12f96b8)), closes [#2375](https://github.com/algolia/instantsearch/issues/2375)
+- **clear-all:** display the query when clearsQuery is true ([#2414](https://github.com/algolia/instantsearch/issues/2414)) ([6921895](https://github.com/algolia/instantsearch/commit/6921895))
+- **range-slider:** Fix slider boundaries ([#2408](https://github.com/algolia/instantsearch/issues/2408)) ([bea43db](https://github.com/algolia/instantsearch/commit/bea43db)), closes [#2386](https://github.com/algolia/instantsearch/issues/2386)
+- **selector:** root classname is applied twice ([#2423](https://github.com/algolia/instantsearch/issues/2423)) ([44dca11](https://github.com/algolia/instantsearch/commit/44dca11)), closes [#2396](https://github.com/algolia/instantsearch/issues/2396) [#2397](https://github.com/algolia/instantsearch/issues/2397)
+- **webpack.dev:** sourcemaps in dev ([#2422](https://github.com/algolia/instantsearch/issues/2422)) ([ba6ca0a](https://github.com/algolia/instantsearch/commit/ba6ca0a))
 
 ### Features
 
-* **menu-select:** add menu select widget ([#2316](https://github.com/algolia/instantsearch.js/issues/2316)) ([680f9bd](https://github.com/algolia/instantsearch.js/commit/680f9bd))
-
-
+- **menu-select:** add menu select widget ([#2316](https://github.com/algolia/instantsearch/issues/2316)) ([680f9bd](https://github.com/algolia/instantsearch/commit/680f9bd))
 
 <a name="2.2.0-beta.1"></a>
-# [2.2.0-beta.1](https://github.com/algolia/instantsearch.js/compare/v2.1.4...v2.2.0-beta.1) (2017-09-18)
 
+# [2.2.0-beta.1](https://github.com/algolia/instantsearch/compare/v2.1.4...v2.2.0-beta.1) (2017-09-18)
 
 ### Features
 
-* **analytics:** Push pagination ([#2337](https://github.com/algolia/instantsearch.js/issues/2337)) ([94ce086](https://github.com/algolia/instantsearch.js/commit/94ce086))
-* **hitsPerPageSelector:** default hits per page setting ([4efd43e](https://github.com/algolia/instantsearch.js/commit/4efd43e))
-* **hitsPerPageSelector:** default hits per page setting ([355f080](https://github.com/algolia/instantsearch.js/commit/355f080))
-
-
+- **analytics:** Push pagination ([#2337](https://github.com/algolia/instantsearch/issues/2337)) ([94ce086](https://github.com/algolia/instantsearch/commit/94ce086))
+- **hitsPerPageSelector:** default hits per page setting ([4efd43e](https://github.com/algolia/instantsearch/commit/4efd43e))
+- **hitsPerPageSelector:** default hits per page setting ([355f080](https://github.com/algolia/instantsearch/commit/355f080))
 
 <a name="2.1.6"></a>
-## [2.1.6](https://github.com/algolia/instantsearch.js/compare/v2.1.5...v2.1.6) (2017-09-26)
 
+## [2.1.6](https://github.com/algolia/instantsearch/compare/v2.1.5...v2.1.6) (2017-09-26)
 
 ### Bug Fixes
 
-* **deps:** update dependency documentation to v^5.0.0 ([#2355](https://github.com/algolia/instantsearch.js/issues/2355)) ([489647a](https://github.com/algolia/instantsearch.js/commit/489647a))
-* **searchbox:** use initial input value if provided in the dom ([#2342](https://github.com/algolia/instantsearch.js/issues/2342)) ([180902a](https://github.com/algolia/instantsearch.js/commit/180902a)), closes [#2289](https://github.com/algolia/instantsearch.js/issues/2289)
-
-
+- **deps:** update dependency documentation to v^5.0.0 ([#2355](https://github.com/algolia/instantsearch/issues/2355)) ([489647a](https://github.com/algolia/instantsearch/commit/489647a))
+- **searchbox:** use initial input value if provided in the dom ([#2342](https://github.com/algolia/instantsearch/issues/2342)) ([180902a](https://github.com/algolia/instantsearch/commit/180902a)), closes [#2289](https://github.com/algolia/instantsearch/issues/2289)
 
 <a name="2.1.5"></a>
-## [2.1.5](https://github.com/algolia/instantsearch.js/compare/v2.1.4...v2.1.5) (2017-09-25)
 
+## [2.1.5](https://github.com/algolia/instantsearch/compare/v2.1.4...v2.1.5) (2017-09-25)
 
 ### Bug Fixes
 
-* **deps:** update dependency algolia-frontend-components to v^0.0.33 ([#2341](https://github.com/algolia/instantsearch.js/issues/2341)) ([16994d8](https://github.com/algolia/instantsearch.js/commit/16994d8))
-* **price-ranges:** update call to refine ([#2377](https://github.com/algolia/instantsearch.js/issues/2377)) ([34915d7](https://github.com/algolia/instantsearch.js/commit/34915d7))
-* **slider:** Fix range slider pips and value 0 ([#2350](https://github.com/algolia/instantsearch.js/issues/2350)) ([fa0dc09](https://github.com/algolia/instantsearch.js/commit/fa0dc09)), closes [#2343](https://github.com/algolia/instantsearch.js/issues/2343)
-
-
+- **deps:** update dependency algolia-frontend-components to v^0.0.33 ([#2341](https://github.com/algolia/instantsearch/issues/2341)) ([16994d8](https://github.com/algolia/instantsearch/commit/16994d8))
+- **price-ranges:** update call to refine ([#2377](https://github.com/algolia/instantsearch/issues/2377)) ([34915d7](https://github.com/algolia/instantsearch/commit/34915d7))
+- **slider:** Fix range slider pips and value 0 ([#2350](https://github.com/algolia/instantsearch/issues/2350)) ([fa0dc09](https://github.com/algolia/instantsearch/commit/fa0dc09)), closes [#2343](https://github.com/algolia/instantsearch/issues/2343)
 
 <a name="2.1.4"></a>
-## [2.1.4](https://github.com/algolia/instantsearch.js/compare/v2.1.3...v2.1.4) (2017-09-14)
 
+## [2.1.4](https://github.com/algolia/instantsearch/compare/v2.1.3...v2.1.4) (2017-09-14)
 
 ### Bug Fixes
 
-* **release-script:** Add the generation of changelog for the release ([#2333](https://github.com/algolia/instantsearch.js/issues/2333)) ([9a2f70b](https://github.com/algolia/instantsearch.js/commit/9a2f70b))
-* **slider:** edge case when min > max ([#2336](https://github.com/algolia/instantsearch.js/issues/2336)) ([8830ab0](https://github.com/algolia/instantsearch.js/commit/8830ab0))
-* **slider:** Fix range slider dev env ([#2320](https://github.com/algolia/instantsearch.js/issues/2320)) ([e78de70](https://github.com/algolia/instantsearch.js/commit/e78de70))
-* **slider:** use algolia fork of rheostat ([#2335](https://github.com/algolia/instantsearch.js/issues/2335)) ([9eae009](https://github.com/algolia/instantsearch.js/commit/9eae009))
-
-
+- **release-script:** Add the generation of changelog for the release ([#2333](https://github.com/algolia/instantsearch/issues/2333)) ([9a2f70b](https://github.com/algolia/instantsearch/commit/9a2f70b))
+- **slider:** edge case when min > max ([#2336](https://github.com/algolia/instantsearch/issues/2336)) ([8830ab0](https://github.com/algolia/instantsearch/commit/8830ab0))
+- **slider:** Fix range slider dev env ([#2320](https://github.com/algolia/instantsearch/issues/2320)) ([e78de70](https://github.com/algolia/instantsearch/commit/e78de70))
+- **slider:** use algolia fork of rheostat ([#2335](https://github.com/algolia/instantsearch/issues/2335)) ([9eae009](https://github.com/algolia/instantsearch/commit/9eae009))
 
 <a name="2.1.3"></a>
-## [2.1.3](https://github.com/algolia/instantsearch.js/compare/v2.1.2...v2.1.3) (2017-09-05)
 
+## [2.1.3](https://github.com/algolia/instantsearch/compare/v2.1.2...v2.1.3) (2017-09-05)
 
 ### Bug Fixes
 
-* **Pagination:** add `autohideContainerHOC` to <Pagination /> ([#2296](https://github.com/algolia/instantsearch.js/issues/2296)) ([545f076](https://github.com/algolia/instantsearch.js/commit/545f076))
-* **sffv:** no error when not providing noResults and no results ([#2310](https://github.com/algolia/instantsearch.js/issues/2310)) ([cc02b71](https://github.com/algolia/instantsearch.js/commit/cc02b71)), closes [#2087](https://github.com/algolia/instantsearch.js/issues/2087)
-
-
+- **Pagination:** add `autohideContainerHOC` to <Pagination /> ([#2296](https://github.com/algolia/instantsearch/issues/2296)) ([545f076](https://github.com/algolia/instantsearch/commit/545f076))
+- **sffv:** no error when not providing noResults and no results ([#2310](https://github.com/algolia/instantsearch/issues/2310)) ([cc02b71](https://github.com/algolia/instantsearch/commit/cc02b71)), closes [#2087](https://github.com/algolia/instantsearch/issues/2087)
 
 <a name="2.1.2"></a>
-## [2.1.2](https://github.com/algolia/instantsearch.js/compare/v2.1.1...v2.1.2) (2017-08-24)
 
+## [2.1.2](https://github.com/algolia/instantsearch/compare/v2.1.1...v2.1.2) (2017-08-24)
 
 ### Bug Fixes
 
-* **es:** wrong path to files ([#2295](https://github.com/algolia/instantsearch.js/issues/2295)) ([a437e19](https://github.com/algolia/instantsearch.js/commit/a437e19))
-
-
+- **es:** wrong path to files ([#2295](https://github.com/algolia/instantsearch/issues/2295)) ([a437e19](https://github.com/algolia/instantsearch/commit/a437e19))
 
 <a name="2.1.1"></a>
-## [2.1.1](https://github.com/algolia/instantsearch.js/compare/v2.1.0...v2.1.1) (2017-08-23)
 
+## [2.1.1](https://github.com/algolia/instantsearch/compare/v2.1.0...v2.1.1) (2017-08-23)
 
 ### Bug Fixes
 
-* **build:** provide unminified css as well ([#2292](https://github.com/algolia/instantsearch.js/issues/2292)) ([a79e067](https://github.com/algolia/instantsearch.js/commit/a79e067))
-
-
+- **build:** provide unminified css as well ([#2292](https://github.com/algolia/instantsearch/issues/2292)) ([a79e067](https://github.com/algolia/instantsearch/commit/a79e067))
 
 <a name="2.1.0"></a>
-# [2.1.0](https://github.com/algolia/instantsearch.js/compare/v2.1.0-beta.4...v2.1.0) (2017-08-21)
 
+# [2.1.0](https://github.com/algolia/instantsearch/compare/v2.1.0-beta.4...v2.1.0) (2017-08-21)
 
 ### Bug Fixes
 
-* **nvmrc:** upgrade nodejs version ([#2291](https://github.com/algolia/instantsearch.js/issues/2291)) ([94529d4](https://github.com/algolia/instantsearch.js/commit/94529d4))
-
-
+- **nvmrc:** upgrade nodejs version ([#2291](https://github.com/algolia/instantsearch/issues/2291)) ([94529d4](https://github.com/algolia/instantsearch/commit/94529d4))
 
 <a name="2.0.2"></a>
-## [2.0.2](https://github.com/algolia/instantsearch.js/compare/v2.0.1...v2.0.2) (2017-07-24)
 
+## [2.0.2](https://github.com/algolia/instantsearch/compare/v2.0.1...v2.0.2) (2017-07-24)
 
 ### Bug Fixes
 
-* **doc:** Cosmetic change ([48bb128](https://github.com/algolia/instantsearch.js/commit/48bb128))
-* **search-box:** fix magnifier and reset customization ([4adfade](https://github.com/algolia/instantsearch.js/commit/4adfade))
-* **theme:** enforce box-sizing: border-box ([e26e50d](https://github.com/algolia/instantsearch.js/commit/e26e50d))
-* **url-sync:** remove is_v from url ([f19a1d5](https://github.com/algolia/instantsearch.js/commit/f19a1d5)), closes [#2233](https://github.com/algolia/instantsearch.js/issues/2233)
-
-
+- **doc:** Cosmetic change ([48bb128](https://github.com/algolia/instantsearch/commit/48bb128))
+- **search-box:** fix magnifier and reset customization ([4adfade](https://github.com/algolia/instantsearch/commit/4adfade))
+- **theme:** enforce box-sizing: border-box ([e26e50d](https://github.com/algolia/instantsearch/commit/e26e50d))
+- **url-sync:** remove is_v from url ([f19a1d5](https://github.com/algolia/instantsearch/commit/f19a1d5)), closes [#2233](https://github.com/algolia/instantsearch/issues/2233)
 
 <a name="2.0.1"></a>
-## [2.0.1](https://github.com/algolia/instantsearch.js/compare/v2.0.0...v2.0.1) (2017-07-12)
 
-
+## [2.0.1](https://github.com/algolia/instantsearch/compare/v2.0.0...v2.0.1) (2017-07-12)
 
 <a name="2.0.0"></a>
-# [2.0.0](https://github.com/algolia/instantsearch.js/compare/v1.11.15...v2.0.0) (2017-07-01)
 
+# [2.0.0](https://github.com/algolia/instantsearch/compare/v1.11.15...v2.0.0) (2017-07-01)
 
 ### Bug Fixes
 
-* **argos-ci:** blur the active element ([66d0551](https://github.com/algolia/instantsearch.js/commit/66d0551))
-* **connectNumericRefinementList:** reset page on refine ([22ec08d](https://github.com/algolia/instantsearch.js/commit/22ec08d))
-* **doc.build:** watch & rebuild `.pug` ([16d8542](https://github.com/algolia/instantsearch.js/commit/16d8542))
-* **doc.build/autoprefixer:** update mtime for onlyChanged plugin ([3b83e58](https://github.com/algolia/instantsearch.js/commit/3b83e58))
-* **escapeHits:** dont apply configuration if not requested ([c89f99d](https://github.com/algolia/instantsearch.js/commit/c89f99d))
-
+- **argos-ci:** blur the active element ([66d0551](https://github.com/algolia/instantsearch/commit/66d0551))
+- **connectNumericRefinementList:** reset page on refine ([22ec08d](https://github.com/algolia/instantsearch/commit/22ec08d))
+- **doc.build:** watch & rebuild `.pug` ([16d8542](https://github.com/algolia/instantsearch/commit/16d8542))
+- **doc.build/autoprefixer:** update mtime for onlyChanged plugin ([3b83e58](https://github.com/algolia/instantsearch/commit/3b83e58))
+- **escapeHits:** dont apply configuration if not requested ([c89f99d](https://github.com/algolia/instantsearch/commit/c89f99d))
 
 ### Features
 
-* **searchFunction:** make search function provide a better API ([8fc0831](https://github.com/algolia/instantsearch.js/commit/8fc0831))
-
-
+- **searchFunction:** make search function provide a better API ([8fc0831](https://github.com/algolia/instantsearch/commit/8fc0831))
 
 <a name="2.0.0-beta.5"></a>
-# [2.0.0-beta.5](https://github.com/algolia/instantsearch.js/compare/v1.11.12...v2.0.0-beta.5) (2017-06-01)
 
+# [2.0.0-beta.5](https://github.com/algolia/instantsearch/compare/v1.11.12...v2.0.0-beta.5) (2017-06-01)
 
 ### Bug Fixes
 
-* **Slider:** dont call `refine()` when it's disabled ([f1eabc9](https://github.com/algolia/instantsearch.js/commit/f1eabc9))
-
+- **Slider:** dont call `refine()` when it's disabled ([f1eabc9](https://github.com/algolia/instantsearch/commit/f1eabc9))
 
 ### Features
 
-* **hits:** opt-in xss filtering for hits and infinite hits. FIX #2138 ([4f67b48](https://github.com/algolia/instantsearch.js/commit/4f67b48)), closes [#2138](https://github.com/algolia/instantsearch.js/issues/2138)
-
-
+- **hits:** opt-in xss filtering for hits and infinite hits. FIX #2138 ([4f67b48](https://github.com/algolia/instantsearch/commit/4f67b48)), closes [#2138](https://github.com/algolia/instantsearch/issues/2138)
 
 <a name="2.0.0-beta.4"></a>
-# [2.0.0-beta.4](https://github.com/algolia/instantsearch.js/compare/v1.11.11...v2.0.0-beta.4) (2017-05-24)
 
+# [2.0.0-beta.4](https://github.com/algolia/instantsearch/compare/v1.11.11...v2.0.0-beta.4) (2017-05-24)
 
 ### Bug Fixes
 
-* **misc:** IE 11 support ([072edfe](https://github.com/algolia/instantsearch.js/commit/072edfe))
-* **misc:** IE11 support without using transpiler ([324f062](https://github.com/algolia/instantsearch.js/commit/324f062))
-* **show-more:** should hide button when show more is not available (#2161) ([fbca3e6](https://github.com/algolia/instantsearch.js/commit/fbca3e6)), closes [#2160](https://github.com/algolia/instantsearch.js/issues/2160)
-* **Slider:** handle edge case where `min === max` ([22a5614](https://github.com/algolia/instantsearch.js/commit/22a5614))
-* **Slider:** restore `slider--handle-lower` && `slider--handle-upper` ([64d7ad2](https://github.com/algolia/instantsearch.js/commit/64d7ad2))
-
-
+- **misc:** IE 11 support ([072edfe](https://github.com/algolia/instantsearch/commit/072edfe))
+- **misc:** IE11 support without using transpiler ([324f062](https://github.com/algolia/instantsearch/commit/324f062))
+- **show-more:** should hide button when show more is not available (#2161) ([fbca3e6](https://github.com/algolia/instantsearch/commit/fbca3e6)), closes [#2160](https://github.com/algolia/instantsearch/issues/2160)
+- **Slider:** handle edge case where `min === max` ([22a5614](https://github.com/algolia/instantsearch/commit/22a5614))
+- **Slider:** restore `slider--handle-lower` && `slider--handle-upper` ([64d7ad2](https://github.com/algolia/instantsearch/commit/64d7ad2))
 
 <a name="2.0.0-beta.2"></a>
-# [2.0.0-beta.2](https://github.com/algolia/instantsearch.js/compare/v1.11.9...v2.0.0-beta.2) (2017-05-17)
 
+# [2.0.0-beta.2](https://github.com/algolia/instantsearch/compare/v1.11.9...v2.0.0-beta.2) (2017-05-17)
 
 ### Bug Fixes
 
-* **autoHideContainer:** dont prevent render with `shouldComponentUpdate` ([8c4b13f](https://github.com/algolia/instantsearch.js/commit/8c4b13f))
-* **clearsQuery:** not applied when only the query was not empty ([e7976ad](https://github.com/algolia/instantsearch.js/commit/e7976ad))
-* **connectors:** ensure `widgetParams` is at least an `{}` ([0c0e98f](https://github.com/algolia/instantsearch.js/commit/0c0e98f))
-* **connectRefinementList:** currentRefinements: return an array instead of first item ([a53223a](https://github.com/algolia/instantsearch.js/commit/a53223a)), closes [#2102](https://github.com/algolia/instantsearch.js/issues/2102)
-* **dev:docs:** dont watch `/docgen/rootFiles` ([ab1a7f5](https://github.com/algolia/instantsearch.js/commit/ab1a7f5))
-* **doc:** add doc for isFirstRendering ([cea6739](https://github.com/algolia/instantsearch.js/commit/cea6739))
-* **docs:** dont filter out `p.type.type` ([881659a](https://github.com/algolia/instantsearch.js/commit/881659a))
-* **documentation.js:** Support for record types ([219ecd9](https://github.com/algolia/instantsearch.js/commit/219ecd9))
-* **documentationjs:** add support litteral string types in type format ([2a08e7d](https://github.com/algolia/instantsearch.js/commit/2a08e7d))
-* **documentationjs:** deeper related types ([6e3121e](https://github.com/algolia/instantsearch.js/commit/6e3121e))
-* **documentationjs:** find related type in TypeApplication ([e0487ee](https://github.com/algolia/instantsearch.js/commit/e0487ee))
-* **documentationjs:** fix 2+ depth structs ([4c8b7ec](https://github.com/algolia/instantsearch.js/commit/4c8b7ec))
-* **documentationjs:** fixed default value parameter ([b62cbc7](https://github.com/algolia/instantsearch.js/commit/b62cbc7))
-* **documentationjs:** records display with , ([8a968f2](https://github.com/algolia/instantsearch.js/commit/8a968f2))
-* **documentationjs:** Updgrade to RC + fixes ([e9f0361](https://github.com/algolia/instantsearch.js/commit/e9f0361))
-* **infinite-hits:** Remove hitsPerPage option (#2128) ([c13e377](https://github.com/algolia/instantsearch.js/commit/c13e377))
-* **live-example:** adapt regex for matching connectors ([774254c](https://github.com/algolia/instantsearch.js/commit/774254c))
-* **pagination:** fix zealous find/replace ([e269d87](https://github.com/algolia/instantsearch.js/commit/e269d87))
-* **price-ranges:** fix test ([fd65cb3](https://github.com/algolia/instantsearch.js/commit/fd65cb3))
-* **price-ranges:** New API uses ranges ([a5a6916](https://github.com/algolia/instantsearch.js/commit/a5a6916))
-* **refinementList:** reimplement show more on refinement list ([72655ab](https://github.com/algolia/instantsearch.js/commit/72655ab))
-* **refinementList:** sffv fix thanks [@julienpa](https://github.com/julienpa) ([30e0e9a](https://github.com/algolia/instantsearch.js/commit/30e0e9a))
-* **sffv:** Fix exhaustive facets ([0cadcc3](https://github.com/algolia/instantsearch.js/commit/0cadcc3))
-* **sortby:** Consistent across widget / connectors + migration ([8e366cc](https://github.com/algolia/instantsearch.js/commit/8e366cc))
-* **widgets/price-ranges:** wrong compute of `templateProps` ([be5e063](https://github.com/algolia/instantsearch.js/commit/be5e063))
-
+- **autoHideContainer:** dont prevent render with `shouldComponentUpdate` ([8c4b13f](https://github.com/algolia/instantsearch/commit/8c4b13f))
+- **clearsQuery:** not applied when only the query was not empty ([e7976ad](https://github.com/algolia/instantsearch/commit/e7976ad))
+- **connectors:** ensure `widgetParams` is at least an `{}` ([0c0e98f](https://github.com/algolia/instantsearch/commit/0c0e98f))
+- **connectRefinementList:** currentRefinements: return an array instead of first item ([a53223a](https://github.com/algolia/instantsearch/commit/a53223a)), closes [#2102](https://github.com/algolia/instantsearch/issues/2102)
+- **dev:docs:** dont watch `/docgen/rootFiles` ([ab1a7f5](https://github.com/algolia/instantsearch/commit/ab1a7f5))
+- **doc:** add doc for isFirstRendering ([cea6739](https://github.com/algolia/instantsearch/commit/cea6739))
+- **docs:** dont filter out `p.type.type` ([881659a](https://github.com/algolia/instantsearch/commit/881659a))
+- **documentation.js:** Support for record types ([219ecd9](https://github.com/algolia/instantsearch/commit/219ecd9))
+- **documentationjs:** add support litteral string types in type format ([2a08e7d](https://github.com/algolia/instantsearch/commit/2a08e7d))
+- **documentationjs:** deeper related types ([6e3121e](https://github.com/algolia/instantsearch/commit/6e3121e))
+- **documentationjs:** find related type in TypeApplication ([e0487ee](https://github.com/algolia/instantsearch/commit/e0487ee))
+- **documentationjs:** fix 2+ depth structs ([4c8b7ec](https://github.com/algolia/instantsearch/commit/4c8b7ec))
+- **documentationjs:** fixed default value parameter ([b62cbc7](https://github.com/algolia/instantsearch/commit/b62cbc7))
+- **documentationjs:** records display with , ([8a968f2](https://github.com/algolia/instantsearch/commit/8a968f2))
+- **documentationjs:** Updgrade to RC + fixes ([e9f0361](https://github.com/algolia/instantsearch/commit/e9f0361))
+- **infinite-hits:** Remove hitsPerPage option (#2128) ([c13e377](https://github.com/algolia/instantsearch/commit/c13e377))
+- **live-example:** adapt regex for matching connectors ([774254c](https://github.com/algolia/instantsearch/commit/774254c))
+- **pagination:** fix zealous find/replace ([e269d87](https://github.com/algolia/instantsearch/commit/e269d87))
+- **price-ranges:** fix test ([fd65cb3](https://github.com/algolia/instantsearch/commit/fd65cb3))
+- **price-ranges:** New API uses ranges ([a5a6916](https://github.com/algolia/instantsearch/commit/a5a6916))
+- **refinementList:** reimplement show more on refinement list ([72655ab](https://github.com/algolia/instantsearch/commit/72655ab))
+- **refinementList:** sffv fix thanks [@julienpa](https://github.com/julienpa) ([30e0e9a](https://github.com/algolia/instantsearch/commit/30e0e9a))
+- **sffv:** Fix exhaustive facets ([0cadcc3](https://github.com/algolia/instantsearch/commit/0cadcc3))
+- **sortby:** Consistent across widget / connectors + migration ([8e366cc](https://github.com/algolia/instantsearch/commit/8e366cc))
+- **widgets/price-ranges:** wrong compute of `templateProps` ([be5e063](https://github.com/algolia/instantsearch/commit/be5e063))
 
 ### Features
 
-* **connectHierarchicalMenu:** remove `currentRefinement` ([3912aaf](https://github.com/algolia/instantsearch.js/commit/3912aaf))
-* **connectHits:** typo `widgetOptions` -> `widgetParams` ([4420231](https://github.com/algolia/instantsearch.js/commit/4420231))
-* **connector:** Add hierarchical menu connector ([f727949](https://github.com/algolia/instantsearch.js/commit/f727949))
-* **connector:** add infinite hits connector ([cdf8675](https://github.com/algolia/instantsearch.js/commit/cdf8675))
-* **connector:** add instantsearchInstance to pagination render ([4fa96dc](https://github.com/algolia/instantsearch.js/commit/4fa96dc))
-* **connector:** add missing jsDoc descriptions ([e26e8e2](https://github.com/algolia/instantsearch.js/commit/e26e8e2))
-* **connector:** add range-slider ([1a02798](https://github.com/algolia/instantsearch.js/commit/1a02798))
-* **connector:** add tests for connectClearAll and connectHierarchicalMenu ([0eb29ec](https://github.com/algolia/instantsearch.js/commit/0eb29ec))
-* **connector:** Adds hits and menu connectors ([77083b7](https://github.com/algolia/instantsearch.js/commit/77083b7))
-* **connector:** Clear and CurrentRefinedValues ([02f7d3e](https://github.com/algolia/instantsearch.js/commit/02f7d3e))
-* **connector:** clearAll connector (iteration 2) ([90aa02e](https://github.com/algolia/instantsearch.js/commit/90aa02e))
-* **connector:** clearAll jsDoc + eslint fixes ([430a420](https://github.com/algolia/instantsearch.js/commit/430a420))
-* **connector:** complete jsdoc + pass instantsearch to view ([e125931](https://github.com/algolia/instantsearch.js/commit/e125931))
-* **connector:** connectClearAll documentation ([9b153aa](https://github.com/algolia/instantsearch.js/commit/9b153aa))
-* **connector:** connectClearAll iteration 2 (fix) ([03653f1](https://github.com/algolia/instantsearch.js/commit/03653f1))
-* **connector:** connectClearAll test ([5409157](https://github.com/algolia/instantsearch.js/commit/5409157))
-* **connector:** connectCurrentRefinedValues (iteration 2) ([68408de](https://github.com/algolia/instantsearch.js/commit/68408de))
-* **connector:** connectHierarchicalMenu (iteration 2) ([589454c](https://github.com/algolia/instantsearch.js/commit/589454c))
-* **connector:** connectHierarchicalMenu jsDoc ([e166090](https://github.com/algolia/instantsearch.js/commit/e166090))
-* **connector:** connectHits (iteration 2) ([bca09af](https://github.com/algolia/instantsearch.js/commit/bca09af))
-* **connector:** connectHitsPerPageSelector (iteration 2) ([26bb273](https://github.com/algolia/instantsearch.js/commit/26bb273))
-* **connector:** connectInfiniteHits (iteration 2) ([410459c](https://github.com/algolia/instantsearch.js/commit/410459c))
-* **connector:** connectNumericRefinementList (iteration 2) ([bfcf860](https://github.com/algolia/instantsearch.js/commit/bfcf860))
-* **connector:** connectNumericSelector (iteration 2) ([1eda8a2](https://github.com/algolia/instantsearch.js/commit/1eda8a2))
-* **connector:** connectNumericSelector jsDoc ([760fcea](https://github.com/algolia/instantsearch.js/commit/760fcea))
-* **connector:** connectRefinementList jsdoc + start document bool isFirstRendering ([52d13de](https://github.com/algolia/instantsearch.js/commit/52d13de))
-* **connector:** connectStats second iteration ([82b1cb3](https://github.com/algolia/instantsearch.js/commit/82b1cb3))
-* **connector:** connectToggle second iteration ([73b0878](https://github.com/algolia/instantsearch.js/commit/73b0878))
-* **connector:** fix createURL usage to generate correct urls ([fdf59d7](https://github.com/algolia/instantsearch.js/commit/fdf59d7))
-* **connector:** fix no param usage on custom infiniteHits ([961348a](https://github.com/algolia/instantsearch.js/commit/961348a))
-* **connector:** fix parameter consistency in connectClearAll ([9ddffd8](https://github.com/algolia/instantsearch.js/commit/9ddffd8))
-* **connector:** Fix parameters for toggle connector ([f96671c](https://github.com/algolia/instantsearch.js/commit/f96671c))
-* **connector:** hits-per-page-selector connector refactoring ([dd794e0](https://github.com/algolia/instantsearch.js/commit/dd794e0))
-* **connector:** jsDoc + check rendering function ([86f9739](https://github.com/algolia/instantsearch.js/commit/86f9739))
-* **connector:** jsDoc connectPagination ([3b284de](https://github.com/algolia/instantsearch.js/commit/3b284de))
-* **connector:** jsDoc for connectMenu ([626d5f1](https://github.com/algolia/instantsearch.js/commit/626d5f1))
-* **connector:** jsDoc updates ([c924043](https://github.com/algolia/instantsearch.js/commit/c924043))
-* **connector:** move clearAll as a rendering option ([ce41cde](https://github.com/algolia/instantsearch.js/commit/ce41cde))
-* **connector:** Numeric selector ([0dc42d2](https://github.com/algolia/instantsearch.js/commit/0dc42d2))
-* **connector:** numericRefinementList connector ([918d971](https://github.com/algolia/instantsearch.js/commit/918d971))
-* **connector:** pagination connector ([7a876f3](https://github.com/algolia/instantsearch.js/commit/7a876f3))
-* **connector:** price ranges connector ([d8bed96](https://github.com/algolia/instantsearch.js/commit/d8bed96))
-* **connector:** provide consistent interface for searchbox renderer ([17d8301](https://github.com/algolia/instantsearch.js/commit/17d8301))
-* **connector:** provide instantsearch instance at render ([12a7935](https://github.com/algolia/instantsearch.js/commit/12a7935))
-* **connector:** refactor search function ([618dca2](https://github.com/algolia/instantsearch.js/commit/618dca2))
-* **connector:** refinement list connector ([c8fcf4e](https://github.com/algolia/instantsearch.js/commit/c8fcf4e))
-* **connector:** remove legacy implementation of toggle ([04437b0](https://github.com/algolia/instantsearch.js/commit/04437b0))
-* **connector:** remove non relevant instantsearch API from test ([c5dce5c](https://github.com/algolia/instantsearch.js/commit/c5dce5c))
-* **connector:** remove unused parameter to searchbox connector ([e639f65](https://github.com/algolia/instantsearch.js/commit/e639f65))
-* **connector:** searchbox connector ([70f8e1f](https://github.com/algolia/instantsearch.js/commit/70f8e1f))
-* **connector:** small internal refactoring for SFFV ([cb5c1fa](https://github.com/algolia/instantsearch.js/commit/cb5c1fa))
-* **connector:** sort by selector connector ([b9847cf](https://github.com/algolia/instantsearch.js/commit/b9847cf))
-* **connector:** star rating connector ([9996b4d](https://github.com/algolia/instantsearch.js/commit/9996b4d))
-* **connector:** stats connector ([680743b](https://github.com/algolia/instantsearch.js/commit/680743b))
-* **connector:** test connectHits ([89c86a5](https://github.com/algolia/instantsearch.js/commit/89c86a5))
-* **connector:** test connectHitsPerPageSelector ([9caab02](https://github.com/algolia/instantsearch.js/commit/9caab02))
-* **connector:** test connectInfiniteHits ([e67e75e](https://github.com/algolia/instantsearch.js/commit/e67e75e))
-* **connector:** test connectMenu ([03c6f11](https://github.com/algolia/instantsearch.js/commit/03c6f11))
-* **connector:** test connectNumericRefinementList ([2f26251](https://github.com/algolia/instantsearch.js/commit/2f26251))
-* **connector:** test connectNumericSelector ([182779b](https://github.com/algolia/instantsearch.js/commit/182779b))
-* **connector:** test connectPagination ([6f125b7](https://github.com/algolia/instantsearch.js/commit/6f125b7))
-* **connector:** test connectPriceRanges ([f5dfba7](https://github.com/algolia/instantsearch.js/commit/f5dfba7))
-* **connector:** test connectRangeSlider ([4f6c180](https://github.com/algolia/instantsearch.js/commit/4f6c180))
-* **connector:** test connectSearchBox ([b4d7e1b](https://github.com/algolia/instantsearch.js/commit/b4d7e1b))
-* **connector:** test connectSortBySelector ([e8825df](https://github.com/algolia/instantsearch.js/commit/e8825df))
-* **connector:** test connectStarRating ([0c16f15](https://github.com/algolia/instantsearch.js/commit/0c16f15)), closes [#2002](https://github.com/algolia/instantsearch.js/issues/2002)
-* **connector:** test connectStats ([c992288](https://github.com/algolia/instantsearch.js/commit/c992288))
-* **connector:** test connectToggle ([441293d](https://github.com/algolia/instantsearch.js/commit/441293d))
-* **connector:** toggle connector ([bf9a9c0](https://github.com/algolia/instantsearch.js/commit/bf9a9c0))
-* **connector:** update doc, move setValue to refine in SortBySelector ([2486f36](https://github.com/algolia/instantsearch.js/commit/2486f36))
-* **connector:** update jsDoc descriptions ([f83022a](https://github.com/algolia/instantsearch.js/commit/f83022a))
-* **connectors:** `refinement-list` widget (iteration2) ([1c6c3a5](https://github.com/algolia/instantsearch.js/commit/1c6c3a5))
-* **connectors:** `setValue()` -> `refine()` / `currentValue` -> `currentRefinement` ([ec7806c](https://github.com/algolia/instantsearch.js/commit/ec7806c))
-* **connectors:** `sortBy` to `['isRefined', 'count:desc']` ([01219f1](https://github.com/algolia/instantsearch.js/commit/01219f1))
-* **connectors:** add `currentRefinement` on `hierarchical-menu` ([154cdb5](https://github.com/algolia/instantsearch.js/commit/154cdb5))
-* **connectors:** connectPagination (iteration2) ([8a615f6](https://github.com/algolia/instantsearch.js/commit/8a615f6))
-* **connectors:** connectPriceRanges (iteration2) ([e34968e](https://github.com/algolia/instantsearch.js/commit/e34968e))
-* **connectors:** connectRangeSlider (iteration2) ([6073d94](https://github.com/algolia/instantsearch.js/commit/6073d94))
-* **connectors:** connectSearchBox (iteration2) ([3161c9b](https://github.com/algolia/instantsearch.js/commit/3161c9b))
-* **connectors:** connectSortBySelector (iteration 2) ([dec2d31](https://github.com/algolia/instantsearch.js/commit/dec2d31))
-* **connectors:** connectStarRating (iteration2) ([7ef7b6b](https://github.com/algolia/instantsearch.js/commit/7ef7b6b))
-* **connectors:** connectToggle, forward initial options to render ([704a455](https://github.com/algolia/instantsearch.js/commit/704a455))
-* **connectors:** dissociate logic & view for `menu` widget ([5a02c88](https://github.com/algolia/instantsearch.js/commit/5a02c88))
-* **connectors:** expose connectors on `instantsearch` instance ([ff799d0](https://github.com/algolia/instantsearch.js/commit/ff799d0))
-* **connectors:** forward `widgetParams` to `renderFn` ([54222a3](https://github.com/algolia/instantsearch.js/commit/54222a3))
-* **connectors:** jsDoc connectHitsPerPageSelector ([75243b0](https://github.com/algolia/instantsearch.js/commit/75243b0))
-* **connectors:** provide `currentRefinement` on menu ([fb7bc5e](https://github.com/algolia/instantsearch.js/commit/fb7bc5e))
-* **connectors:** provide `currentRefinement` on numeric refinement list ([91f7928](https://github.com/algolia/instantsearch.js/commit/91f7928))
-* **connectors.numeric-selector:** `currentValue` -> `currentRefinement` / `setValue()` -> `refine()` ([998faf1](https://github.com/algolia/instantsearch.js/commit/998faf1))
-* **connectors.price-ranges:** provides `currentRefiment` value ([39af437](https://github.com/algolia/instantsearch.js/commit/39af437))
-* **connectors.refinement-list:** provide `currentRefinement` to `renderFn` ([7e86be3](https://github.com/algolia/instantsearch.js/commit/7e86be3))
-* **connectors.star-rating:** provide `currentRefinement` value ([c08b3e4](https://github.com/algolia/instantsearch.js/commit/c08b3e4))
-* **connectRefinementList:** first good iteration ([88fd6d5](https://github.com/algolia/instantsearch.js/commit/88fd6d5))
-* **doc:** re-bootstrap doc based on instantsearch-android ([e4e816e](https://github.com/algolia/instantsearch.js/commit/e4e816e))
-* **docs:** bootstrap v2 docs ([0db6caf](https://github.com/algolia/instantsearch.js/commit/0db6caf))
-* **docs:** pages structure ([fe89dcf](https://github.com/algolia/instantsearch.js/commit/fe89dcf))
-* **getting-started:** add `.zip` boilerplate ([7d3769c](https://github.com/algolia/instantsearch.js/commit/7d3769c))
-* **getting-started:** add result example of guide ([78d9017](https://github.com/algolia/instantsearch.js/commit/78d9017))
-* **live-example:** add support of connectors ([e4f3158](https://github.com/algolia/instantsearch.js/commit/e4f3158))
-* **live-example:** include jquery on connectors example pages ([f32936f](https://github.com/algolia/instantsearch.js/commit/f32936f))
-* **main:** export all the widgets at once ([4bc2d21](https://github.com/algolia/instantsearch.js/commit/4bc2d21))
-* **numeric-refinement-list:** `facetValues` -> `items` / `toggleRefinement` -> `refine` ([eb2c993](https://github.com/algolia/instantsearch.js/commit/eb2c993))
-* **pagination:** `setPage()` -> `refine()` / `currentPage` -> `currentRefinement` ([f783fea](https://github.com/algolia/instantsearch.js/commit/f783fea))
-* **range-slider:** use `rheostat` as slider component (#2142) ([910a0a0](https://github.com/algolia/instantsearch.js/commit/910a0a0))
-* **searchFunction:** Update API, fix #1924 ([c7beb1d](https://github.com/algolia/instantsearch.js/commit/c7beb1d)), closes [#1924](https://github.com/algolia/instantsearch.js/issues/1924)
-* **sort-by-selector:** `currentValue` -> `currentRefinement` ([e94c8c7](https://github.com/algolia/instantsearch.js/commit/e94c8c7))
-* **Template:** remove support for react element ([ca2ab44](https://github.com/algolia/instantsearch.js/commit/ca2ab44))
-
-
+- **connectHierarchicalMenu:** remove `currentRefinement` ([3912aaf](https://github.com/algolia/instantsearch/commit/3912aaf))
+- **connectHits:** typo `widgetOptions` -> `widgetParams` ([4420231](https://github.com/algolia/instantsearch/commit/4420231))
+- **connector:** Add hierarchical menu connector ([f727949](https://github.com/algolia/instantsearch/commit/f727949))
+- **connector:** add infinite hits connector ([cdf8675](https://github.com/algolia/instantsearch/commit/cdf8675))
+- **connector:** add instantsearchInstance to pagination render ([4fa96dc](https://github.com/algolia/instantsearch/commit/4fa96dc))
+- **connector:** add missing jsDoc descriptions ([e26e8e2](https://github.com/algolia/instantsearch/commit/e26e8e2))
+- **connector:** add range-slider ([1a02798](https://github.com/algolia/instantsearch/commit/1a02798))
+- **connector:** add tests for connectClearAll and connectHierarchicalMenu ([0eb29ec](https://github.com/algolia/instantsearch/commit/0eb29ec))
+- **connector:** Adds hits and menu connectors ([77083b7](https://github.com/algolia/instantsearch/commit/77083b7))
+- **connector:** Clear and CurrentRefinedValues ([02f7d3e](https://github.com/algolia/instantsearch/commit/02f7d3e))
+- **connector:** clearAll connector (iteration 2) ([90aa02e](https://github.com/algolia/instantsearch/commit/90aa02e))
+- **connector:** clearAll jsDoc + eslint fixes ([430a420](https://github.com/algolia/instantsearch/commit/430a420))
+- **connector:** complete jsdoc + pass instantsearch to view ([e125931](https://github.com/algolia/instantsearch/commit/e125931))
+- **connector:** connectClearAll documentation ([9b153aa](https://github.com/algolia/instantsearch/commit/9b153aa))
+- **connector:** connectClearAll iteration 2 (fix) ([03653f1](https://github.com/algolia/instantsearch/commit/03653f1))
+- **connector:** connectClearAll test ([5409157](https://github.com/algolia/instantsearch/commit/5409157))
+- **connector:** connectCurrentRefinedValues (iteration 2) ([68408de](https://github.com/algolia/instantsearch/commit/68408de))
+- **connector:** connectHierarchicalMenu (iteration 2) ([589454c](https://github.com/algolia/instantsearch/commit/589454c))
+- **connector:** connectHierarchicalMenu jsDoc ([e166090](https://github.com/algolia/instantsearch/commit/e166090))
+- **connector:** connectHits (iteration 2) ([bca09af](https://github.com/algolia/instantsearch/commit/bca09af))
+- **connector:** connectHitsPerPageSelector (iteration 2) ([26bb273](https://github.com/algolia/instantsearch/commit/26bb273))
+- **connector:** connectInfiniteHits (iteration 2) ([410459c](https://github.com/algolia/instantsearch/commit/410459c))
+- **connector:** connectNumericRefinementList (iteration 2) ([bfcf860](https://github.com/algolia/instantsearch/commit/bfcf860))
+- **connector:** connectNumericSelector (iteration 2) ([1eda8a2](https://github.com/algolia/instantsearch/commit/1eda8a2))
+- **connector:** connectNumericSelector jsDoc ([760fcea](https://github.com/algolia/instantsearch/commit/760fcea))
+- **connector:** connectRefinementList jsdoc + start document bool isFirstRendering ([52d13de](https://github.com/algolia/instantsearch/commit/52d13de))
+- **connector:** connectStats second iteration ([82b1cb3](https://github.com/algolia/instantsearch/commit/82b1cb3))
+- **connector:** connectToggle second iteration ([73b0878](https://github.com/algolia/instantsearch/commit/73b0878))
+- **connector:** fix createURL usage to generate correct urls ([fdf59d7](https://github.com/algolia/instantsearch/commit/fdf59d7))
+- **connector:** fix no param usage on custom infiniteHits ([961348a](https://github.com/algolia/instantsearch/commit/961348a))
+- **connector:** fix parameter consistency in connectClearAll ([9ddffd8](https://github.com/algolia/instantsearch/commit/9ddffd8))
+- **connector:** Fix parameters for toggle connector ([f96671c](https://github.com/algolia/instantsearch/commit/f96671c))
+- **connector:** hits-per-page-selector connector refactoring ([dd794e0](https://github.com/algolia/instantsearch/commit/dd794e0))
+- **connector:** jsDoc + check rendering function ([86f9739](https://github.com/algolia/instantsearch/commit/86f9739))
+- **connector:** jsDoc connectPagination ([3b284de](https://github.com/algolia/instantsearch/commit/3b284de))
+- **connector:** jsDoc for connectMenu ([626d5f1](https://github.com/algolia/instantsearch/commit/626d5f1))
+- **connector:** jsDoc updates ([c924043](https://github.com/algolia/instantsearch/commit/c924043))
+- **connector:** move clearAll as a rendering option ([ce41cde](https://github.com/algolia/instantsearch/commit/ce41cde))
+- **connector:** Numeric selector ([0dc42d2](https://github.com/algolia/instantsearch/commit/0dc42d2))
+- **connector:** numericRefinementList connector ([918d971](https://github.com/algolia/instantsearch/commit/918d971))
+- **connector:** pagination connector ([7a876f3](https://github.com/algolia/instantsearch/commit/7a876f3))
+- **connector:** price ranges connector ([d8bed96](https://github.com/algolia/instantsearch/commit/d8bed96))
+- **connector:** provide consistent interface for searchbox renderer ([17d8301](https://github.com/algolia/instantsearch/commit/17d8301))
+- **connector:** provide instantsearch instance at render ([12a7935](https://github.com/algolia/instantsearch/commit/12a7935))
+- **connector:** refactor search function ([618dca2](https://github.com/algolia/instantsearch/commit/618dca2))
+- **connector:** refinement list connector ([c8fcf4e](https://github.com/algolia/instantsearch/commit/c8fcf4e))
+- **connector:** remove legacy implementation of toggle ([04437b0](https://github.com/algolia/instantsearch/commit/04437b0))
+- **connector:** remove non relevant instantsearch API from test ([c5dce5c](https://github.com/algolia/instantsearch/commit/c5dce5c))
+- **connector:** remove unused parameter to searchbox connector ([e639f65](https://github.com/algolia/instantsearch/commit/e639f65))
+- **connector:** searchbox connector ([70f8e1f](https://github.com/algolia/instantsearch/commit/70f8e1f))
+- **connector:** small internal refactoring for SFFV ([cb5c1fa](https://github.com/algolia/instantsearch/commit/cb5c1fa))
+- **connector:** sort by selector connector ([b9847cf](https://github.com/algolia/instantsearch/commit/b9847cf))
+- **connector:** star rating connector ([9996b4d](https://github.com/algolia/instantsearch/commit/9996b4d))
+- **connector:** stats connector ([680743b](https://github.com/algolia/instantsearch/commit/680743b))
+- **connector:** test connectHits ([89c86a5](https://github.com/algolia/instantsearch/commit/89c86a5))
+- **connector:** test connectHitsPerPageSelector ([9caab02](https://github.com/algolia/instantsearch/commit/9caab02))
+- **connector:** test connectInfiniteHits ([e67e75e](https://github.com/algolia/instantsearch/commit/e67e75e))
+- **connector:** test connectMenu ([03c6f11](https://github.com/algolia/instantsearch/commit/03c6f11))
+- **connector:** test connectNumericRefinementList ([2f26251](https://github.com/algolia/instantsearch/commit/2f26251))
+- **connector:** test connectNumericSelector ([182779b](https://github.com/algolia/instantsearch/commit/182779b))
+- **connector:** test connectPagination ([6f125b7](https://github.com/algolia/instantsearch/commit/6f125b7))
+- **connector:** test connectPriceRanges ([f5dfba7](https://github.com/algolia/instantsearch/commit/f5dfba7))
+- **connector:** test connectRangeSlider ([4f6c180](https://github.com/algolia/instantsearch/commit/4f6c180))
+- **connector:** test connectSearchBox ([b4d7e1b](https://github.com/algolia/instantsearch/commit/b4d7e1b))
+- **connector:** test connectSortBySelector ([e8825df](https://github.com/algolia/instantsearch/commit/e8825df))
+- **connector:** test connectStarRating ([0c16f15](https://github.com/algolia/instantsearch/commit/0c16f15)), closes [#2002](https://github.com/algolia/instantsearch/issues/2002)
+- **connector:** test connectStats ([c992288](https://github.com/algolia/instantsearch/commit/c992288))
+- **connector:** test connectToggle ([441293d](https://github.com/algolia/instantsearch/commit/441293d))
+- **connector:** toggle connector ([bf9a9c0](https://github.com/algolia/instantsearch/commit/bf9a9c0))
+- **connector:** update doc, move setValue to refine in SortBySelector ([2486f36](https://github.com/algolia/instantsearch/commit/2486f36))
+- **connector:** update jsDoc descriptions ([f83022a](https://github.com/algolia/instantsearch/commit/f83022a))
+- **connectors:** `refinement-list` widget (iteration2) ([1c6c3a5](https://github.com/algolia/instantsearch/commit/1c6c3a5))
+- **connectors:** `setValue()` -> `refine()` / `currentValue` -> `currentRefinement` ([ec7806c](https://github.com/algolia/instantsearch/commit/ec7806c))
+- **connectors:** `sortBy` to `['isRefined', 'count:desc']` ([01219f1](https://github.com/algolia/instantsearch/commit/01219f1))
+- **connectors:** add `currentRefinement` on `hierarchical-menu` ([154cdb5](https://github.com/algolia/instantsearch/commit/154cdb5))
+- **connectors:** connectPagination (iteration2) ([8a615f6](https://github.com/algolia/instantsearch/commit/8a615f6))
+- **connectors:** connectPriceRanges (iteration2) ([e34968e](https://github.com/algolia/instantsearch/commit/e34968e))
+- **connectors:** connectRangeSlider (iteration2) ([6073d94](https://github.com/algolia/instantsearch/commit/6073d94))
+- **connectors:** connectSearchBox (iteration2) ([3161c9b](https://github.com/algolia/instantsearch/commit/3161c9b))
+- **connectors:** connectSortBySelector (iteration 2) ([dec2d31](https://github.com/algolia/instantsearch/commit/dec2d31))
+- **connectors:** connectStarRating (iteration2) ([7ef7b6b](https://github.com/algolia/instantsearch/commit/7ef7b6b))
+- **connectors:** connectToggle, forward initial options to render ([704a455](https://github.com/algolia/instantsearch/commit/704a455))
+- **connectors:** dissociate logic & view for `menu` widget ([5a02c88](https://github.com/algolia/instantsearch/commit/5a02c88))
+- **connectors:** expose connectors on `instantsearch` instance ([ff799d0](https://github.com/algolia/instantsearch/commit/ff799d0))
+- **connectors:** forward `widgetParams` to `renderFn` ([54222a3](https://github.com/algolia/instantsearch/commit/54222a3))
+- **connectors:** jsDoc connectHitsPerPageSelector ([75243b0](https://github.com/algolia/instantsearch/commit/75243b0))
+- **connectors:** provide `currentRefinement` on menu ([fb7bc5e](https://github.com/algolia/instantsearch/commit/fb7bc5e))
+- **connectors:** provide `currentRefinement` on numeric refinement list ([91f7928](https://github.com/algolia/instantsearch/commit/91f7928))
+- **connectors.numeric-selector:** `currentValue` -> `currentRefinement` / `setValue()` -> `refine()` ([998faf1](https://github.com/algolia/instantsearch/commit/998faf1))
+- **connectors.price-ranges:** provides `currentRefiment` value ([39af437](https://github.com/algolia/instantsearch/commit/39af437))
+- **connectors.refinement-list:** provide `currentRefinement` to `renderFn` ([7e86be3](https://github.com/algolia/instantsearch/commit/7e86be3))
+- **connectors.star-rating:** provide `currentRefinement` value ([c08b3e4](https://github.com/algolia/instantsearch/commit/c08b3e4))
+- **connectRefinementList:** first good iteration ([88fd6d5](https://github.com/algolia/instantsearch/commit/88fd6d5))
+- **doc:** re-bootstrap doc based on instantsearch-android ([e4e816e](https://github.com/algolia/instantsearch/commit/e4e816e))
+- **docs:** bootstrap v2 docs ([0db6caf](https://github.com/algolia/instantsearch/commit/0db6caf))
+- **docs:** pages structure ([fe89dcf](https://github.com/algolia/instantsearch/commit/fe89dcf))
+- **getting-started:** add `.zip` boilerplate ([7d3769c](https://github.com/algolia/instantsearch/commit/7d3769c))
+- **getting-started:** add result example of guide ([78d9017](https://github.com/algolia/instantsearch/commit/78d9017))
+- **live-example:** add support of connectors ([e4f3158](https://github.com/algolia/instantsearch/commit/e4f3158))
+- **live-example:** include jquery on connectors example pages ([f32936f](https://github.com/algolia/instantsearch/commit/f32936f))
+- **main:** export all the widgets at once ([4bc2d21](https://github.com/algolia/instantsearch/commit/4bc2d21))
+- **numeric-refinement-list:** `facetValues` -> `items` / `toggleRefinement` -> `refine` ([eb2c993](https://github.com/algolia/instantsearch/commit/eb2c993))
+- **pagination:** `setPage()` -> `refine()` / `currentPage` -> `currentRefinement` ([f783fea](https://github.com/algolia/instantsearch/commit/f783fea))
+- **range-slider:** use `rheostat` as slider component (#2142) ([910a0a0](https://github.com/algolia/instantsearch/commit/910a0a0))
+- **searchFunction:** Update API, fix #1924 ([c7beb1d](https://github.com/algolia/instantsearch/commit/c7beb1d)), closes [#1924](https://github.com/algolia/instantsearch/issues/1924)
+- **sort-by-selector:** `currentValue` -> `currentRefinement` ([e94c8c7](https://github.com/algolia/instantsearch/commit/e94c8c7))
+- **Template:** remove support for react element ([ca2ab44](https://github.com/algolia/instantsearch/commit/ca2ab44))
 
 <a name="1.11.15"></a>
-## [1.11.15](https://github.com/algolia/instantsearch.js/compare/v1.11.14...v1.11.15) (2017-06-20)
 
+## [1.11.15](https://github.com/algolia/instantsearch/compare/v1.11.14...v1.11.15) (2017-06-20)
 
 ### Bug Fixes
 
-* **numeric-refinement-list:** reset page on refine ([ee55ccb](https://github.com/algolia/instantsearch.js/commit/ee55ccb))
-
-
+- **numeric-refinement-list:** reset page on refine ([ee55ccb](https://github.com/algolia/instantsearch/commit/ee55ccb))
 
 <a name="1.11.14"></a>
-## [1.11.14](https://github.com/algolia/instantsearch.js/compare/v1.11.13...v1.11.14) (2017-06-19)
 
+## [1.11.14](https://github.com/algolia/instantsearch/compare/v1.11.13...v1.11.14) (2017-06-19)
 
 ### Bug Fixes
 
-* **powered-by:** update logo ([7e68b51](https://github.com/algolia/instantsearch.js/commit/7e68b51)), closes [#2126](https://github.com/algolia/instantsearch.js/issues/2126)
-
-
+- **powered-by:** update logo ([7e68b51](https://github.com/algolia/instantsearch/commit/7e68b51)), closes [#2126](https://github.com/algolia/instantsearch/issues/2126)
 
 <a name="1.11.13"></a>
-## [1.11.13](https://github.com/algolia/instantsearch.js/compare/v1.11.12...v1.11.13) (2017-06-07)
 
+## [1.11.13](https://github.com/algolia/instantsearch/compare/v1.11.12...v1.11.13) (2017-06-07)
 
 ### Bug Fixes
 
-* **url-sync:** reverting back to using `change` event (#2183) ([07f4be0](https://github.com/algolia/instantsearch.js/commit/07f4be0)), closes [#2173](https://github.com/algolia/instantsearch.js/issues/2173) [#2171](https://github.com/algolia/instantsearch.js/issues/2171)
-
-
+- **url-sync:** reverting back to using `change` event (#2183) ([07f4be0](https://github.com/algolia/instantsearch/commit/07f4be0)), closes [#2173](https://github.com/algolia/instantsearch/issues/2173) [#2171](https://github.com/algolia/instantsearch/issues/2171)
 
 <a name="1.11.12"></a>
-## [1.11.12](https://github.com/algolia/instantsearch.js/compare/v1.11.11...v1.11.12) (2017-05-30)
 
+## [1.11.12](https://github.com/algolia/instantsearch/compare/v1.11.11...v1.11.12) (2017-05-30)
 
 ### Bug Fixes
 
-* **sffv:** when using a large limit, retain the search (#2163) ([3d95d4c](https://github.com/algolia/instantsearch.js/commit/3d95d4c)), closes [#2156](https://github.com/algolia/instantsearch.js/issues/2156)
-
-
+- **sffv:** when using a large limit, retain the search (#2163) ([3d95d4c](https://github.com/algolia/instantsearch/commit/3d95d4c)), closes [#2156](https://github.com/algolia/instantsearch/issues/2156)
 
 <a name="1.11.10"></a>
-## [1.11.10](https://github.com/algolia/instantsearch.js/compare/v1.11.9...v1.11.10) (2017-05-17)
 
-
+## [1.11.10](https://github.com/algolia/instantsearch/compare/v1.11.9...v1.11.10) (2017-05-17)
 
 <a name="1.11.9"></a>
-## [1.11.9](https://github.com/algolia/instantsearch.js/compare/v1.11.8...v1.11.9) (2017-05-17)
 
-
+## [1.11.9](https://github.com/algolia/instantsearch/compare/v1.11.8...v1.11.9) (2017-05-17)
 
 <a name="1.11.8"></a>
-## [1.11.8](https://github.com/algolia/instantsearch.js/compare/v1.11.7...v1.11.8) (2017-05-16)
 
+## [1.11.8](https://github.com/algolia/instantsearch/compare/v1.11.7...v1.11.8) (2017-05-16)
 
 ### Bug Fixes
 
-* **url-sync:** set firstRender to be class attribute ([22dbaeb](https://github.com/algolia/instantsearch.js/commit/22dbaeb))
-
-
+- **url-sync:** set firstRender to be class attribute ([22dbaeb](https://github.com/algolia/instantsearch/commit/22dbaeb))
 
 <a name="1.11.7"></a>
-## [1.11.7](https://github.com/algolia/instantsearch.js/compare/v1.11.6...v1.11.7) (2017-04-24)
 
+## [1.11.7](https://github.com/algolia/instantsearch/compare/v1.11.6...v1.11.7) (2017-04-24)
 
 ### Bug Fixes
 
-* **sffv:** add class for disabled state at the form level (#2122) ([029fa5f](https://github.com/algolia/instantsearch.js/commit/029fa5f))
-* **sffv:** fixes typo (: was left) ([26d2845](https://github.com/algolia/instantsearch.js/commit/26d2845))
-
-
+- **sffv:** add class for disabled state at the form level (#2122) ([029fa5f](https://github.com/algolia/instantsearch/commit/029fa5f))
+- **sffv:** fixes typo (: was left) ([26d2845](https://github.com/algolia/instantsearch/commit/26d2845))
 
 <a name="1.11.6"></a>
-## [1.11.6](https://github.com/algolia/instantsearch.js/compare/v1.11.5...v1.11.6) (2017-04-20)
 
+## [1.11.6](https://github.com/algolia/instantsearch/compare/v1.11.5...v1.11.6) (2017-04-20)
 
 ### Bug Fixes
 
-* **CONTRIBUTING:** remove section about beta releases (#2109) ([5640131](https://github.com/algolia/instantsearch.js/commit/5640131))
-* **sffv:** disable sffv input when few facet values FIX #2111 ([1e33c10](https://github.com/algolia/instantsearch.js/commit/1e33c10)), closes [#2111](https://github.com/algolia/instantsearch.js/issues/2111)
-
-
+- **CONTRIBUTING:** remove section about beta releases (#2109) ([5640131](https://github.com/algolia/instantsearch/commit/5640131))
+- **sffv:** disable sffv input when few facet values FIX #2111 ([1e33c10](https://github.com/algolia/instantsearch/commit/1e33c10)), closes [#2111](https://github.com/algolia/instantsearch/issues/2111)
 
 <a name="1.11.5"></a>
-## [1.11.5](https://github.com/algolia/instantsearch.js/compare/v1.11.4...v1.11.5) (2017-04-12)
 
+## [1.11.5](https://github.com/algolia/instantsearch/compare/v1.11.4...v1.11.5) (2017-04-12)
 
 ### Bug Fixes
 
-* **url-sync:** sync url on search (#2108) ([7f33ffb](https://github.com/algolia/instantsearch.js/commit/7f33ffb))
-
-
+- **url-sync:** sync url on search (#2108) ([7f33ffb](https://github.com/algolia/instantsearch/commit/7f33ffb))
 
 <a name="1.11.4"></a>
-## [1.11.4](https://github.com/algolia/instantsearch.js/compare/v1.11.3...v1.11.4) (2017-03-29)
 
+## [1.11.4](https://github.com/algolia/instantsearch/compare/v1.11.3...v1.11.4) (2017-03-29)
 
 ### Bug Fixes
 
-* **autoHideContainer:** dont prevent render with `shouldComponentUpdate` (#2076) ([b520400](https://github.com/algolia/instantsearch.js/commit/b520400))
-* **star-rating:** make max value inclusive ([f5fc41c](https://github.com/algolia/instantsearch.js/commit/f5fc41c)), closes [#2002](https://github.com/algolia/instantsearch.js/issues/2002)
-
-
+- **autoHideContainer:** dont prevent render with `shouldComponentUpdate` (#2076) ([b520400](https://github.com/algolia/instantsearch/commit/b520400))
+- **star-rating:** make max value inclusive ([f5fc41c](https://github.com/algolia/instantsearch/commit/f5fc41c)), closes [#2002](https://github.com/algolia/instantsearch/issues/2002)
 
 <a name="1.11.3"></a>
-## [1.11.3](https://github.com/algolia/instantsearch.js/compare/v1.11.2...v1.11.3) (2017-03-22)
 
+## [1.11.3](https://github.com/algolia/instantsearch/compare/v1.11.2...v1.11.3) (2017-03-22)
 
 ### Bug Fixes
 
-* **Slider:** display disabled slider when `min === max` (#2041) ([511fdfd](https://github.com/algolia/instantsearch.js/commit/511fdfd)), closes [#2037](https://github.com/algolia/instantsearch.js/issues/2037)
-
-
+- **Slider:** display disabled slider when `min === max` (#2041) ([511fdfd](https://github.com/algolia/instantsearch/commit/511fdfd)), closes [#2037](https://github.com/algolia/instantsearch/issues/2037)
 
 <a name="1.11.2"></a>
-## [1.11.2](https://github.com/algolia/instantsearch.js/compare/v1.11.1...v1.11.2) (2017-02-28)
 
+## [1.11.2](https://github.com/algolia/instantsearch/compare/v1.11.1...v1.11.2) (2017-02-28)
 
 ### Bug Fixes
 
-* **searchBox:** avoid unwanted cursor jumps on hashchange (#2013) ([d0103db](https://github.com/algolia/instantsearch.js/commit/d0103db)), closes [#2012](https://github.com/algolia/instantsearch.js/issues/2012)
-
-
+- **searchBox:** avoid unwanted cursor jumps on hashchange (#2013) ([d0103db](https://github.com/algolia/instantsearch/commit/d0103db)), closes [#2012](https://github.com/algolia/instantsearch/issues/2012)
 
 <a name="1.11.1"></a>
-## [1.11.1](https://github.com/algolia/instantsearch.js/compare/v1.11.0...v1.11.1) (2017-02-14)
 
+## [1.11.1](https://github.com/algolia/instantsearch/compare/v1.11.0...v1.11.1) (2017-02-14)
 
 ### Bug Fixes
 
-* **infinite-hits:** disable load more button when no more pages (#1973) ([745ed89](https://github.com/algolia/instantsearch.js/commit/745ed89)), closes [#1971](https://github.com/algolia/instantsearch.js/issues/1971)
-
-
+- **infinite-hits:** disable load more button when no more pages (#1973) ([745ed89](https://github.com/algolia/instantsearch/commit/745ed89)), closes [#1971](https://github.com/algolia/instantsearch/issues/1971)
 
 <a name="1.11.0"></a>
-# [1.11.0](https://github.com/algolia/instantsearch.js/compare/v1.10.5...v1.11.0) (2017-02-12)
 
+# [1.11.0](https://github.com/algolia/instantsearch/compare/v1.10.5...v1.11.0) (2017-02-12)
 
 ### Features
 
-* **analytics-widget:** add a new parameter pushInitialSearch (#1963) ([d777997](https://github.com/algolia/instantsearch.js/commit/d777997))
-* **custom client:** allows to provide a custom JS client instance (#1948) ([cce4f2e](https://github.com/algolia/instantsearch.js/commit/cce4f2e))
-* **InfiniteHits:** add new widget ([2d77e4b](https://github.com/algolia/instantsearch.js/commit/2d77e4b))
-
-
+- **analytics-widget:** add a new parameter pushInitialSearch (#1963) ([d777997](https://github.com/algolia/instantsearch/commit/d777997))
+- **custom client:** allows to provide a custom JS client instance (#1948) ([cce4f2e](https://github.com/algolia/instantsearch/commit/cce4f2e))
+- **InfiniteHits:** add new widget ([2d77e4b](https://github.com/algolia/instantsearch/commit/2d77e4b))
 
 <a name="1.10.5"></a>
-## [1.10.5](https://github.com/algolia/instantsearch.js/compare/v1.10.4...v1.10.5) (2017-02-06)
 
+## [1.10.5](https://github.com/algolia/instantsearch/compare/v1.10.4...v1.10.5) (2017-02-06)
 
 ### Bug Fixes
 
-* **urlSync:** update url only after threshold (#1917) ([b0f0cf1](https://github.com/algolia/instantsearch.js/commit/b0f0cf1)), closes [#1856](https://github.com/algolia/instantsearch.js/issues/1856)
-
-
+- **urlSync:** update url only after threshold (#1917) ([b0f0cf1](https://github.com/algolia/instantsearch/commit/b0f0cf1)), closes [#1856](https://github.com/algolia/instantsearch/issues/1856)
 
 <a name="1.10.4"></a>
-## [1.10.4](https://github.com/algolia/instantsearch.js/compare/v1.10.3...v1.10.4) (2017-01-25)
 
-
+## [1.10.4](https://github.com/algolia/instantsearch/compare/v1.10.3...v1.10.4) (2017-01-25)
 
 <a name="1.10.3"></a>
-## [1.10.3](https://github.com/algolia/instantsearch.js/compare/v1.10.2...v1.10.3) (2016-12-26)
 
+## [1.10.3](https://github.com/algolia/instantsearch/compare/v1.10.2...v1.10.3) (2016-12-26)
 
 ### Bug Fixes
 
-* **sffv-searchbox:** update classnames to avoid conflicts (#1781) ([f53e8fd](https://github.com/algolia/instantsearch.js/commit/f53e8fd))
-
-
+- **sffv-searchbox:** update classnames to avoid conflicts (#1781) ([f53e8fd](https://github.com/algolia/instantsearch/commit/f53e8fd))
 
 <a name="1.10.2"></a>
-## [1.10.2](https://github.com/algolia/instantsearch.js/compare/v1.10.1...v1.10.2) (2016-12-23)
 
+## [1.10.2](https://github.com/algolia/instantsearch/compare/v1.10.1...v1.10.2) (2016-12-23)
 
 ### Bug Fixes
 
-* **url:** clear timeout on pop ([41ad9af](https://github.com/algolia/instantsearch.js/commit/41ad9af))
-
-
+- **url:** clear timeout on pop ([41ad9af](https://github.com/algolia/instantsearch/commit/41ad9af))
 
 <a name="1.10.1"></a>
-## [1.10.1](https://github.com/algolia/instantsearch.js/compare/v1.10.0...v1.10.1) (2016-12-23)
 
+## [1.10.1](https://github.com/algolia/instantsearch/compare/v1.10.0...v1.10.1) (2016-12-23)
 
 ### Bug Fixes
 
-* **url:** default param ([7a18e1c](https://github.com/algolia/instantsearch.js/commit/7a18e1c))
-
+- **url:** default param ([7a18e1c](https://github.com/algolia/instantsearch/commit/7a18e1c))
 
 ### Features
 
-* **url:** add a beta updateOnEveryKeystroke option (#1779) ([63f73fe](https://github.com/algolia/instantsearch.js/commit/63f73fe))
-
-
+- **url:** add a beta updateOnEveryKeystroke option (#1779) ([63f73fe](https://github.com/algolia/instantsearch/commit/63f73fe))
 
 <a name="1.10.0"></a>
-# [1.10.0](https://github.com/algolia/instantsearch.js/compare/v1.9.0...v1.10.0) (2016-12-22)
 
+# [1.10.0](https://github.com/algolia/instantsearch/compare/v1.9.0...v1.10.0) (2016-12-22)
 
 ### Features
 
-* **widget:** Search for facet values - refinement list (#1753) ([b9e20f3](https://github.com/algolia/instantsearch.js/commit/b9e20f3))
-
-
+- **widget:** Search for facet values - refinement list (#1753) ([b9e20f3](https://github.com/algolia/instantsearch/commit/b9e20f3))
 
 <a name="1.9.0"></a>
-# [1.9.0](https://github.com/algolia/instantsearch.js/compare/v1.8.16...v1.9.0) (2016-12-14)
 
+# [1.9.0](https://github.com/algolia/instantsearch/compare/v1.8.16...v1.9.0) (2016-12-14)
 
 ### Bug Fixes
 
-* **currentRefinedValues:** unescape disjunctive facet refinement names (#1574) ([9ab65c4](https://github.com/algolia/instantsearch.js/commit/9ab65c4)), closes [#1569](https://github.com/algolia/instantsearch.js/issues/1569)
-* **transformData:** default data is an object when not provided (#1570) ([8eeeeba](https://github.com/algolia/instantsearch.js/commit/8eeeeba)), closes [#1538](https://github.com/algolia/instantsearch.js/issues/1538)
-
+- **currentRefinedValues:** unescape disjunctive facet refinement names (#1574) ([9ab65c4](https://github.com/algolia/instantsearch/commit/9ab65c4)), closes [#1569](https://github.com/algolia/instantsearch/issues/1569)
+- **transformData:** default data is an object when not provided (#1570) ([8eeeeba](https://github.com/algolia/instantsearch/commit/8eeeeba)), closes [#1538](https://github.com/algolia/instantsearch/issues/1538)
 
 ### Features
 
-* **analytics:** new analytics widget to easily plug search to any analytics service ([09d8fda](https://github.com/algolia/instantsearch.js/commit/09d8fda))
-* **retry strategy:** new retry strategy ([afdcc3c](https://github.com/algolia/instantsearch.js/commit/afdcc3c))
-
-
+- **analytics:** new analytics widget to easily plug search to any analytics service ([09d8fda](https://github.com/algolia/instantsearch/commit/09d8fda))
+- **retry strategy:** new retry strategy ([afdcc3c](https://github.com/algolia/instantsearch/commit/afdcc3c))
 
 <a name="1.8.16"></a>
-## [1.8.16](https://github.com/algolia/instantsearch.js/compare/v1.8.15...v1.8.16) (2016-11-16)
 
-
+## [1.8.16](https://github.com/algolia/instantsearch/compare/v1.8.15...v1.8.16) (2016-11-16)
 
 <a name="1.8.15"></a>
-## [1.8.15](https://github.com/algolia/instantsearch.js/compare/v1.8.14...v1.8.15) (2016-11-16)
 
+## [1.8.15](https://github.com/algolia/instantsearch/compare/v1.8.14...v1.8.15) (2016-11-16)
 
 ### Bug Fixes
 
-* **priceRanges:** avoid displaying solo ranges (#1544) ([ff396f0](https://github.com/algolia/instantsearch.js/commit/ff396f0)), closes [#1536](https://github.com/algolia/instantsearch.js/issues/1536)
-* **priceRanges:** use formatNumber in defaultTemplate (#1559) ([557a501](https://github.com/algolia/instantsearch.js/commit/557a501)), closes [#1230](https://github.com/algolia/instantsearch.js/issues/1230)
-* **toggle:** support negative numeric values for on/off (#1551) ([e4d88e0](https://github.com/algolia/instantsearch.js/commit/e4d88e0)), closes [#1537](https://github.com/algolia/instantsearch.js/issues/1537)
-* **transformData:** always call transformData (#1555) ([49bfeca](https://github.com/algolia/instantsearch.js/commit/49bfeca)), closes [#1538](https://github.com/algolia/instantsearch.js/issues/1538)
-
-
+- **priceRanges:** avoid displaying solo ranges (#1544) ([ff396f0](https://github.com/algolia/instantsearch/commit/ff396f0)), closes [#1536](https://github.com/algolia/instantsearch/issues/1536)
+- **priceRanges:** use formatNumber in defaultTemplate (#1559) ([557a501](https://github.com/algolia/instantsearch/commit/557a501)), closes [#1230](https://github.com/algolia/instantsearch/issues/1230)
+- **toggle:** support negative numeric values for on/off (#1551) ([e4d88e0](https://github.com/algolia/instantsearch/commit/e4d88e0)), closes [#1537](https://github.com/algolia/instantsearch/issues/1537)
+- **transformData:** always call transformData (#1555) ([49bfeca](https://github.com/algolia/instantsearch/commit/49bfeca)), closes [#1538](https://github.com/algolia/instantsearch/issues/1538)
 
 <a name="1.8.14"></a>
-## [1.8.14](https://github.com/algolia/instantsearch.js/compare/v1.8.13...v1.8.14) (2016-11-03)
 
+## [1.8.14](https://github.com/algolia/instantsearch/compare/v1.8.13...v1.8.14) (2016-11-03)
 
 ### Bug Fixes
 
-* **slider:** avoid multi touch issues (#1501) ([0b8a242](https://github.com/algolia/instantsearch.js/commit/0b8a242)), closes [#1186](https://github.com/algolia/instantsearch.js/issues/1186)
-
-
+- **slider:** avoid multi touch issues (#1501) ([0b8a242](https://github.com/algolia/instantsearch/commit/0b8a242)), closes [#1186](https://github.com/algolia/instantsearch/issues/1186)
 
 <a name="1.8.13"></a>
-## [1.8.13](https://github.com/algolia/instantsearch.js/compare/v1.8.12...v1.8.13) (2016-10-21)
 
+## [1.8.13](https://github.com/algolia/instantsearch/compare/v1.8.12...v1.8.13) (2016-10-21)
 
 ### Bug Fixes
 
-* **searchbox:** poweredBy Algolia logo weren't visible in firefox ([39701f8](https://github.com/algolia/instantsearch.js/commit/39701f8))
-
-
+- **searchbox:** poweredBy Algolia logo weren't visible in firefox ([39701f8](https://github.com/algolia/instantsearch/commit/39701f8))
 
 <a name="1.8.12"></a>
-## [1.8.12](https://github.com/algolia/instantsearch.js/compare/v1.8.11...v1.8.12) (2016-10-19)
 
+## [1.8.12](https://github.com/algolia/instantsearch/compare/v1.8.11...v1.8.12) (2016-10-19)
 
 ### Bug Fixes
 
-* **numericRefinementList:** classes on radio buttons (#1358) (#1432) ([fec6495](https://github.com/algolia/instantsearch.js/commit/fec6495))
-
-
+- **numericRefinementList:** classes on radio buttons (#1358) (#1432) ([fec6495](https://github.com/algolia/instantsearch/commit/fec6495))
 
 <a name="1.8.11"></a>
-## [1.8.11](https://github.com/algolia/instantsearch.js/compare/v1.8.10...v1.8.11) (2016-10-07)
 
+## [1.8.11](https://github.com/algolia/instantsearch/compare/v1.8.10...v1.8.11) (2016-10-07)
 
 ### Bug Fixes
 
-* **merge:** merge only plain object from searchParameters ([aab1c87](https://github.com/algolia/instantsearch.js/commit/aab1c87))
-
-
+- **merge:** merge only plain object from searchParameters ([aab1c87](https://github.com/algolia/instantsearch/commit/aab1c87))
 
 <a name="1.8.10"></a>
-## [1.8.10](https://github.com/algolia/instantsearch.js/compare/v1.8.9...v1.8.10) (2016-10-07)
 
+## [1.8.10](https://github.com/algolia/instantsearch/compare/v1.8.9...v1.8.10) (2016-10-07)
 
 ### Bug Fixes
 
-* **lodash:** set lodash back to 4.15.0, fixes build, unknown issue for now ([ba4247e](https://github.com/algolia/instantsearch.js/commit/ba4247e))
-
-
+- **lodash:** set lodash back to 4.15.0, fixes build, unknown issue for now ([ba4247e](https://github.com/algolia/instantsearch/commit/ba4247e))
 
 <a name="1.8.9"></a>
-## [1.8.9](https://github.com/algolia/instantsearch.js/compare/v1.8.8...v1.8.9) (2016-10-07)
 
+## [1.8.9](https://github.com/algolia/instantsearch/compare/v1.8.8...v1.8.9) (2016-10-07)
 
 ### Bug Fixes
 
-* **react:** avoid duplicating React ([59010f6](https://github.com/algolia/instantsearch.js/commit/59010f6)), closes [#1386](https://github.com/algolia/instantsearch.js/issues/1386)
-
-
+- **react:** avoid duplicating React ([59010f6](https://github.com/algolia/instantsearch/commit/59010f6)), closes [#1386](https://github.com/algolia/instantsearch/issues/1386)
 
 <a name="1.8.8"></a>
-## [1.8.8](https://github.com/algolia/instantsearch.js/compare/v1.8.6...v1.8.8) (2016-09-14)
 
+## [1.8.8](https://github.com/algolia/instantsearch/compare/v1.8.6...v1.8.8) (2016-09-14)
 
 ### Bug Fixes
 
-* **numericSelector:** do not change state on init (#1280) ([cf27db3](https://github.com/algolia/instantsearch.js/commit/cf27db3)), closes [#1253](https://github.com/algolia/instantsearch.js/issues/1253)
-* **Slider:** default precision to 2 (#1279) ([552b9ea](https://github.com/algolia/instantsearch.js/commit/552b9ea))
-
-
+- **numericSelector:** do not change state on init (#1280) ([cf27db3](https://github.com/algolia/instantsearch/commit/cf27db3)), closes [#1253](https://github.com/algolia/instantsearch/issues/1253)
+- **Slider:** default precision to 2 (#1279) ([552b9ea](https://github.com/algolia/instantsearch/commit/552b9ea))
 
 <a name="1.8.6"></a>
-## [1.8.6](https://github.com/algolia/instantsearch.js/compare/v1.8.5...v1.8.6) (2016-09-12)
 
-
+## [1.8.6](https://github.com/algolia/instantsearch/compare/v1.8.5...v1.8.6) (2016-09-12)
 
 <a name="1.8.5"></a>
-## [1.8.5](https://github.com/algolia/instantsearch.js/compare/v1.8.4...v1.8.5) (2016-09-06)
 
+## [1.8.5](https://github.com/algolia/instantsearch/compare/v1.8.4...v1.8.5) (2016-09-06)
 
 ### Bug Fixes
 
-* **deps:** upgrade all deps 2016-09-05 (#1261) ([408d597](https://github.com/algolia/instantsearch.js/commit/408d597))
-* **rangeSlider:** round pips numbers when step is integer (#1255) ([b993033](https://github.com/algolia/instantsearch.js/commit/b993033)), closes [#1254](https://github.com/algolia/instantsearch.js/issues/1254)
-
-
+- **deps:** upgrade all deps 2016-09-05 (#1261) ([408d597](https://github.com/algolia/instantsearch/commit/408d597))
+- **rangeSlider:** round pips numbers when step is integer (#1255) ([b993033](https://github.com/algolia/instantsearch/commit/b993033)), closes [#1254](https://github.com/algolia/instantsearch/issues/1254)
 
 <a name="1.8.4"></a>
-## [1.8.4](https://github.com/algolia/instantsearch.js/compare/v1.8.3...v1.8.4) (2016-08-29)
 
+## [1.8.4](https://github.com/algolia/instantsearch/compare/v1.8.3...v1.8.4) (2016-08-29)
 
 ### Bug Fixes
 
-* **bundle:** switch back to React by default, create a preact build (#1228) ([4845868](https://github.com/algolia/instantsearch.js/commit/4845868))
-
-
+- **bundle:** switch back to React by default, create a preact build (#1228) ([4845868](https://github.com/algolia/instantsearch/commit/4845868))
 
 <a name="1.8.3"></a>
-## [1.8.3](https://github.com/algolia/instantsearch.js/compare/v1.8.2...v1.8.3) (2016-08-29)
 
+## [1.8.3](https://github.com/algolia/instantsearch/compare/v1.8.2...v1.8.3) (2016-08-29)
 
 ### Bug Fixes
 
-* **numericSelector:** if no currentValue found, use the first option ([ef56dfa](https://github.com/algolia/instantsearch.js/commit/ef56dfa))
-* **poweredBy:** fixed Algolia logo version (#1223) ([aab3fc3](https://github.com/algolia/instantsearch.js/commit/aab3fc3)), closes [#1223](https://github.com/algolia/instantsearch.js/issues/1223) [#1222](https://github.com/algolia/instantsearch.js/issues/1222)
-* **Selector:** render a controlled component ([e9f6ff7](https://github.com/algolia/instantsearch.js/commit/e9f6ff7))
-
+- **numericSelector:** if no currentValue found, use the first option ([ef56dfa](https://github.com/algolia/instantsearch/commit/ef56dfa))
+- **poweredBy:** fixed Algolia logo version (#1223) ([aab3fc3](https://github.com/algolia/instantsearch/commit/aab3fc3)), closes [#1223](https://github.com/algolia/instantsearch/issues/1223) [#1222](https://github.com/algolia/instantsearch/issues/1222)
+- **Selector:** render a controlled component ([e9f6ff7](https://github.com/algolia/instantsearch/commit/e9f6ff7))
 
 ### Performance Improvements
 
-* **filesize:** use preact in production build (#1224) ([5bb38f2](https://github.com/algolia/instantsearch.js/commit/5bb38f2)), closes [#1030](https://github.com/algolia/instantsearch.js/issues/1030)
-
-
+- **filesize:** use preact in production build (#1224) ([5bb38f2](https://github.com/algolia/instantsearch/commit/5bb38f2)), closes [#1030](https://github.com/algolia/instantsearch/issues/1030)
 
 <a name="1.8.2"></a>
-## [1.8.2](https://github.com/algolia/instantsearch.js/compare/v1.8.1...v1.8.2) (2016-08-25)
 
+## [1.8.2](https://github.com/algolia/instantsearch/compare/v1.8.1...v1.8.2) (2016-08-25)
 
 ### Bug Fixes
 
-* **lodash:** use lodash v4, reduce build size ([216d1e0](https://github.com/algolia/instantsearch.js/commit/216d1e0))
-
-
+- **lodash:** use lodash v4, reduce build size ([216d1e0](https://github.com/algolia/instantsearch/commit/216d1e0))
 
 <a name="1.8.1"></a>
-## [1.8.1](https://github.com/algolia/instantsearch.js/compare/v1.8.0...v1.8.1) (2016-08-24)
 
+## [1.8.1](https://github.com/algolia/instantsearch/compare/v1.8.0...v1.8.1) (2016-08-24)
 
 ### Bug Fixes
 
-* **searchBox:** handle BFCache browsers (#1212) ([7deb9c3](https://github.com/algolia/instantsearch.js/commit/7deb9c3))
-* **toggle:** make autoHide check facetValue.count (#1213) ([86872eb](https://github.com/algolia/instantsearch.js/commit/86872eb))
-
-
+- **searchBox:** handle BFCache browsers (#1212) ([7deb9c3](https://github.com/algolia/instantsearch/commit/7deb9c3))
+- **toggle:** make autoHide check facetValue.count (#1213) ([86872eb](https://github.com/algolia/instantsearch/commit/86872eb))
 
 <a name="1.8.0"></a>
-# [1.8.0](https://github.com/algolia/instantsearch.js/compare/v1.7.1...v1.8.0) (2016-08-18)
 
+# [1.8.0](https://github.com/algolia/instantsearch/compare/v1.7.1...v1.8.0) (2016-08-18)
 
 ### Bug Fixes
 
-* **documentation:** Change instantsearch.widgets.stats typo data.processingTimMS to data.processingTimeMS ([034703e](https://github.com/algolia/instantsearch.js/commit/034703e))
-* **documentation:** Change responsiveNavigation.js & header.html to fix #1090 ([bf3a808](https://github.com/algolia/instantsearch.js/commit/bf3a808)), closes [#1090](https://github.com/algolia/instantsearch.js/issues/1090)
-* **nouislider:** fix the slider for nouislider 8.5.1 ([af8f56b](https://github.com/algolia/instantsearch.js/commit/af8f56b))
-
+- **documentation:** Change instantsearch.widgets.stats typo data.processingTimMS to data.processingTimeMS ([034703e](https://github.com/algolia/instantsearch/commit/034703e))
+- **documentation:** Change responsiveNavigation.js & header.html to fix #1090 ([bf3a808](https://github.com/algolia/instantsearch/commit/bf3a808)), closes [#1090](https://github.com/algolia/instantsearch/issues/1090)
+- **nouislider:** fix the slider for nouislider 8.5.1 ([af8f56b](https://github.com/algolia/instantsearch/commit/af8f56b))
 
 ### Features
 
-* **clearAll:** Add optional excludeAttributes to list protected filters ([fe6d19c](https://github.com/algolia/instantsearch.js/commit/fe6d19c))
-
-
+- **clearAll:** Add optional excludeAttributes to list protected filters ([fe6d19c](https://github.com/algolia/instantsearch/commit/fe6d19c))
 
 <a name="1.7.1"></a>
-## [1.7.1](https://github.com/algolia/instantsearch.js/compare/v1.7.0...v1.7.1) (2016-07-28)
 
+## [1.7.1](https://github.com/algolia/instantsearch/compare/v1.7.0...v1.7.1) (2016-07-28)
 
 ### Bug Fixes
 
-* **toggle:** add backward compatibility for previous toggle implem (#1154) ([a1973a0](https://github.com/algolia/instantsearch.js/commit/a1973a0))
-
-
+- **toggle:** add backward compatibility for previous toggle implem (#1154) ([a1973a0](https://github.com/algolia/instantsearch/commit/a1973a0))
 
 <a name="1.7.0"></a>
-# [1.7.0](https://github.com/algolia/instantsearch.js/compare/v1.6.4...v1.7.0) (2016-07-26)
 
+# [1.7.0](https://github.com/algolia/instantsearch/compare/v1.6.4...v1.7.0) (2016-07-26)
 
 ### Bug Fixes
 
-* **searchParameters:** avoid mutating provided objects (#1148) ([0ea3bef](https://github.com/algolia/instantsearch.js/commit/0ea3bef)), closes [#1130](https://github.com/algolia/instantsearch.js/issues/1130)
-
+- **searchParameters:** avoid mutating provided objects (#1148) ([0ea3bef](https://github.com/algolia/instantsearch/commit/0ea3bef)), closes [#1130](https://github.com/algolia/instantsearch/issues/1130)
 
 ### Features
 
-* **toggle:** Provide a better default widget (#1146) ([d54107e](https://github.com/algolia/instantsearch.js/commit/d54107e)), closes [#1096](https://github.com/algolia/instantsearch.js/issues/1096) [#919](https://github.com/algolia/instantsearch.js/issues/919)
-
-
+- **toggle:** Provide a better default widget (#1146) ([d54107e](https://github.com/algolia/instantsearch/commit/d54107e)), closes [#1096](https://github.com/algolia/instantsearch/issues/1096) [#919](https://github.com/algolia/instantsearch/issues/919)
 
 <a name="1.6.4"></a>
-## [1.6.4](https://github.com/algolia/instantsearch.js/compare/v1.6.3...v1.6.4) (2016-07-12)
 
-
+## [1.6.4](https://github.com/algolia/instantsearch/compare/v1.6.3...v1.6.4) (2016-07-12)
 
 <a name="1.6.3"></a>
-## [1.6.3](https://github.com/algolia/instantsearch.js/compare/v1.6.2...v1.6.3) (2016-07-11)
 
+## [1.6.3](https://github.com/algolia/instantsearch/compare/v1.6.2...v1.6.3) (2016-07-11)
 
 ### Bug Fixes
 
-* **Hits:** always render hits ([2e7bf8a](https://github.com/algolia/instantsearch.js/commit/2e7bf8a)), closes [#1100](https://github.com/algolia/instantsearch.js/issues/1100)
-
-
+- **Hits:** always render hits ([2e7bf8a](https://github.com/algolia/instantsearch/commit/2e7bf8a)), closes [#1100](https://github.com/algolia/instantsearch/issues/1100)
 
 <a name="1.6.2"></a>
-## [1.6.2](https://github.com/algolia/instantsearch.js/compare/v1.6.1...v1.6.2) (2016-07-11)
 
+## [1.6.2](https://github.com/algolia/instantsearch/compare/v1.6.1...v1.6.2) (2016-07-11)
 
 ### Bug Fixes
 
-* **paginationLink:** it's aria-label not ariaLabel (#1125) ([70a190c](https://github.com/algolia/instantsearch.js/commit/70a190c))
-* **pricesRange:** fill the form according to the current refinement (#1126) ([12ebde7](https://github.com/algolia/instantsearch.js/commit/12ebde7)), closes [#1009](https://github.com/algolia/instantsearch.js/issues/1009)
-* **rangeSlider:** handles now support stacking (#1129) ([ad394d3](https://github.com/algolia/instantsearch.js/commit/ad394d3))
-* **rangeSlider:** use stats min/max when only user min or max is provided (#1124) ([4348463](https://github.com/algolia/instantsearch.js/commit/4348463)), closes [#1004](https://github.com/algolia/instantsearch.js/issues/1004)
-* **searchBox:** force cursor position to be at the end of the query (#1123) ([8a27769](https://github.com/algolia/instantsearch.js/commit/8a27769)), closes [#946](https://github.com/algolia/instantsearch.js/issues/946)
-* **searchBox:** IE8, IE9 needs to listen for setQuery ([97c166a](https://github.com/algolia/instantsearch.js/commit/97c166a))
-* **searchBox:** update helper query on every keystroke (#1127) ([997c0c2](https://github.com/algolia/instantsearch.js/commit/997c0c2)), closes [#1015](https://github.com/algolia/instantsearch.js/issues/1015)
-* **urlSync:** urls should be safe by default (#1104) ([db833c6](https://github.com/algolia/instantsearch.js/commit/db833c6)), closes [#982](https://github.com/algolia/instantsearch.js/issues/982)
-
-
+- **paginationLink:** it's aria-label not ariaLabel (#1125) ([70a190c](https://github.com/algolia/instantsearch/commit/70a190c))
+- **pricesRange:** fill the form according to the current refinement (#1126) ([12ebde7](https://github.com/algolia/instantsearch/commit/12ebde7)), closes [#1009](https://github.com/algolia/instantsearch/issues/1009)
+- **rangeSlider:** handles now support stacking (#1129) ([ad394d3](https://github.com/algolia/instantsearch/commit/ad394d3))
+- **rangeSlider:** use stats min/max when only user min or max is provided (#1124) ([4348463](https://github.com/algolia/instantsearch/commit/4348463)), closes [#1004](https://github.com/algolia/instantsearch/issues/1004)
+- **searchBox:** force cursor position to be at the end of the query (#1123) ([8a27769](https://github.com/algolia/instantsearch/commit/8a27769)), closes [#946](https://github.com/algolia/instantsearch/issues/946)
+- **searchBox:** IE8, IE9 needs to listen for setQuery ([97c166a](https://github.com/algolia/instantsearch/commit/97c166a))
+- **searchBox:** update helper query on every keystroke (#1127) ([997c0c2](https://github.com/algolia/instantsearch/commit/997c0c2)), closes [#1015](https://github.com/algolia/instantsearch/issues/1015)
+- **urlSync:** urls should be safe by default (#1104) ([db833c6](https://github.com/algolia/instantsearch/commit/db833c6)), closes [#982](https://github.com/algolia/instantsearch/issues/982)
 
 <a name="1.6.1"></a>
-## [1.6.1](https://github.com/algolia/instantsearch.js/compare/v1.6.0...v1.6.1) (2016-06-20)
 
+## [1.6.1](https://github.com/algolia/instantsearch/compare/v1.6.0...v1.6.1) (2016-06-20)
 
 ### Bug Fixes
 
-* **meteorjs:** lite build must point to the browser lite (#1097) ([265ace3](https://github.com/algolia/instantsearch.js/commit/265ace3))
-* **toggle:** read numerical facet results stats for toggle count (#1098) ([1feb539](https://github.com/algolia/instantsearch.js/commit/1feb539)), closes [#1096](https://github.com/algolia/instantsearch.js/issues/1096)
-* **website:** footer wording ([8355460](https://github.com/algolia/instantsearch.js/commit/8355460))
-
-
+- **meteorjs:** lite build must point to the browser lite (#1097) ([265ace3](https://github.com/algolia/instantsearch/commit/265ace3))
+- **toggle:** read numerical facet results stats for toggle count (#1098) ([1feb539](https://github.com/algolia/instantsearch/commit/1feb539)), closes [#1096](https://github.com/algolia/instantsearch/issues/1096)
+- **website:** footer wording ([8355460](https://github.com/algolia/instantsearch/commit/8355460))
 
 <a name="1.6.0"></a>
-# [1.6.0](https://github.com/algolia/instantsearch.js/compare/v1.5.2...v1.6.0) (2016-06-13)
 
+# [1.6.0](https://github.com/algolia/instantsearch/compare/v1.5.2...v1.6.0) (2016-06-13)
 
 ### Bug Fixes
 
-* **hits:** rename __position to hitIndex ([d051a54](https://github.com/algolia/instantsearch.js/commit/d051a54))
-* **refinementList/header:** rename count to refinedFacetCount ([89ad602](https://github.com/algolia/instantsearch.js/commit/89ad602))
+- **hits:** rename \_\_position to hitIndex ([d051a54](https://github.com/algolia/instantsearch/commit/d051a54))
+- **refinementList/header:** rename count to refinedFacetCount ([89ad602](https://github.com/algolia/instantsearch/commit/89ad602))
 
 ### Features
 
-* **header:** Pass count of current refined filters in header ([d9e8582](https://github.com/algolia/instantsearch.js/commit/d9e8582)), closes [#1013](https://github.com/algolia/instantsearch.js/issues/1013) [#1041](https://github.com/algolia/instantsearch.js/issues/1041)
-* **hits:** Add a `__position` attribute to data passed to items ([43ce1c7](https://github.com/algolia/instantsearch.js/commit/43ce1c7)), closes [#903](https://github.com/algolia/instantsearch.js/issues/903)
-
-
+- **header:** Pass count of current refined filters in header ([d9e8582](https://github.com/algolia/instantsearch/commit/d9e8582)), closes [#1013](https://github.com/algolia/instantsearch/issues/1013) [#1041](https://github.com/algolia/instantsearch/issues/1041)
+- **hits:** Add a `__position` attribute to data passed to items ([43ce1c7](https://github.com/algolia/instantsearch/commit/43ce1c7)), closes [#903](https://github.com/algolia/instantsearch/issues/903)
 
 <a name="1.5.2"></a>
-## [1.5.2](https://github.com/algolia/instantsearch.js/compare/v1.5.1...v1.5.2) (2016-06-10)
 
+## [1.5.2](https://github.com/algolia/instantsearch/compare/v1.5.1...v1.5.2) (2016-06-10)
 
 ### Bug Fixes
 
-* **lite:** use lite algoliasearch build (js client) ([219fa9f](https://github.com/algolia/instantsearch.js/commit/219fa9f)), closes [#1024](https://github.com/algolia/instantsearch.js/issues/1024)
-* **poweredBy:** Let users define their own poweredBy template ([f1a96d8](https://github.com/algolia/instantsearch.js/commit/f1a96d8))
-
-
+- **lite:** use lite algoliasearch build (js client) ([219fa9f](https://github.com/algolia/instantsearch/commit/219fa9f)), closes [#1024](https://github.com/algolia/instantsearch/issues/1024)
+- **poweredBy:** Let users define their own poweredBy template ([f1a96d8](https://github.com/algolia/instantsearch/commit/f1a96d8))
 
 <a name="1.5.1"></a>
-## [1.5.1](https://github.com/algolia/instantsearch.js/compare/v1.5.0...v1.5.1) (2016-05-17)
 
+## [1.5.1](https://github.com/algolia/instantsearch/compare/v1.5.0...v1.5.1) (2016-05-17)
 
 ### Bug Fixes
 
-* **numericRefinementList:** Correctly apply active class ([7cca9a4](https://github.com/algolia/instantsearch.js/commit/7cca9a4)), closes [#1010](https://github.com/algolia/instantsearch.js/issues/1010)
-
-
+- **numericRefinementList:** Correctly apply active class ([7cca9a4](https://github.com/algolia/instantsearch/commit/7cca9a4)), closes [#1010](https://github.com/algolia/instantsearch/issues/1010)
 
 <a name="1.5.0"></a>
-# [1.5.0](https://github.com/algolia/instantsearch.js/compare/v1.4.5...v1.5.0) (2016-04-29)
 
+# [1.5.0](https://github.com/algolia/instantsearch/compare/v1.4.5...v1.5.0) (2016-04-29)
 
 ### Bug Fixes
 
-* **base href:** always create absolute URLS in widgets ([ae6dbf6](https://github.com/algolia/instantsearch.js/commit/ae6dbf6)), closes [#970](https://github.com/algolia/instantsearch.js/issues/970)
-* **IE11:** classList do not supports .add(class, class) ([ab10347](https://github.com/algolia/instantsearch.js/commit/ab10347)), closes [#989](https://github.com/algolia/instantsearch.js/issues/989)
-* **lifecycle:** save configuration done in widget.init ([07d1fea](https://github.com/algolia/instantsearch.js/commit/07d1fea))
-* **RefinementList:** use attributeNameKey when calling createURL ([253ec28](https://github.com/algolia/instantsearch.js/commit/253ec28))
-* **rootpath:** remember rootpath option on 'back' button ([01ecdaa](https://github.com/algolia/instantsearch.js/commit/01ecdaa))
-* **searchBox:** do not trigger a search when input value is the same ([81c2e80](https://github.com/algolia/instantsearch.js/commit/81c2e80))
-* **urlSync:** only start watching for changes at first render ([4a672ae](https://github.com/algolia/instantsearch.js/commit/4a672ae))
+- **base href:** always create absolute URLS in widgets ([ae6dbf6](https://github.com/algolia/instantsearch/commit/ae6dbf6)), closes [#970](https://github.com/algolia/instantsearch/issues/970)
+- **IE11:** classList do not supports .add(class, class) ([ab10347](https://github.com/algolia/instantsearch/commit/ab10347)), closes [#989](https://github.com/algolia/instantsearch/issues/989)
+- **lifecycle:** save configuration done in widget.init ([07d1fea](https://github.com/algolia/instantsearch/commit/07d1fea))
+- **RefinementList:** use attributeNameKey when calling createURL ([253ec28](https://github.com/algolia/instantsearch/commit/253ec28))
+- **rootpath:** remember rootpath option on 'back' button ([01ecdaa](https://github.com/algolia/instantsearch/commit/01ecdaa))
+- **searchBox:** do not trigger a search when input value is the same ([81c2e80](https://github.com/algolia/instantsearch/commit/81c2e80))
+- **urlSync:** only start watching for changes at first render ([4a672ae](https://github.com/algolia/instantsearch/commit/4a672ae))
 
 ### Features
 
-* **urlSync:** allow overriding replaceState(state)/pushState(state) ([989856c](https://github.com/algolia/instantsearch.js/commit/989856c))
-
-
+- **urlSync:** allow overriding replaceState(state)/pushState(state) ([989856c](https://github.com/algolia/instantsearch/commit/989856c))
 
 <a name="1.4.5"></a>
-## [1.4.5](https://github.com/algolia/instantsearch.js/compare/v1.4.4...v1.4.5) (2016-04-18)
 
+## [1.4.5](https://github.com/algolia/instantsearch/compare/v1.4.4...v1.4.5) (2016-04-18)
 
 ### Bug Fixes
 
-* **showMore:** hide "show less" when nothing to hide ([5ac2bb6](https://github.com/algolia/instantsearch.js/commit/5ac2bb6))
-
-
+- **showMore:** hide "show less" when nothing to hide ([5ac2bb6](https://github.com/algolia/instantsearch/commit/5ac2bb6))
 
 <a name="1.4.4"></a>
-## [1.4.4](https://github.com/algolia/instantsearch.js/compare/v1.4.3...v1.4.4) (2016-04-15)
 
+## [1.4.4](https://github.com/algolia/instantsearch/compare/v1.4.3...v1.4.4) (2016-04-15)
 
 ### Bug Fixes
 
-* **pagination:** Disabled pagination link can no longer be clicked ([88b567f](https://github.com/algolia/instantsearch.js/commit/88b567f)), closes [#974](https://github.com/algolia/instantsearch.js/issues/974)
-* **showMore:** hide showMore when no more facet values to show ([cc31b1a](https://github.com/algolia/instantsearch.js/commit/cc31b1a))
-
-
+- **pagination:** Disabled pagination link can no longer be clicked ([88b567f](https://github.com/algolia/instantsearch/commit/88b567f)), closes [#974](https://github.com/algolia/instantsearch/issues/974)
+- **showMore:** hide showMore when no more facet values to show ([cc31b1a](https://github.com/algolia/instantsearch/commit/cc31b1a))
 
 <a name="1.4.3"></a>
-## [1.4.3](https://github.com/algolia/instantsearch.js/compare/v1.4.2...v1.4.3) (2016-04-01)
 
+## [1.4.3](https://github.com/algolia/instantsearch/compare/v1.4.2...v1.4.3) (2016-04-01)
 
 ### Bug Fixes
 
-* **rangeSlider:** step accepts a float value ([6ecc925](https://github.com/algolia/instantsearch.js/commit/6ecc925))
-
-
+- **rangeSlider:** step accepts a float value ([6ecc925](https://github.com/algolia/instantsearch/commit/6ecc925))
 
 <a name="1.4.2"></a>
-## [1.4.2](https://github.com/algolia/instantsearch.js/compare/v1.4.1...v1.4.2) (2016-03-24)
 
+## [1.4.2](https://github.com/algolia/instantsearch/compare/v1.4.1...v1.4.2) (2016-03-24)
 
 ### Performance Improvements
 
-* **refinementList:** Stop creating URL for hidden refinements. ([2cdd17d](https://github.com/algolia/instantsearch.js/commit/2cdd17d))
-
-
+- **refinementList:** Stop creating URL for hidden refinements. ([2cdd17d](https://github.com/algolia/instantsearch/commit/2cdd17d))
 
 <a name="1.4.1"></a>
-## [1.4.1](https://github.com/algolia/instantsearch.js/compare/v1.4.0...v1.4.1) (2016-03-22)
 
+## [1.4.1](https://github.com/algolia/instantsearch/compare/v1.4.0...v1.4.1) (2016-03-22)
 
 ### Bug Fixes
 
-* **searchBox:** do not update the input when focused ([61cf9be](https://github.com/algolia/instantsearch.js/commit/61cf9be)), closes [#944](https://github.com/algolia/instantsearch.js/issues/944)
-
-
+- **searchBox:** do not update the input when focused ([61cf9be](https://github.com/algolia/instantsearch/commit/61cf9be)), closes [#944](https://github.com/algolia/instantsearch/issues/944)
 
 <a name="1.4.0"></a>
-# [1.4.0](https://github.com/algolia/instantsearch.js/compare/v1.3.3...v1.4.0) (2016-03-16)
 
+# [1.4.0](https://github.com/algolia/instantsearch/compare/v1.3.3...v1.4.0) (2016-03-16)
 
 ### Bug Fixes
 
-* **url:** allow hierarchical facets in trackedParameters ([36b4011](https://github.com/algolia/instantsearch.js/commit/36b4011))
+- **url:** allow hierarchical facets in trackedParameters ([36b4011](https://github.com/algolia/instantsearch/commit/36b4011))
 
 ### Features
 
-* **url-sync:** use the new mapping option ([f869885](https://github.com/algolia/instantsearch.js/commit/f869885)), closes [#838](https://github.com/algolia/instantsearch.js/issues/838)
-
-
+- **url-sync:** use the new mapping option ([f869885](https://github.com/algolia/instantsearch/commit/f869885)), closes [#838](https://github.com/algolia/instantsearch/issues/838)
 
 <a name="1.3.3"></a>
-## [1.3.3](https://github.com/algolia/instantsearch.js/compare/v1.3.2...v1.3.3) (2016-03-07)
 
+## [1.3.3](https://github.com/algolia/instantsearch/compare/v1.3.2...v1.3.3) (2016-03-07)
 
 ### Bug Fixes
 
-* **headerFooter:** make collapsible click handler work ([add0d50](https://github.com/algolia/instantsearch.js/commit/add0d50))
+- **headerFooter:** make collapsible click handler work ([add0d50](https://github.com/algolia/instantsearch/commit/add0d50))
 
 ### Performance Improvements
 
-* **linters:** Greatly improve the `npm run lint` task speed ([1ba53b0](https://github.com/algolia/instantsearch.js/commit/1ba53b0))
-
-
+- **linters:** Greatly improve the `npm run lint` task speed ([1ba53b0](https://github.com/algolia/instantsearch/commit/1ba53b0))
 
 <a name="1.3.2"></a>
-## [1.3.2](https://github.com/algolia/instantsearch.js/compare/v1.3.1...v1.3.2) (2016-03-07)
 
+## [1.3.2](https://github.com/algolia/instantsearch/compare/v1.3.1...v1.3.2) (2016-03-07)
 
 ### Bug Fixes
 
-* **Template:** stop leaking `data="[object Object]"` attributes in production builds ([7ec0431](https://github.com/algolia/instantsearch.js/commit/7ec0431)), closes [#899](https://github.com/algolia/instantsearch.js/issues/899)
+- **Template:** stop leaking `data="[object Object]"` attributes in production builds ([7ec0431](https://github.com/algolia/instantsearch/commit/7ec0431)), closes [#899](https://github.com/algolia/instantsearch/issues/899)
 
 ### Features
 
-* **validate-pr:** Allow `docs()` commits to be merged in master ([0abc689](https://github.com/algolia/instantsearch.js/commit/0abc689))
-
-
+- **validate-pr:** Allow `docs()` commits to be merged in master ([0abc689](https://github.com/algolia/instantsearch/commit/0abc689))
 
 <a name="1.3.1"></a>
-## [1.3.1](https://github.com/algolia/instantsearch.js/compare/v1.3.0...v1.3.1) (2016-03-07)
 
+## [1.3.1](https://github.com/algolia/instantsearch/compare/v1.3.0...v1.3.1) (2016-03-07)
 
 ### Bug Fixes
 
-* **collapsible:** stop duplicating collapsible styling ([7362901](https://github.com/algolia/instantsearch.js/commit/7362901))
-* **lodash:** stop leaking lodash in the global scope ([91f71dc](https://github.com/algolia/instantsearch.js/commit/91f71dc)), closes [#900](https://github.com/algolia/instantsearch.js/issues/900)
-
-
+- **collapsible:** stop duplicating collapsible styling ([7362901](https://github.com/algolia/instantsearch/commit/7362901))
+- **lodash:** stop leaking lodash in the global scope ([91f71dc](https://github.com/algolia/instantsearch/commit/91f71dc)), closes [#900](https://github.com/algolia/instantsearch/issues/900)
 
 <a name="1.3.0"></a>
-# [1.3.0](https://github.com/algolia/instantsearch.js/compare/v1.2.5...v1.3.0) (2016-03-04)
 
+# [1.3.0](https://github.com/algolia/instantsearch/compare/v1.2.5...v1.3.0) (2016-03-04)
 
 ### Bug Fixes
 
-* **browser support:** make IE lte 10 work by fixing Object.getPrototypeOf ([bbb264b](https://github.com/algolia/instantsearch.js/commit/bbb264b))
-* **menu,refinementList:** sort by count AND name to avoid reorders on refine ([02fe7bf](https://github.com/algolia/instantsearch.js/commit/02fe7bf)), closes [#65](https://github.com/algolia/instantsearch.js/issues/65)
-* **priceRanges:** pass the bound refine to the form ([ce2b956](https://github.com/algolia/instantsearch.js/commit/ce2b956))
-* **searchBox:** handle external updates of the query ([6a0af14](https://github.com/algolia/instantsearch.js/commit/6a0af14)), closes [#803](https://github.com/algolia/instantsearch.js/issues/803)
-* **searchBox:** stop setting the query twice ([91270b2](https://github.com/algolia/instantsearch.js/commit/91270b2))
-* **searchBox:** stop updating query at eachkeystroke with searchOnEnterKeyPressOnly ([28dc4d2](https://github.com/algolia/instantsearch.js/commit/28dc4d2)), closes [#875](https://github.com/algolia/instantsearch.js/issues/875)
-* **Slider:** do not render Slider when range.min === range.max ([f20274e](https://github.com/algolia/instantsearch.js/commit/f20274e))
-* **Template:** now render() when templateKey changes ([8906224](https://github.com/algolia/instantsearch.js/commit/8906224))
-* **toggle:** pass isRefined to toggleRefinement ([8ac494e](https://github.com/algolia/instantsearch.js/commit/8ac494e))
-* **url-sync:** always decode incoming query string ([bea38e3](https://github.com/algolia/instantsearch.js/commit/bea38e3)), closes [#848](https://github.com/algolia/instantsearch.js/issues/848)
-* **url-sync:** handle <base> href pages ([e58aadc](https://github.com/algolia/instantsearch.js/commit/e58aadc)), closes [#790](https://github.com/algolia/instantsearch.js/issues/790)
+- **browser support:** make IE lte 10 work by fixing Object.getPrototypeOf ([bbb264b](https://github.com/algolia/instantsearch/commit/bbb264b))
+- **menu,refinementList:** sort by count AND name to avoid reorders on refine ([02fe7bf](https://github.com/algolia/instantsearch/commit/02fe7bf)), closes [#65](https://github.com/algolia/instantsearch/issues/65)
+- **priceRanges:** pass the bound refine to the form ([ce2b956](https://github.com/algolia/instantsearch/commit/ce2b956))
+- **searchBox:** handle external updates of the query ([6a0af14](https://github.com/algolia/instantsearch/commit/6a0af14)), closes [#803](https://github.com/algolia/instantsearch/issues/803)
+- **searchBox:** stop setting the query twice ([91270b2](https://github.com/algolia/instantsearch/commit/91270b2))
+- **searchBox:** stop updating query at eachkeystroke with searchOnEnterKeyPressOnly ([28dc4d2](https://github.com/algolia/instantsearch/commit/28dc4d2)), closes [#875](https://github.com/algolia/instantsearch/issues/875)
+- **Slider:** do not render Slider when range.min === range.max ([f20274e](https://github.com/algolia/instantsearch/commit/f20274e))
+- **Template:** now render() when templateKey changes ([8906224](https://github.com/algolia/instantsearch/commit/8906224))
+- **toggle:** pass isRefined to toggleRefinement ([8ac494e](https://github.com/algolia/instantsearch/commit/8ac494e))
+- **url-sync:** always decode incoming query string ([bea38e3](https://github.com/algolia/instantsearch/commit/bea38e3)), closes [#848](https://github.com/algolia/instantsearch/issues/848)
+- **url-sync:** handle <base> href pages ([e58aadc](https://github.com/algolia/instantsearch/commit/e58aadc)), closes [#790](https://github.com/algolia/instantsearch/issues/790)
 
 ### Features
 
-* **collapsable widgets:** add collapsable and collapsed option ([c4df7c5](https://github.com/algolia/instantsearch.js/commit/c4df7c5))
-* **instantsearch:** allow overriding the helper.search function ([9a930e7](https://github.com/algolia/instantsearch.js/commit/9a930e7))
-* **rangeSlider:** allow passing min and max values ([409295c](https://github.com/algolia/instantsearch.js/commit/409295c)), closes [#858](https://github.com/algolia/instantsearch.js/issues/858)
-* **searchBox:** allow to pass a queryHook ([5786a64](https://github.com/algolia/instantsearch.js/commit/5786a64))
-* **Template:** allow template functions to return a React element ([748077d](https://github.com/algolia/instantsearch.js/commit/748077d))
-* **Template:** allow template functions to return a React element ([0f9296d](https://github.com/algolia/instantsearch.js/commit/0f9296d))
+- **collapsable widgets:** add collapsable and collapsed option ([c4df7c5](https://github.com/algolia/instantsearch/commit/c4df7c5))
+- **instantsearch:** allow overriding the helper.search function ([9a930e7](https://github.com/algolia/instantsearch/commit/9a930e7))
+- **rangeSlider:** allow passing min and max values ([409295c](https://github.com/algolia/instantsearch/commit/409295c)), closes [#858](https://github.com/algolia/instantsearch/issues/858)
+- **searchBox:** allow to pass a queryHook ([5786a64](https://github.com/algolia/instantsearch/commit/5786a64))
+- **Template:** allow template functions to return a React element ([748077d](https://github.com/algolia/instantsearch/commit/748077d))
+- **Template:** allow template functions to return a React element ([0f9296d](https://github.com/algolia/instantsearch/commit/0f9296d))
 
 ### Performance Improvements
 
-* **autoHideContainer:** stop re-creating React components ([8c89862](https://github.com/algolia/instantsearch.js/commit/8c89862))
-* **formatting numbers:** stop using a default locale, use the system one ([b056554](https://github.com/algolia/instantsearch.js/commit/b056554))
-* **nouislider:** upgrade nouislider, shaves some more ms ([fefbe65](https://github.com/algolia/instantsearch.js/commit/fefbe65))
-* **React:** use babel `optimisation` option for React ([95f940c](https://github.com/algolia/instantsearch.js/commit/95f940c))
-* **React, widgets:** implement shouldComponentUpdate, reduce bind ([5efaac1](https://github.com/algolia/instantsearch.js/commit/5efaac1))
-
-
+- **autoHideContainer:** stop re-creating React components ([8c89862](https://github.com/algolia/instantsearch/commit/8c89862))
+- **formatting numbers:** stop using a default locale, use the system one ([b056554](https://github.com/algolia/instantsearch/commit/b056554))
+- **nouislider:** upgrade nouislider, shaves some more ms ([fefbe65](https://github.com/algolia/instantsearch/commit/fefbe65))
+- **React:** use babel `optimisation` option for React ([95f940c](https://github.com/algolia/instantsearch/commit/95f940c))
+- **React, widgets:** implement shouldComponentUpdate, reduce bind ([5efaac1](https://github.com/algolia/instantsearch/commit/5efaac1))
 
 <a name="1.2.5"></a>
-## [1.2.5](https://github.com/algolia/instantsearch.js/compare/v1.2.4...v1.2.5) (2016-03-02)
 
+## [1.2.5](https://github.com/algolia/instantsearch/compare/v1.2.4...v1.2.5) (2016-03-02)
 
 ### Bug Fixes
 
-* **hierarchicalMenu:** configure maxValuesPerFacet using the limit option ([4868717](https://github.com/algolia/instantsearch.js/commit/4868717)), closes [#66](https://github.com/algolia/instantsearch.js/issues/66)
-
-
+- **hierarchicalMenu:** configure maxValuesPerFacet using the limit option ([4868717](https://github.com/algolia/instantsearch/commit/4868717)), closes [#66](https://github.com/algolia/instantsearch/issues/66)
 
 <a name="1.2.4"></a>
-## [1.2.4](https://github.com/algolia/instantsearch.js/compare/v1.2.3...v1.2.4) (2016-02-29)
+
+## [1.2.4](https://github.com/algolia/instantsearch/compare/v1.2.3...v1.2.4) (2016-02-29)
 
 Upgraded the helper to 2.9.0 to support undocumented parameters from the API.
 
-
 <a name="1.2.3"></a>
-## [1.2.3](https://github.com/algolia/instantsearch.js/compare/v1.2.2...v1.2.3) (2016-02-18)
 
+## [1.2.3](https://github.com/algolia/instantsearch/compare/v1.2.2...v1.2.3) (2016-02-18)
 
 ### Bug Fixes
 
-* **currentRefinedValues:** clear numeric refinements using original value ([9a0ad45](https://github.com/algolia/instantsearch.js/commit/9a0ad45)), closes [#844](https://github.com/algolia/instantsearch.js/issues/844)
-
-
+- **currentRefinedValues:** clear numeric refinements using original value ([9a0ad45](https://github.com/algolia/instantsearch/commit/9a0ad45)), closes [#844](https://github.com/algolia/instantsearch/issues/844)
 
 <a name="1.2.2"></a>
-## [1.2.2](https://github.com/algolia/instantsearch.js/compare/v1.2.1...v1.2.2) (2016-02-03)
 
+## [1.2.2](https://github.com/algolia/instantsearch/compare/v1.2.1...v1.2.2) (2016-02-03)
 
 ### Features
 
-* **menu:** add showMore option ([e7e7677](https://github.com/algolia/instantsearch.js/commit/e7e7677)), closes [#815](https://github.com/algolia/instantsearch.js/issues/815)
-
-
+- **menu:** add showMore option ([e7e7677](https://github.com/algolia/instantsearch/commit/e7e7677)), closes [#815](https://github.com/algolia/instantsearch/issues/815)
 
 <a name="1.2.1"></a>
-## [1.2.1](https://github.com/algolia/instantsearch.js/compare/v1.2.0...v1.2.1) (2016-02-02)
 
+## [1.2.1](https://github.com/algolia/instantsearch/compare/v1.2.0...v1.2.1) (2016-02-02)
 
 ### Bug Fixes
 
-* **showmore:** now showMore in doc and also show-more BEM ([a020439](https://github.com/algolia/instantsearch.js/commit/a020439))
-
-
+- **showmore:** now showMore in doc and also show-more BEM ([a020439](https://github.com/algolia/instantsearch/commit/a020439))
 
 <a name="1.2.0"></a>
-# [1.2.0](https://github.com/algolia/instantsearch.js/compare/v1.1.3...v1.2.0) (2016-02-02)
 
+# [1.2.0](https://github.com/algolia/instantsearch/compare/v1.1.3...v1.2.0) (2016-02-02)
 
 ### Bug Fixes
 
-* **all:** typos ([fa8ba09](https://github.com/algolia/instantsearch.js/commit/fa8ba09))
-* **currentRefinedValues:** allow array of strings for cssClasses.* ([55b3a3f](https://github.com/algolia/instantsearch.js/commit/55b3a3f))
-* **docs:** fixed bad link to scss in custom themes section ([823a859](https://github.com/algolia/instantsearch.js/commit/823a859))
-* **getRefinements:** a name should be a string ([7efd1fd](https://github.com/algolia/instantsearch.js/commit/7efd1fd))
-* **getRefinements:** hierarchical facets ([fe0fc5d](https://github.com/algolia/instantsearch.js/commit/fe0fc5d))
-* **index:** Use module.exports instead of export on index ([81e7eee](https://github.com/algolia/instantsearch.js/commit/81e7eee))
-* **pagination:** remove default value of maxPages. Fixes #761 ([607fe9a](https://github.com/algolia/instantsearch.js/commit/607fe9a)), closes [#761](https://github.com/algolia/instantsearch.js/issues/761)
-* **prepareTemplates:** uses templates with keys that are not in defaults ([c4bf8ec](https://github.com/algolia/instantsearch.js/commit/c4bf8ec))
-* **rangeSlider:**     prevent slider from extending farther than the last pip ([6e534f5](https://github.com/algolia/instantsearch.js/commit/6e534f5))
-* **search-box:** update value when state changes from the outside ([4550f99](https://github.com/algolia/instantsearch.js/commit/4550f99))
-* **url-sync:** adds indexName in the helper configuration ([e50bafd](https://github.com/algolia/instantsearch.js/commit/e50bafd))
-* **url-sync:** Makes url sync more reliable ([3157abc](https://github.com/algolia/instantsearch.js/commit/3157abc)), closes [#730](https://github.com/algolia/instantsearch.js/issues/730) [#729](https://github.com/algolia/instantsearch.js/issues/729)
+- **all:** typos ([fa8ba09](https://github.com/algolia/instantsearch/commit/fa8ba09))
+- **currentRefinedValues:** allow array of strings for cssClasses.\* ([55b3a3f](https://github.com/algolia/instantsearch/commit/55b3a3f))
+- **docs:** fixed bad link to scss in custom themes section ([823a859](https://github.com/algolia/instantsearch/commit/823a859))
+- **getRefinements:** a name should be a string ([7efd1fd](https://github.com/algolia/instantsearch/commit/7efd1fd))
+- **getRefinements:** hierarchical facets ([fe0fc5d](https://github.com/algolia/instantsearch/commit/fe0fc5d))
+- **index:** Use module.exports instead of export on index ([81e7eee](https://github.com/algolia/instantsearch/commit/81e7eee))
+- **pagination:** remove default value of maxPages. Fixes #761 ([607fe9a](https://github.com/algolia/instantsearch/commit/607fe9a)), closes [#761](https://github.com/algolia/instantsearch/issues/761)
+- **prepareTemplates:** uses templates with keys that are not in defaults ([c4bf8ec](https://github.com/algolia/instantsearch/commit/c4bf8ec))
+- **rangeSlider:** prevent slider from extending farther than the last pip ([6e534f5](https://github.com/algolia/instantsearch/commit/6e534f5))
+- **search-box:** update value when state changes from the outside ([4550f99](https://github.com/algolia/instantsearch/commit/4550f99))
+- **url-sync:** adds indexName in the helper configuration ([e50bafd](https://github.com/algolia/instantsearch/commit/e50bafd))
+- **url-sync:** Makes url sync more reliable ([3157abc](https://github.com/algolia/instantsearch/commit/3157abc)), closes [#730](https://github.com/algolia/instantsearch/issues/730) [#729](https://github.com/algolia/instantsearch/issues/729)
 
 ### Features
 
-* **currentRefinedValues:** new widget ([6c926d0](https://github.com/algolia/instantsearch.js/commit/6c926d0)), closes [#404](https://github.com/algolia/instantsearch.js/issues/404)
-* **hits:** adds allItems template as an alternative to item ([1f3f889](https://github.com/algolia/instantsearch.js/commit/1f3f889))
-* **poweredBy:** automatically add utm link to poweredBy ([05d1425](https://github.com/algolia/instantsearch.js/commit/05d1425)), closes [#711](https://github.com/algolia/instantsearch.js/issues/711)
-* **priceRanges:** add currency option ([f41484a](https://github.com/algolia/instantsearch.js/commit/f41484a))
-* **refinementlist:** lets configure showmore feature ([3b8688a](https://github.com/algolia/instantsearch.js/commit/3b8688a))
-* **Template:** accepts any parameters and forwards them ([5170f53](https://github.com/algolia/instantsearch.js/commit/5170f53))
-
-
+- **currentRefinedValues:** new widget ([6c926d0](https://github.com/algolia/instantsearch/commit/6c926d0)), closes [#404](https://github.com/algolia/instantsearch/issues/404)
+- **hits:** adds allItems template as an alternative to item ([1f3f889](https://github.com/algolia/instantsearch/commit/1f3f889))
+- **poweredBy:** automatically add utm link to poweredBy ([05d1425](https://github.com/algolia/instantsearch/commit/05d1425)), closes [#711](https://github.com/algolia/instantsearch/issues/711)
+- **priceRanges:** add currency option ([f41484a](https://github.com/algolia/instantsearch/commit/f41484a))
+- **refinementlist:** lets configure showmore feature ([3b8688a](https://github.com/algolia/instantsearch/commit/3b8688a))
+- **Template:** accepts any parameters and forwards them ([5170f53](https://github.com/algolia/instantsearch/commit/5170f53))
 
 <a name="1.1.3"></a>
-## [1.1.3](https://github.com/algolia/instantsearch.js/compare/v1.1.2...v1.1.3) (2016-01-12)
 
+## [1.1.3](https://github.com/algolia/instantsearch/compare/v1.1.2...v1.1.3) (2016-01-12)
 
 ### Bug Fixes
 
-* **searchBox:** fixes cssClasses option ([660ee2f](https://github.com/algolia/instantsearch.js/commit/660ee2f)), closes [#775](https://github.com/algolia/instantsearch.js/issues/775)
-
-
+- **searchBox:** fixes cssClasses option ([660ee2f](https://github.com/algolia/instantsearch/commit/660ee2f)), closes [#775](https://github.com/algolia/instantsearch/issues/775)
 
 <a name="1.1.2"></a>
-## [1.1.2](https://github.com/algolia/instantsearch.js/compare/v1.1.1...v1.1.2) (2016-01-08)
 
-
-
+## [1.1.2](https://github.com/algolia/instantsearch/compare/v1.1.1...v1.1.2) (2016-01-08)
 
 <a name="1.1.1"></a>
-## [1.1.1](https://github.com/algolia/instantsearch.js/compare/v1.1.0...v1.1.1) (2016-01-07)
 
+## [1.1.1](https://github.com/algolia/instantsearch/compare/v1.1.0...v1.1.1) (2016-01-07)
 
 ### Bug Fixes
 
-* **style:** keyframes ([40eb0a5](https://github.com/algolia/instantsearch.js/commit/40eb0a5))
-* **url-sync:** adds indexName in the helper configuration ([c2c0bc7](https://github.com/algolia/instantsearch.js/commit/c2c0bc7))
+- **style:** keyframes ([40eb0a5](https://github.com/algolia/instantsearch/commit/40eb0a5))
+- **url-sync:** adds indexName in the helper configuration ([c2c0bc7](https://github.com/algolia/instantsearch/commit/c2c0bc7))
 
 ### Features
 
-* **clearRefinements:** Added two utils methods ([49564e1](https://github.com/algolia/instantsearch.js/commit/49564e1))
-
-
+- **clearRefinements:** Added two utils methods ([49564e1](https://github.com/algolia/instantsearch/commit/49564e1))
 
 <a name="1.1.0"></a>
-# [1.1.0](https://github.com/algolia/instantsearch.js/compare/v1.0.0...v1.1.0) (2015-11-26)
 
+# [1.1.0](https://github.com/algolia/instantsearch/compare/v1.0.0...v1.1.0) (2015-11-26)
 
 ### Bug Fixes
 
-* **pagination:** fix #668 edge case ([d8f1196](https://github.com/algolia/instantsearch.js/commit/d8f1196)), closes [#668](https://github.com/algolia/instantsearch.js/issues/668)
-* **priceRanges:** Remove round from first range ([bf82395](https://github.com/algolia/instantsearch.js/commit/bf82395))
-* **slider:** hide the slider when stats.min=stats.max ([42e4b64](https://github.com/algolia/instantsearch.js/commit/42e4b64))
-* **starRating:** Retrieve the correct count and use numericRefinement ([f00ce38](https://github.com/algolia/instantsearch.js/commit/f00ce38)), closes [#615](https://github.com/algolia/instantsearch.js/issues/615)
+- **pagination:** fix #668 edge case ([d8f1196](https://github.com/algolia/instantsearch/commit/d8f1196)), closes [#668](https://github.com/algolia/instantsearch/issues/668)
+- **priceRanges:** Remove round from first range ([bf82395](https://github.com/algolia/instantsearch/commit/bf82395))
+- **slider:** hide the slider when stats.min=stats.max ([42e4b64](https://github.com/algolia/instantsearch/commit/42e4b64))
+- **starRating:** Retrieve the correct count and use numericRefinement ([f00ce38](https://github.com/algolia/instantsearch/commit/f00ce38)), closes [#615](https://github.com/algolia/instantsearch/issues/615)
 
 ### Features
 
-* **hierarchical:** expose rootPath and showParentLevel ([6e9bb7c](https://github.com/algolia/instantsearch.js/commit/6e9bb7c))
-
-
+- **hierarchical:** expose rootPath and showParentLevel ([6e9bb7c](https://github.com/algolia/instantsearch/commit/6e9bb7c))
 
 <a name="1.0.0"></a>
-# [1.0.0](https://github.com/algolia/instantsearch.js/compare/v0.14.9...v1.0.0) (2015-11-18)
 
-
-
+# [1.0.0](https://github.com/algolia/instantsearch/compare/v0.14.9...v1.0.0) (2015-11-18)
 
 <a name="0.14.9"></a>
-## [0.14.9](https://github.com/algolia/instantsearch.js/compare/v0.14.8...v0.14.9) (2015-11-18)
 
-
-
+## [0.14.9](https://github.com/algolia/instantsearch/compare/v0.14.8...v0.14.9) (2015-11-18)
 
 <a name="0.14.8"></a>
-## [0.14.8](https://github.com/algolia/instantsearch.js/compare/v0.14.7...v0.14.8) (2015-11-18)
 
-
-
+## [0.14.8](https://github.com/algolia/instantsearch/compare/v0.14.7...v0.14.8) (2015-11-18)
 
 <a name="0.14.7"></a>
-## [0.14.7](https://github.com/algolia/instantsearch.js/compare/v0.14.6...v0.14.7) (2015-11-18)
 
-
-
+## [0.14.7](https://github.com/algolia/instantsearch/compare/v0.14.6...v0.14.7) (2015-11-18)
 
 <a name="0.14.6"></a>
-## [0.14.6](https://github.com/algolia/instantsearch.js/compare/v0.14.5...v0.14.6) (2015-11-17)
 
-
-
+## [0.14.6](https://github.com/algolia/instantsearch/compare/v0.14.5...v0.14.6) (2015-11-17)
 
 <a name="0.14.5"></a>
-## [0.14.5](https://github.com/algolia/instantsearch.js/compare/v0.14.4...v0.14.5) (2015-11-17)
 
-
-
+## [0.14.5](https://github.com/algolia/instantsearch/compare/v0.14.4...v0.14.5) (2015-11-17)
 
 <a name="0.14.4"></a>
-## [0.14.4](https://github.com/algolia/instantsearch.js/compare/v0.14.3...v0.14.4) (2015-11-17)
 
+## [0.14.4](https://github.com/algolia/instantsearch/compare/v0.14.3...v0.14.4) (2015-11-17)
 
 ### Bug Fixes
 
-* **doc:** Expand input on documentation page ([6814a14](https://github.com/algolia/instantsearch.js/commit/6814a14))
-
-
+- **doc:** Expand input on documentation page ([6814a14](https://github.com/algolia/instantsearch/commit/6814a14))
 
 <a name="0.14.3"></a>
-## [0.14.3](https://github.com/algolia/instantsearch.js/compare/v0.14.2...v0.14.3) (2015-11-17)
 
+## [0.14.3](https://github.com/algolia/instantsearch/compare/v0.14.2...v0.14.3) (2015-11-17)
 
 ### Bug Fixes
 
-* **examples:** media logo ([64f850e](https://github.com/algolia/instantsearch.js/commit/64f850e))
-* **website:** demos link to https ([b69c0f5](https://github.com/algolia/instantsearch.js/commit/b69c0f5))
-
-
+- **examples:** media logo ([64f850e](https://github.com/algolia/instantsearch/commit/64f850e))
+- **website:** demos link to https ([b69c0f5](https://github.com/algolia/instantsearch/commit/b69c0f5))
 
 <a name="0.14.2"></a>
-## [0.14.2](https://github.com/algolia/instantsearch.js/compare/v0.14.1...v0.14.2) (2015-11-17)
 
+## [0.14.2](https://github.com/algolia/instantsearch/compare/v0.14.1...v0.14.2) (2015-11-17)
 
 ### Bug Fixes
 
-* **numericSelector:** pass currentValue as the refined value, not the full obj ([9286b4b](https://github.com/algolia/instantsearch.js/commit/9286b4b))
-* **website:** search icon ([623f071](https://github.com/algolia/instantsearch.js/commit/623f071))
-
-
+- **numericSelector:** pass currentValue as the refined value, not the full obj ([9286b4b](https://github.com/algolia/instantsearch/commit/9286b4b))
+- **website:** search icon ([623f071](https://github.com/algolia/instantsearch/commit/623f071))
 
 <a name="0.14.1"></a>
-## [0.14.1](https://github.com/algolia/instantsearch.js/compare/v0.14.0...v0.14.1) (2015-11-16)
 
+## [0.14.1](https://github.com/algolia/instantsearch/compare/v0.14.0...v0.14.1) (2015-11-16)
 
 ### Bug Fixes
 
-* **docs:** minor CSS fixes ([94fa868](https://github.com/algolia/instantsearch.js/commit/94fa868)), closes [#573](https://github.com/algolia/instantsearch.js/issues/573)
-
-
+- **docs:** minor CSS fixes ([94fa868](https://github.com/algolia/instantsearch/commit/94fa868)), closes [#573](https://github.com/algolia/instantsearch/issues/573)
 
 <a name="0.14.0"></a>
-# [0.14.0](https://github.com/algolia/instantsearch.js/compare/v0.13.0...v0.14.0) (2015-11-13)
 
+# [0.14.0](https://github.com/algolia/instantsearch/compare/v0.13.0...v0.14.0) (2015-11-13)
 
 ### Bug Fixes
 
-* **hierarchicalMenu:** handle limit option ([968cf58](https://github.com/algolia/instantsearch.js/commit/968cf58)), closes [#585](https://github.com/algolia/instantsearch.js/issues/585) [#235](https://github.com/algolia/instantsearch.js/issues/235)
-* **numeric-selector:** makes init comply with the new API ([068e8d3](https://github.com/algolia/instantsearch.js/commit/068e8d3))
+- **hierarchicalMenu:** handle limit option ([968cf58](https://github.com/algolia/instantsearch/commit/968cf58)), closes [#585](https://github.com/algolia/instantsearch/issues/585) [#235](https://github.com/algolia/instantsearch/issues/235)
+- **numeric-selector:** makes init comply with the new API ([068e8d3](https://github.com/algolia/instantsearch/commit/068e8d3))
 
 ### Features
 
-* **core:** sends a custom User Agent ([2561154](https://github.com/algolia/instantsearch.js/commit/2561154))
-* **lifecycle:** makes init API consistent with the rest ([e7ed81f](https://github.com/algolia/instantsearch.js/commit/e7ed81f))
+- **core:** sends a custom User Agent ([2561154](https://github.com/algolia/instantsearch/commit/2561154))
+- **lifecycle:** makes init API consistent with the rest ([e7ed81f](https://github.com/algolia/instantsearch/commit/e7ed81f))
 
 ### BREAKING CHANGES
 
-* all widgets using "facetName" are now using "attributeName"
+- all widgets using "facetName" are now using "attributeName"
 
 <a name="0.13.0"></a>
-# [0.13.0](https://github.com/algolia/instantsearch.js/compare/v0.12.3...v0.13.0) (2015-11-12)
 
+# [0.13.0](https://github.com/algolia/instantsearch/compare/v0.12.3...v0.13.0) (2015-11-12)
 
 ### Features
 
-* **clearAll:** New widget ([9e61a14](https://github.com/algolia/instantsearch.js/commit/9e61a14))
-
-
+- **clearAll:** New widget ([9e61a14](https://github.com/algolia/instantsearch/commit/9e61a14))
 
 <a name="0.12.3"></a>
-## [0.12.3](https://github.com/algolia/instantsearch.js/compare/v0.12.2...v0.12.3) (2015-11-12)
 
-
-
+## [0.12.3](https://github.com/algolia/instantsearch/compare/v0.12.2...v0.12.3) (2015-11-12)
 
 <a name="0.12.2"></a>
-## [0.12.2](https://github.com/algolia/instantsearch.js/compare/v0.12.1...v0.12.2) (2015-11-12)
 
+## [0.12.2](https://github.com/algolia/instantsearch/compare/v0.12.1...v0.12.2) (2015-11-12)
 
 ### Bug Fixes
 
-* **layout:** missing div (did we lost that fix?) ([9a515e4](https://github.com/algolia/instantsearch.js/commit/9a515e4))
-
-
+- **layout:** missing div (did we lost that fix?) ([9a515e4](https://github.com/algolia/instantsearch/commit/9a515e4))
 
 <a name="0.12.1"></a>
-## [0.12.1](https://github.com/algolia/instantsearch.js/compare/v0.12.0...v0.12.1) (2015-11-12)
 
+## [0.12.1](https://github.com/algolia/instantsearch/compare/v0.12.0...v0.12.1) (2015-11-12)
 
 ### Bug Fixes
 
-* **counts:** missing formatNumber calls ([65e5ba0](https://github.com/algolia/instantsearch.js/commit/65e5ba0)), closes [#560](https://github.com/algolia/instantsearch.js/issues/560)
-* **doc:** ensure selector is not conflicting ([6528f2c](https://github.com/algolia/instantsearch.js/commit/6528f2c)), closes [#505](https://github.com/algolia/instantsearch.js/issues/505)
-* **docs:** improved label/input hover debug ([58573db](https://github.com/algolia/instantsearch.js/commit/58573db)), closes [#503](https://github.com/algolia/instantsearch.js/issues/503)
-* **examples/airbnb:** Use default theme from CDN ([f379c0a](https://github.com/algolia/instantsearch.js/commit/f379c0a)), closes [#522](https://github.com/algolia/instantsearch.js/issues/522)
-* **examples/youtube:** use the default theme ([cf9a4b6](https://github.com/algolia/instantsearch.js/commit/cf9a4b6))
-* **rangeSlider:** fixed tooltip CSS & outdated default theme. ([c4be2ef](https://github.com/algolia/instantsearch.js/commit/c4be2ef))
-
-
+- **counts:** missing formatNumber calls ([65e5ba0](https://github.com/algolia/instantsearch/commit/65e5ba0)), closes [#560](https://github.com/algolia/instantsearch/issues/560)
+- **doc:** ensure selector is not conflicting ([6528f2c](https://github.com/algolia/instantsearch/commit/6528f2c)), closes [#505](https://github.com/algolia/instantsearch/issues/505)
+- **docs:** improved label/input hover debug ([58573db](https://github.com/algolia/instantsearch/commit/58573db)), closes [#503](https://github.com/algolia/instantsearch/issues/503)
+- **examples/airbnb:** Use default theme from CDN ([f379c0a](https://github.com/algolia/instantsearch/commit/f379c0a)), closes [#522](https://github.com/algolia/instantsearch/issues/522)
+- **examples/youtube:** use the default theme ([cf9a4b6](https://github.com/algolia/instantsearch/commit/cf9a4b6))
+- **rangeSlider:** fixed tooltip CSS & outdated default theme. ([c4be2ef](https://github.com/algolia/instantsearch/commit/c4be2ef))
 
 <a name="0.12.0"></a>
-# [0.12.0](https://github.com/algolia/instantsearch.js/compare/v0.11.1...v0.12.0) (2015-11-10)
 
+# [0.12.0](https://github.com/algolia/instantsearch/compare/v0.11.1...v0.12.0) (2015-11-10)
 
 ### Bug Fixes
 
-* **pagination:** Fix double BEM classes on elements ([2ede317](https://github.com/algolia/instantsearch.js/commit/2ede317)), closes [#500](https://github.com/algolia/instantsearch.js/issues/500)
-* **price-ranges:** fix usage + add test ([89601d7](https://github.com/algolia/instantsearch.js/commit/89601d7))
-* **range-slider:** check usage + display (fixes #395) ([301643a](https://github.com/algolia/instantsearch.js/commit/301643a)), closes [#395](https://github.com/algolia/instantsearch.js/issues/395)
-* **rangeSlider:** error when no result ([70e8554](https://github.com/algolia/instantsearch.js/commit/70e8554))
-* **theme:** Revert default spacing into pagination ([d755fd5](https://github.com/algolia/instantsearch.js/commit/d755fd5))
-
+- **pagination:** Fix double BEM classes on elements ([2ede317](https://github.com/algolia/instantsearch/commit/2ede317)), closes [#500](https://github.com/algolia/instantsearch/issues/500)
+- **price-ranges:** fix usage + add test ([89601d7](https://github.com/algolia/instantsearch/commit/89601d7))
+- **range-slider:** check usage + display (fixes #395) ([301643a](https://github.com/algolia/instantsearch/commit/301643a)), closes [#395](https://github.com/algolia/instantsearch/issues/395)
+- **rangeSlider:** error when no result ([70e8554](https://github.com/algolia/instantsearch/commit/70e8554))
+- **theme:** Revert default spacing into pagination ([d755fd5](https://github.com/algolia/instantsearch/commit/d755fd5))
 
 ### BREAKING CHANGES
 
-* pagination: Removes all `__disabled`, `__first`, `__last`,
-`__next`, `__previous`, `__active` and `__page` classes added on the links in the
-pagination. It only ads them to the parent `li`. Links instead now
-have a `.ais-pagination--link` class
+- pagination: Removes all `__disabled`, `__first`, `__last`, `__next`, `__previous`, `__active` and `__page` classes added on the links in the pagination. It only ads them to the parent `li`. Links instead now have a `.ais-pagination--link` class
 
-Previously, the same CSS classes where added to both the `item` (`li`) and the
-link inside it. I've split them in `--item` and `--link`.
+Previously, the same CSS classes where added to both the `item` (`li`) and the link inside it. I've split them in `--item` and `--link`.
 
-I've also made the various active/first/disabled/etc modifiers as
-actual `__modifier` classes.
+I've also made the various active/first/disabled/etc modifiers as actual `__modifier` classes.
 
-I've updated the tests, the CSS skeleton, the examples and the docs
-accordingly.
-
-
+I've updated the tests, the CSS skeleton, the examples and the docs accordingly.
 
 <a name="0.11.1"></a>
-## [0.11.1](https://github.com/algolia/instantsearch.js/compare/v0.11.0...v0.11.1) (2015-11-10)
 
-
-
+## [0.11.1](https://github.com/algolia/instantsearch/compare/v0.11.0...v0.11.1) (2015-11-10)
 
 <a name="0.11.0"></a>
-# [0.11.0](https://github.com/algolia/instantsearch.js/compare/v0.10.0...v0.11.0) (2015-11-06)
+
+# [0.11.0](https://github.com/algolia/instantsearch/compare/v0.10.0...v0.11.0) (2015-11-06)
 
 ### Bug Fixes
 
-* **bem:** Make scss mixins actually follow BEM ([fcfb408](https://github.com/algolia/instantsearch.js/commit/fcfb408))
-* **doc:** bolder font for the navigation ([64f6d56](https://github.com/algolia/instantsearch.js/commit/64f6d56))
-* **InstantSearch:** throw error when init and render are not defined. Fixes #499 ([2830cd3](https://github.com/algolia/instantsearch.js/commit/2830cd3)), closes [#499](https://github.com/algolia/instantsearch.js/issues/499)
-* **live-doc:** adds a start at a responsive display ([c83967e](https://github.com/algolia/instantsearch.js/commit/c83967e))
-* **live-doc:** adds navigation menu for smaller screens ([a6bb71e](https://github.com/algolia/instantsearch.js/commit/a6bb71e))
-* **live-doc:** fixes flow for texts ([3855071](https://github.com/algolia/instantsearch.js/commit/3855071))
-* **live-doc:** Momentum scroll for iPhone ([60a36ff](https://github.com/algolia/instantsearch.js/commit/60a36ff))
-* **live-doc:** uses only h4 and fixes style of h4 (mobile) ([0fdd2d0](https://github.com/algolia/instantsearch.js/commit/0fdd2d0))
-* **middle-click:** Allow middle click on links ([a7601c0](https://github.com/algolia/instantsearch.js/commit/a7601c0))
-* **range-slider:** Use lodash find instead of Array.prototype.find ([056153c](https://github.com/algolia/instantsearch.js/commit/056153c))
-* **searchBox:** handling pasting event with contextual menu. ([a172458](https://github.com/algolia/instantsearch.js/commit/a172458)), closes [#467](https://github.com/algolia/instantsearch.js/issues/467)
-* **website:** defered doc scripts ([0c1324f](https://github.com/algolia/instantsearch.js/commit/0c1324f))
-* **website:** doc layout responsive ([a4dc894](https://github.com/algolia/instantsearch.js/commit/a4dc894))
-* **website:** fixed space overlay color animation ([200b8a7](https://github.com/algolia/instantsearch.js/commit/200b8a7))
-* **website:** Fixes & responsive stuff for doc ([7a8f920](https://github.com/algolia/instantsearch.js/commit/7a8f920))
-* **website:** footer markup ([95364a1](https://github.com/algolia/instantsearch.js/commit/95364a1))
-* **website:** home.js lint ([b70e06e](https://github.com/algolia/instantsearch.js/commit/b70e06e))
-* **website:** icon-theme didn't like svgo (to fix) ([38d84af](https://github.com/algolia/instantsearch.js/commit/38d84af))
-* **website:** image alt ([30cca29](https://github.com/algolia/instantsearch.js/commit/30cca29))
-* **website:** jsdelivr for every scripts ([06591d4](https://github.com/algolia/instantsearch.js/commit/06591d4))
-* **website:** Nav Icon + logo ([c1f419c](https://github.com/algolia/instantsearch.js/commit/c1f419c))
-* **website:** only load what's needed in bootstrap ([4843474](https://github.com/algolia/instantsearch.js/commit/4843474))
-* **website:** removed animation debug ([01ac079](https://github.com/algolia/instantsearch.js/commit/01ac079))
-* **website:** space bg fadeIn ([5e09844](https://github.com/algolia/instantsearch.js/commit/5e09844))
-* **website:** unclosed content block ([d42dc3e](https://github.com/algolia/instantsearch.js/commit/d42dc3e))
+- **bem:** Make scss mixins actually follow BEM ([fcfb408](https://github.com/algolia/instantsearch/commit/fcfb408))
+- **doc:** bolder font for the navigation ([64f6d56](https://github.com/algolia/instantsearch/commit/64f6d56))
+- **InstantSearch:** throw error when init and render are not defined. Fixes #499 ([2830cd3](https://github.com/algolia/instantsearch/commit/2830cd3)), closes [#499](https://github.com/algolia/instantsearch/issues/499)
+- **live-doc:** adds a start at a responsive display ([c83967e](https://github.com/algolia/instantsearch/commit/c83967e))
+- **live-doc:** adds navigation menu for smaller screens ([a6bb71e](https://github.com/algolia/instantsearch/commit/a6bb71e))
+- **live-doc:** fixes flow for texts ([3855071](https://github.com/algolia/instantsearch/commit/3855071))
+- **live-doc:** Momentum scroll for iPhone ([60a36ff](https://github.com/algolia/instantsearch/commit/60a36ff))
+- **live-doc:** uses only h4 and fixes style of h4 (mobile) ([0fdd2d0](https://github.com/algolia/instantsearch/commit/0fdd2d0))
+- **middle-click:** Allow middle click on links ([a7601c0](https://github.com/algolia/instantsearch/commit/a7601c0))
+- **range-slider:** Use lodash find instead of Array.prototype.find ([056153c](https://github.com/algolia/instantsearch/commit/056153c))
+- **searchBox:** handling pasting event with contextual menu. ([a172458](https://github.com/algolia/instantsearch/commit/a172458)), closes [#467](https://github.com/algolia/instantsearch/issues/467)
+- **website:** defered doc scripts ([0c1324f](https://github.com/algolia/instantsearch/commit/0c1324f))
+- **website:** doc layout responsive ([a4dc894](https://github.com/algolia/instantsearch/commit/a4dc894))
+- **website:** fixed space overlay color animation ([200b8a7](https://github.com/algolia/instantsearch/commit/200b8a7))
+- **website:** Fixes & responsive stuff for doc ([7a8f920](https://github.com/algolia/instantsearch/commit/7a8f920))
+- **website:** footer markup ([95364a1](https://github.com/algolia/instantsearch/commit/95364a1))
+- **website:** home.js lint ([b70e06e](https://github.com/algolia/instantsearch/commit/b70e06e))
+- **website:** icon-theme didn't like svgo (to fix) ([38d84af](https://github.com/algolia/instantsearch/commit/38d84af))
+- **website:** image alt ([30cca29](https://github.com/algolia/instantsearch/commit/30cca29))
+- **website:** jsdelivr for every scripts ([06591d4](https://github.com/algolia/instantsearch/commit/06591d4))
+- **website:** Nav Icon + logo ([c1f419c](https://github.com/algolia/instantsearch/commit/c1f419c))
+- **website:** only load what's needed in bootstrap ([4843474](https://github.com/algolia/instantsearch/commit/4843474))
+- **website:** removed animation debug ([01ac079](https://github.com/algolia/instantsearch/commit/01ac079))
+- **website:** space bg fadeIn ([5e09844](https://github.com/algolia/instantsearch/commit/5e09844))
+- **website:** unclosed content block ([d42dc3e](https://github.com/algolia/instantsearch/commit/d42dc3e))
 
 ### Features
 
-* **hierarchicalMenu:** Adding indentation with default theme ([34885d2](https://github.com/algolia/instantsearch.js/commit/34885d2))
-
+- **hierarchicalMenu:** Adding indentation with default theme ([34885d2](https://github.com/algolia/instantsearch/commit/34885d2))
 
 ### BREAKING CHANGES
 
-* hierarchicalMenu: Hierarchical menu levels 1 and 2 now have
-a margin-left added in the default theme.
-
+- hierarchicalMenu: Hierarchical menu levels 1 and 2 now have a margin-left added in the default theme.
 
 <a name="0.10.0"></a>
-# [0.10.0](https://github.com/algolia/instantsearch.js/compare/v0.9.0...v0.10.0) (2015-11-06)
 
+# [0.10.0](https://github.com/algolia/instantsearch/compare/v0.9.0...v0.10.0) (2015-11-06)
 
 ### Bug Fixes
 
-* **api:** rename hideContainerWhenNoResults to autoHideContainer ([3f64bef](https://github.com/algolia/instantsearch.js/commit/3f64bef)), closes [#407](https://github.com/algolia/instantsearch.js/issues/407)
-* **doc:** ensure the documentation content doesn't overflow ([1e28a4e](https://github.com/algolia/instantsearch.js/commit/1e28a4e)), closes [#444](https://github.com/algolia/instantsearch.js/issues/444)
-* **hitsPerPageSelector:** Be more tolerant in options ([e14a344](https://github.com/algolia/instantsearch.js/commit/e14a344))
-* **numeric widgets:** synchronizes rounded value between widgets ([b314160](https://github.com/algolia/instantsearch.js/commit/b314160))
-* **numeric-refinement:** Replace Array.find with lodash find/includes ([b3e815c](https://github.com/algolia/instantsearch.js/commit/b3e815c))
-* **price-ranges:** makes it uses same operator as the slider ([ad6f5c2](https://github.com/algolia/instantsearch.js/commit/ad6f5c2))
-* **range-slider:** fixes bound definition ([e15c9b7](https://github.com/algolia/instantsearch.js/commit/e15c9b7))
-* **selector:** makes component as uncontrolled component ([1dda12a](https://github.com/algolia/instantsearch.js/commit/1dda12a))
-* **slider:** fixed `pip` propTypes constraint ([c77b7f4](https://github.com/algolia/instantsearch.js/commit/c77b7f4))
-* **website:** fix images path ([a3f62eb](https://github.com/algolia/instantsearch.js/commit/a3f62eb))
+- **api:** rename hideContainerWhenNoResults to autoHideContainer ([3f64bef](https://github.com/algolia/instantsearch/commit/3f64bef)), closes [#407](https://github.com/algolia/instantsearch/issues/407)
+- **doc:** ensure the documentation content doesn't overflow ([1e28a4e](https://github.com/algolia/instantsearch/commit/1e28a4e)), closes [#444](https://github.com/algolia/instantsearch/issues/444)
+- **hitsPerPageSelector:** Be more tolerant in options ([e14a344](https://github.com/algolia/instantsearch/commit/e14a344))
+- **numeric widgets:** synchronizes rounded value between widgets ([b314160](https://github.com/algolia/instantsearch/commit/b314160))
+- **numeric-refinement:** Replace Array.find with lodash find/includes ([b3e815c](https://github.com/algolia/instantsearch/commit/b3e815c))
+- **price-ranges:** makes it uses same operator as the slider ([ad6f5c2](https://github.com/algolia/instantsearch/commit/ad6f5c2))
+- **range-slider:** fixes bound definition ([e15c9b7](https://github.com/algolia/instantsearch/commit/e15c9b7))
+- **selector:** makes component as uncontrolled component ([1dda12a](https://github.com/algolia/instantsearch/commit/1dda12a))
+- **slider:** fixed `pip` propTypes constraint ([c77b7f4](https://github.com/algolia/instantsearch/commit/c77b7f4))
+- **website:** fix images path ([a3f62eb](https://github.com/algolia/instantsearch/commit/a3f62eb))
 
 ### Features
 
-* **searchBox:** ability to be non-instant ([b3ef871](https://github.com/algolia/instantsearch.js/commit/b3ef871)), closes [#458](https://github.com/algolia/instantsearch.js/issues/458)
-* **toggle:** Allow custom on/off values ([9b6c2bf](https://github.com/algolia/instantsearch.js/commit/9b6c2bf)), closes [#409](https://github.com/algolia/instantsearch.js/issues/409)
+- **searchBox:** ability to be non-instant ([b3ef871](https://github.com/algolia/instantsearch/commit/b3ef871)), closes [#458](https://github.com/algolia/instantsearch/issues/458)
+- **toggle:** Allow custom on/off values ([9b6c2bf](https://github.com/algolia/instantsearch/commit/9b6c2bf)), closes [#409](https://github.com/algolia/instantsearch/issues/409)
 
 ### Performance Improvements
 
-* **hitsPerPageSelector:** Use the correct lodash function ([be9aea7](https://github.com/algolia/instantsearch.js/commit/be9aea7))
-
+- **hitsPerPageSelector:** Use the correct lodash function ([be9aea7](https://github.com/algolia/instantsearch/commit/be9aea7))
 
 ### BREAKING CHANGES
 
-* api: use autoHideContainer instead of
-hideContainerWhenNoResults
-
-
+- api: use autoHideContainer instead of hideContainerWhenNoResults
 
 <a name="0.9.0"></a>
-# [0.9.0](https://github.com/algolia/instantsearch.js/compare/v0.8.2...v0.9.0) (2015-11-04)
 
+# [0.9.0](https://github.com/algolia/instantsearch/compare/v0.8.2...v0.9.0) (2015-11-04)
 
 ### Features
 
-* **numericRefinementList:** create numericRefinementList widget using refinementList component ([a29e9c7](https://github.com/algolia/instantsearch.js/commit/a29e9c7))
-
-
+- **numericRefinementList:** create numericRefinementList widget using refinementList component ([a29e9c7](https://github.com/algolia/instantsearch/commit/a29e9c7))
 
 <a name="0.8.2"></a>
-## [0.8.2](https://github.com/algolia/instantsearch.js/compare/v0.8.1...v0.8.2) (2015-11-04)
 
+## [0.8.2](https://github.com/algolia/instantsearch/compare/v0.8.1...v0.8.2) (2015-11-04)
 
 ### Bug Fixes
 
-* **doc:** All wigdets in docs are not anymore linked together #fix #446 ([4361320](https://github.com/algolia/instantsearch.js/commit/4361320)), closes [#446](https://github.com/algolia/instantsearch.js/issues/446)
-* **hitsPerPageSelector:** Issue when state did not have a `hitsPerPage` ([dc9371c](https://github.com/algolia/instantsearch.js/commit/dc9371c))
-
-
+- **doc:** All wigdets in docs are not anymore linked together #fix #446 ([4361320](https://github.com/algolia/instantsearch/commit/4361320)), closes [#446](https://github.com/algolia/instantsearch/issues/446)
+- **hitsPerPageSelector:** Issue when state did not have a `hitsPerPage` ([dc9371c](https://github.com/algolia/instantsearch/commit/dc9371c))
 
 <a name="0.8.1"></a>
-## [0.8.1](https://github.com/algolia/instantsearch.js/compare/v0.8.0...v0.8.1) (2015-11-04)
 
+## [0.8.1](https://github.com/algolia/instantsearch/compare/v0.8.0...v0.8.1) (2015-11-04)
 
 ### Bug Fixes
 
-* **hierarchicalMenu:** handle cases where no results after a search ([0a1d0ac](https://github.com/algolia/instantsearch.js/commit/0a1d0ac)), closes [#385](https://github.com/algolia/instantsearch.js/issues/385)
+- **hierarchicalMenu:** handle cases where no results after a search ([0a1d0ac](https://github.com/algolia/instantsearch/commit/0a1d0ac)), closes [#385](https://github.com/algolia/instantsearch/issues/385)
 
 ### Features
 
-* **build:** allow building React based custom widgets ([cfbbfe4](https://github.com/algolia/instantsearch.js/commit/cfbbfe4)), closes [#373](https://github.com/algolia/instantsearch.js/issues/373)
-
-
+- **build:** allow building React based custom widgets ([cfbbfe4](https://github.com/algolia/instantsearch/commit/cfbbfe4)), closes [#373](https://github.com/algolia/instantsearch/issues/373)
 
 <a name="0.8.0"></a>
-# [0.8.0](https://github.com/algolia/instantsearch.js/compare/v0.7.0...v0.8.0) (2015-11-03)
 
+# [0.8.0](https://github.com/algolia/instantsearch/compare/v0.7.0...v0.8.0) (2015-11-03)
 
 ### Bug Fixes
 
-* **cssClasses:** Fixed duplication of classNames ([e193f45](https://github.com/algolia/instantsearch.js/commit/e193f45)), closes [#388](https://github.com/algolia/instantsearch.js/issues/388)
-* **doc:** add doctype were missing ([86a18aa](https://github.com/algolia/instantsearch.js/commit/86a18aa))
-* **doc:** new color scheme ([deccc17](https://github.com/algolia/instantsearch.js/commit/deccc17))
-* **doc:** only show a scrollbar when needed ([f2d955b](https://github.com/algolia/instantsearch.js/commit/f2d955b))
-* **hierarchical:** setPage 0 when toggling ([a976539](https://github.com/algolia/instantsearch.js/commit/a976539)), closes [#371](https://github.com/algolia/instantsearch.js/issues/371)
-* **jsdoc:** use babel-node ([453dc21](https://github.com/algolia/instantsearch.js/commit/453dc21))
-* **live-doc:** generates missing ul ([b43e6e2](https://github.com/algolia/instantsearch.js/commit/b43e6e2))
-* **live-doc:** move scrollbars, removes useless ones ([548ae5f](https://github.com/algolia/instantsearch.js/commit/548ae5f))
-* **live-doc:** moves octocat link to top. Removes stackOverflow ([8ff6a79](https://github.com/algolia/instantsearch.js/commit/8ff6a79))
-* **live-doc:** Moves version in the main content ([27731c3](https://github.com/algolia/instantsearch.js/commit/27731c3))
-* **live-reload:** integrates the links into the menu flow ([c118051](https://github.com/algolia/instantsearch.js/commit/c118051))
-* **numerical widgets:** s/facetName/attributeName ([f209f5d](https://github.com/algolia/instantsearch.js/commit/f209f5d)), closes [#431](https://github.com/algolia/instantsearch.js/issues/431)
-* **refinementList:** ensure the key reflects the underlying state ([b048f0b](https://github.com/algolia/instantsearch.js/commit/b048f0b)), closes [#398](https://github.com/algolia/instantsearch.js/issues/398)
+- **cssClasses:** Fixed duplication of classNames ([e193f45](https://github.com/algolia/instantsearch/commit/e193f45)), closes [#388](https://github.com/algolia/instantsearch/issues/388)
+- **doc:** add doctype were missing ([86a18aa](https://github.com/algolia/instantsearch/commit/86a18aa))
+- **doc:** new color scheme ([deccc17](https://github.com/algolia/instantsearch/commit/deccc17))
+- **doc:** only show a scrollbar when needed ([f2d955b](https://github.com/algolia/instantsearch/commit/f2d955b))
+- **hierarchical:** setPage 0 when toggling ([a976539](https://github.com/algolia/instantsearch/commit/a976539)), closes [#371](https://github.com/algolia/instantsearch/issues/371)
+- **jsdoc:** use babel-node ([453dc21](https://github.com/algolia/instantsearch/commit/453dc21))
+- **live-doc:** generates missing ul ([b43e6e2](https://github.com/algolia/instantsearch/commit/b43e6e2))
+- **live-doc:** move scrollbars, removes useless ones ([548ae5f](https://github.com/algolia/instantsearch/commit/548ae5f))
+- **live-doc:** moves octocat link to top. Removes stackOverflow ([8ff6a79](https://github.com/algolia/instantsearch/commit/8ff6a79))
+- **live-doc:** Moves version in the main content ([27731c3](https://github.com/algolia/instantsearch/commit/27731c3))
+- **live-reload:** integrates the links into the menu flow ([c118051](https://github.com/algolia/instantsearch/commit/c118051))
+- **numerical widgets:** s/facetName/attributeName ([f209f5d](https://github.com/algolia/instantsearch/commit/f209f5d)), closes [#431](https://github.com/algolia/instantsearch/issues/431)
+- **refinementList:** ensure the key reflects the underlying state ([b048f0b](https://github.com/algolia/instantsearch/commit/b048f0b)), closes [#398](https://github.com/algolia/instantsearch/issues/398)
 
 ### Features
 
-* **examples:** try examples instead of themes ([bedffce](https://github.com/algolia/instantsearch.js/commit/bedffce))
-* **headerFooter:** Only add markup if a template is defined ([7a2d22d](https://github.com/algolia/instantsearch.js/commit/7a2d22d)), closes [#370](https://github.com/algolia/instantsearch.js/issues/370)
-* **priceRanges:** Add BEM classes and tests ([ad58d7a](https://github.com/algolia/instantsearch.js/commit/ad58d7a)), closes [#387](https://github.com/algolia/instantsearch.js/issues/387)
-
+- **examples:** try examples instead of themes ([bedffce](https://github.com/algolia/instantsearch/commit/bedffce))
+- **headerFooter:** Only add markup if a template is defined ([7a2d22d](https://github.com/algolia/instantsearch/commit/7a2d22d)), closes [#370](https://github.com/algolia/instantsearch/issues/370)
+- **priceRanges:** Add BEM classes and tests ([ad58d7a](https://github.com/algolia/instantsearch/commit/ad58d7a)), closes [#387](https://github.com/algolia/instantsearch/issues/387)
 
 ### BREAKING CHANGES
 
-* numerical widgets: the priceRanges and rangeSlider widgets are now using `attributeName` instead of `facetName`.
-* priceRanges: `ais-price-ranges--range` are now named
-`ais-price-ranges--item` and are wrapped in
-a `ais-price-ranges--list`.
+- numerical widgets: the priceRanges and rangeSlider widgets are now using `attributeName` instead of `facetName`.
+- priceRanges: `ais-price-ranges--range` are now named `ais-price-ranges--item` and are wrapped in a `ais-price-ranges--list`.
 
-I've moved the bottom form into it's own PriceRangesForm component,
-along with its own tests. I've fixed a minor typo where the component
-was internally named PriceRange (without the final __s__).
+I've moved the bottom form into it's own PriceRangesForm component, along with its own tests. I've fixed a minor typo where the component was internally named PriceRange (without the final **s**).
 
-I factorize some logic form the render in individual methods and
-manage to individually test them. This was not an easy task. I had to
-mock the default `render` (so it does nothing) before instantiating
-the component. Then, I was able to call each inner method
-individually. This requires to stub prototype methods in beforeEach,
-then restore them in afterEach. I've added a few helper methods, this
-can surely be simplified again but this gives nice granularity in
-testing.
+I factorize some logic form the render in individual methods and manage to individually test them. This was not an easy task. I had to mock the default `render` (so it does nothing) before instantiating the component. Then, I was able to call each inner method individually. This requires to stub prototype methods in beforeEach, then restore them in afterEach. I've added a few helper methods, this can surely be simplified again but this gives nice granularity in testing.
 
-I've renamed the `range` items to `item` and wrapped them in a `list`.
-I've also added classes to all elements we add (`label`, `separator`,
-etc). I've removed the empty `span`s.
-* headerFooter: The `<div class="ais-header">` and `<div
-class="ais-footer">` markup is only added when
-a `templates.{header,footer}` is passed.
+I've renamed the `range` items to `item` and wrapped them in a `list`. I've also added classes to all elements we add (`label`, `separator`, etc). I've removed the empty `span`s.
 
-
+- headerFooter: The `<div class="ais-header">` and `<div class="ais-footer">` markup is only added when a `templates.{header,footer}` is passed.
 
 <a name="0.7.0"></a>
-# [0.7.0](https://github.com/algolia/instantsearch.js/compare/v0.6.5...v0.7.0) (2015-10-28)
 
+# [0.7.0](https://github.com/algolia/instantsearch/compare/v0.6.5...v0.7.0) (2015-10-28)
 
 ### Features
 
-* **searchBox:** Add `wrapInput` option ([b327dbc](https://github.com/algolia/instantsearch.js/commit/b327dbc))
-* **urls:** ability to create an URL from a set of params ([9ca8369](https://github.com/algolia/instantsearch.js/commit/9ca8369)), closes [#372](https://github.com/algolia/instantsearch.js/issues/372)
-
+- **searchBox:** Add `wrapInput` option ([b327dbc](https://github.com/algolia/instantsearch/commit/b327dbc))
+- **urls:** ability to create an URL from a set of params ([9ca8369](https://github.com/algolia/instantsearch/commit/9ca8369)), closes [#372](https://github.com/algolia/instantsearch/issues/372)
 
 ### BREAKING CHANGES
 
-* urls: the instantsearch.createURL method is now taking a
-simple JS object and not a SearchParameter instance anymore.
-* searchBox: The `input` used by the search-box widget is now
-wrapped in a `<div class="ais-search-box">` by default. This can be
-turned off with `wrapInput: false`.
+- urls: the instantsearch.createURL method is now taking a simple JS object and not a SearchParameter instance anymore.
+- searchBox: The `input` used by the search-box widget is now wrapped in a `<div class="ais-search-box">` by default. This can be turned off with `wrapInput: false`.
 
-This PR is a bit long, I had to do some minor refactoring to keep the
-new code understandable. I simply split the large `init` method into
-calls to smaller methods.
+This PR is a bit long, I had to do some minor refactoring to keep the new code understandable. I simply split the large `init` method into calls to smaller methods.
 
-There is some vanilla JS DOM manipulation involved to handle all the
-possible cases: targeting an `input` or a `div`, adding or not the
-`poweredBy`, adding or not the wrapping div.
+There is some vanilla JS DOM manipulation involved to handle all the possible cases: targeting an `input` or a `div`, adding or not the `poweredBy`, adding or not the wrapping div.
 
-Note that there is no `targetNode.insertAfter(newNode)` method, so
-I had to resort to the old trick of `parentNode.insertBefore(newNode,
-targetNode.nextSibling)`.
-
-
+Note that there is no `targetNode.insertAfter(newNode)` method, so I had to resort to the old trick of `parentNode.insertBefore(newNode, targetNode.nextSibling)`.
 
 <a name="0.6.5"></a>
-## [0.6.5](https://github.com/algolia/instantsearch.js/compare/v0.6.4...v0.6.5) (2015-10-27)
 
-
-
+## [0.6.5](https://github.com/algolia/instantsearch/compare/v0.6.4...v0.6.5) (2015-10-27)
 
 <a name="0.6.4"></a>
-## [0.6.4](https://github.com/algolia/instantsearch.js/compare/v0.6.3...v0.6.4) (2015-10-27)
 
-
-
+## [0.6.4](https://github.com/algolia/instantsearch/compare/v0.6.3...v0.6.4) (2015-10-27)
 
 <a name="0.6.3"></a>
-## [0.6.3](https://github.com/algolia/instantsearch.js/compare/v0.6.2...v0.6.3) (2015-10-27)
 
-
-
+## [0.6.3](https://github.com/algolia/instantsearch/compare/v0.6.2...v0.6.3) (2015-10-27)
 
 <a name="0.6.2"></a>
-## [0.6.2](https://github.com/algolia/instantsearch.js/compare/v0.6.1...v0.6.2) (2015-10-27)
 
-
-
+## [0.6.2](https://github.com/algolia/instantsearch/compare/v0.6.1...v0.6.2) (2015-10-27)
 
 <a name="0.6.1"></a>
-## [0.6.1](https://github.com/algolia/instantsearch.js/compare/v0.6.0...v0.6.1) (2015-10-27)
 
-
-
+## [0.6.1](https://github.com/algolia/instantsearch/compare/v0.6.0...v0.6.1) (2015-10-27)
 
 <a name="0.6.0"></a>
-# [0.6.0](https://github.com/algolia/instantsearch.js/compare/v0.5.1...v0.6.0) (2015-10-27)
 
+# [0.6.0](https://github.com/algolia/instantsearch/compare/v0.5.1...v0.6.0) (2015-10-27)
 
 ### Bug Fixes
 
-* **generateRanges:** avoid any infinite loop. Fix #351 ([4965222](https://github.com/algolia/instantsearch.js/commit/4965222)), closes [#351](https://github.com/algolia/instantsearch.js/issues/351)
-* **index-selector:** Fix tests passing with incorrect parameters ([8fc31b9](https://github.com/algolia/instantsearch.js/commit/8fc31b9))
-* **index-selector:** Update usage and error ([a7e4c10](https://github.com/algolia/instantsearch.js/commit/a7e4c10))
-* **priceRanges:** fixed 'active' CSS class not using BEM ([ec0d1b1](https://github.com/algolia/instantsearch.js/commit/ec0d1b1))
-* **priceRanges:** plug the URL computation. Fix #354 ([fbf4022](https://github.com/algolia/instantsearch.js/commit/fbf4022)), closes [#354](https://github.com/algolia/instantsearch.js/issues/354)
-* **template:** transformData checks too strict ([609f123](https://github.com/algolia/instantsearch.js/commit/609f123)), closes [#347](https://github.com/algolia/instantsearch.js/issues/347)
+- **generateRanges:** avoid any infinite loop. Fix #351 ([4965222](https://github.com/algolia/instantsearch/commit/4965222)), closes [#351](https://github.com/algolia/instantsearch/issues/351)
+- **index-selector:** Fix tests passing with incorrect parameters ([8fc31b9](https://github.com/algolia/instantsearch/commit/8fc31b9))
+- **index-selector:** Update usage and error ([a7e4c10](https://github.com/algolia/instantsearch/commit/a7e4c10))
+- **priceRanges:** fixed 'active' CSS class not using BEM ([ec0d1b1](https://github.com/algolia/instantsearch/commit/ec0d1b1))
+- **priceRanges:** plug the URL computation. Fix #354 ([fbf4022](https://github.com/algolia/instantsearch/commit/fbf4022)), closes [#354](https://github.com/algolia/instantsearch/issues/354)
+- **template:** transformData checks too strict ([609f123](https://github.com/algolia/instantsearch/commit/609f123)), closes [#347](https://github.com/algolia/instantsearch/issues/347)
 
 ### Features
 
-* **hits-per-page-selector:** New widget to change hitsPerPage ([a3e0f78](https://github.com/algolia/instantsearch.js/commit/a3e0f78)), closes [#331](https://github.com/algolia/instantsearch.js/issues/331)
-
+- **hits-per-page-selector:** New widget to change hitsPerPage ([a3e0f78](https://github.com/algolia/instantsearch/commit/a3e0f78)), closes [#331](https://github.com/algolia/instantsearch/issues/331)
 
 ### BREAKING CHANGES
 
-* priceRanges: the `input-group` modifier has been renamed to `form`
-
-
+- priceRanges: the `input-group` modifier has been renamed to `form`
 
 <a name="0.5.1"></a>
-## [0.5.1](https://github.com/algolia/instantsearch.js/compare/v0.5.0...v0.5.1) (2015-10-22)
 
+## [0.5.1](https://github.com/algolia/instantsearch/compare/v0.5.0...v0.5.1) (2015-10-22)
 
 ### Bug Fixes
 
-* **autohide:** Rename attribute to `hideContainerWhenNoResults` ([ecb6756](https://github.com/algolia/instantsearch.js/commit/ecb6756)), closes [#325](https://github.com/algolia/instantsearch.js/issues/325)
-
+- **autohide:** Rename attribute to `hideContainerWhenNoResults` ([ecb6756](https://github.com/algolia/instantsearch/commit/ecb6756)), closes [#325](https://github.com/algolia/instantsearch/issues/325)
 
 ### BREAKING CHANGES
 
-* autohide: Widget attribute is now named
-`hideContainerWhenNoResults` instead of `hideWhenNoResults` to be more
-explicit on what it is really doing.
+- autohide: Widget attribute is now named `hideContainerWhenNoResults` instead of `hideWhenNoResults` to be more explicit on what it is really doing.
 
-Also internally renamed the `autoHide` decorator to
-`autoHideContainer`
-
-
+Also internally renamed the `autoHide` decorator to `autoHideContainer`
 
 <a name="0.5.0"></a>
-# [0.5.0](https://github.com/algolia/instantsearch.js/compare/v0.4.1...v0.5.0) (2015-10-22)
 
+# [0.5.0](https://github.com/algolia/instantsearch/compare/v0.4.1...v0.5.0) (2015-10-22)
 
 ### Bug Fixes
 
-* **example:** Example searchbox ([cdad6c7](https://github.com/algolia/instantsearch.js/commit/cdad6c7)), closes [#157](https://github.com/algolia/instantsearch.js/issues/157)
-* **hierarchicalFacets:** use a real attribute name for the hierarchicalFacet name ([0d2a455](https://github.com/algolia/instantsearch.js/commit/0d2a455))
-* **hits:** Fix warning about unique key in iterator ([0c9468c](https://github.com/algolia/instantsearch.js/commit/0c9468c))
-* **onClick:** do not replace the browser's behavior on special clicks ([8562d49](https://github.com/algolia/instantsearch.js/commit/8562d49)), closes [#278](https://github.com/algolia/instantsearch.js/issues/278)
-* **package.json:** typo in repository ([33cf196](https://github.com/algolia/instantsearch.js/commit/33cf196))
-* **pagination:** do not generate the URL for disabled pages. ([e5d78ab](https://github.com/algolia/instantsearch.js/commit/e5d78ab)), closes [#282](https://github.com/algolia/instantsearch.js/issues/282)
-* **poweredBy:** Extract its hiding capabilities ([f5fa9ee](https://github.com/algolia/instantsearch.js/commit/f5fa9ee)), closes [#189](https://github.com/algolia/instantsearch.js/issues/189)
-* **rangeSlider:** refinements cleanuo ([16c132c](https://github.com/algolia/instantsearch.js/commit/16c132c)), closes [#147](https://github.com/algolia/instantsearch.js/issues/147)
-* **rangeSlider:** restore wrongly removed state nesting ([3ed3d39](https://github.com/algolia/instantsearch.js/commit/3ed3d39))
-* **React:** require React in order for JSX to work in widgets ([64d6011](https://github.com/algolia/instantsearch.js/commit/64d6011))
-* **react-nouislider:** upgrade react-nouislider to avoid mutating props ([1b7cd1d](https://github.com/algolia/instantsearch.js/commit/1b7cd1d))
-* **refinementList:** Remove `singleRefine` attribute ([db73e38](https://github.com/algolia/instantsearch.js/commit/db73e38)), closes [#220](https://github.com/algolia/instantsearch.js/issues/220)
-* **refinementList:** singleRefine is not dependant from operator ([d29dff6](https://github.com/algolia/instantsearch.js/commit/d29dff6))
-* **RefinementList:** click on child should not click on parent ([d476da2](https://github.com/algolia/instantsearch.js/commit/d476da2)), closes [#191](https://github.com/algolia/instantsearch.js/issues/191)
-* **Slider:** cssClasses.body handled by headerFooter HOC ([d8d20b2](https://github.com/algolia/instantsearch.js/commit/d8d20b2))
-* **stats:** Move CSS classes definition to widget from component ([99073cd](https://github.com/algolia/instantsearch.js/commit/99073cd))
-* **transformData:** add an explicit error message ([94c53d3](https://github.com/algolia/instantsearch.js/commit/94c53d3)), closes [#212](https://github.com/algolia/instantsearch.js/issues/212)
-* **transformData:** this test is not needed, already covered by Template ([36e5b9c](https://github.com/algolia/instantsearch.js/commit/36e5b9c))
-* **validate-commit:** Update the regexp ([96b93ba](https://github.com/algolia/instantsearch.js/commit/96b93ba))
+- **example:** Example searchbox ([cdad6c7](https://github.com/algolia/instantsearch/commit/cdad6c7)), closes [#157](https://github.com/algolia/instantsearch/issues/157)
+- **hierarchicalFacets:** use a real attribute name for the hierarchicalFacet name ([0d2a455](https://github.com/algolia/instantsearch/commit/0d2a455))
+- **hits:** Fix warning about unique key in iterator ([0c9468c](https://github.com/algolia/instantsearch/commit/0c9468c))
+- **onClick:** do not replace the browser's behavior on special clicks ([8562d49](https://github.com/algolia/instantsearch/commit/8562d49)), closes [#278](https://github.com/algolia/instantsearch/issues/278)
+- **package.json:** typo in repository ([33cf196](https://github.com/algolia/instantsearch/commit/33cf196))
+- **pagination:** do not generate the URL for disabled pages. ([e5d78ab](https://github.com/algolia/instantsearch/commit/e5d78ab)), closes [#282](https://github.com/algolia/instantsearch/issues/282)
+- **poweredBy:** Extract its hiding capabilities ([f5fa9ee](https://github.com/algolia/instantsearch/commit/f5fa9ee)), closes [#189](https://github.com/algolia/instantsearch/issues/189)
+- **rangeSlider:** refinements cleanuo ([16c132c](https://github.com/algolia/instantsearch/commit/16c132c)), closes [#147](https://github.com/algolia/instantsearch/issues/147)
+- **rangeSlider:** restore wrongly removed state nesting ([3ed3d39](https://github.com/algolia/instantsearch/commit/3ed3d39))
+- **React:** require React in order for JSX to work in widgets ([64d6011](https://github.com/algolia/instantsearch/commit/64d6011))
+- **react-nouislider:** upgrade react-nouislider to avoid mutating props ([1b7cd1d](https://github.com/algolia/instantsearch/commit/1b7cd1d))
+- **refinementList:** Remove `singleRefine` attribute ([db73e38](https://github.com/algolia/instantsearch/commit/db73e38)), closes [#220](https://github.com/algolia/instantsearch/issues/220)
+- **refinementList:** singleRefine is not dependant from operator ([d29dff6](https://github.com/algolia/instantsearch/commit/d29dff6))
+- **RefinementList:** click on child should not click on parent ([d476da2](https://github.com/algolia/instantsearch/commit/d476da2)), closes [#191](https://github.com/algolia/instantsearch/issues/191)
+- **Slider:** cssClasses.body handled by headerFooter HOC ([d8d20b2](https://github.com/algolia/instantsearch/commit/d8d20b2))
+- **stats:** Move CSS classes definition to widget from component ([99073cd](https://github.com/algolia/instantsearch/commit/99073cd))
+- **transformData:** add an explicit error message ([94c53d3](https://github.com/algolia/instantsearch/commit/94c53d3)), closes [#212](https://github.com/algolia/instantsearch/issues/212)
+- **transformData:** this test is not needed, already covered by Template ([36e5b9c](https://github.com/algolia/instantsearch/commit/36e5b9c))
+- **validate-commit:** Update the regexp ([96b93ba](https://github.com/algolia/instantsearch/commit/96b93ba))
 
 ### Features
 
-* **bem:** Add BEM to the index-selector widget ([564da51](https://github.com/algolia/instantsearch.js/commit/564da51))
-* **bem:** Add BEM-styling to the Stats widget ([92cebeb](https://github.com/algolia/instantsearch.js/commit/92cebeb))
-* **build:** Add minified CSS theme version to build ([77f0640](https://github.com/algolia/instantsearch.js/commit/77f0640))
-* **core/lifecycle-event:** emits `render` when render ([7f03ae9](https://github.com/algolia/instantsearch.js/commit/7f03ae9))
-* **es7:** Enable `es7.objectRestSpread` ([fc2fbc4](https://github.com/algolia/instantsearch.js/commit/fc2fbc4))
-* **headerFooter:** Add BEM classes to header and footer ([9e9d438](https://github.com/algolia/instantsearch.js/commit/9e9d438)), closes [#259](https://github.com/algolia/instantsearch.js/issues/259)
-* **hierarchical-menu:** Add BEM classes ([58ec191](https://github.com/algolia/instantsearch.js/commit/58ec191))
-* **hierarchical-menu:** Add CSS classes dependent on the depth ([1256ea8](https://github.com/algolia/instantsearch.js/commit/1256ea8))
-* **hits:** Add BEM styling to the `hits` widget ([6681960](https://github.com/algolia/instantsearch.js/commit/6681960))
-* **menu:** Add BEM classes ([467f49e](https://github.com/algolia/instantsearch.js/commit/467f49e))
-* **pagination:** add `scrollTo` option ([e6cd621](https://github.com/algolia/instantsearch.js/commit/e6cd621)), closes [#73](https://github.com/algolia/instantsearch.js/issues/73)
-* **priceRanges:** new Amazon-style price ranges widget ([e5fe344](https://github.com/algolia/instantsearch.js/commit/e5fe344))
-* **priceRanges:** polish priceRanges widget ([0994e6f](https://github.com/algolia/instantsearch.js/commit/0994e6f))
-* **refinement-list:** Add BEM naming ([b09b830](https://github.com/algolia/instantsearch.js/commit/b09b830))
-* **refinementlist:** Move default templates to its own file ([cb6fa16](https://github.com/algolia/instantsearch.js/commit/cb6fa16))
-* **refinementList:** Limits improvement ([ebcc8a9](https://github.com/algolia/instantsearch.js/commit/ebcc8a9))
-* **searchbox:** Make the searchBox BEMish ([db8bd60](https://github.com/algolia/instantsearch.js/commit/db8bd60))
-* **theme:** Add `searchBox` widget to default theme ([def831f](https://github.com/algolia/instantsearch.js/commit/def831f))
-* **theme:** Add debug.css file ([ff8f2dc](https://github.com/algolia/instantsearch.js/commit/ff8f2dc)), closes [#249](https://github.com/algolia/instantsearch.js/issues/249)
-* **theme:** Move `indexSelector` styling to default.css ([1841ef1](https://github.com/algolia/instantsearch.js/commit/1841ef1))
-* **theme:** Move all default css rules to `default.css` ([57c8c65](https://github.com/algolia/instantsearch.js/commit/57c8c65))
-* **toggle:** Adding BEM class naming ([8730c97](https://github.com/algolia/instantsearch.js/commit/8730c97))
-* **urlSync:** url generation for widget links. Fix #29 ([23dd505](https://github.com/algolia/instantsearch.js/commit/23dd505)), closes [#29](https://github.com/algolia/instantsearch.js/issues/29)
-
+- **bem:** Add BEM to the index-selector widget ([564da51](https://github.com/algolia/instantsearch/commit/564da51))
+- **bem:** Add BEM-styling to the Stats widget ([92cebeb](https://github.com/algolia/instantsearch/commit/92cebeb))
+- **build:** Add minified CSS theme version to build ([77f0640](https://github.com/algolia/instantsearch/commit/77f0640))
+- **core/lifecycle-event:** emits `render` when render ([7f03ae9](https://github.com/algolia/instantsearch/commit/7f03ae9))
+- **es7:** Enable `es7.objectRestSpread` ([fc2fbc4](https://github.com/algolia/instantsearch/commit/fc2fbc4))
+- **headerFooter:** Add BEM classes to header and footer ([9e9d438](https://github.com/algolia/instantsearch/commit/9e9d438)), closes [#259](https://github.com/algolia/instantsearch/issues/259)
+- **hierarchical-menu:** Add BEM classes ([58ec191](https://github.com/algolia/instantsearch/commit/58ec191))
+- **hierarchical-menu:** Add CSS classes dependent on the depth ([1256ea8](https://github.com/algolia/instantsearch/commit/1256ea8))
+- **hits:** Add BEM styling to the `hits` widget ([6681960](https://github.com/algolia/instantsearch/commit/6681960))
+- **menu:** Add BEM classes ([467f49e](https://github.com/algolia/instantsearch/commit/467f49e))
+- **pagination:** add `scrollTo` option ([e6cd621](https://github.com/algolia/instantsearch/commit/e6cd621)), closes [#73](https://github.com/algolia/instantsearch/issues/73)
+- **priceRanges:** new Amazon-style price ranges widget ([e5fe344](https://github.com/algolia/instantsearch/commit/e5fe344))
+- **priceRanges:** polish priceRanges widget ([0994e6f](https://github.com/algolia/instantsearch/commit/0994e6f))
+- **refinement-list:** Add BEM naming ([b09b830](https://github.com/algolia/instantsearch/commit/b09b830))
+- **refinementlist:** Move default templates to its own file ([cb6fa16](https://github.com/algolia/instantsearch/commit/cb6fa16))
+- **refinementList:** Limits improvement ([ebcc8a9](https://github.com/algolia/instantsearch/commit/ebcc8a9))
+- **searchbox:** Make the searchBox BEMish ([db8bd60](https://github.com/algolia/instantsearch/commit/db8bd60))
+- **theme:** Add `searchBox` widget to default theme ([def831f](https://github.com/algolia/instantsearch/commit/def831f))
+- **theme:** Add debug.css file ([ff8f2dc](https://github.com/algolia/instantsearch/commit/ff8f2dc)), closes [#249](https://github.com/algolia/instantsearch/issues/249)
+- **theme:** Move `indexSelector` styling to default.css ([1841ef1](https://github.com/algolia/instantsearch/commit/1841ef1))
+- **theme:** Move all default css rules to `default.css` ([57c8c65](https://github.com/algolia/instantsearch/commit/57c8c65))
+- **toggle:** Adding BEM class naming ([8730c97](https://github.com/algolia/instantsearch/commit/8730c97))
+- **urlSync:** url generation for widget links. Fix #29 ([23dd505](https://github.com/algolia/instantsearch/commit/23dd505)), closes [#29](https://github.com/algolia/instantsearch/issues/29)
 
 ### BREAKING CHANGES
 
-* build: You should now include the `default.css` file in your
-page to get the default styling.
+- build: You should now include the `default.css` file in your page to get the default styling.
 
-- Added `clean-css` as minifier
-- Updated build script
-- Updated documentation about loading it from jsdeliver
-- `npm shrinkwrap` madness
-* hits: The hit template and transform data key is renamed
-from `hit` to `item` to stay consistent with the other widgets
-* menu: The default template now has the count element inside
-the link, not outside.
-* stats: `cssClasses.root` now applies to the main root
-element (above header and footer) and no longer to the template
-wrapper. To style the template wrapper, use `cssClasses.body`
-* theme: Classes are now named `ais-index-selector` and
-`ais-index-selector--item` to stay consistent with other widgets.
+* Added `clean-css` as minifier
+* Updated build script
+* Updated documentation about loading it from jsdeliver
+* `npm shrinkwrap` madness
 
-Updated tests as well. Widget is responsible for adding default
-classes + user-defined ones. Then component simply add them to the
-markup.
-* theme: "Powered by" styles are now
-`ais-search-box--powered-by` and `ais-search-box--powered-by-link`.
-* urlSync: urlSync is not a widget anymore. It's now an option of
-instantsearch(appID, apiKey, opts);. See the README.md for more info.
-* searchbox: The `searchBox` widget now expect
-a `cssClasses.{input, poweredBy}`
-* bem: We now use a `span.ais-stats--time` instead of
-a `small` tag in the stats widget.
-* bem: We now use `cssClasses.select` and
-`cssClasses.option` instead of `cssClass` for the index-selector
-widget.
+- hits: The hit template and transform data key is renamed from `hit` to `item` to stay consistent with the other widgets
+- menu: The default template now has the count element inside the link, not outside.
+- stats: `cssClasses.root` now applies to the main root element (above header and footer) and no longer to the template wrapper. To style the template wrapper, use `cssClasses.body`
+- theme: Classes are now named `ais-index-selector` and `ais-index-selector--item` to stay consistent with other widgets.
 
+Updated tests as well. Widget is responsible for adding default classes + user-defined ones. Then component simply add them to the markup.
 
+- theme: "Powered by" styles are now `ais-search-box--powered-by` and `ais-search-box--powered-by-link`.
+- urlSync: urlSync is not a widget anymore. It's now an option of instantsearch(appID, apiKey, opts);. See the README.md for more info.
+- searchbox: The `searchBox` widget now expect a `cssClasses.{input, poweredBy}`
+- bem: We now use a `span.ais-stats--time` instead of a `small` tag in the stats widget.
+- bem: We now use `cssClasses.select` and `cssClasses.option` instead of `cssClass` for the index-selector widget.
 
 <a name="0.4.1"></a>
-## [0.4.1](https://github.com/algolia/instantsearch.js/compare/v0.4.0...v0.4.1) (2015-10-05)
 
+## [0.4.1](https://github.com/algolia/instantsearch/compare/v0.4.0...v0.4.1) (2015-10-05)
 
 ### Bug Fixes
 
-* allow passing only one key of transformData as an object ([e0ce89f](https://github.com/algolia/instantsearch.js/commit/e0ce89f))
-* **search-box:** Fix #137 autofocus must be configurable ([51f01be](https://github.com/algolia/instantsearch.js/commit/51f01be)), closes [#137](https://github.com/algolia/instantsearch.js/issues/137)
-* **searchBox:** do not update input's value if focused ([0e85f0d](https://github.com/algolia/instantsearch.js/commit/0e85f0d)), closes [#163](https://github.com/algolia/instantsearch.js/issues/163)
-* **templatesConfig:** helpers are now following Mustache spec ([8f3502f](https://github.com/algolia/instantsearch.js/commit/8f3502f))
-* **url-sync:** handle both hash and query parameter fix #165 ([8d84de6](https://github.com/algolia/instantsearch.js/commit/8d84de6)), closes [#165](https://github.com/algolia/instantsearch.js/issues/165)
-
-
+- allow passing only one key of transformData as an object ([e0ce89f](https://github.com/algolia/instantsearch/commit/e0ce89f))
+- **search-box:** Fix #137 autofocus must be configurable ([51f01be](https://github.com/algolia/instantsearch/commit/51f01be)), closes [#137](https://github.com/algolia/instantsearch/issues/137)
+- **searchBox:** do not update input's value if focused ([0e85f0d](https://github.com/algolia/instantsearch/commit/0e85f0d)), closes [#163](https://github.com/algolia/instantsearch/issues/163)
+- **templatesConfig:** helpers are now following Mustache spec ([8f3502f](https://github.com/algolia/instantsearch/commit/8f3502f))
+- **url-sync:** handle both hash and query parameter fix #165 ([8d84de6](https://github.com/algolia/instantsearch/commit/8d84de6)), closes [#165](https://github.com/algolia/instantsearch/issues/165)
 
 <a name="0.4.0"></a>
-# [0.4.0](https://github.com/algolia/instantsearch.js/compare/v0.3.0...v0.4.0) (2015-09-30)
 
+# [0.4.0](https://github.com/algolia/instantsearch/compare/v0.3.0...v0.4.0) (2015-09-30)
 
 ### Bug Fixes
 
-* **pagination:** handle cases where maxPages is low ([d3c9959](https://github.com/algolia/instantsearch.js/commit/d3c9959)), closes [#100](https://github.com/algolia/instantsearch.js/issues/100)
-* **searchBox:** allow searchBox to reuse an `<input>` ([e820cc3](https://github.com/algolia/instantsearch.js/commit/e820cc3))
-* **searchBox:** Use `hasAttribute` instead of `getAttribute` ([a122af9](https://github.com/algolia/instantsearch.js/commit/a122af9))
-* **slider:** allow handles to reach the real start and end of the slider ([03ed3f5](https://github.com/algolia/instantsearch.js/commit/03ed3f5))
-* **slider:** fix tap event throwing ([d906d3e](https://github.com/algolia/instantsearch.js/commit/d906d3e)), closes [#120](https://github.com/algolia/instantsearch.js/issues/120)
-* **Template:** add default value for template ([4291014](https://github.com/algolia/instantsearch.js/commit/4291014))
-* **url-sync:** make input not to lose focus ([63488d3](https://github.com/algolia/instantsearch.js/commit/63488d3))
+- **pagination:** handle cases where maxPages is low ([d3c9959](https://github.com/algolia/instantsearch/commit/d3c9959)), closes [#100](https://github.com/algolia/instantsearch/issues/100)
+- **searchBox:** allow searchBox to reuse an `<input>` ([e820cc3](https://github.com/algolia/instantsearch/commit/e820cc3))
+- **searchBox:** Use `hasAttribute` instead of `getAttribute` ([a122af9](https://github.com/algolia/instantsearch/commit/a122af9))
+- **slider:** allow handles to reach the real start and end of the slider ([03ed3f5](https://github.com/algolia/instantsearch/commit/03ed3f5))
+- **slider:** fix tap event throwing ([d906d3e](https://github.com/algolia/instantsearch/commit/d906d3e)), closes [#120](https://github.com/algolia/instantsearch/issues/120)
+- **Template:** add default value for template ([4291014](https://github.com/algolia/instantsearch/commit/4291014))
+- **url-sync:** make input not to lose focus ([63488d3](https://github.com/algolia/instantsearch/commit/63488d3))
 
 ### Features
 
-* **rangeSlider:** add headerFooter decorator ([19090c3](https://github.com/algolia/instantsearch.js/commit/19090c3))
-* **searchBox:** add headerFooter decorator to the Component ([5974a88](https://github.com/algolia/instantsearch.js/commit/5974a88))
-* **templatesConfig:** helpers and options transferred to Template ([456d781](https://github.com/algolia/instantsearch.js/commit/456d781)), closes [#99](https://github.com/algolia/instantsearch.js/issues/99)
-* **toggle:** add headerFooter decorator ([8a70c7d](https://github.com/algolia/instantsearch.js/commit/8a70c7d))
-* **url-sync:** Add `is_v` version to url ([9f597a0](https://github.com/algolia/instantsearch.js/commit/9f597a0)), closes [#70](https://github.com/algolia/instantsearch.js/issues/70)
-* hierarchicalWidget ([1facd9d](https://github.com/algolia/instantsearch.js/commit/1facd9d))
-
+- **rangeSlider:** add headerFooter decorator ([19090c3](https://github.com/algolia/instantsearch/commit/19090c3))
+- **searchBox:** add headerFooter decorator to the Component ([5974a88](https://github.com/algolia/instantsearch/commit/5974a88))
+- **templatesConfig:** helpers and options transferred to Template ([456d781](https://github.com/algolia/instantsearch/commit/456d781)), closes [#99](https://github.com/algolia/instantsearch/issues/99)
+- **toggle:** add headerFooter decorator ([8a70c7d](https://github.com/algolia/instantsearch/commit/8a70c7d))
+- **url-sync:** Add `is_v` version to url ([9f597a0](https://github.com/algolia/instantsearch/commit/9f597a0)), closes [#70](https://github.com/algolia/instantsearch/issues/70)
+- hierarchicalWidget ([1facd9d](https://github.com/algolia/instantsearch/commit/1facd9d))
 
 ### BREAKING CHANGES
 
-* S:
-- toggle: removed template
-* - removed: inputClass
+- S:
 
+* toggle: removed template
 
+- - removed: inputClass
 
 <a name="0.3.0"></a>
-# [0.3.0](https://github.com/algolia/instantsearch.js/compare/v0.2.2...v0.3.0) (2015-09-24)
 
+# [0.3.0](https://github.com/algolia/instantsearch/compare/v0.2.2...v0.3.0) (2015-09-24)
 
 ### Bug Fixes
 
-* Allow not specifying `cssClass` on index selector ([4e9324f](https://github.com/algolia/instantsearch.js/commit/4e9324f))
-* More explicit error message when DOM selector is invalid ([d36a2ad](https://github.com/algolia/instantsearch.js/commit/d36a2ad)), closes [#105](https://github.com/algolia/instantsearch.js/issues/105)
-* Pass nbHits, hitsPerPage, nbPages and page to Stats widget ([deefd23](https://github.com/algolia/instantsearch.js/commit/deefd23)), closes [#106](https://github.com/algolia/instantsearch.js/issues/106)
-* **hideIfEmpty:** should be hideWhenNoResults ([21877a0](https://github.com/algolia/instantsearch.js/commit/21877a0))
-* **Hits:** handle the display when there is no result ([544ff5c](https://github.com/algolia/instantsearch.js/commit/544ff5c))
-* **menu:** send an empty array values when no values ([12cd7dc](https://github.com/algolia/instantsearch.js/commit/12cd7dc)), closes [#107](https://github.com/algolia/instantsearch.js/issues/107)
-* **pagination:** missing showFirstLast attribute when instantiating ([28fa0ae](https://github.com/algolia/instantsearch.js/commit/28fa0ae))
-* **SearchBox:** Missing poweredBy in the not focused SearchBox ([ef695ff](https://github.com/algolia/instantsearch.js/commit/ef695ff))
-* **slider:** hide slider if when no hits/matches ([31e4a80](https://github.com/algolia/instantsearch.js/commit/31e4a80)), closes [#107](https://github.com/algolia/instantsearch.js/issues/107)
+- Allow not specifying `cssClass` on index selector ([4e9324f](https://github.com/algolia/instantsearch/commit/4e9324f))
+- More explicit error message when DOM selector is invalid ([d36a2ad](https://github.com/algolia/instantsearch/commit/d36a2ad)), closes [#105](https://github.com/algolia/instantsearch/issues/105)
+- Pass nbHits, hitsPerPage, nbPages and page to Stats widget ([deefd23](https://github.com/algolia/instantsearch/commit/deefd23)), closes [#106](https://github.com/algolia/instantsearch/issues/106)
+- **hideIfEmpty:** should be hideWhenNoResults ([21877a0](https://github.com/algolia/instantsearch/commit/21877a0))
+- **Hits:** handle the display when there is no result ([544ff5c](https://github.com/algolia/instantsearch/commit/544ff5c))
+- **menu:** send an empty array values when no values ([12cd7dc](https://github.com/algolia/instantsearch/commit/12cd7dc)), closes [#107](https://github.com/algolia/instantsearch/issues/107)
+- **pagination:** missing showFirstLast attribute when instantiating ([28fa0ae](https://github.com/algolia/instantsearch/commit/28fa0ae))
+- **SearchBox:** Missing poweredBy in the not focused SearchBox ([ef695ff](https://github.com/algolia/instantsearch/commit/ef695ff))
+- **slider:** hide slider if when no hits/matches ([31e4a80](https://github.com/algolia/instantsearch/commit/31e4a80)), closes [#107](https://github.com/algolia/instantsearch/issues/107)
 
 ### Features
 
-* **menu,refinementList:** add header/item/footer templating solution ([58275dc](https://github.com/algolia/instantsearch.js/commit/58275dc)), closes [#101](https://github.com/algolia/instantsearch.js/issues/101)
-* **searchBox:** add poweredBy option, disabled by default ([c9da165](https://github.com/algolia/instantsearch.js/commit/c9da165))
-* **stats:** add query variable to the template ([75f457d](https://github.com/algolia/instantsearch.js/commit/75f457d))
-* **transformData:** add to every widget using the Template component ([d080a03](https://github.com/algolia/instantsearch.js/commit/d080a03)), closes [#116](https://github.com/algolia/instantsearch.js/issues/116)
-* **transformData:** refinementList + menu implementation ([0a0e36e](https://github.com/algolia/instantsearch.js/commit/0a0e36e))
-* **urlSync:** add urlSync widget ([50fc4ce](https://github.com/algolia/instantsearch.js/commit/50fc4ce))
-* **widgets:** auto hide some widgets ([187b4bd](https://github.com/algolia/instantsearch.js/commit/187b4bd))
-
+- **menu,refinementList:** add header/item/footer templating solution ([58275dc](https://github.com/algolia/instantsearch/commit/58275dc)), closes [#101](https://github.com/algolia/instantsearch/issues/101)
+- **searchBox:** add poweredBy option, disabled by default ([c9da165](https://github.com/algolia/instantsearch/commit/c9da165))
+- **stats:** add query variable to the template ([75f457d](https://github.com/algolia/instantsearch/commit/75f457d))
+- **transformData:** add to every widget using the Template component ([d080a03](https://github.com/algolia/instantsearch/commit/d080a03)), closes [#116](https://github.com/algolia/instantsearch/issues/116)
+- **transformData:** refinementList + menu implementation ([0a0e36e](https://github.com/algolia/instantsearch/commit/0a0e36e))
+- **urlSync:** add urlSync widget ([50fc4ce](https://github.com/algolia/instantsearch/commit/50fc4ce))
+- **widgets:** auto hide some widgets ([187b4bd](https://github.com/algolia/instantsearch/commit/187b4bd))
 
 ### BREAKING CHANGES
 
-* Removed from menu and refinementList:
-- rootClass => cssClasses.root
-- itemCLass => cssClasses.item
-- template => templates.item
+- Removed from menu and refinementList:
+
+* rootClass => cssClasses.root
+* itemCLass => cssClasses.item
+* template => templates.item
 
 Added to menu and refinementList:
+
 - cssClasses{root,list,item}
 - templates{header,item,footer}
 - widget (container) is automatically hidden by default
@@ -3994,26 +3136,22 @@ Added to menu and refinementList:
 
 This was done to allow more templating solutions like discussed in #101.
 
-
-
 <a name="0.2.2"></a>
-## [0.2.2](https://github.com/algolia/instantsearch.js/compare/v0.1.0...v0.2.2) (2015-09-17)
 
-
-
+## [0.2.2](https://github.com/algolia/instantsearch/compare/v0.1.0...v0.2.2) (2015-09-17)
 
 <a name="0.2.1"></a>
-## [0.2.1](https://github.com/algolia/instantsearch.js/compare/v0.1.0...v0.2.1) (2015-09-17)
 
-
-
+## [0.2.1](https://github.com/algolia/instantsearch/compare/v0.1.0...v0.2.1) (2015-09-17)
 
 <a name="0.1.0"></a>
+
 # 0.1.0 (2015-09-17)
 
 First release
 
 <a name="0.0.0"></a>
-## [0.0.0](https://github.com/algolia/instantsearch.js/compare/v0.0.0...v0.0.0) (2015-09-17)
+
+## [0.0.0](https://github.com/algolia/instantsearch/compare/v0.0.0...v0.0.0) (2015-09-17)
 
 First commit

--- a/packages/instantsearch.js/README.md
+++ b/packages/instantsearch.js/README.md
@@ -12,14 +12,13 @@
 
 InstantSearch.js is a vanilla JavaScript library that lets you create an instant-search result experience using [Algolia][algolia-website]’s search API. It is part of the InstantSearch family:
 
-**InstantSearch.js** | [React InstantSearch][react-instantsearch-github] | [Vue InstantSearch][vue-instantsearch-github] | [Angular InstantSearch][instantsearch-angular-github] | [React InstantSearch Native][react-instantsearch-github] | [InstantSearch Android][instantsearch-android-github] | [InstantSearch iOS][instantsearch-ios-github]
+**InstantSearch.js** | [React InstantSearch][instantsearch-github] | [Vue InstantSearch][instantsearch-github] | [Angular InstantSearch][instantsearch-angular-github] | [React InstantSearch Native][instantsearch-github] | [InstantSearch Android][instantsearch-android-github] | [InstantSearch iOS][instantsearch-ios-github]
 
 <details>
   <summary><strong>Table of contents</strong></summary>
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 
 - [Why](#why)
 - [Getting started](#getting-started)
@@ -169,7 +168,7 @@ To start contributing to code, you need to:
 1.  Run the development mode: `yarn storybook`
 1.  [Open the stories](http://localhost:6006)
 
-Please read [our contribution process](https://github.com/algolia/instantsearch.js/blob/master/CONTRIBUTING.md) to learn more.
+Please read [our contribution process](https://github.com/algolia/instantsearch/blob/master/CONTRIBUTING.md) to learn more.
 
 ## License
 
@@ -179,14 +178,13 @@ InstantSearch.js is [MIT licensed][license-url].
 
 [license-url]: LICENSE
 [algolia-website]: https://www.algolia.com/?utm_source=instantsearch.js&utm_campaign=repository
-[react-instantsearch-github]: https://github.com/algolia/instantsearch.js/
-[vue-instantsearch-github]: https://github.com/algolia/vue-instantsearch
+[instantsearch-github]: https://github.com/algolia/instantsearch/
 [instantsearch-android-github]: https://github.com/algolia/instantsearch-android
 [instantsearch-ios-github]: https://github.com/algolia/instantsearch-ios
 [instantsearch-angular-github]: https://github.com/algolia/angular-instantsearch
-[contributing-bugreport]: https://github.com/algolia/instantsearch.js/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20InstantSearch.js
-[contributing-featurerequest]: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage,Library%3A%20InstantSearch.js&title=Feature%20request%3A%20
-[contributing-newissue]: https://github.com/algolia/instantsearch.js/issues/new?labels=triage,Library%3A%20InstantSearch.js
-[contributing-label-easy]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20InstantSearch.js%22
-[contributing-label-bug]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20InstantSearch.js%22
-[contributing-label-chore]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20InstantSearch.js%22
+[contributing-bugreport]: https://github.com/algolia/instantsearch/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20InstantSearch.js
+[contributing-featurerequest]: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage,Library%3A%20InstantSearch.js&title=Feature%20request%3A%20
+[contributing-newissue]: https://github.com/algolia/instantsearch/issues/new?labels=triage,Library%3A%20InstantSearch.js
+[contributing-label-easy]: https://github.com/algolia/instantsearch/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20InstantSearch.js%22
+[contributing-label-bug]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20InstantSearch.js%22
+[contributing-label-chore]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20InstantSearch.js%22

--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -13,7 +13,7 @@
   ],
   "author": "Algolia <support@algolia.com>",
   "license": "MIT",
-  "repository": "algolia/instantsearch.js",
+  "repository": "algolia/instantsearch",
   "main": "cjs/index.js",
   "module": "es/index.js",
   "jsdelivr": "dist/instantsearch.production.min.js",

--- a/packages/instantsearch.js/scripts/rollup/rollup.config.js
+++ b/packages/instantsearch.js/scripts/rollup/rollup.config.js
@@ -12,7 +12,7 @@ const version =
     ? packageJson.version
     : `UNRELEASED (${new Date().toUTCString()})`;
 const algolia = '© Algolia, Inc. and contributors; MIT License';
-const link = 'https://github.com/algolia/instantsearch.js';
+const link = 'https://github.com/algolia/instantsearch';
 const license = `/*! InstantSearch.js ${version} | ${algolia} | ${link} */`;
 
 const plugins = [

--- a/packages/instantsearch.js/src/components/SearchBox/SearchBox.tsx
+++ b/packages/instantsearch.js/src/components/SearchBox/SearchBox.tsx
@@ -97,7 +97,7 @@ class SearchBox extends Component<
     /**
      * when the user is typing, we don't want to replace the query typed
      * by the user (state.query) with the query exposed by the connector (props.query)
-     * see: https://github.com/algolia/instantsearch.js/issues/4141
+     * see: https://github.com/algolia/instantsearch/issues/4141
      */
     if (!this.state.focused && nextProps.query !== this.state.query) {
       this.setState({ query: nextProps.query });

--- a/packages/instantsearch.js/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
+++ b/packages/instantsearch.js/src/connectors/numeric-menu/__tests__/connectNumericMenu-test.ts
@@ -1132,7 +1132,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
   });
 
   describe('insights', () => {
-    // See: https://github.com/algolia/instantsearch.js/pull/5085
+    // See: https://github.com/algolia/instantsearch/pull/5085
     it(`doesn't send event when a facet is added`, () => {
       const rendering = jest.fn();
       const makeWidget = connectNumericMenu(rendering);

--- a/packages/instantsearch.js/src/connectors/range/__tests__/connectRange-test.ts
+++ b/packages/instantsearch.js/src/connectors/range/__tests__/connectRange-test.ts
@@ -2220,7 +2220,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/range-input
 });
 
 describe('insights', () => {
-  // See: https://github.com/algolia/instantsearch.js/pull/5085
+  // See: https://github.com/algolia/instantsearch/pull/5085
   it(`doesn't send event when a facet is added`, () => {
     const rendering = jest.fn();
     const makeWidget = connectRange(rendering);

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -636,7 +636,7 @@ See ${createDocumentationLink({
   /**
    * Removes all widgets without triggering a search afterwards. This is an **EXPERIMENTAL** feature,
    * if you find an issue with it, please
-   * [open an issue](https://github.com/algolia/instantsearch.js/issues/new?title=Problem%20with%20dispose).
+   * [open an issue](https://github.com/algolia/instantsearch/issues/new?title=Problem%20with%20dispose).
    * @return {undefined} This method does not return anything
    */
   public dispose(): void {

--- a/packages/instantsearch.js/src/lib/routers/history.ts
+++ b/packages/instantsearch.js/src/lib/routers/history.ts
@@ -204,7 +204,7 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
    *
    * It always generates the full URL, not a relative one.
    * This allows to handle cases like using a <base href>.
-   * See: https://github.com/algolia/instantsearch.js/issues/790
+   * See: https://github.com/algolia/instantsearch/issues/790
    */
   public createURL(routeState: TRouteState): string {
     const url = this._createURL({

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -2484,7 +2484,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       });
     });
 
-    // https://github.com/algolia/instantsearch.js/pull/2623
+    // https://github.com/algolia/instantsearch/pull/2623
     it('does not call `render` without `lastResults`', () => {
       const instance = index({ indexName: 'indexName' });
 

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -582,7 +582,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       // configuration step. This is mainly for backward compatibility with custom
       // widgets. When the subscription happens before the `init` step, the (static)
       // configuration of the widget is pushed in the URL. That's what we want to avoid.
-      // https://github.com/algolia/instantsearch.js/pull/994/commits/4a672ae3fd78809e213de0368549ef12e9dc9454
+      // https://github.com/algolia/instantsearch/pull/994/commits/4a672ae3fd78809e213de0368549ef12e9dc9454
       helper.on('change', (event) => {
         const { state } = event;
 

--- a/packages/instantsearch.js/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
+++ b/packages/instantsearch.js/src/widgets/numeric-menu/__tests__/numeric-menu-test.ts
@@ -165,7 +165,7 @@ describe('numericMenu()', () => {
   });
 
   it('does not alter the initial items when rendering', () => {
-    // Note: https://github.com/algolia/instantsearch.js/issues/1010
+    // Note: https://github.com/algolia/instantsearch/issues/1010
     // Make sure we work on a copy of the initial facetValues when rendering,
     // not directly editing it
 

--- a/packages/instantsearch.js/test/createInstantSearch.ts
+++ b/packages/instantsearch.js/test/createInstantSearch.ts
@@ -48,7 +48,7 @@ export const createInstantSearch = (
     // Since we defer `onInternalStateChange` with our `defer` util which
     // creates a scoped deferred function, we're not able to spy that method.
     // We'll therefore need to override it when calling `createInstantSearch`.
-    // See https://github.com/algolia/instantsearch.js/blob/f3213b2f118d75acac31a1f6cf4640241c438e9d/src/lib/utils/defer.ts#L13-L28
+    // See https://github.com/algolia/instantsearch/blob/f3213b2f118d75acac31a1f6cf4640241c438e9d/src/lib/utils/defer.ts#L13-L28
     onInternalStateChange: jest.fn() as any,
     createURL: jest.fn(() => '#'),
     addWidget: jest.fn(),

--- a/packages/react-instantsearch-core/CHANGELOG.md
+++ b/packages/react-instantsearch-core/CHANGELOG.md
@@ -1,29 +1,20 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.0.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-core@7.0.1...react-instantsearch-core@7.0.2) (2023-09-05)
-
-**Note:** Version bump only for package react-instantsearch-core
-
-
-
-
-
-## [7.0.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-core@7.0.0...react-instantsearch-core@7.0.1) (2023-08-08)
+## [7.0.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-core@7.0.1...react-instantsearch-core@7.0.2) (2023-09-05)
 
 **Note:** Version bump only for package react-instantsearch-core
 
+## [7.0.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-core@7.0.0...react-instantsearch-core@7.0.1) (2023-08-08)
 
+**Note:** Version bump only for package react-instantsearch-core
 
-
-
-# [7.0.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-core@6.40.4...react-instantsearch-core@7.0.0) (2023-08-07)
+# [7.0.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-core@6.40.4...react-instantsearch-core@7.0.0) (2023-08-07)
 
 ### Features
 
-- rename packages ([#5787](https://github.com/algolia/instantsearch.js/issues/5787)) ([c133170](https://github.com/algolia/instantsearch.js/commit/c133170e563592dfc15a95daced1f8447327a09a))
+- rename packages ([#5787](https://github.com/algolia/instantsearch/issues/5787)) ([c133170](https://github.com/algolia/instantsearch/commit/c133170e563592dfc15a95daced1f8447327a09a))
 
 ### Breaking Changes
 
@@ -35,163 +26,163 @@ The following APIs have been changed:
 
 See detailed instructions in the [upgrade guide](https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/).
 
-## [6.47.3](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.47.2...react-instantsearch-hooks@6.47.3) (2023-07-27)
+## [6.47.3](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.47.2...react-instantsearch-hooks@6.47.3) (2023-07-27)
 
 ### Bug Fixes
 
-- add a future warning when the package name changes ([#5778](https://github.com/algolia/instantsearch.js/issues/5778)) ([3d22ee4](https://github.com/algolia/instantsearch.js/commit/3d22ee45e1f03a443323a371621262f1fe45e664))
-- **useInstantSearch:** deprecate `use` function ([#5781](https://github.com/algolia/instantsearch.js/issues/5781)) ([ec16c6e](https://github.com/algolia/instantsearch.js/commit/ec16c6e74cc9e364aca47d64983be32bf0cce0fe))
+- add a future warning when the package name changes ([#5778](https://github.com/algolia/instantsearch/issues/5778)) ([3d22ee4](https://github.com/algolia/instantsearch/commit/3d22ee45e1f03a443323a371621262f1fe45e664))
+- **useInstantSearch:** deprecate `use` function ([#5781](https://github.com/algolia/instantsearch/issues/5781)) ([ec16c6e](https://github.com/algolia/instantsearch/commit/ec16c6e74cc9e364aca47d64983be32bf0cce0fe))
 
-## [6.47.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.47.1...react-instantsearch-hooks@6.47.2) (2023-07-25)
+## [6.47.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.47.1...react-instantsearch-hooks@6.47.2) (2023-07-25)
 
 **Note:** Version bump only for package react-instantsearch-hooks
 
-## [6.47.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.47.0...react-instantsearch-hooks@6.47.1) (2023-07-19)
+## [6.47.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.47.0...react-instantsearch-hooks@6.47.1) (2023-07-19)
 
 ### Bug Fixes
 
-- **instantsearch:** keep algoliasearch-helper as external dependency during build ([#5765](https://github.com/algolia/instantsearch.js/issues/5765)) ([550fefa](https://github.com/algolia/instantsearch.js/commit/550fefa1401773f38dedc20322513ae662faa25d))
+- **instantsearch:** keep algoliasearch-helper as external dependency during build ([#5765](https://github.com/algolia/instantsearch/issues/5765)) ([550fefa](https://github.com/algolia/instantsearch/commit/550fefa1401773f38dedc20322513ae662faa25d))
 
-# [6.47.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.46.0...react-instantsearch-hooks@6.47.0) (2023-07-18)
+# [6.47.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.46.0...react-instantsearch-hooks@6.47.0) (2023-07-18)
 
 **Note:** Version bump only for package react-instantsearch-hooks
 
-# [6.46.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.45.1...react-instantsearch-hooks@6.46.0) (2023-07-10)
+# [6.46.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.45.1...react-instantsearch-hooks@6.46.0) (2023-07-10)
 
 ### Bug Fixes
 
-- **url:** base createURL on UiState instead of SearchParameters ([#5696](https://github.com/algolia/instantsearch.js/issues/5696)) ([7e2c8a2](https://github.com/algolia/instantsearch.js/commit/7e2c8a295a6fc5ba36d9482f645ef55b422d5e75)), closes [#5694](https://github.com/algolia/instantsearch.js/issues/5694)
+- **url:** base createURL on UiState instead of SearchParameters ([#5696](https://github.com/algolia/instantsearch/issues/5696)) ([7e2c8a2](https://github.com/algolia/instantsearch/commit/7e2c8a295a6fc5ba36d9482f645ef55b422d5e75)), closes [#5694](https://github.com/algolia/instantsearch/issues/5694)
 
 ### Features
 
-- **GeoSearch:** expose useGeoSearch() hook in RISH ([#5693](https://github.com/algolia/instantsearch.js/issues/5693)) ([b951b7b](https://github.com/algolia/instantsearch.js/commit/b951b7bcafb384d990ccf02538d9bb9e248a6bba))
+- **GeoSearch:** expose useGeoSearch() hook in RISH ([#5693](https://github.com/algolia/instantsearch/issues/5693)) ([b951b7b](https://github.com/algolia/instantsearch/commit/b951b7bcafb384d990ccf02538d9bb9e248a6bba))
 
-## [6.45.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.45.0...react-instantsearch-hooks@6.45.1) (2023-07-04)
+## [6.45.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.45.0...react-instantsearch-hooks@6.45.1) (2023-07-04)
 
 **Note:** Version bump only for package react-instantsearch-hooks
 
-# [6.45.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.44.3...react-instantsearch-hooks@6.45.0) (2023-06-20)
+# [6.45.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.44.3...react-instantsearch-hooks@6.45.0) (2023-06-20)
 
 ### Bug Fixes
 
-- **dependencies:** update helper requirement ([#5676](https://github.com/algolia/instantsearch.js/issues/5676)) ([c289120](https://github.com/algolia/instantsearch.js/commit/c2891205c1125b1203b3b3db946d57e0fc4e4687)), closes [#5658](https://github.com/algolia/instantsearch.js/issues/5658)
+- **dependencies:** update helper requirement ([#5676](https://github.com/algolia/instantsearch/issues/5676)) ([c289120](https://github.com/algolia/instantsearch/commit/c2891205c1125b1203b3b3db946d57e0fc4e4687)), closes [#5658](https://github.com/algolia/instantsearch/issues/5658)
 
 ### Features
 
-- **algoliaAgent:** track Next.js version as Algolia agent ([#5677](https://github.com/algolia/instantsearch.js/issues/5677)) ([b205ac0](https://github.com/algolia/instantsearch.js/commit/b205ac019f79699cd608d63792b8ff5a0832aa7c))
+- **algoliaAgent:** track Next.js version as Algolia agent ([#5677](https://github.com/algolia/instantsearch/issues/5677)) ([b205ac0](https://github.com/algolia/instantsearch/commit/b205ac019f79699cd608d63792b8ff5a0832aa7c))
 
-## [6.44.3](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.44.2...react-instantsearch-hooks@6.44.3) (2023-06-13)
+## [6.44.3](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.44.2...react-instantsearch-hooks@6.44.3) (2023-06-13)
 
 **Note:** Version bump only for package react-instantsearch-hooks
 
-## [6.44.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.44.1...react-instantsearch-hooks@6.44.2) (2023-06-05)
+## [6.44.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.44.1...react-instantsearch-hooks@6.44.2) (2023-06-05)
 
 ### Bug Fixes
 
-- **hooks:** generate version for algoliaAgent in build ([#5655](https://github.com/algolia/instantsearch.js/issues/5655)) ([4d92ac4](https://github.com/algolia/instantsearch.js/commit/4d92ac4769e19e81fb55481aedc71121bef981cb))
+- **hooks:** generate version for algoliaAgent in build ([#5655](https://github.com/algolia/instantsearch/issues/5655)) ([4d92ac4](https://github.com/algolia/instantsearch/commit/4d92ac4769e19e81fb55481aedc71121bef981cb))
 
-## [6.44.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.44.0...react-instantsearch-hooks@6.44.1) (2023-05-30)
+## [6.44.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.44.0...react-instantsearch-hooks@6.44.1) (2023-05-30)
 
 **Note:** Version bump only for package react-instantsearch-hooks
 
-# [6.44.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.43.0...react-instantsearch-hooks@6.44.0) (2023-05-16)
+# [6.44.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.43.0...react-instantsearch-hooks@6.44.0) (2023-05-16)
 
 ### Bug Fixes
 
-- **this:** ensure all functions are able to be destructured ([#5611](https://github.com/algolia/instantsearch.js/issues/5611)) ([a8b5c1e](https://github.com/algolia/instantsearch.js/commit/a8b5c1e5bbd6afac39fce523f7d7c2ec02f51153)), closes [#5589](https://github.com/algolia/instantsearch.js/issues/5589)
+- **this:** ensure all functions are able to be destructured ([#5611](https://github.com/algolia/instantsearch/issues/5611)) ([a8b5c1e](https://github.com/algolia/instantsearch/commit/a8b5c1e5bbd6afac39fce523f7d7c2ec02f51153)), closes [#5589](https://github.com/algolia/instantsearch/issues/5589)
 
 ### Features
 
-- **instantsearch:** make root indexName optional ([#5590](https://github.com/algolia/instantsearch.js/issues/5590)) ([80f309e](https://github.com/algolia/instantsearch.js/commit/80f309ed69b61534ca118b60c9c88691e0148fca))
+- **instantsearch:** make root indexName optional ([#5590](https://github.com/algolia/instantsearch/issues/5590)) ([80f309e](https://github.com/algolia/instantsearch/commit/80f309ed69b61534ca118b60c9c88691e0148fca))
 
-# [6.43.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.42.2...react-instantsearch-hooks@6.43.0) (2023-04-24)
+# [6.43.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.42.2...react-instantsearch-hooks@6.43.0) (2023-04-24)
 
 ### Bug Fixes
 
-- **lifecycle:** prevent extra network requests when unmounting multiple widgets ([#5602](https://github.com/algolia/instantsearch.js/issues/5602)) ([11458ee](https://github.com/algolia/instantsearch.js/commit/11458eee7e7f0f3e9c5f368584a16f58646b1cdd))
+- **lifecycle:** prevent extra network requests when unmounting multiple widgets ([#5602](https://github.com/algolia/instantsearch/issues/5602)) ([11458ee](https://github.com/algolia/instantsearch/commit/11458eee7e7f0f3e9c5f368584a16f58646b1cdd))
 
 ### Features
 
-- **insights:** add insights option to InstantSearch ([#5488](https://github.com/algolia/instantsearch.js/issues/5488)) ([9031573](https://github.com/algolia/instantsearch.js/commit/9031573807fa6803dcfae9f33d61b8f111f68423)) ([#5578](https://github.com/algolia/instantsearch.js/issues/5578)) ([8fb517f](https://github.com/algolia/instantsearch.js/commit/8fb517f15381ecb32ea00cf4b01a0fd5e70e1d17)) ([#5545](https://github.com/algolia/instantsearch.js/issues/5545)) ([99a0972](https://github.com/algolia/instantsearch.js/commit/99a0972663b8f3284cac3b5621571ced7a33908f)) ([#5493](https://github.com/algolia/instantsearch.js/issues/5493)) ([cff723f](https://github.com/algolia/instantsearch.js/commit/cff723fc95a90ebb2ed14c46c51ab05764835a47))
-- **insights:** always pass Algolia credentials locally ([#5554](https://github.com/algolia/instantsearch.js/issues/5554)) ([654ab81](https://github.com/algolia/instantsearch.js/commit/654ab81e1669354c249710b6756610fba35d54b4)) ([#5558](https://github.com/algolia/instantsearch.js/issues/5558)) ([82144c0](https://github.com/algolia/instantsearch.js/commit/82144c0a0b18e6b47d6f508e5c670a9de274c121)) ([#5529](https://github.com/algolia/instantsearch.js/issues/5529)) ([8537f8f](https://github.com/algolia/instantsearch.js/commit/8537f8f7a10bcaf053ff62180c082e077b1b052d))
-- **insights:** annotate events with algoliaSource ([#5580](https://github.com/algolia/instantsearch.js/issues/5580)) ([c419307](https://github.com/algolia/instantsearch.js/commit/c419307a5f7fe46d5032c9437a17c8e3dad57fe5))
-- **insights:** automatically load search-insights if not passed ([#5484](https://github.com/algolia/instantsearch.js/issues/5484)) ([a85797b](https://github.com/algolia/instantsearch.js/commit/a85797b503edc94e001c5bfb3b754db6cb556943))
-- **insights:** enable default click events on hits and infinite hits ([#5522](https://github.com/algolia/instantsearch.js/issues/5522)) ([271bd12](https://github.com/algolia/instantsearch.js/commit/271bd12e34bc55656976bb53c90282193083eb86)) ([#5527](https://github.com/algolia/instantsearch.js/issues/5527)) ([0e55821](https://github.com/algolia/instantsearch.js/commit/0e558213c807cd17d592fadec052f3d1fc692e6c))
-- **insights:** prevent potential errors ([#5487](https://github.com/algolia/instantsearch.js/issues/5487)) ([33fe510](https://github.com/algolia/instantsearch.js/commit/33fe510307e4b382a5ba1153a0eaf160420acd11)) ([#5606](https://github.com/algolia/instantsearch.js/issues/5606)) ([bdd9290](https://github.com/algolia/instantsearch.js/commit/bdd92901b59ae4e5d7311eadfbf53ed656bbaf4a)) ([#5512](https://github.com/algolia/instantsearch.js/issues/5512)) ([85dfbc9](https://github.com/algolia/instantsearch.js/commit/85dfbc9ebd722fbe6a7e1bd056950fdbcc16d8d9))
-- **metadata:** register metadata around middleware ([#5492](https://github.com/algolia/instantsearch.js/issues/5492)) ([3e72ec8](https://github.com/algolia/instantsearch.js/commit/3e72ec82894a05a071328a4802d2f764233fe005))
+- **insights:** add insights option to InstantSearch ([#5488](https://github.com/algolia/instantsearch/issues/5488)) ([9031573](https://github.com/algolia/instantsearch/commit/9031573807fa6803dcfae9f33d61b8f111f68423)) ([#5578](https://github.com/algolia/instantsearch/issues/5578)) ([8fb517f](https://github.com/algolia/instantsearch/commit/8fb517f15381ecb32ea00cf4b01a0fd5e70e1d17)) ([#5545](https://github.com/algolia/instantsearch/issues/5545)) ([99a0972](https://github.com/algolia/instantsearch/commit/99a0972663b8f3284cac3b5621571ced7a33908f)) ([#5493](https://github.com/algolia/instantsearch/issues/5493)) ([cff723f](https://github.com/algolia/instantsearch/commit/cff723fc95a90ebb2ed14c46c51ab05764835a47))
+- **insights:** always pass Algolia credentials locally ([#5554](https://github.com/algolia/instantsearch/issues/5554)) ([654ab81](https://github.com/algolia/instantsearch/commit/654ab81e1669354c249710b6756610fba35d54b4)) ([#5558](https://github.com/algolia/instantsearch/issues/5558)) ([82144c0](https://github.com/algolia/instantsearch/commit/82144c0a0b18e6b47d6f508e5c670a9de274c121)) ([#5529](https://github.com/algolia/instantsearch/issues/5529)) ([8537f8f](https://github.com/algolia/instantsearch/commit/8537f8f7a10bcaf053ff62180c082e077b1b052d))
+- **insights:** annotate events with algoliaSource ([#5580](https://github.com/algolia/instantsearch/issues/5580)) ([c419307](https://github.com/algolia/instantsearch/commit/c419307a5f7fe46d5032c9437a17c8e3dad57fe5))
+- **insights:** automatically load search-insights if not passed ([#5484](https://github.com/algolia/instantsearch/issues/5484)) ([a85797b](https://github.com/algolia/instantsearch/commit/a85797b503edc94e001c5bfb3b754db6cb556943))
+- **insights:** enable default click events on hits and infinite hits ([#5522](https://github.com/algolia/instantsearch/issues/5522)) ([271bd12](https://github.com/algolia/instantsearch/commit/271bd12e34bc55656976bb53c90282193083eb86)) ([#5527](https://github.com/algolia/instantsearch/issues/5527)) ([0e55821](https://github.com/algolia/instantsearch/commit/0e558213c807cd17d592fadec052f3d1fc692e6c))
+- **insights:** prevent potential errors ([#5487](https://github.com/algolia/instantsearch/issues/5487)) ([33fe510](https://github.com/algolia/instantsearch/commit/33fe510307e4b382a5ba1153a0eaf160420acd11)) ([#5606](https://github.com/algolia/instantsearch/issues/5606)) ([bdd9290](https://github.com/algolia/instantsearch/commit/bdd92901b59ae4e5d7311eadfbf53ed656bbaf4a)) ([#5512](https://github.com/algolia/instantsearch/issues/5512)) ([85dfbc9](https://github.com/algolia/instantsearch/commit/85dfbc9ebd722fbe6a7e1bd056950fdbcc16d8d9))
+- **metadata:** register metadata around middleware ([#5492](https://github.com/algolia/instantsearch/issues/5492)) ([3e72ec8](https://github.com/algolia/instantsearch/commit/3e72ec82894a05a071328a4802d2f764233fe005))
 
-## [6.42.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.42.1...react-instantsearch-hooks@6.42.2) (2023-04-11)
+## [6.42.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.42.1...react-instantsearch-hooks@6.42.2) (2023-04-11)
 
 **Note:** Version bump only for package react-instantsearch-hooks
 
-## [6.42.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.42.0...react-instantsearch-hooks@6.42.1) (2023-03-28)
+## [6.42.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.42.0...react-instantsearch-hooks@6.42.1) (2023-03-28)
 
 ### Features
 
-- **InstantSearch**: warn when an unstable search client is detected ([#5563](https://github.com/algolia/instantsearch.js/issues/5563)) ([0fcf716](https://github.com/algolia/instantsearch/commit/0fcf7162ce77246133c0d4a6ff7ea975ba17cc4c))
+- **InstantSearch**: warn when an unstable search client is detected ([#5563](https://github.com/algolia/instantsearch/issues/5563)) ([0fcf716](https://github.com/algolia/instantsearch/commit/0fcf7162ce77246133c0d4a6ff7ea975ba17cc4c))
 
-# [6.42.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.41.0...react-instantsearch-hooks@6.42.0) (2023-03-21)
-
-### Features
-
-- **current-refinements:** provide indexId of refinements in transformItems ([#5546](https://github.com/algolia/instantsearch.js/issues/5546)) ([89781db](https://github.com/algolia/instantsearch.js/commit/89781db6cb1d2b8ebbc116e9bcd8a10f646e7baf))
-
-# [6.41.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.40.1...react-instantsearch-hooks@6.41.0) (2023-03-07)
+# [6.42.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.41.0...react-instantsearch-hooks@6.42.0) (2023-03-21)
 
 ### Features
 
-- **index:** introduce setIndexUiState ([#5504](https://github.com/algolia/instantsearch.js/issues/5504)) ([c199feb](https://github.com/algolia/instantsearch.js/commit/c199febbc3381df574afbb2504edd7373b32904a))
-- **react:** export `InstantSearchApi` type ([#5518](https://github.com/algolia/instantsearch.js/issues/5518)) ([27b478f](https://github.com/algolia/instantsearch.js/commit/27b478f8f20c4e8835914cceabbdce57ff5d4650))
+- **current-refinements:** provide indexId of refinements in transformItems ([#5546](https://github.com/algolia/instantsearch/issues/5546)) ([89781db](https://github.com/algolia/instantsearch/commit/89781db6cb1d2b8ebbc116e9bcd8a10f646e7baf))
+
+# [6.41.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.40.1...react-instantsearch-hooks@6.41.0) (2023-03-07)
+
+### Features
+
+- **index:** introduce setIndexUiState ([#5504](https://github.com/algolia/instantsearch/issues/5504)) ([c199feb](https://github.com/algolia/instantsearch/commit/c199febbc3381df574afbb2504edd7373b32904a))
+- **react:** export `InstantSearchApi` type ([#5518](https://github.com/algolia/instantsearch/issues/5518)) ([27b478f](https://github.com/algolia/instantsearch/commit/27b478f8f20c4e8835914cceabbdce57ff5d4650))
 
 ## Bug Fixes
 
-- **DynamicWidgets**: prevent non-stable fallbackComponent ([#5532](https://github.com/algolia/instantsearch.js/issues/5532)) ([0625c90](https://github.com/algolia/instantsearch.js/commit/0625c90346e32b926d6ce276a4e0b13d4fa4bf6c))
+- **DynamicWidgets**: prevent non-stable fallbackComponent ([#5532](https://github.com/algolia/instantsearch/issues/5532)) ([0625c90](https://github.com/algolia/instantsearch/commit/0625c90346e32b926d6ce276a4e0b13d4fa4bf6c))
 
-## [6.40.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.40.1...react-instantsearch-hooks@6.40.2) (2023-02-28)
-
-**Note:** Version bump only for package react-instantsearch-hooks
-
-## [6.40.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.40.0...react-instantsearch-hooks@6.40.1) (2023-02-21)
+## [6.40.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.40.1...react-instantsearch-hooks@6.40.2) (2023-02-28)
 
 **Note:** Version bump only for package react-instantsearch-hooks
 
-# [6.40.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.39.3...react-instantsearch-hooks@6.40.0) (2023-02-14)
+## [6.40.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.40.0...react-instantsearch-hooks@6.40.1) (2023-02-21)
+
+**Note:** Version bump only for package react-instantsearch-hooks
+
+# [6.40.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.39.3...react-instantsearch-hooks@6.40.0) (2023-02-14)
 
 ### Features
 
-- Warn when not using the dedicated Next.js router ([#5432](https://github.com/algolia/instantsearch.js/issues/5432)) ([39b5859](https://github.com/algolia/instantsearch.js/commit/39b5859ba78a5e8472a80e357a35ba900c963b61))
+- Warn when not using the dedicated Next.js router ([#5432](https://github.com/algolia/instantsearch/issues/5432)) ([39b5859](https://github.com/algolia/instantsearch/commit/39b5859ba78a5e8472a80e357a35ba900c963b61))
 
 ### Bug Fixes
 
-- Prevent issue where instantsearch instance got created twice in ssr ([#5432](https://github.com/algolia/instantsearch.js/issues/5432)) ([39b5859](https://github.com/algolia/instantsearch.js/commit/39b5859ba78a5e8472a80e357a35ba900c963b61))
+- Prevent issue where instantsearch instance got created twice in ssr ([#5432](https://github.com/algolia/instantsearch/issues/5432)) ([39b5859](https://github.com/algolia/instantsearch/commit/39b5859ba78a5e8472a80e357a35ba900c963b61))
 
-## [6.39.3](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.39.2...react-instantsearch-hooks@6.39.3) (2023-02-07)
-
-**Note:** Version bump only for package react-instantsearch-hooks
-
-## [6.39.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.39.1...react-instantsearch-hooks@6.39.2) (2023-01-30)
+## [6.39.3](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.39.2...react-instantsearch-hooks@6.39.3) (2023-02-07)
 
 **Note:** Version bump only for package react-instantsearch-hooks
 
-## [6.39.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.39.0...react-instantsearch-hooks@6.39.1) (2023-01-26)
+## [6.39.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.39.1...react-instantsearch-hooks@6.39.2) (2023-01-30)
 
 **Note:** Version bump only for package react-instantsearch-hooks
 
-# [6.39.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.38.3...react-instantsearch-hooks@6.39.0) (2023-01-25)
+## [6.39.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.39.0...react-instantsearch-hooks@6.39.1) (2023-01-26)
+
+**Note:** Version bump only for package react-instantsearch-hooks
+
+# [6.39.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.38.3...react-instantsearch-hooks@6.39.0) (2023-01-25)
 
 ### Features
 
-- **react-instantsearch-hooks-web:** Add stats widget and ui component ([#5427](https://github.com/algolia/instantsearch.js/issues/5427)) ([d07cf0d](https://github.com/algolia/instantsearch.js/commit/d07cf0d0310bf4e49d4a4c2142b3783d9bcda79d))
-- **react-instantsearch-hooks:** Add useStats hook ([#5425](https://github.com/algolia/instantsearch.js/issues/5425)) ([772c918](https://github.com/algolia/instantsearch.js/commit/772c918f47aec183af3f1aa78c65505f70dd0088))
-- **rendering:** always render with current state ([#5429](https://github.com/algolia/instantsearch.js/issues/5429)) ([920e951](https://github.com/algolia/instantsearch.js/commit/920e951f03aada0e6a1ce16bc389a82a2f00b202))
+- **react-instantsearch-hooks-web:** Add stats widget and ui component ([#5427](https://github.com/algolia/instantsearch/issues/5427)) ([d07cf0d](https://github.com/algolia/instantsearch/commit/d07cf0d0310bf4e49d4a4c2142b3783d9bcda79d))
+- **react-instantsearch-hooks:** Add useStats hook ([#5425](https://github.com/algolia/instantsearch/issues/5425)) ([772c918](https://github.com/algolia/instantsearch/commit/772c918f47aec183af3f1aa78c65505f70dd0088))
+- **rendering:** always render with current state ([#5429](https://github.com/algolia/instantsearch/issues/5429)) ([920e951](https://github.com/algolia/instantsearch/commit/920e951f03aada0e6a1ce16bc389a82a2f00b202))
 
-## [6.38.3](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.38.2...react-instantsearch-hooks@6.38.3) (2023-01-09)
+## [6.38.3](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.38.2...react-instantsearch-hooks@6.38.3) (2023-01-09)
 
 ### Bug Fixes
 
-- **dependencies:** update helper requirement for minor PP vulnerability ([#5417](https://github.com/algolia/instantsearch.js/issues/5417)) ([254ef00](https://github.com/algolia/instantsearch.js/commit/254ef00439a9af48be15f22b4fd9902899610226))
+- **dependencies:** update helper requirement for minor PP vulnerability ([#5417](https://github.com/algolia/instantsearch/issues/5417)) ([254ef00](https://github.com/algolia/instantsearch/commit/254ef00439a9af48be15f22b4fd9902899610226))
 
-## [6.38.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks@6.38.1...react-instantsearch-hooks@6.38.2) (2023-01-03)
+## [6.38.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks@6.38.1...react-instantsearch-hooks@6.38.2) (2023-01-03)
 
 **Note:** Version bump only for package react-instantsearch-hooks
 
@@ -317,7 +308,7 @@ See detailed instructions in the [upgrade guide](https://www.algolia.com/doc/gui
 - **hooks-server:** import react server via an expression ([#3515](https://github.com/algolia/react-instantsearch/issues/3515)) ([91b96f7](https://github.com/algolia/react-instantsearch/commit/91b96f743b9315ed5ea781681b77fc7f5604ab6e)), closes [#3512](https://github.com/algolia/react-instantsearch/issues/3512)
 - **hooks-web:** fix duplicated key in <CurrentRefinements> ([#3513](https://github.com/algolia/react-instantsearch/issues/3513)) ([fc94d80](https://github.com/algolia/react-instantsearch/commit/fc94d806daf139f58b234cdc0b450da2efe861ee))
 - **hooks:** mount widgets in SSR to retrieve HTML ([#3518](https://github.com/algolia/react-instantsearch/issues/3518)) ([aa5f9d8](https://github.com/algolia/react-instantsearch/commit/aa5f9d84ddb6e97d05e6ad1baf2c6caa23891281))
-- **types:** allow useInstantSearch to be generic ([#3508](https://github.com/algolia/react-instantsearch/issues/3508)) ([6807232](https://github.com/algolia/react-instantsearch/commit/68072324cf302801502a1b4c3d06703e57b55a97)), closes [algolia/instantsearch.js#5060](https://github.com/algolia/instantsearch.js/issues/5060)
+- **types:** allow useInstantSearch to be generic ([#3508](https://github.com/algolia/react-instantsearch/issues/3508)) ([6807232](https://github.com/algolia/react-instantsearch/commit/68072324cf302801502a1b4c3d06703e57b55a97)), closes [algolia/instantsearch#5060](https://github.com/algolia/instantsearch/issues/5060)
 - **types:** support React 18 types ([#3481](https://github.com/algolia/react-instantsearch/issues/3481)) ([74cf8cb](https://github.com/algolia/react-instantsearch/commit/74cf8cb9be8ff3d113b57a50e7083df0d1bc94f2))
 
 ### Features
@@ -1397,19 +1388,19 @@ You can find all the details of the release and the migration guide from v3 to v
 
 <a name="4.0.0-beta.1"></a>
 
-# [4.0.0-beta.1](https://github.com/algolia/instantsearch.js/compare/v4.0.0-beta.0...v4.0.0-beta.1) (2017-04-03)
+# [4.0.0-beta.1](https://github.com/algolia/instantsearch/compare/v4.0.0-beta.0...v4.0.0-beta.1) (2017-04-03)
 
 ### Bug Fixes
 
-- **SFFV:** fix wrong query behaviour with slow network (#2086) ([c251e8f](https://github.com/algolia/instantsearch.js/commit/c251e8f)), closes [#2086](https://github.com/algolia/instantsearch.js/issues/2086)
+- **SFFV:** fix wrong query behaviour with slow network (#2086) ([c251e8f](https://github.com/algolia/instantsearch/commit/c251e8f)), closes [#2086](https://github.com/algolia/instantsearch/issues/2086)
 
 <a name="4.0.0-beta.0"></a>
 
-# [4.0.0-beta.0](https://github.com/algolia/instantsearch.js/compare/v3.3.0...v4.0.0-beta.0) (2017-03-28)
+# [4.0.0-beta.0](https://github.com/algolia/instantsearch/compare/v3.3.0...v4.0.0-beta.0) (2017-03-28)
 
 ### Features
 
-- **multi-index:** ease multi index and auto complete ([09a4e1d](https://github.com/algolia/instantsearch.js/commit/09a4e1d))
+- **multi-index:** ease multi index and auto complete ([09a4e1d](https://github.com/algolia/instantsearch/commit/09a4e1d))
 
 ### BREAKING CHANGES
 
@@ -1420,49 +1411,49 @@ You can find all the details of the release and the migration guide from v3 to v
 
 <a name="3.3.0"></a>
 
-# [3.3.0](https://github.com/algolia/instantsearch.js/compare/v3.2.2-beta0...v3.3.0) (2017-03-22)
+# [3.3.0](https://github.com/algolia/instantsearch/compare/v3.2.2-beta0...v3.3.0) (2017-03-22)
 
 ### Bug Fixes
 
-- **example:** Fix access to props in react-router example ([1417d6f](https://github.com/algolia/instantsearch.js/commit/1417d6f))
+- **example:** Fix access to props in react-router example ([1417d6f](https://github.com/algolia/instantsearch/commit/1417d6f))
 
 <a name="3.2.2-beta0"></a>
 
-## [3.2.2-beta0](https://github.com/algolia/instantsearch.js/compare/v3.2.1...v3.2.2-beta0) (2017-03-20)
+## [3.2.2-beta0](https://github.com/algolia/instantsearch/compare/v3.2.1...v3.2.2-beta0) (2017-03-20)
 
 ### Bug Fixes
 
-- **InfiniteHits:** provide translation key for `Load More` (#2048) ([6130bf2](https://github.com/algolia/instantsearch.js/commit/6130bf2))
-- **SearchBox:** better mobile behaviour by default ([ea968b3](https://github.com/algolia/instantsearch.js/commit/ea968b3))
-- **example:** link to instantsearch/react (#2007) ([5e674cd](https://github.com/algolia/instantsearch.js/commit/5e674cd))
-- **recipes:** react router v4 ([de673bf](https://github.com/algolia/instantsearch.js/commit/de673bf))
+- **InfiniteHits:** provide translation key for `Load More` (#2048) ([6130bf2](https://github.com/algolia/instantsearch/commit/6130bf2))
+- **SearchBox:** better mobile behaviour by default ([ea968b3](https://github.com/algolia/instantsearch/commit/ea968b3))
+- **example:** link to instantsearch/react (#2007) ([5e674cd](https://github.com/algolia/instantsearch/commit/5e674cd))
+- **recipes:** react router v4 ([de673bf](https://github.com/algolia/instantsearch/commit/de673bf))
 
 ### Features
 
-- **SearchBox:** add role=search to the form (#2046) ([d1e90f3](https://github.com/algolia/instantsearch.js/commit/d1e90f3))
-- **SearchBox:** allow custom reset and submit components (#1991) ([cd303d7](https://github.com/algolia/instantsearch.js/commit/cd303d7))
-- **searchBox:** add event handling ([e267ab6](https://github.com/algolia/instantsearch.js/commit/e267ab6)), closes [#2017](https://github.com/algolia/instantsearch.js/issues/2017)
+- **SearchBox:** add role=search to the form (#2046) ([d1e90f3](https://github.com/algolia/instantsearch/commit/d1e90f3))
+- **SearchBox:** allow custom reset and submit components (#1991) ([cd303d7](https://github.com/algolia/instantsearch/commit/cd303d7))
+- **searchBox:** add event handling ([e267ab6](https://github.com/algolia/instantsearch/commit/e267ab6)), closes [#2017](https://github.com/algolia/instantsearch/issues/2017)
 
 <a name="3.2.1"></a>
 
-## [3.2.1](https://github.com/algolia/instantsearch.js/compare/v3.2.0...v3.2.1) (2017-02-22)
+## [3.2.1](https://github.com/algolia/instantsearch/compare/v3.2.0...v3.2.1) (2017-02-22)
 
 ### Bug Fixes
 
-- **umd:** Add connectors to UMD build (#1988) ([23ac5e6](https://github.com/algolia/instantsearch.js/commit/23ac5e6)), closes [#1987](https://github.com/algolia/instantsearch.js/issues/1987)
+- **umd:** Add connectors to UMD build (#1988) ([23ac5e6](https://github.com/algolia/instantsearch/commit/23ac5e6)), closes [#1987](https://github.com/algolia/instantsearch/issues/1987)
 
 <a name="3.2.0"></a>
 
-# [3.2.0](https://github.com/algolia/instantsearch.js/compare/v3.1.0...v3.2.0) (2017-02-15)
+# [3.2.0](https://github.com/algolia/instantsearch/compare/v3.1.0...v3.2.0) (2017-02-15)
 
 ### Bug Fixes
 
-- **Configure:** use props a unique source of truth (#1967) ([9d53d86](https://github.com/algolia/instantsearch.js/commit/9d53d86))
-- **SearchBox:** Safari can only have <use> with xlinkHref (#1970) ([7ab00bd](https://github.com/algolia/instantsearch.js/commit/7ab00bd)), closes [#1968](https://github.com/algolia/instantsearch.js/issues/1968)
+- **Configure:** use props a unique source of truth (#1967) ([9d53d86](https://github.com/algolia/instantsearch/commit/9d53d86))
+- **SearchBox:** Safari can only have <use> with xlinkHref (#1970) ([7ab00bd](https://github.com/algolia/instantsearch/commit/7ab00bd)), closes [#1968](https://github.com/algolia/instantsearch/issues/1968)
 
 ### Features
 
-- **MultiRange:** add an all range (#1959) ([a3dc950](https://github.com/algolia/instantsearch.js/commit/a3dc950))
+- **MultiRange:** add an all range (#1959) ([a3dc950](https://github.com/algolia/instantsearch/commit/a3dc950))
 
 ### BREAKING CHANGES
 
@@ -1470,37 +1461,37 @@ You can find all the details of the release and the migration guide from v3 to v
 
 <a name="3.1.0"></a>
 
-# [3.1.0](https://github.com/algolia/instantsearch.js/compare/v3.0.0...v3.1.0) (2017-02-08)
+# [3.1.0](https://github.com/algolia/instantsearch/compare/v3.0.0...v3.1.0) (2017-02-08)
 
 ### Bug Fixes
 
-- **Configure:** call onSearchStateChange when props are updated (#1953) ([7e151db](https://github.com/algolia/instantsearch.js/commit/7e151db)), closes [#1950](https://github.com/algolia/instantsearch.js/issues/1950)
-- **Configure:** trigger onSearchStateChange with the right data ([11e5af8](https://github.com/algolia/instantsearch.js/commit/11e5af8))
-- **createConnector:** updates with latest props on state change (#1951) ([cd3a82c](https://github.com/algolia/instantsearch.js/commit/cd3a82c))
+- **Configure:** call onSearchStateChange when props are updated (#1953) ([7e151db](https://github.com/algolia/instantsearch/commit/7e151db)), closes [#1950](https://github.com/algolia/instantsearch/issues/1950)
+- **Configure:** trigger onSearchStateChange with the right data ([11e5af8](https://github.com/algolia/instantsearch/commit/11e5af8))
+- **createConnector:** updates with latest props on state change (#1951) ([cd3a82c](https://github.com/algolia/instantsearch/commit/cd3a82c))
 
 ### Features
 
-- **ClearAll:** add withQuery to also clear the search query (#1958) ([c0e695b](https://github.com/algolia/instantsearch.js/commit/c0e695b))
+- **ClearAll:** add withQuery to also clear the search query (#1958) ([c0e695b](https://github.com/algolia/instantsearch/commit/c0e695b))
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/algolia/instantsearch.js/compare/v2.2.5...v3.0.0) (2017-02-06)
+# [3.0.0](https://github.com/algolia/instantsearch/compare/v2.2.5...v3.0.0) (2017-02-06)
 
 ### Bug Fixes
 
-- **\*List:** disable shortcuts in \*List SearchBoxes (#1921) ([51a76ae](https://github.com/algolia/instantsearch.js/commit/51a76ae)), closes [#1920](https://github.com/algolia/instantsearch.js/issues/1920)
-- **Configure:** add configure parameters in search state (#1935) ([0971330](https://github.com/algolia/instantsearch.js/commit/0971330)), closes [#1863](https://github.com/algolia/instantsearch.js/issues/1863)
-- **Hits:** limit the hitComponent to be only a function (#1912) ([b3c9578](https://github.com/algolia/instantsearch.js/commit/b3c9578))
-- **Pagination:** fix and indicate when pagination is disabled ([5f20199](https://github.com/algolia/instantsearch.js/commit/5f20199)), closes [#1938](https://github.com/algolia/instantsearch.js/issues/1938)
-- **StarRating:** usage with filters (#1933) ([667e9d5](https://github.com/algolia/instantsearch.js/commit/667e9d5))
-- **withSearchBox:** keep displaying searchBox when no items found (#1930) ([30de4cd](https://github.com/algolia/instantsearch.js/commit/30de4cd))
+- **\*List:** disable shortcuts in \*List SearchBoxes (#1921) ([51a76ae](https://github.com/algolia/instantsearch/commit/51a76ae)), closes [#1920](https://github.com/algolia/instantsearch/issues/1920)
+- **Configure:** add configure parameters in search state (#1935) ([0971330](https://github.com/algolia/instantsearch/commit/0971330)), closes [#1863](https://github.com/algolia/instantsearch/issues/1863)
+- **Hits:** limit the hitComponent to be only a function (#1912) ([b3c9578](https://github.com/algolia/instantsearch/commit/b3c9578))
+- **Pagination:** fix and indicate when pagination is disabled ([5f20199](https://github.com/algolia/instantsearch/commit/5f20199)), closes [#1938](https://github.com/algolia/instantsearch/issues/1938)
+- **StarRating:** usage with filters (#1933) ([667e9d5](https://github.com/algolia/instantsearch/commit/667e9d5))
+- **withSearchBox:** keep displaying searchBox when no items found (#1930) ([30de4cd](https://github.com/algolia/instantsearch/commit/30de4cd))
 
 ### Features
 
-- **MultiRange:** indicate if a range has no refinements (#1926) ([80b6450](https://github.com/algolia/instantsearch.js/commit/80b6450))
-- **panel:** add a panel widget (#1889) ([594e1a1](https://github.com/algolia/instantsearch.js/commit/594e1a1))
-- **starRating:** indicate when any refinement has no effect ([c547ae5](https://github.com/algolia/instantsearch.js/commit/c547ae5))
-- **widgets:** default design for disabled states (#1929) ([31f010b](https://github.com/algolia/instantsearch.js/commit/31f010b))
+- **MultiRange:** indicate if a range has no refinements (#1926) ([80b6450](https://github.com/algolia/instantsearch/commit/80b6450))
+- **panel:** add a panel widget (#1889) ([594e1a1](https://github.com/algolia/instantsearch/commit/594e1a1))
+- **starRating:** indicate when any refinement has no effect ([c547ae5](https://github.com/algolia/instantsearch/commit/c547ae5))
+- **widgets:** default design for disabled states (#1929) ([31f010b](https://github.com/algolia/instantsearch/commit/31f010b))
 
 ### Migration guide
 
@@ -1513,96 +1504,96 @@ There are two breaking changes that you will need to handle in your codebase:
 
 <a name="2.2.5"></a>
 
-## [2.2.5](https://github.com/algolia/instantsearch.js/compare/v2.2.4...v2.2.5) (2017-01-23)
+## [2.2.5](https://github.com/algolia/instantsearch/compare/v2.2.4...v2.2.5) (2017-01-23)
 
 ### Bug Fixes
 
-- **currentRefinements:** make removing a toggle refinement work ([8995e64](https://github.com/algolia/instantsearch.js/commit/8995e64))
+- **currentRefinements:** make removing a toggle refinement work ([8995e64](https://github.com/algolia/instantsearch/commit/8995e64))
 
 <a name="2.2.4"></a>
 
-## [2.2.4](https://github.com/algolia/instantsearch.js/compare/v2.2.3...v2.2.4) (2017-01-20)
+## [2.2.4](https://github.com/algolia/instantsearch/compare/v2.2.3...v2.2.4) (2017-01-20)
 
 ### Bug Fixes
 
-- **publish:** publish react-instantsearch/dist instead of root (#1884) ([64414e0](https://github.com/algolia/instantsearch.js/commit/64414e0))
+- **publish:** publish react-instantsearch/dist instead of root (#1884) ([64414e0](https://github.com/algolia/instantsearch/commit/64414e0))
 
 <a name="2.2.3"></a>
 
-## [2.2.3](https://github.com/algolia/instantsearch.js/compare/v2.2.2...v2.2.3) (2017-01-20)
+## [2.2.3](https://github.com/algolia/instantsearch/compare/v2.2.2...v2.2.3) (2017-01-20)
 
 ### Bug Fixes
 
-- **SFFV:** translations for searchbox were not applied (#1879) ([e9b4ee1](https://github.com/algolia/instantsearch.js/commit/e9b4ee1))
+- **SFFV:** translations for searchbox were not applied (#1879) ([e9b4ee1](https://github.com/algolia/instantsearch/commit/e9b4ee1))
 
 <a name="2.2.2"></a>
 
-## [2.2.2](https://github.com/algolia/instantsearch.js/compare/v2.2.1...v2.2.2) (2017-01-18)
+## [2.2.2](https://github.com/algolia/instantsearch/compare/v2.2.1...v2.2.2) (2017-01-18)
 
 ### Bug Fixes
 
-- **react-router:** search was triggered two many times (#1840) ([25e9db5](https://github.com/algolia/instantsearch.js/commit/25e9db5))
-- **SFFV:** empty query triggered a new SFFV (#1875) ([6c8259a](https://github.com/algolia/instantsearch.js/commit/6c8259a))
+- **react-router:** search was triggered two many times (#1840) ([25e9db5](https://github.com/algolia/instantsearch/commit/25e9db5))
+- **SFFV:** empty query triggered a new SFFV (#1875) ([6c8259a](https://github.com/algolia/instantsearch/commit/6c8259a))
 
 <a name="2.2.1"></a>
 
-## [2.2.1](https://github.com/algolia/instantsearch.js/compare/v2.2.0...v2.2.1) (2017-01-18)
+## [2.2.1](https://github.com/algolia/instantsearch/compare/v2.2.0...v2.2.1) (2017-01-18)
 
 ### Bug Fixes
 
-- **createInstantsearch:** fix missing props (#1867) ([8d319b5](https://github.com/algolia/instantsearch.js/commit/8d319b5)), closes [#1867](https://github.com/algolia/instantsearch.js/issues/1867)
+- **createInstantsearch:** fix missing props (#1867) ([8d319b5](https://github.com/algolia/instantsearch/commit/8d319b5)), closes [#1867](https://github.com/algolia/instantsearch/issues/1867)
 
 <a name="2.2.0"></a>
 
-# [2.2.0](https://github.com/algolia/instantsearch.js/compare/v2.1.0...v2.2.0) (2017-01-17)
+# [2.2.0](https://github.com/algolia/instantsearch/compare/v2.1.0...v2.2.0) (2017-01-17)
 
 ### Bug Fixes
 
-- **clear:** clearing wasn't working with too+ same type facets selected (#1820) ([a9a2364](https://github.com/algolia/instantsearch.js/commit/a9a2364))
-- **connectSearchBox:** handle `defaultRefinement` (#1829) ([7a730e2](https://github.com/algolia/instantsearch.js/commit/7a730e2)), closes [#1826](https://github.com/algolia/instantsearch.js/issues/1826)
-- **Instantsearch:** Update all props on InstantSearch (#1828) ([2ed9b49](https://github.com/algolia/instantsearch.js/commit/2ed9b49))
-- **InstantSearch:** add specific `react-instantsearch ${version}` agent (#1844) ([a1113bc](https://github.com/algolia/instantsearch.js/commit/a1113bc))
-- **SFFV:** correct propTypes and add missing default values (#1845) ([a4c1b31](https://github.com/algolia/instantsearch.js/commit/a4c1b31))
-- **test:** add missing Snippet and Highliter snapshot ([4accce5](https://github.com/algolia/instantsearch.js/commit/4accce5))
-- **widgets:** replace setImmediate use with Promise use when update is needed (#1811) ([17e2497](https://github.com/algolia/instantsearch.js/commit/17e2497))
+- **clear:** clearing wasn't working with too+ same type facets selected (#1820) ([a9a2364](https://github.com/algolia/instantsearch/commit/a9a2364))
+- **connectSearchBox:** handle `defaultRefinement` (#1829) ([7a730e2](https://github.com/algolia/instantsearch/commit/7a730e2)), closes [#1826](https://github.com/algolia/instantsearch/issues/1826)
+- **Instantsearch:** Update all props on InstantSearch (#1828) ([2ed9b49](https://github.com/algolia/instantsearch/commit/2ed9b49))
+- **InstantSearch:** add specific `react-instantsearch ${version}` agent (#1844) ([a1113bc](https://github.com/algolia/instantsearch/commit/a1113bc))
+- **SFFV:** correct propTypes and add missing default values (#1845) ([a4c1b31](https://github.com/algolia/instantsearch/commit/a4c1b31))
+- **test:** add missing Snippet and Highliter snapshot ([4accce5](https://github.com/algolia/instantsearch/commit/4accce5))
+- **widgets:** replace setImmediate use with Promise use when update is needed (#1811) ([17e2497](https://github.com/algolia/instantsearch/commit/17e2497))
 
 ### Features
 
-- **Menu, connectMenu:** add search for facet values (#1822) ([a6c513e](https://github.com/algolia/instantsearch.js/commit/a6c513e))
-- **snippet:** add a snippet widget to be able to highlight snippet results (#1797) ([2aecc40](https://github.com/algolia/instantsearch.js/commit/2aecc40))
-- **widgets:** add transformItems to be able to sort and filter (#1809) ([ba539f0](https://github.com/algolia/instantsearch.js/commit/ba539f0))
+- **Menu, connectMenu:** add search for facet values (#1822) ([a6c513e](https://github.com/algolia/instantsearch/commit/a6c513e))
+- **snippet:** add a snippet widget to be able to highlight snippet results (#1797) ([2aecc40](https://github.com/algolia/instantsearch/commit/2aecc40))
+- **widgets:** add transformItems to be able to sort and filter (#1809) ([ba539f0](https://github.com/algolia/instantsearch/commit/ba539f0))
 
 <a name="2.1.0"></a>
 
-# [2.1.0](https://github.com/algolia/instantsearch.js/compare/v2.0.1...v2.1.0) (2017-01-04)
+# [2.1.0](https://github.com/algolia/instantsearch/compare/v2.0.1...v2.1.0) (2017-01-04)
 
 ### Bug Fixes
 
-- **createInstantSearchManager:** drop outdated response (#1765) ([76c5312](https://github.com/algolia/instantsearch.js/commit/76c5312))
-- **highlight:** highlight should work even if the attribute is missing (#1791) ([5b79b15](https://github.com/algolia/instantsearch.js/commit/5b79b15)), closes [#1790](https://github.com/algolia/instantsearch.js/issues/1790)
-- **InfiniteHits:** better classname to loadmore btn (#1789) ([ad2ded3](https://github.com/algolia/instantsearch.js/commit/ad2ded3))
-- **starRatings:** click on selected range doesn't unselect it (#1766) ([beacc72](https://github.com/algolia/instantsearch.js/commit/beacc72))
-- **website:** broken demo links (#1802) ([0abe2f5](https://github.com/algolia/instantsearch.js/commit/0abe2f5))
-- **widgets:** add 300px width for the default SearchBox (#1803) ([bf5d791](https://github.com/algolia/instantsearch.js/commit/bf5d791))
+- **createInstantSearchManager:** drop outdated response (#1765) ([76c5312](https://github.com/algolia/instantsearch/commit/76c5312))
+- **highlight:** highlight should work even if the attribute is missing (#1791) ([5b79b15](https://github.com/algolia/instantsearch/commit/5b79b15)), closes [#1790](https://github.com/algolia/instantsearch/issues/1790)
+- **InfiniteHits:** better classname to loadmore btn (#1789) ([ad2ded3](https://github.com/algolia/instantsearch/commit/ad2ded3))
+- **starRatings:** click on selected range doesn't unselect it (#1766) ([beacc72](https://github.com/algolia/instantsearch/commit/beacc72))
+- **website:** broken demo links (#1802) ([0abe2f5](https://github.com/algolia/instantsearch/commit/0abe2f5))
+- **widgets:** add 300px width for the default SearchBox (#1803) ([bf5d791](https://github.com/algolia/instantsearch/commit/bf5d791))
 
 ### Features
 
-- **InfiniteHits:** Add class to load more button (#1787) ([416febd](https://github.com/algolia/instantsearch.js/commit/416febd))
-- **RefinementList, connectRefinementList:** allow to search for facet values ([e086a81](https://github.com/algolia/instantsearch.js/commit/e086a81))
+- **InfiniteHits:** Add class to load more button (#1787) ([416febd](https://github.com/algolia/instantsearch/commit/416febd))
+- **RefinementList, connectRefinementList:** allow to search for facet values ([e086a81](https://github.com/algolia/instantsearch/commit/e086a81))
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/algolia/instantsearch.js/compare/v2.0.0...v2.0.1) (2016-12-15)
+## [2.0.1](https://github.com/algolia/instantsearch/compare/v2.0.0...v2.0.1) (2016-12-15)
 
 ### Bug Fixes
 
-- **connectRange:** when unfinite numbers are passed throw ([75bec0d](https://github.com/algolia/instantsearch.js/commit/75bec0d))
-- **react-native:** use View as a container for react-native (#1729) ([5b76f75](https://github.com/algolia/instantsearch.js/commit/5b76f75)), closes [#1730](https://github.com/algolia/instantsearch.js/issues/1730)
-- **SearchBox:** autocomplete was not disabled by default (#1742) ([bc76618](https://github.com/algolia/instantsearch.js/commit/bc76618))
-- **starRating:** call createURL with the right interface (min/max) (#1747) ([f9ab9b6](https://github.com/algolia/instantsearch.js/commit/f9ab9b6))
+- **connectRange:** when unfinite numbers are passed throw ([75bec0d](https://github.com/algolia/instantsearch/commit/75bec0d))
+- **react-native:** use View as a container for react-native (#1729) ([5b76f75](https://github.com/algolia/instantsearch/commit/5b76f75)), closes [#1730](https://github.com/algolia/instantsearch/issues/1730)
+- **SearchBox:** autocomplete was not disabled by default (#1742) ([bc76618](https://github.com/algolia/instantsearch/commit/bc76618))
+- **starRating:** call createURL with the right interface (min/max) (#1747) ([f9ab9b6](https://github.com/algolia/instantsearch/commit/f9ab9b6))
 
 <a name="2.0.0"></a>
 
-## [2.0.0](https://github.com/algolia/instantsearch.js/compare/v2.0.0...v2.0.0) (2016-12-08)
+## [2.0.0](https://github.com/algolia/instantsearch/compare/v2.0.0...v2.0.0) (2016-12-08)
 
 First release of `react-instantsearch`

--- a/packages/react-instantsearch-core/README.md
+++ b/packages/react-instantsearch-core/README.md
@@ -1,6 +1,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+**Table of Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
 
 - [react-instantsearch-core](#react-instantsearch-core)
   - [Installation](#installation)
@@ -19,7 +20,7 @@ React InstantSearch Core is an open-source UI library for React that lets you qu
 InstantSearch’s goal is to help you implement awesome search experiences as smoothly as possible by providing a [complete search ecosystem](https://algolia.com/doc/guides/getting-started/how-algolia-works/#the-full-ecosystem). InstantSearch tackles an important part of this vast goal by providing front-end primitives that you can assemble into unique search interfaces.
 
 <p align="center">
-  <a href="https://codesandbox.io/s/github/algolia/instantsearch.js/tree/master/examples/react/default-themes" title="Edit on CodeSandbox">
+  <a href="https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react/default-themes" title="Edit on CodeSandbox">
     <img alt="Edit on CodeSandbox" src="https://codesandbox.io/static/img/play-codesandbox.svg">
   </a>
 </p>
@@ -65,7 +66,7 @@ To start contributing to code, you need to:
 1.  [Clone the repository](https://help.github.com/articles/cloning-a-repository/)
 1.  Install the dependencies: `yarn`
 
-Please read [our contribution process](https://github.com/algolia/instantsearch.js/blob/master/CONTRIBUTING.md) to learn more.
+Please read [our contribution process](https://github.com/algolia/instantsearch/blob/master/CONTRIBUTING.md) to learn more.
 
 ## License
 
@@ -73,9 +74,9 @@ React InstantSearch is [MIT licensed](../../LICENSE).
 
 <!-- Links -->
 
-[contributing-bugreport]: https://github.com/algolia/instantsearch.js/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20React+InstantSearch
-[contributing-featurerequest]: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage,Library%3A%20React+InstantSearch&title=Feature%20request%3A%20
-[contributing-newissue]: https://github.com/algolia/instantsearch.js/issues/new?labels=triage,Library%3A%20React+InstantSearch
-[contributing-label-easy]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20React+InstantSearch%22
-[contributing-label-bug]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20React+InstantSearch%22
-[contributing-label-chore]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-bugreport]: https://github.com/algolia/instantsearch/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20React+InstantSearch
+[contributing-featurerequest]: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage,Library%3A%20React+InstantSearch&title=Feature%20request%3A%20
+[contributing-newissue]: https://github.com/algolia/instantsearch/issues/new?labels=triage,Library%3A%20React+InstantSearch
+[contributing-label-easy]: https://github.com/algolia/instantsearch/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-label-bug]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-label-chore]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20React+InstantSearch%22

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/algolia/instantsearch.js"
+    "url": "https://github.com/algolia/instantsearch"
   },
   "author": {
     "name": "Algolia, Inc.",

--- a/packages/react-instantsearch-core/rollup.config.js
+++ b/packages/react-instantsearch-core/rollup.config.js
@@ -10,7 +10,7 @@ const clear = (x) => x.filter(Boolean);
 
 const version = process.env.VERSION || 'UNRELEASED';
 const algolia = '© Algolia, inc.';
-const link = 'https://github.com/algolia/instantsearch.js';
+const link = 'https://github.com/algolia/instantsearch';
 const createBanner = (name) =>
   `/*! React InstantSearch${name} ${version} | ${algolia} | ${link} */`;
 

--- a/packages/react-instantsearch-core/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-core/src/hooks/useConnector.ts
@@ -111,7 +111,7 @@ export function useConnector<
 
       // We get the widget render state by providing the same parameters as
       // InstantSearch provides to the widget's `render` method.
-      // See https://github.com/algolia/instantsearch.js/blob/019cd18d0de6dd320284aa4890541b7fe2198c65/src/widgets/index/index.ts#L604-L617
+      // See https://github.com/algolia/instantsearch/blob/019cd18d0de6dd320284aa4890541b7fe2198c65/src/widgets/index/index.ts#L604-L617
       const { widgetParams, ...renderState } = widget.getWidgetRenderState({
         helper,
         parent: parentIndex,

--- a/packages/react-instantsearch-core/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-core/src/lib/useInstantSearchApi.ts
@@ -72,7 +72,7 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
   if (searchRef.current === null) {
     // We don't use the `instantsearch()` function because it comes with other
     // top-level APIs that we don't need.
-    // See https://github.com/algolia/instantsearch.js/blob/5b529f43d8acc680f85837eaaa41f7fd03a3f833/src/index.es.ts#L63-L86
+    // See https://github.com/algolia/instantsearch/blob/5b529f43d8acc680f85837eaaa41f7fd03a3f833/src/index.es.ts#L63-L86
     const search = new InstantSearch(props) as InternalInstantSearch<
       TUiState,
       TRouteState

--- a/packages/react-instantsearch-core/src/lib/useSearchResults.ts
+++ b/packages/react-instantsearch-core/src/lib/useSearchResults.ts
@@ -25,7 +25,7 @@ export function useSearchResults(): SearchResultsApi {
 
       // Results can be `null` when the first search is stalled.
       // In this case, we skip the update.
-      // See: https://github.com/algolia/instantsearch.js/blob/20996c7a159988c58e00ff24d2d2dc98af8b980f/src/widgets/index/index.ts#L652-L657
+      // See: https://github.com/algolia/instantsearch/blob/20996c7a159988c58e00ff24d2d2dc98af8b980f/src/widgets/index/index.ts#L652-L657
       if (results !== null) {
         setSearchResults({
           results,

--- a/packages/react-instantsearch-router-nextjs/CHANGELOG.md
+++ b/packages/react-instantsearch-router-nextjs/CHANGELOG.md
@@ -1,29 +1,20 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [7.0.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-router-nextjs@7.0.1...react-instantsearch-router-nextjs@7.0.2) (2023-09-05)
-
-**Note:** Version bump only for package react-instantsearch-router-nextjs
-
-
-
-
-
-## [7.0.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-router-nextjs@7.0.0...react-instantsearch-router-nextjs@7.0.1) (2023-08-08)
+## [7.0.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-router-nextjs@7.0.1...react-instantsearch-router-nextjs@7.0.2) (2023-09-05)
 
 **Note:** Version bump only for package react-instantsearch-router-nextjs
 
+## [7.0.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-router-nextjs@7.0.0...react-instantsearch-router-nextjs@7.0.1) (2023-08-08)
 
-
-
+**Note:** Version bump only for package react-instantsearch-router-nextjs
 
 # 7.0.0 (2023-08-07)
 
 ### Features
 
-- rename packages ([#5787](https://github.com/algolia/instantsearch.js/issues/5787)) ([c133170](https://github.com/algolia/instantsearch.js/commit/c133170e563592dfc15a95daced1f8447327a09a))
+- rename packages ([#5787](https://github.com/algolia/instantsearch/issues/5787)) ([c133170](https://github.com/algolia/instantsearch/commit/c133170e563592dfc15a95daced1f8447327a09a))
 
 ### Breaking Changes
 
@@ -35,83 +26,83 @@ The following APIs have been changed:
 
 See detailed instructions in the [upgrade guide](https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/).
 
-## [6.47.3](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.47.2...react-instantsearch-hooks-router-nextjs@6.47.3) (2023-07-27)
+## [6.47.3](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.47.2...react-instantsearch-hooks-router-nextjs@6.47.3) (2023-07-27)
 
 ### Bug Fixes
 
-- add a future warning when the package name changes ([#5778](https://github.com/algolia/instantsearch.js/issues/5778)) ([3d22ee4](https://github.com/algolia/instantsearch.js/commit/3d22ee45e1f03a443323a371621262f1fe45e664))
+- add a future warning when the package name changes ([#5778](https://github.com/algolia/instantsearch/issues/5778)) ([3d22ee4](https://github.com/algolia/instantsearch/commit/3d22ee45e1f03a443323a371621262f1fe45e664))
 
-## [6.47.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.47.1...react-instantsearch-hooks-router-nextjs@6.47.2) (2023-07-25)
-
-**Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
-
-## [6.47.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.47.0...react-instantsearch-hooks-router-nextjs@6.47.1) (2023-07-19)
+## [6.47.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.47.1...react-instantsearch-hooks-router-nextjs@6.47.2) (2023-07-25)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.47.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.46.0...react-instantsearch-hooks-router-nextjs@6.47.0) (2023-07-18)
+## [6.47.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.47.0...react-instantsearch-hooks-router-nextjs@6.47.1) (2023-07-19)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.46.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.45.1...react-instantsearch-hooks-router-nextjs@6.46.0) (2023-07-10)
+## [6.47.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.46.0...react-instantsearch-hooks-router-nextjs@6.47.0) (2023-07-18)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.45.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.45.0...react-instantsearch-hooks-router-nextjs@6.45.1) (2023-07-04)
+## [6.46.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.45.1...react-instantsearch-hooks-router-nextjs@6.46.0) (2023-07-10)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.45.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.44.3...react-instantsearch-hooks-router-nextjs@6.45.0) (2023-06-20)
+## [6.45.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.45.0...react-instantsearch-hooks-router-nextjs@6.45.1) (2023-07-04)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.44.3](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.44.2...react-instantsearch-hooks-router-nextjs@6.44.3) (2023-06-13)
+## [6.45.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.44.3...react-instantsearch-hooks-router-nextjs@6.45.0) (2023-06-20)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.44.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.44.1...react-instantsearch-hooks-router-nextjs@6.44.2) (2023-06-05)
+## [6.44.3](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.44.2...react-instantsearch-hooks-router-nextjs@6.44.3) (2023-06-13)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.44.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.44.0...react-instantsearch-hooks-router-nextjs@6.44.1) (2023-05-30)
+## [6.44.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.44.1...react-instantsearch-hooks-router-nextjs@6.44.2) (2023-06-05)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.43.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.43.0...react-instantsearch-hooks-router-nextjs@6.43.1) (2023-05-16)
+## [6.44.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.44.0...react-instantsearch-hooks-router-nextjs@6.44.1) (2023-05-30)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-# [6.43.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.42.2...react-instantsearch-hooks-router-nextjs@6.43.0) (2023-04-24)
+## [6.43.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.43.0...react-instantsearch-hooks-router-nextjs@6.43.1) (2023-05-16)
+
+**Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
+
+# [6.43.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.42.2...react-instantsearch-hooks-router-nextjs@6.43.0) (2023-04-24)
 
 ### Bug Fixes
 
-- **dependencies:** depend on sync version of React InstantSearch Hooks ([#5600](https://github.com/algolia/instantsearch.js/issues/5600)) ([82cfbd8](https://github.com/algolia/instantsearch.js/commit/82cfbd8cba47b2e9d0c8f8c74107d2ead1d072bf)), closes [#5568](https://github.com/algolia/instantsearch.js/issues/5568)
+- **dependencies:** depend on sync version of React InstantSearch Hooks ([#5600](https://github.com/algolia/instantsearch/issues/5600)) ([82cfbd8](https://github.com/algolia/instantsearch/commit/82cfbd8cba47b2e9d0c8f8c74107d2ead1d072bf)), closes [#5568](https://github.com/algolia/instantsearch/issues/5568)
 
 ### Features
 
-- **metadata:** register metadata around middleware ([#5492](https://github.com/algolia/instantsearch.js/issues/5492)) ([3e72ec8](https://github.com/algolia/instantsearch.js/commit/3e72ec82894a05a071328a4802d2f764233fe005))
+- **metadata:** register metadata around middleware ([#5492](https://github.com/algolia/instantsearch/issues/5492)) ([3e72ec8](https://github.com/algolia/instantsearch/commit/3e72ec82894a05a071328a4802d2f764233fe005))
 
-## [6.42.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.42.1...react-instantsearch-hooks-router-nextjs@6.42.2) (2023-04-11)
-
-**Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
-
-## [6.42.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.42.0...react-instantsearch-hooks-router-nextjs@6.42.1) (2023-03-28)
+## [6.42.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.42.1...react-instantsearch-hooks-router-nextjs@6.42.2) (2023-04-11)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.42.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.41.0...react-instantsearch-hooks-router-nextjs@6.42.0) (2023-03-21)
+## [6.42.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.42.0...react-instantsearch-hooks-router-nextjs@6.42.1) (2023-03-28)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.41.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.40.1...react-instantsearch-hooks-router-nextjs@6.41.0) (2023-03-07)
+## [6.42.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.41.0...react-instantsearch-hooks-router-nextjs@6.42.0) (2023-03-21)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.40.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.40.1...react-instantsearch-hooks-router-nextjs@6.40.2) (2023-02-28)
+## [6.41.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.40.1...react-instantsearch-hooks-router-nextjs@6.41.0) (2023-03-07)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
-## [6.40.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-router-nextjs@6.40.0...react-instantsearch-hooks-router-nextjs@6.40.1) (2023-02-21)
+## [6.40.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.40.1...react-instantsearch-hooks-router-nextjs@6.40.2) (2023-02-28)
+
+**Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
+
+## [6.40.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-router-nextjs@6.40.0...react-instantsearch-hooks-router-nextjs@6.40.1) (2023-02-21)
 
 **Note:** Version bump only for package react-instantsearch-hooks-router-nextjs
 
@@ -119,4 +110,4 @@ See detailed instructions in the [upgrade guide](https://www.algolia.com/doc/gui
 
 ### Features
 
-- handling routing in Next.js ([#5432](https://github.com/algolia/instantsearch.js/issues/5432)) ([39b5859](https://github.com/algolia/instantsearch.js/commit/39b5859ba78a5e8472a80e357a35ba900c963b61))
+- handling routing in Next.js ([#5432](https://github.com/algolia/instantsearch/issues/5432)) ([39b5859](https://github.com/algolia/instantsearch/commit/39b5859ba78a5e8472a80e357a35ba900c963b61))

--- a/packages/react-instantsearch-router-nextjs/README.md
+++ b/packages/react-instantsearch-router-nextjs/README.md
@@ -1,6 +1,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+**Table of Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
 
 - [react-instantsearch-router-nextjs](#react-instantsearch-router-nextjs)
   - [Installation](#installation)
@@ -42,7 +43,12 @@ export default function Page({ serverState, url }) {
       <InstantSearch
         searchClient={searchClient}
         indexName="instant_search"
-        routing={{ router: createInstantSearchRouterNext({ singletonRouter, serverUrl: url }) }}
+        routing={{
+          router: createInstantSearchRouterNext({
+            singletonRouter,
+            serverUrl: url,
+          }),
+        }}
       >
         {/* ... */}
       </InstantSearch>
@@ -118,7 +124,7 @@ For troubleshooting purposes, some other options are available :
 
 ## Troubleshooting
 
-If you're experiencing issues, please refer to the [**Need help?**](https://algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/#need-help) section of the docs, or [open a new issue](https://github.com/algolia/instantsearch.js/issues/new?assignees=&labels=triage&template=BUG_REPORT.yml).
+If you're experiencing issues, please refer to the [**Need help?**](https://algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/#need-help) section of the docs, or [open a new issue](https://github.com/algolia/instantsearch/issues/new?assignees=&labels=triage&template=BUG_REPORT.yml).
 
 ## Contributing
 
@@ -135,7 +141,7 @@ To start contributing to code, you need to:
 1.  [Clone the repository](https://help.github.com/articles/cloning-a-repository/)
 1.  Install the dependencies: `yarn`
 
-Please read [our contribution process](https://github.com/algolia/instantsearch.js/blob/master/CONTRIBUTING.md) to learn more.
+Please read [our contribution process](https://github.com/algolia/instantsearch/blob/master/CONTRIBUTING.md) to learn more.
 
 ## License
 
@@ -143,9 +149,9 @@ React InstantSearch is [MIT licensed](../../LICENSE).
 
 <!-- Links -->
 
-[contributing-bugreport]: https://github.com/algolia/instantsearch.js/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20React+InstantSearch
-[contributing-featurerequest]: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage,Library%3A%20React+InstantSearch&title=Feature%20request%3A%20
-[contributing-newissue]: https://github.com/algolia/instantsearch.js/issues/new?labels=triage,Library%3A%20React+InstantSearch
-[contributing-label-easy]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20React+InstantSearch%22
-[contributing-label-bug]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20React+InstantSearch%22
-[contributing-label-chore]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-bugreport]: https://github.com/algolia/instantsearch/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20React+InstantSearch
+[contributing-featurerequest]: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage,Library%3A%20React+InstantSearch&title=Feature%20request%3A%20
+[contributing-newissue]: https://github.com/algolia/instantsearch/issues/new?labels=triage,Library%3A%20React+InstantSearch
+[contributing-label-easy]: https://github.com/algolia/instantsearch/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-label-bug]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-label-chore]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20React+InstantSearch%22

--- a/packages/react-instantsearch-router-nextjs/package.json
+++ b/packages/react-instantsearch-router-nextjs/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/algolia/instantsearch.js"
+    "url": "https://github.com/algolia/instantsearch"
   },
   "author": {
     "name": "Algolia, Inc.",

--- a/packages/react-instantsearch/CHANGELOG.md
+++ b/packages/react-instantsearch/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [7.0.2](https://github.com/algolia/instantsearch/compare/react-instantsearch@7.0.1...react-instantsearch@7.0.2) (2023-09-05)
 
@@ -13,14 +12,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [7.0.1](https://github.com/algolia/instantsearch/compare/react-instantsearch@7.0.0...react-instantsearch@7.0.1) (2023-08-08)
 
-
 ### Bug Fixes
 
-* **pagination:** correctly use 1-based pagination in createURL ([#5798](https://github.com/algolia/instantsearch/issues/5798)) ([69ec7de](https://github.com/algolia/instantsearch/commit/69ec7deba05a60a223b833c6a117d5a0f2e83012))
-
-
-
-
+- **pagination:** correctly use 1-based pagination in createURL ([#5798](https://github.com/algolia/instantsearch/issues/5798)) ([69ec7de](https://github.com/algolia/instantsearch/commit/69ec7deba05a60a223b833c6a117d5a0f2e83012))
 
 # [7.0.0](https://github.com/algolia/instantsearch/compare/react-instantsearch@6.40.4...react-instantsearch@7.0.0) (2023-08-07)
 
@@ -38,141 +32,141 @@ The following APIs have been changed:
 
 See detailed instructions in the [upgrade guide](https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/react/).
 
-## [6.47.3](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.47.2...react-instantsearch-hooks-web@6.47.3) (2023-07-27)
+## [6.47.3](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.47.2...react-instantsearch-hooks-web@6.47.3) (2023-07-27)
 
 ### Bug Fixes
 
-- add a future warning when the package name changes ([#5778](https://github.com/algolia/instantsearch.js/issues/5778)) ([3d22ee4](https://github.com/algolia/instantsearch.js/commit/3d22ee45e1f03a443323a371621262f1fe45e664))
+- add a future warning when the package name changes ([#5778](https://github.com/algolia/instantsearch/issues/5778)) ([3d22ee4](https://github.com/algolia/instantsearch/commit/3d22ee45e1f03a443323a371621262f1fe45e664))
 
-## [6.47.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.47.1...react-instantsearch-hooks-web@6.47.2) (2023-07-25)
+## [6.47.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.47.1...react-instantsearch-hooks-web@6.47.2) (2023-07-25)
 
 **Note:** Version bump only for package react-instantsearch-hooks-web
 
-## [6.47.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.47.0...react-instantsearch-hooks-web@6.47.1) (2023-07-19)
+## [6.47.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.47.0...react-instantsearch-hooks-web@6.47.1) (2023-07-19)
 
 ### Bug Fixes
 
-- **instantsearch:** keep algoliasearch-helper as external dependency during build ([#5765](https://github.com/algolia/instantsearch.js/issues/5765)) ([550fefa](https://github.com/algolia/instantsearch.js/commit/550fefa1401773f38dedc20322513ae662faa25d))
+- **instantsearch:** keep algoliasearch-helper as external dependency during build ([#5765](https://github.com/algolia/instantsearch/issues/5765)) ([550fefa](https://github.com/algolia/instantsearch/commit/550fefa1401773f38dedc20322513ae662faa25d))
 
-# [6.47.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.46.0...react-instantsearch-hooks-web@6.47.0) (2023-07-18)
+# [6.47.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.46.0...react-instantsearch-hooks-web@6.47.0) (2023-07-18)
 
 ### Features
 
-- **react-instantsearch-hooks web:** rename `<Stats>` translation ([#5756](https://github.com/algolia/instantsearch.js/issues/5756)) ([6c70035](https://github.com/algolia/instantsearch.js/commit/6c700350377d69a71b8ed44f70952d33ed81d085))
+- **react-instantsearch-hooks web:** rename `<Stats>` translation ([#5756](https://github.com/algolia/instantsearch/issues/5756)) ([6c70035](https://github.com/algolia/instantsearch/commit/6c700350377d69a71b8ed44f70952d33ed81d085))
 
-## [6.46.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.45.1...react-instantsearch-hooks-web@6.46.0) (2023-07-10)
-
-### Bug Fixes
-
-- **url:** base createURL on UiState instead of SearchParameters ([#5696](https://github.com/algolia/instantsearch.js/issues/5696)) ([7e2c8a2](https://github.com/algolia/instantsearch.js/commit/7e2c8a295a6fc5ba36d9482f645ef55b422d5e75)), closes [#5694](https://github.com/algolia/instantsearch.js/issues/5694)
-
-## [6.45.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.45.0...react-instantsearch-hooks-web@6.45.1) (2023-07-04)
-
-**Note:** Version bump only for package react-instantsearch-hooks-web
-
-## [6.45.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.44.3...react-instantsearch-hooks-web@6.45.0) (2023-06-20)
-
-**Note:** Version bump only for package react-instantsearch-hooks-web
-
-## [6.44.3](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.44.2...react-instantsearch-hooks-web@6.44.3) (2023-06-13)
-
-**Note:** Version bump only for package react-instantsearch-hooks-web
-
-## [6.44.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.44.1...react-instantsearch-hooks-web@6.44.2) (2023-06-05)
-
-**Note:** Version bump only for package react-instantsearch-hooks-web
-
-## [6.44.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.44.0...react-instantsearch-hooks-web@6.44.1) (2023-05-30)
+## [6.46.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.45.1...react-instantsearch-hooks-web@6.46.0) (2023-07-10)
 
 ### Bug Fixes
 
-- **insights:** send default click event when using auxiliary pointer button ([#5634](https://github.com/algolia/instantsearch.js/issues/5634)) ([7e4a216](https://github.com/algolia/instantsearch.js/commit/7e4a2162f87596a384b35c97efa51db9bb6f8973))
+- **url:** base createURL on UiState instead of SearchParameters ([#5696](https://github.com/algolia/instantsearch/issues/5696)) ([7e2c8a2](https://github.com/algolia/instantsearch/commit/7e2c8a295a6fc5ba36d9482f645ef55b422d5e75)), closes [#5694](https://github.com/algolia/instantsearch/issues/5694)
 
-## [6.43.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.43.0...react-instantsearch-hooks-web@6.43.1) (2023-05-16)
+## [6.45.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.45.0...react-instantsearch-hooks-web@6.45.1) (2023-07-04)
+
+**Note:** Version bump only for package react-instantsearch-hooks-web
+
+## [6.45.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.44.3...react-instantsearch-hooks-web@6.45.0) (2023-06-20)
+
+**Note:** Version bump only for package react-instantsearch-hooks-web
+
+## [6.44.3](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.44.2...react-instantsearch-hooks-web@6.44.3) (2023-06-13)
+
+**Note:** Version bump only for package react-instantsearch-hooks-web
+
+## [6.44.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.44.1...react-instantsearch-hooks-web@6.44.2) (2023-06-05)
+
+**Note:** Version bump only for package react-instantsearch-hooks-web
+
+## [6.44.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.44.0...react-instantsearch-hooks-web@6.44.1) (2023-05-30)
 
 ### Bug Fixes
 
-- **rangeinput:** allow input of numbers with precision ([#5541](https://github.com/algolia/instantsearch.js/issues/5541)) ([fb48951](https://github.com/algolia/instantsearch.js/commit/fb489513a8550528f3e2867be30fb380229ad188))
-- **this:** ensure all functions are able to be destructured ([#5611](https://github.com/algolia/instantsearch.js/issues/5611)) ([a8b5c1e](https://github.com/algolia/instantsearch.js/commit/a8b5c1e5bbd6afac39fce523f7d7c2ec02f51153)), closes [#5589](https://github.com/algolia/instantsearch.js/issues/5589)
+- **insights:** send default click event when using auxiliary pointer button ([#5634](https://github.com/algolia/instantsearch/issues/5634)) ([7e4a216](https://github.com/algolia/instantsearch/commit/7e4a2162f87596a384b35c97efa51db9bb6f8973))
 
-# [6.43.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.42.2...react-instantsearch-hooks-web@6.43.0) (2023-04-24)
+## [6.43.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.43.0...react-instantsearch-hooks-web@6.43.1) (2023-05-16)
 
 ### Bug Fixes
 
-- **lifecycle:** prevent extra network requests when unmounting multiple widgets ([#5602](https://github.com/algolia/instantsearch.js/issues/5602)) ([11458ee](https://github.com/algolia/instantsearch.js/commit/11458eee7e7f0f3e9c5f368584a16f58646b1cdd))
+- **rangeinput:** allow input of numbers with precision ([#5541](https://github.com/algolia/instantsearch/issues/5541)) ([fb48951](https://github.com/algolia/instantsearch/commit/fb489513a8550528f3e2867be30fb380229ad188))
+- **this:** ensure all functions are able to be destructured ([#5611](https://github.com/algolia/instantsearch/issues/5611)) ([a8b5c1e](https://github.com/algolia/instantsearch/commit/a8b5c1e5bbd6afac39fce523f7d7c2ec02f51153)), closes [#5589](https://github.com/algolia/instantsearch/issues/5589)
+
+# [6.43.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.42.2...react-instantsearch-hooks-web@6.43.0) (2023-04-24)
+
+### Bug Fixes
+
+- **lifecycle:** prevent extra network requests when unmounting multiple widgets ([#5602](https://github.com/algolia/instantsearch/issues/5602)) ([11458ee](https://github.com/algolia/instantsearch/commit/11458eee7e7f0f3e9c5f368584a16f58646b1cdd))
 
 ### Features
 
-- **insights:** add insights option to InstantSearch ([#5488](https://github.com/algolia/instantsearch.js/issues/5488)) ([9031573](https://github.com/algolia/instantsearch.js/commit/9031573807fa6803dcfae9f33d61b8f111f68423)) ([#5578](https://github.com/algolia/instantsearch.js/issues/5578)) ([8fb517f](https://github.com/algolia/instantsearch.js/commit/8fb517f15381ecb32ea00cf4b01a0fd5e70e1d17)) ([#5545](https://github.com/algolia/instantsearch.js/issues/5545)) ([99a0972](https://github.com/algolia/instantsearch.js/commit/99a0972663b8f3284cac3b5621571ced7a33908f)) ([#5493](https://github.com/algolia/instantsearch.js/issues/5493)) ([cff723f](https://github.com/algolia/instantsearch.js/commit/cff723fc95a90ebb2ed14c46c51ab05764835a47))
-- **insights:** always pass Algolia credentials locally ([#5554](https://github.com/algolia/instantsearch.js/issues/5554)) ([654ab81](https://github.com/algolia/instantsearch.js/commit/654ab81e1669354c249710b6756610fba35d54b4)) ([#5558](https://github.com/algolia/instantsearch.js/issues/5558)) ([82144c0](https://github.com/algolia/instantsearch.js/commit/82144c0a0b18e6b47d6f508e5c670a9de274c121)) ([#5529](https://github.com/algolia/instantsearch.js/issues/5529)) ([8537f8f](https://github.com/algolia/instantsearch.js/commit/8537f8f7a10bcaf053ff62180c082e077b1b052d))
-- **insights:** annotate events with algoliaSource ([#5580](https://github.com/algolia/instantsearch.js/issues/5580)) ([c419307](https://github.com/algolia/instantsearch.js/commit/c419307a5f7fe46d5032c9437a17c8e3dad57fe5))
-- **insights:** automatically load search-insights if not passed ([#5484](https://github.com/algolia/instantsearch.js/issues/5484)) ([a85797b](https://github.com/algolia/instantsearch.js/commit/a85797b503edc94e001c5bfb3b754db6cb556943))
-- **insights:** enable default click events on hits and infinite hits ([#5522](https://github.com/algolia/instantsearch.js/issues/5522)) ([271bd12](https://github.com/algolia/instantsearch.js/commit/271bd12e34bc55656976bb53c90282193083eb86)) ([#5527](https://github.com/algolia/instantsearch.js/issues/5527)) ([0e55821](https://github.com/algolia/instantsearch.js/commit/0e558213c807cd17d592fadec052f3d1fc692e6c))
-- **insights:** prevent potential errors ([#5487](https://github.com/algolia/instantsearch.js/issues/5487)) ([33fe510](https://github.com/algolia/instantsearch.js/commit/33fe510307e4b382a5ba1153a0eaf160420acd11)) ([#5606](https://github.com/algolia/instantsearch.js/issues/5606)) ([bdd9290](https://github.com/algolia/instantsearch.js/commit/bdd92901b59ae4e5d7311eadfbf53ed656bbaf4a)) ([#5512](https://github.com/algolia/instantsearch.js/issues/5512)) ([85dfbc9](https://github.com/algolia/instantsearch.js/commit/85dfbc9ebd722fbe6a7e1bd056950fdbcc16d8d9))
-- **metadata:** register metadata around middleware ([#5492](https://github.com/algolia/instantsearch.js/issues/5492)) ([3e72ec8](https://github.com/algolia/instantsearch.js/commit/3e72ec82894a05a071328a4802d2f764233fe005))
+- **insights:** add insights option to InstantSearch ([#5488](https://github.com/algolia/instantsearch/issues/5488)) ([9031573](https://github.com/algolia/instantsearch/commit/9031573807fa6803dcfae9f33d61b8f111f68423)) ([#5578](https://github.com/algolia/instantsearch/issues/5578)) ([8fb517f](https://github.com/algolia/instantsearch/commit/8fb517f15381ecb32ea00cf4b01a0fd5e70e1d17)) ([#5545](https://github.com/algolia/instantsearch/issues/5545)) ([99a0972](https://github.com/algolia/instantsearch/commit/99a0972663b8f3284cac3b5621571ced7a33908f)) ([#5493](https://github.com/algolia/instantsearch/issues/5493)) ([cff723f](https://github.com/algolia/instantsearch/commit/cff723fc95a90ebb2ed14c46c51ab05764835a47))
+- **insights:** always pass Algolia credentials locally ([#5554](https://github.com/algolia/instantsearch/issues/5554)) ([654ab81](https://github.com/algolia/instantsearch/commit/654ab81e1669354c249710b6756610fba35d54b4)) ([#5558](https://github.com/algolia/instantsearch/issues/5558)) ([82144c0](https://github.com/algolia/instantsearch/commit/82144c0a0b18e6b47d6f508e5c670a9de274c121)) ([#5529](https://github.com/algolia/instantsearch/issues/5529)) ([8537f8f](https://github.com/algolia/instantsearch/commit/8537f8f7a10bcaf053ff62180c082e077b1b052d))
+- **insights:** annotate events with algoliaSource ([#5580](https://github.com/algolia/instantsearch/issues/5580)) ([c419307](https://github.com/algolia/instantsearch/commit/c419307a5f7fe46d5032c9437a17c8e3dad57fe5))
+- **insights:** automatically load search-insights if not passed ([#5484](https://github.com/algolia/instantsearch/issues/5484)) ([a85797b](https://github.com/algolia/instantsearch/commit/a85797b503edc94e001c5bfb3b754db6cb556943))
+- **insights:** enable default click events on hits and infinite hits ([#5522](https://github.com/algolia/instantsearch/issues/5522)) ([271bd12](https://github.com/algolia/instantsearch/commit/271bd12e34bc55656976bb53c90282193083eb86)) ([#5527](https://github.com/algolia/instantsearch/issues/5527)) ([0e55821](https://github.com/algolia/instantsearch/commit/0e558213c807cd17d592fadec052f3d1fc692e6c))
+- **insights:** prevent potential errors ([#5487](https://github.com/algolia/instantsearch/issues/5487)) ([33fe510](https://github.com/algolia/instantsearch/commit/33fe510307e4b382a5ba1153a0eaf160420acd11)) ([#5606](https://github.com/algolia/instantsearch/issues/5606)) ([bdd9290](https://github.com/algolia/instantsearch/commit/bdd92901b59ae4e5d7311eadfbf53ed656bbaf4a)) ([#5512](https://github.com/algolia/instantsearch/issues/5512)) ([85dfbc9](https://github.com/algolia/instantsearch/commit/85dfbc9ebd722fbe6a7e1bd056950fdbcc16d8d9))
+- **metadata:** register metadata around middleware ([#5492](https://github.com/algolia/instantsearch/issues/5492)) ([3e72ec8](https://github.com/algolia/instantsearch/commit/3e72ec82894a05a071328a4802d2f764233fe005))
 
-## [6.42.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.42.1...react-instantsearch-hooks-web@6.42.2) (2023-04-11)
-
-**Note:** Version bump only for package react-instantsearch-hooks-web
-
-## [6.42.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.42.0...react-instantsearch-hooks-web@6.42.1) (2023-03-28)
+## [6.42.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.42.1...react-instantsearch-hooks-web@6.42.2) (2023-04-11)
 
 **Note:** Version bump only for package react-instantsearch-hooks-web
 
-## [6.42.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.41.0...react-instantsearch-hooks-web@6.42.0) (2023-03-21)
+## [6.42.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.42.0...react-instantsearch-hooks-web@6.42.1) (2023-03-28)
+
+**Note:** Version bump only for package react-instantsearch-hooks-web
+
+## [6.42.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.41.0...react-instantsearch-hooks-web@6.42.0) (2023-03-21)
 
 ### Bug Fixes
 
-- **searchbox:** add aria-hidden to svg icons ([#5547](https://github.com/algolia/instantsearch.js/issues/5547)) ([50344e3](https://github.com/algolia/instantsearch.js/commit/50344e3b14c22c886415c0e7d799aca778dc39ab)), closes [#5546](https://github.com/algolia/instantsearch.js/issues/5546)
+- **searchbox:** add aria-hidden to svg icons ([#5547](https://github.com/algolia/instantsearch/issues/5547)) ([50344e3](https://github.com/algolia/instantsearch/commit/50344e3b14c22c886415c0e7d799aca778dc39ab)), closes [#5546](https://github.com/algolia/instantsearch/issues/5546)
 
-## [6.41.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.40.1...react-instantsearch-hooks-web@6.41.0) (2023-03-07)
-
-**Note:** Version bump only for package react-instantsearch-hooks-web
-
-## [6.40.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.40.1...react-instantsearch-hooks-web@6.40.2) (2023-02-28)
+## [6.41.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.40.1...react-instantsearch-hooks-web@6.41.0) (2023-03-07)
 
 **Note:** Version bump only for package react-instantsearch-hooks-web
 
-## [6.40.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.40.0...react-instantsearch-hooks-web@6.40.1) (2023-02-21)
+## [6.40.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.40.1...react-instantsearch-hooks-web@6.40.2) (2023-02-28)
+
+**Note:** Version bump only for package react-instantsearch-hooks-web
+
+## [6.40.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.40.0...react-instantsearch-hooks-web@6.40.1) (2023-02-21)
 
 ### Bug Fixes
 
-- **breadcrumb:** guard against undefined facets ([#5482](https://github.com/algolia/instantsearch.js/issues/5482)) ([3159afe](https://github.com/algolia/instantsearch.js/commit/3159afe57472fe2b669dceb5f1ee638b658f7f52))
+- **breadcrumb:** guard against undefined facets ([#5482](https://github.com/algolia/instantsearch/issues/5482)) ([3159afe](https://github.com/algolia/instantsearch/commit/3159afe57472fe2b669dceb5f1ee638b658f7f52))
 
-## [6.40.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.39.3...react-instantsearch-hooks-web@6.40.0) (2023-02-14)
-
-**Note:** Version bump only for package react-instantsearch-hooks-web
-
-## [6.39.3](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.39.2...react-instantsearch-hooks-web@6.39.3) (2023-02-07)
+## [6.40.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.39.3...react-instantsearch-hooks-web@6.40.0) (2023-02-14)
 
 **Note:** Version bump only for package react-instantsearch-hooks-web
 
-## [6.39.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.39.1...react-instantsearch-hooks-web@6.39.2) (2023-01-30)
+## [6.39.3](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.39.2...react-instantsearch-hooks-web@6.39.3) (2023-02-07)
+
+**Note:** Version bump only for package react-instantsearch-hooks-web
+
+## [6.39.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.39.1...react-instantsearch-hooks-web@6.39.2) (2023-01-30)
 
 ### Bug Fixes
 
-- **infiniteHits:** read cache correctly when search is loading ([#5461](https://github.com/algolia/instantsearch.js/issues/5461)) ([bfabe00](https://github.com/algolia/instantsearch.js/commit/bfabe002a26e15e13b33200c355379f4e3c60f21))
+- **infiniteHits:** read cache correctly when search is loading ([#5461](https://github.com/algolia/instantsearch/issues/5461)) ([bfabe00](https://github.com/algolia/instantsearch/commit/bfabe002a26e15e13b33200c355379f4e3c60f21))
 
-## [6.39.1](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.39.0...react-instantsearch-hooks-web@6.39.1) (2023-01-26)
+## [6.39.1](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.39.0...react-instantsearch-hooks-web@6.39.1) (2023-01-26)
 
 ### Bug Fixes
 
-- **dependencies:** update typescript ([#5454](https://github.com/algolia/instantsearch.js/issues/5454)) ([0e6bb48](https://github.com/algolia/instantsearch.js/commit/0e6bb485a31cd3294436ac9902c2c2662dfcdf8b))
-- **HierarchicalMenu:** don't give --parent class if data is empty ([#5458](https://github.com/algolia/instantsearch.js/issues/5458)) ([1d1a209](https://github.com/algolia/instantsearch.js/commit/1d1a209992e86b720939607cd22e37a04e865195)), closes [/github.com/algolia/instantsearch/blob/f84c01b2f66ac279f7e33fafe5f1cd559436edef/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx#L175-L179](https://github.com//github.com/algolia/instantsearch/blob/f84c01b2f66ac279f7e33fafe5f1cd559436edef/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx/issues/L175-L179)
+- **dependencies:** update typescript ([#5454](https://github.com/algolia/instantsearch/issues/5454)) ([0e6bb48](https://github.com/algolia/instantsearch/commit/0e6bb485a31cd3294436ac9902c2c2662dfcdf8b))
+- **HierarchicalMenu:** don't give --parent class if data is empty ([#5458](https://github.com/algolia/instantsearch/issues/5458)) ([1d1a209](https://github.com/algolia/instantsearch/commit/1d1a209992e86b720939607cd22e37a04e865195)), closes [/github.com/algolia/instantsearch/blob/f84c01b2f66ac279f7e33fafe5f1cd559436edef/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx#L175-L179](https://github.com//github.com/algolia/instantsearch/blob/f84c01b2f66ac279f7e33fafe5f1cd559436edef/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx/issues/L175-L179)
 
-# [6.39.0](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.38.3...react-instantsearch-hooks-web@6.39.0) (2023-01-25)
+# [6.39.0](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.38.3...react-instantsearch-hooks-web@6.39.0) (2023-01-25)
 
 ### Features
 
-- **react-instantsearch-hooks-web:** Add stats widget and ui component ([#5427](https://github.com/algolia/instantsearch.js/issues/5427)) ([d07cf0d](https://github.com/algolia/instantsearch.js/commit/d07cf0d0310bf4e49d4a4c2142b3783d9bcda79d))
-- **rendering:** always render with current state ([#5429](https://github.com/algolia/instantsearch.js/issues/5429)) ([920e951](https://github.com/algolia/instantsearch.js/commit/920e951f03aada0e6a1ce16bc389a82a2f00b202))
-- **rendering:** revert search state on error ([#5438](https://github.com/algolia/instantsearch.js/issues/5438)) ([732fcac](https://github.com/algolia/instantsearch.js/commit/732fcac79ea1f51b19f62d5c4bf1fdf22619fa73))
+- **react-instantsearch-hooks-web:** Add stats widget and ui component ([#5427](https://github.com/algolia/instantsearch/issues/5427)) ([d07cf0d](https://github.com/algolia/instantsearch/commit/d07cf0d0310bf4e49d4a4c2142b3783d9bcda79d))
+- **rendering:** always render with current state ([#5429](https://github.com/algolia/instantsearch/issues/5429)) ([920e951](https://github.com/algolia/instantsearch/commit/920e951f03aada0e6a1ce16bc389a82a2f00b202))
+- **rendering:** revert search state on error ([#5438](https://github.com/algolia/instantsearch/issues/5438)) ([732fcac](https://github.com/algolia/instantsearch/commit/732fcac79ea1f51b19f62d5c4bf1fdf22619fa73))
 
-## [6.38.3](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.38.2...react-instantsearch-hooks-web@6.38.3) (2023-01-09)
+## [6.38.3](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.38.2...react-instantsearch-hooks-web@6.38.3) (2023-01-09)
 
 **Note:** Version bump only for package react-instantsearch-hooks-web
 
-## [6.38.2](https://github.com/algolia/instantsearch.js/compare/react-instantsearch-hooks-web@6.38.1...react-instantsearch-hooks-web@6.38.2) (2023-01-03)
+## [6.38.2](https://github.com/algolia/instantsearch/compare/react-instantsearch-hooks-web@6.38.1...react-instantsearch-hooks-web@6.38.2) (2023-01-03)
 
 **Note:** Version bump only for package react-instantsearch-hooks-web
 
@@ -298,7 +292,7 @@ See detailed instructions in the [upgrade guide](https://www.algolia.com/doc/gui
 - **hooks-server:** import react server via an expression ([#3515](https://github.com/algolia/react-instantsearch/issues/3515)) ([91b96f7](https://github.com/algolia/react-instantsearch/commit/91b96f743b9315ed5ea781681b77fc7f5604ab6e)), closes [#3512](https://github.com/algolia/react-instantsearch/issues/3512)
 - **hooks-web:** fix duplicated key in <CurrentRefinements> ([#3513](https://github.com/algolia/react-instantsearch/issues/3513)) ([fc94d80](https://github.com/algolia/react-instantsearch/commit/fc94d806daf139f58b234cdc0b450da2efe861ee))
 - **hooks:** mount widgets in SSR to retrieve HTML ([#3518](https://github.com/algolia/react-instantsearch/issues/3518)) ([aa5f9d8](https://github.com/algolia/react-instantsearch/commit/aa5f9d84ddb6e97d05e6ad1baf2c6caa23891281))
-- **types:** allow useInstantSearch to be generic ([#3508](https://github.com/algolia/react-instantsearch/issues/3508)) ([6807232](https://github.com/algolia/react-instantsearch/commit/68072324cf302801502a1b4c3d06703e57b55a97)), closes [algolia/instantsearch.js#5060](https://github.com/algolia/instantsearch.js/issues/5060)
+- **types:** allow useInstantSearch to be generic ([#3508](https://github.com/algolia/react-instantsearch/issues/3508)) ([6807232](https://github.com/algolia/react-instantsearch/commit/68072324cf302801502a1b4c3d06703e57b55a97)), closes [algolia/instantsearch#5060](https://github.com/algolia/instantsearch/issues/5060)
 - **types:** support React 18 types ([#3481](https://github.com/algolia/react-instantsearch/issues/3481)) ([74cf8cb](https://github.com/algolia/react-instantsearch/commit/74cf8cb9be8ff3d113b57a50e7083df0d1bc94f2))
 
 ### Features
@@ -1378,19 +1372,19 @@ You can find all the details of the release and the migration guide from v3 to v
 
 <a name="4.0.0-beta.1"></a>
 
-# [4.0.0-beta.1](https://github.com/algolia/instantsearch.js/compare/v4.0.0-beta.0...v4.0.0-beta.1) (2017-04-03)
+# [4.0.0-beta.1](https://github.com/algolia/instantsearch/compare/v4.0.0-beta.0...v4.0.0-beta.1) (2017-04-03)
 
 ### Bug Fixes
 
-- **SFFV:** fix wrong query behaviour with slow network (#2086) ([c251e8f](https://github.com/algolia/instantsearch.js/commit/c251e8f)), closes [#2086](https://github.com/algolia/instantsearch.js/issues/2086)
+- **SFFV:** fix wrong query behaviour with slow network (#2086) ([c251e8f](https://github.com/algolia/instantsearch/commit/c251e8f)), closes [#2086](https://github.com/algolia/instantsearch/issues/2086)
 
 <a name="4.0.0-beta.0"></a>
 
-# [4.0.0-beta.0](https://github.com/algolia/instantsearch.js/compare/v3.3.0...v4.0.0-beta.0) (2017-03-28)
+# [4.0.0-beta.0](https://github.com/algolia/instantsearch/compare/v3.3.0...v4.0.0-beta.0) (2017-03-28)
 
 ### Features
 
-- **multi-index:** ease multi index and auto complete ([09a4e1d](https://github.com/algolia/instantsearch.js/commit/09a4e1d))
+- **multi-index:** ease multi index and auto complete ([09a4e1d](https://github.com/algolia/instantsearch/commit/09a4e1d))
 
 ### BREAKING CHANGES
 
@@ -1401,49 +1395,49 @@ You can find all the details of the release and the migration guide from v3 to v
 
 <a name="3.3.0"></a>
 
-# [3.3.0](https://github.com/algolia/instantsearch.js/compare/v3.2.2-beta0...v3.3.0) (2017-03-22)
+# [3.3.0](https://github.com/algolia/instantsearch/compare/v3.2.2-beta0...v3.3.0) (2017-03-22)
 
 ### Bug Fixes
 
-- **example:** Fix access to props in react-router example ([1417d6f](https://github.com/algolia/instantsearch.js/commit/1417d6f))
+- **example:** Fix access to props in react-router example ([1417d6f](https://github.com/algolia/instantsearch/commit/1417d6f))
 
 <a name="3.2.2-beta0"></a>
 
-## [3.2.2-beta0](https://github.com/algolia/instantsearch.js/compare/v3.2.1...v3.2.2-beta0) (2017-03-20)
+## [3.2.2-beta0](https://github.com/algolia/instantsearch/compare/v3.2.1...v3.2.2-beta0) (2017-03-20)
 
 ### Bug Fixes
 
-- **InfiniteHits:** provide translation key for `Load More` (#2048) ([6130bf2](https://github.com/algolia/instantsearch.js/commit/6130bf2))
-- **SearchBox:** better mobile behaviour by default ([ea968b3](https://github.com/algolia/instantsearch.js/commit/ea968b3))
-- **example:** link to instantsearch/react (#2007) ([5e674cd](https://github.com/algolia/instantsearch.js/commit/5e674cd))
-- **recipes:** react router v4 ([de673bf](https://github.com/algolia/instantsearch.js/commit/de673bf))
+- **InfiniteHits:** provide translation key for `Load More` (#2048) ([6130bf2](https://github.com/algolia/instantsearch/commit/6130bf2))
+- **SearchBox:** better mobile behaviour by default ([ea968b3](https://github.com/algolia/instantsearch/commit/ea968b3))
+- **example:** link to instantsearch/react (#2007) ([5e674cd](https://github.com/algolia/instantsearch/commit/5e674cd))
+- **recipes:** react router v4 ([de673bf](https://github.com/algolia/instantsearch/commit/de673bf))
 
 ### Features
 
-- **SearchBox:** add role=search to the form (#2046) ([d1e90f3](https://github.com/algolia/instantsearch.js/commit/d1e90f3))
-- **SearchBox:** allow custom reset and submit components (#1991) ([cd303d7](https://github.com/algolia/instantsearch.js/commit/cd303d7))
-- **searchBox:** add event handling ([e267ab6](https://github.com/algolia/instantsearch.js/commit/e267ab6)), closes [#2017](https://github.com/algolia/instantsearch.js/issues/2017)
+- **SearchBox:** add role=search to the form (#2046) ([d1e90f3](https://github.com/algolia/instantsearch/commit/d1e90f3))
+- **SearchBox:** allow custom reset and submit components (#1991) ([cd303d7](https://github.com/algolia/instantsearch/commit/cd303d7))
+- **searchBox:** add event handling ([e267ab6](https://github.com/algolia/instantsearch/commit/e267ab6)), closes [#2017](https://github.com/algolia/instantsearch/issues/2017)
 
 <a name="3.2.1"></a>
 
-## [3.2.1](https://github.com/algolia/instantsearch.js/compare/v3.2.0...v3.2.1) (2017-02-22)
+## [3.2.1](https://github.com/algolia/instantsearch/compare/v3.2.0...v3.2.1) (2017-02-22)
 
 ### Bug Fixes
 
-- **umd:** Add connectors to UMD build (#1988) ([23ac5e6](https://github.com/algolia/instantsearch.js/commit/23ac5e6)), closes [#1987](https://github.com/algolia/instantsearch.js/issues/1987)
+- **umd:** Add connectors to UMD build (#1988) ([23ac5e6](https://github.com/algolia/instantsearch/commit/23ac5e6)), closes [#1987](https://github.com/algolia/instantsearch/issues/1987)
 
 <a name="3.2.0"></a>
 
-# [3.2.0](https://github.com/algolia/instantsearch.js/compare/v3.1.0...v3.2.0) (2017-02-15)
+# [3.2.0](https://github.com/algolia/instantsearch/compare/v3.1.0...v3.2.0) (2017-02-15)
 
 ### Bug Fixes
 
-- **Configure:** use props a unique source of truth (#1967) ([9d53d86](https://github.com/algolia/instantsearch.js/commit/9d53d86))
-- **SearchBox:** Safari can only have <use> with xlinkHref (#1970) ([7ab00bd](https://github.com/algolia/instantsearch.js/commit/7ab00bd)), closes [#1968](https://github.com/algolia/instantsearch.js/issues/1968)
+- **Configure:** use props a unique source of truth (#1967) ([9d53d86](https://github.com/algolia/instantsearch/commit/9d53d86))
+- **SearchBox:** Safari can only have <use> with xlinkHref (#1970) ([7ab00bd](https://github.com/algolia/instantsearch/commit/7ab00bd)), closes [#1968](https://github.com/algolia/instantsearch/issues/1968)
 
 ### Features
 
-- **MultiRange:** add an all range (#1959) ([a3dc950](https://github.com/algolia/instantsearch.js/commit/a3dc950))
+- **MultiRange:** add an all range (#1959) ([a3dc950](https://github.com/algolia/instantsearch/commit/a3dc950))
 
 ### BREAKING CHANGES
 
@@ -1451,37 +1445,37 @@ You can find all the details of the release and the migration guide from v3 to v
 
 <a name="3.1.0"></a>
 
-# [3.1.0](https://github.com/algolia/instantsearch.js/compare/v3.0.0...v3.1.0) (2017-02-08)
+# [3.1.0](https://github.com/algolia/instantsearch/compare/v3.0.0...v3.1.0) (2017-02-08)
 
 ### Bug Fixes
 
-- **Configure:** call onSearchStateChange when props are updated (#1953) ([7e151db](https://github.com/algolia/instantsearch.js/commit/7e151db)), closes [#1950](https://github.com/algolia/instantsearch.js/issues/1950)
-- **Configure:** trigger onSearchStateChange with the right data ([11e5af8](https://github.com/algolia/instantsearch.js/commit/11e5af8))
-- **createConnector:** updates with latest props on state change (#1951) ([cd3a82c](https://github.com/algolia/instantsearch.js/commit/cd3a82c))
+- **Configure:** call onSearchStateChange when props are updated (#1953) ([7e151db](https://github.com/algolia/instantsearch/commit/7e151db)), closes [#1950](https://github.com/algolia/instantsearch/issues/1950)
+- **Configure:** trigger onSearchStateChange with the right data ([11e5af8](https://github.com/algolia/instantsearch/commit/11e5af8))
+- **createConnector:** updates with latest props on state change (#1951) ([cd3a82c](https://github.com/algolia/instantsearch/commit/cd3a82c))
 
 ### Features
 
-- **ClearAll:** add withQuery to also clear the search query (#1958) ([c0e695b](https://github.com/algolia/instantsearch.js/commit/c0e695b))
+- **ClearAll:** add withQuery to also clear the search query (#1958) ([c0e695b](https://github.com/algolia/instantsearch/commit/c0e695b))
 
 <a name="3.0.0"></a>
 
-# [3.0.0](https://github.com/algolia/instantsearch.js/compare/v2.2.5...v3.0.0) (2017-02-06)
+# [3.0.0](https://github.com/algolia/instantsearch/compare/v2.2.5...v3.0.0) (2017-02-06)
 
 ### Bug Fixes
 
-- **\*List:** disable shortcuts in \*List SearchBoxes (#1921) ([51a76ae](https://github.com/algolia/instantsearch.js/commit/51a76ae)), closes [#1920](https://github.com/algolia/instantsearch.js/issues/1920)
-- **Configure:** add configure parameters in search state (#1935) ([0971330](https://github.com/algolia/instantsearch.js/commit/0971330)), closes [#1863](https://github.com/algolia/instantsearch.js/issues/1863)
-- **Hits:** limit the hitComponent to be only a function (#1912) ([b3c9578](https://github.com/algolia/instantsearch.js/commit/b3c9578))
-- **Pagination:** fix and indicate when pagination is disabled ([5f20199](https://github.com/algolia/instantsearch.js/commit/5f20199)), closes [#1938](https://github.com/algolia/instantsearch.js/issues/1938)
-- **StarRating:** usage with filters (#1933) ([667e9d5](https://github.com/algolia/instantsearch.js/commit/667e9d5))
-- **withSearchBox:** keep displaying searchBox when no items found (#1930) ([30de4cd](https://github.com/algolia/instantsearch.js/commit/30de4cd))
+- **\*List:** disable shortcuts in \*List SearchBoxes (#1921) ([51a76ae](https://github.com/algolia/instantsearch/commit/51a76ae)), closes [#1920](https://github.com/algolia/instantsearch/issues/1920)
+- **Configure:** add configure parameters in search state (#1935) ([0971330](https://github.com/algolia/instantsearch/commit/0971330)), closes [#1863](https://github.com/algolia/instantsearch/issues/1863)
+- **Hits:** limit the hitComponent to be only a function (#1912) ([b3c9578](https://github.com/algolia/instantsearch/commit/b3c9578))
+- **Pagination:** fix and indicate when pagination is disabled ([5f20199](https://github.com/algolia/instantsearch/commit/5f20199)), closes [#1938](https://github.com/algolia/instantsearch/issues/1938)
+- **StarRating:** usage with filters (#1933) ([667e9d5](https://github.com/algolia/instantsearch/commit/667e9d5))
+- **withSearchBox:** keep displaying searchBox when no items found (#1930) ([30de4cd](https://github.com/algolia/instantsearch/commit/30de4cd))
 
 ### Features
 
-- **MultiRange:** indicate if a range has no refinements (#1926) ([80b6450](https://github.com/algolia/instantsearch.js/commit/80b6450))
-- **panel:** add a panel widget (#1889) ([594e1a1](https://github.com/algolia/instantsearch.js/commit/594e1a1))
-- **starRating:** indicate when any refinement has no effect ([c547ae5](https://github.com/algolia/instantsearch.js/commit/c547ae5))
-- **widgets:** default design for disabled states (#1929) ([31f010b](https://github.com/algolia/instantsearch.js/commit/31f010b))
+- **MultiRange:** indicate if a range has no refinements (#1926) ([80b6450](https://github.com/algolia/instantsearch/commit/80b6450))
+- **panel:** add a panel widget (#1889) ([594e1a1](https://github.com/algolia/instantsearch/commit/594e1a1))
+- **starRating:** indicate when any refinement has no effect ([c547ae5](https://github.com/algolia/instantsearch/commit/c547ae5))
+- **widgets:** default design for disabled states (#1929) ([31f010b](https://github.com/algolia/instantsearch/commit/31f010b))
 
 ### Migration guide
 
@@ -1494,96 +1488,96 @@ There are two breaking changes that you will need to handle in your codebase:
 
 <a name="2.2.5"></a>
 
-## [2.2.5](https://github.com/algolia/instantsearch.js/compare/v2.2.4...v2.2.5) (2017-01-23)
+## [2.2.5](https://github.com/algolia/instantsearch/compare/v2.2.4...v2.2.5) (2017-01-23)
 
 ### Bug Fixes
 
-- **currentRefinements:** make removing a toggle refinement work ([8995e64](https://github.com/algolia/instantsearch.js/commit/8995e64))
+- **currentRefinements:** make removing a toggle refinement work ([8995e64](https://github.com/algolia/instantsearch/commit/8995e64))
 
 <a name="2.2.4"></a>
 
-## [2.2.4](https://github.com/algolia/instantsearch.js/compare/v2.2.3...v2.2.4) (2017-01-20)
+## [2.2.4](https://github.com/algolia/instantsearch/compare/v2.2.3...v2.2.4) (2017-01-20)
 
 ### Bug Fixes
 
-- **publish:** publish react-instantsearch/dist instead of root (#1884) ([64414e0](https://github.com/algolia/instantsearch.js/commit/64414e0))
+- **publish:** publish react-instantsearch/dist instead of root (#1884) ([64414e0](https://github.com/algolia/instantsearch/commit/64414e0))
 
 <a name="2.2.3"></a>
 
-## [2.2.3](https://github.com/algolia/instantsearch.js/compare/v2.2.2...v2.2.3) (2017-01-20)
+## [2.2.3](https://github.com/algolia/instantsearch/compare/v2.2.2...v2.2.3) (2017-01-20)
 
 ### Bug Fixes
 
-- **SFFV:** translations for searchbox were not applied (#1879) ([e9b4ee1](https://github.com/algolia/instantsearch.js/commit/e9b4ee1))
+- **SFFV:** translations for searchbox were not applied (#1879) ([e9b4ee1](https://github.com/algolia/instantsearch/commit/e9b4ee1))
 
 <a name="2.2.2"></a>
 
-## [2.2.2](https://github.com/algolia/instantsearch.js/compare/v2.2.1...v2.2.2) (2017-01-18)
+## [2.2.2](https://github.com/algolia/instantsearch/compare/v2.2.1...v2.2.2) (2017-01-18)
 
 ### Bug Fixes
 
-- **react-router:** search was triggered two many times (#1840) ([25e9db5](https://github.com/algolia/instantsearch.js/commit/25e9db5))
-- **SFFV:** empty query triggered a new SFFV (#1875) ([6c8259a](https://github.com/algolia/instantsearch.js/commit/6c8259a))
+- **react-router:** search was triggered two many times (#1840) ([25e9db5](https://github.com/algolia/instantsearch/commit/25e9db5))
+- **SFFV:** empty query triggered a new SFFV (#1875) ([6c8259a](https://github.com/algolia/instantsearch/commit/6c8259a))
 
 <a name="2.2.1"></a>
 
-## [2.2.1](https://github.com/algolia/instantsearch.js/compare/v2.2.0...v2.2.1) (2017-01-18)
+## [2.2.1](https://github.com/algolia/instantsearch/compare/v2.2.0...v2.2.1) (2017-01-18)
 
 ### Bug Fixes
 
-- **createInstantsearch:** fix missing props (#1867) ([8d319b5](https://github.com/algolia/instantsearch.js/commit/8d319b5)), closes [#1867](https://github.com/algolia/instantsearch.js/issues/1867)
+- **createInstantsearch:** fix missing props (#1867) ([8d319b5](https://github.com/algolia/instantsearch/commit/8d319b5)), closes [#1867](https://github.com/algolia/instantsearch/issues/1867)
 
 <a name="2.2.0"></a>
 
-# [2.2.0](https://github.com/algolia/instantsearch.js/compare/v2.1.0...v2.2.0) (2017-01-17)
+# [2.2.0](https://github.com/algolia/instantsearch/compare/v2.1.0...v2.2.0) (2017-01-17)
 
 ### Bug Fixes
 
-- **clear:** clearing wasn't working with too+ same type facets selected (#1820) ([a9a2364](https://github.com/algolia/instantsearch.js/commit/a9a2364))
-- **connectSearchBox:** handle `defaultRefinement` (#1829) ([7a730e2](https://github.com/algolia/instantsearch.js/commit/7a730e2)), closes [#1826](https://github.com/algolia/instantsearch.js/issues/1826)
-- **Instantsearch:** Update all props on InstantSearch (#1828) ([2ed9b49](https://github.com/algolia/instantsearch.js/commit/2ed9b49))
-- **InstantSearch:** add specific `react-instantsearch ${version}` agent (#1844) ([a1113bc](https://github.com/algolia/instantsearch.js/commit/a1113bc))
-- **SFFV:** correct propTypes and add missing default values (#1845) ([a4c1b31](https://github.com/algolia/instantsearch.js/commit/a4c1b31))
-- **test:** add missing Snippet and Highliter snapshot ([4accce5](https://github.com/algolia/instantsearch.js/commit/4accce5))
-- **widgets:** replace setImmediate use with Promise use when update is needed (#1811) ([17e2497](https://github.com/algolia/instantsearch.js/commit/17e2497))
+- **clear:** clearing wasn't working with too+ same type facets selected (#1820) ([a9a2364](https://github.com/algolia/instantsearch/commit/a9a2364))
+- **connectSearchBox:** handle `defaultRefinement` (#1829) ([7a730e2](https://github.com/algolia/instantsearch/commit/7a730e2)), closes [#1826](https://github.com/algolia/instantsearch/issues/1826)
+- **Instantsearch:** Update all props on InstantSearch (#1828) ([2ed9b49](https://github.com/algolia/instantsearch/commit/2ed9b49))
+- **InstantSearch:** add specific `react-instantsearch ${version}` agent (#1844) ([a1113bc](https://github.com/algolia/instantsearch/commit/a1113bc))
+- **SFFV:** correct propTypes and add missing default values (#1845) ([a4c1b31](https://github.com/algolia/instantsearch/commit/a4c1b31))
+- **test:** add missing Snippet and Highliter snapshot ([4accce5](https://github.com/algolia/instantsearch/commit/4accce5))
+- **widgets:** replace setImmediate use with Promise use when update is needed (#1811) ([17e2497](https://github.com/algolia/instantsearch/commit/17e2497))
 
 ### Features
 
-- **Menu, connectMenu:** add search for facet values (#1822) ([a6c513e](https://github.com/algolia/instantsearch.js/commit/a6c513e))
-- **snippet:** add a snippet widget to be able to highlight snippet results (#1797) ([2aecc40](https://github.com/algolia/instantsearch.js/commit/2aecc40))
-- **widgets:** add transformItems to be able to sort and filter (#1809) ([ba539f0](https://github.com/algolia/instantsearch.js/commit/ba539f0))
+- **Menu, connectMenu:** add search for facet values (#1822) ([a6c513e](https://github.com/algolia/instantsearch/commit/a6c513e))
+- **snippet:** add a snippet widget to be able to highlight snippet results (#1797) ([2aecc40](https://github.com/algolia/instantsearch/commit/2aecc40))
+- **widgets:** add transformItems to be able to sort and filter (#1809) ([ba539f0](https://github.com/algolia/instantsearch/commit/ba539f0))
 
 <a name="2.1.0"></a>
 
-# [2.1.0](https://github.com/algolia/instantsearch.js/compare/v2.0.1...v2.1.0) (2017-01-04)
+# [2.1.0](https://github.com/algolia/instantsearch/compare/v2.0.1...v2.1.0) (2017-01-04)
 
 ### Bug Fixes
 
-- **createInstantSearchManager:** drop outdated response (#1765) ([76c5312](https://github.com/algolia/instantsearch.js/commit/76c5312))
-- **highlight:** highlight should work even if the attribute is missing (#1791) ([5b79b15](https://github.com/algolia/instantsearch.js/commit/5b79b15)), closes [#1790](https://github.com/algolia/instantsearch.js/issues/1790)
-- **InfiniteHits:** better classname to loadmore btn (#1789) ([ad2ded3](https://github.com/algolia/instantsearch.js/commit/ad2ded3))
-- **starRatings:** click on selected range doesn't unselect it (#1766) ([beacc72](https://github.com/algolia/instantsearch.js/commit/beacc72))
-- **website:** broken demo links (#1802) ([0abe2f5](https://github.com/algolia/instantsearch.js/commit/0abe2f5))
-- **widgets:** add 300px width for the default SearchBox (#1803) ([bf5d791](https://github.com/algolia/instantsearch.js/commit/bf5d791))
+- **createInstantSearchManager:** drop outdated response (#1765) ([76c5312](https://github.com/algolia/instantsearch/commit/76c5312))
+- **highlight:** highlight should work even if the attribute is missing (#1791) ([5b79b15](https://github.com/algolia/instantsearch/commit/5b79b15)), closes [#1790](https://github.com/algolia/instantsearch/issues/1790)
+- **InfiniteHits:** better classname to loadmore btn (#1789) ([ad2ded3](https://github.com/algolia/instantsearch/commit/ad2ded3))
+- **starRatings:** click on selected range doesn't unselect it (#1766) ([beacc72](https://github.com/algolia/instantsearch/commit/beacc72))
+- **website:** broken demo links (#1802) ([0abe2f5](https://github.com/algolia/instantsearch/commit/0abe2f5))
+- **widgets:** add 300px width for the default SearchBox (#1803) ([bf5d791](https://github.com/algolia/instantsearch/commit/bf5d791))
 
 ### Features
 
-- **InfiniteHits:** Add class to load more button (#1787) ([416febd](https://github.com/algolia/instantsearch.js/commit/416febd))
-- **RefinementList, connectRefinementList:** allow to search for facet values ([e086a81](https://github.com/algolia/instantsearch.js/commit/e086a81))
+- **InfiniteHits:** Add class to load more button (#1787) ([416febd](https://github.com/algolia/instantsearch/commit/416febd))
+- **RefinementList, connectRefinementList:** allow to search for facet values ([e086a81](https://github.com/algolia/instantsearch/commit/e086a81))
 
 <a name="2.0.1"></a>
 
-## [2.0.1](https://github.com/algolia/instantsearch.js/compare/v2.0.0...v2.0.1) (2016-12-15)
+## [2.0.1](https://github.com/algolia/instantsearch/compare/v2.0.0...v2.0.1) (2016-12-15)
 
 ### Bug Fixes
 
-- **connectRange:** when unfinite numbers are passed throw ([75bec0d](https://github.com/algolia/instantsearch.js/commit/75bec0d))
-- **react-native:** use View as a container for react-native (#1729) ([5b76f75](https://github.com/algolia/instantsearch.js/commit/5b76f75)), closes [#1730](https://github.com/algolia/instantsearch.js/issues/1730)
-- **SearchBox:** autocomplete was not disabled by default (#1742) ([bc76618](https://github.com/algolia/instantsearch.js/commit/bc76618))
-- **starRating:** call createURL with the right interface (min/max) (#1747) ([f9ab9b6](https://github.com/algolia/instantsearch.js/commit/f9ab9b6))
+- **connectRange:** when unfinite numbers are passed throw ([75bec0d](https://github.com/algolia/instantsearch/commit/75bec0d))
+- **react-native:** use View as a container for react-native (#1729) ([5b76f75](https://github.com/algolia/instantsearch/commit/5b76f75)), closes [#1730](https://github.com/algolia/instantsearch/issues/1730)
+- **SearchBox:** autocomplete was not disabled by default (#1742) ([bc76618](https://github.com/algolia/instantsearch/commit/bc76618))
+- **starRating:** call createURL with the right interface (min/max) (#1747) ([f9ab9b6](https://github.com/algolia/instantsearch/commit/f9ab9b6))
 
 <a name="2.0.0"></a>
 
-## [2.0.0](https://github.com/algolia/instantsearch.js/compare/v2.0.0...v2.0.0) (2016-12-08)
+## [2.0.0](https://github.com/algolia/instantsearch/compare/v2.0.0...v2.0.0) (2016-12-08)
 
 First release of `react-instantsearch`

--- a/packages/react-instantsearch/README.md
+++ b/packages/react-instantsearch/README.md
@@ -1,6 +1,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+**Table of Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
 
 - [react-instantsearch](#react-instantsearch)
   - [Why](#why)
@@ -17,15 +18,15 @@
 
 React InstantSearch is an open-source React library that lets you create an instant search result experience using [Algolia][algolia-website]’s search API. It is part of the InstantSearch family:
 
-**React InstantSearch** | [InstantSearch.js][instantsearch.js-github] | [Angular InstantSearch][instantsearch-angular-github] | [Vue InstantSearch][instantsearch-vue-github] | [InstantSearch Android][instantsearch-android-github] | [InstantSearch iOS][instantsearch-ios-github]
+**React InstantSearch** | [InstantSearch.js][instantsearch-github] | [Angular InstantSearch][instantsearch-angular-github] | [Vue InstantSearch][instantsearch-github] | [InstantSearch Android][instantsearch-android-github] | [InstantSearch iOS][instantsearch-ios-github]
 
 ## Why
 
 You should be using React InstantSearch if you want to:
 
-* Design search experiences with best practices
-* Customize your components at will
-* Follow React principles
+- Design search experiences with best practices
+- Customize your components at will
+- Follow React principles
 
 Note: If you are working with React Native, or otherwise do not use the DOM, check out `react-instantsearch-core` instead.
 
@@ -55,10 +56,7 @@ const searchClient = algoliasearch(
 );
 
 const App = () => (
-  <InstantSearch
-    indexName="bestbuy"
-    searchClient={searchClient}
-  >
+  <InstantSearch indexName="bestbuy" searchClient={searchClient}>
     <SearchBox />
     <Hits />
   </InstantSearch>
@@ -66,7 +64,7 @@ const App = () => (
 ```
 
 <p align="center">
-  <a href="https://codesandbox.io/s/github/algolia/instantsearch.js/tree/master/examples/react/default-theme" title="Edit on CodeSandbox">
+  <a href="https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react/default-theme" title="Edit on CodeSandbox">
     <img alt="Edit on CodeSandbox" src="https://codesandbox.io/static/img/play-codesandbox.svg">
   </a>
 </p>
@@ -98,7 +96,7 @@ To start contributing to code, you need to:
 1.  [Clone the repository](https://help.github.com/articles/cloning-a-repository/)
 1.  Install the dependencies: `yarn`
 
-Please read [our contribution process](https://github.com/algolia/instantsearch.js/blob/master/CONTRIBUTING.md) to learn more.
+Please read [our contribution process](https://github.com/algolia/instantsearch/blob/master/CONTRIBUTING.md) to learn more.
 
 ## License
 
@@ -111,14 +109,13 @@ React InstantSearch is [MIT licensed](../../LICENSE).
 [doc-guides]: https://www.algolia.com/doc/guides/building-search-ui/going-further/server-side-rendering/react/
 [doc-playground]: https://codesandbox.io/s/github/algolia/instantsearch/tree/master/examples/react/default-theme
 [algolia-website]: https://www.algolia.com/
-[instantsearch.js-github]: https://github.com/algolia/instantsearch.js
+[instantsearch-github]: https://github.com/algolia/instantsearch
 [instantsearch-android-github]: https://github.com/algolia/instantsearch-android
 [instantsearch-ios-github]: https://github.com/algolia/instantsearch-ios
-[instantsearch-vue-github]: https://github.com/algolia/vue-instantsearch
 [instantsearch-angular-github]: https://github.com/algolia/angular-instantsearch
-[contributing-bugreport]: https://github.com/algolia/instantsearch.js/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20React+InstantSearch
-[contributing-featurerequest]: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage,Library%3A%20React+InstantSearch&title=Feature%20request%3A%20
-[contributing-newissue]: https://github.com/algolia/instantsearch.js/issues/new?labels=triage,Library%3A%20React+InstantSearch
-[contributing-label-easy]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20React+InstantSearch%22
-[contributing-label-bug]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20React+InstantSearch%22
-[contributing-label-chore]: https://github.com/algolia/instantsearch.js/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-bugreport]: https://github.com/algolia/instantsearch/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20React+InstantSearch
+[contributing-featurerequest]: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage,Library%3A%20React+InstantSearch&title=Feature%20request%3A%20
+[contributing-newissue]: https://github.com/algolia/instantsearch/issues/new?labels=triage,Library%3A%20React+InstantSearch
+[contributing-label-easy]: https://github.com/algolia/instantsearch/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-label-bug]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-label-chore]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20React+InstantSearch%22

--- a/packages/react-instantsearch/rollup.config.js
+++ b/packages/react-instantsearch/rollup.config.js
@@ -10,7 +10,7 @@ const clear = (x) => x.filter(Boolean);
 
 const version = process.env.VERSION || 'UNRELEASED';
 const algolia = '© Algolia, inc.';
-const link = 'https://github.com/algolia/instantsearch.js';
+const link = 'https://github.com/algolia/instantsearch';
 const createBanner = (name) =>
   `/*! React InstantSearch${name} ${version} | ${algolia} | ${link} */`;
 

--- a/packages/vue-instantsearch/.storybook/config.js
+++ b/packages/vue-instantsearch/.storybook/config.js
@@ -3,7 +3,7 @@ import { setOptions } from '@storybook/addon-options';
 
 setOptions({
   name: 'vue-instantsearch',
-  url: 'https://github.com/algolia/instantsearch.js',
+  url: 'https://github.com/algolia/instantsearch',
   goFullScreen: false,
   showStoriesPanel: true,
   showAddonPanel: true,
@@ -24,7 +24,7 @@ Vue.use(InstantSearch);
 const req = require.context('../stories', true, /\.stories\.js$/);
 
 function loadStories() {
-  req.keys().forEach(filename => req(filename));
+  req.keys().forEach((filename) => req(filename));
 }
 
 configure(loadStories, module);

--- a/packages/vue-instantsearch/CHANGELOG.md
+++ b/packages/vue-instantsearch/CHANGELOG.md
@@ -1,420 +1,257 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [4.10.10](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.10.9...vue-instantsearch@4.10.10) (2023-09-05)
-
-**Note:** Version bump only for package vue-instantsearch
-
-
-
-
-
-## [4.10.9](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.10.8...vue-instantsearch@4.10.9) (2023-08-08)
+## [4.10.10](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.10.9...vue-instantsearch@4.10.10) (2023-09-05)
 
 **Note:** Version bump only for package vue-instantsearch
 
-
-
-
-
-## [4.10.8](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.10.7...vue-instantsearch@4.10.8) (2023-07-25)
+## [4.10.9](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.10.8...vue-instantsearch@4.10.9) (2023-08-08)
 
 **Note:** Version bump only for package vue-instantsearch
 
-
-
-
-
-## [4.10.7](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.10.6...vue-instantsearch@4.10.7) (2023-07-19)
-
-
-### Bug Fixes
-
-* **instantsearch:** keep algoliasearch-helper as external dependency during build ([#5765](https://github.com/algolia/instantsearch.js/issues/5765)) ([550fefa](https://github.com/algolia/instantsearch.js/commit/550fefa1401773f38dedc20322513ae662faa25d))
-
-
-
-
-
-## [4.10.6](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.10.5...vue-instantsearch@4.10.6) (2023-07-18)
+## [4.10.8](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.10.7...vue-instantsearch@4.10.8) (2023-07-25)
 
 **Note:** Version bump only for package vue-instantsearch
 
-
-
-
-
-## [4.10.5](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.10.4...vue-instantsearch@4.10.5) (2023-07-10)
-
+## [4.10.7](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.10.6...vue-instantsearch@4.10.7) (2023-07-19)
 
 ### Bug Fixes
 
-* **url:** base createURL on UiState instead of SearchParameters ([#5696](https://github.com/algolia/instantsearch.js/issues/5696)) ([7e2c8a2](https://github.com/algolia/instantsearch.js/commit/7e2c8a295a6fc5ba36d9482f645ef55b422d5e75)), closes [#5694](https://github.com/algolia/instantsearch.js/issues/5694)
+- **instantsearch:** keep algoliasearch-helper as external dependency during build ([#5765](https://github.com/algolia/instantsearch/issues/5765)) ([550fefa](https://github.com/algolia/instantsearch/commit/550fefa1401773f38dedc20322513ae662faa25d))
 
-
-
-
-
-## [4.10.4](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.10.3...vue-instantsearch@4.10.4) (2023-07-04)
+## [4.10.6](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.10.5...vue-instantsearch@4.10.6) (2023-07-18)
 
 **Note:** Version bump only for package vue-instantsearch
 
-
-
-
-
-## [4.10.3](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.10.2...vue-instantsearch@4.10.3) (2023-06-20)
-
+## [4.10.5](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.10.4...vue-instantsearch@4.10.5) (2023-07-10)
 
 ### Bug Fixes
 
-* **dependencies:** update helper requirement ([#5676](https://github.com/algolia/instantsearch.js/issues/5676)) ([c289120](https://github.com/algolia/instantsearch.js/commit/c2891205c1125b1203b3b3db946d57e0fc4e4687)), closes [#5658](https://github.com/algolia/instantsearch.js/issues/5658)
+- **url:** base createURL on UiState instead of SearchParameters ([#5696](https://github.com/algolia/instantsearch/issues/5696)) ([7e2c8a2](https://github.com/algolia/instantsearch/commit/7e2c8a295a6fc5ba36d9482f645ef55b422d5e75)), closes [#5694](https://github.com/algolia/instantsearch/issues/5694)
 
+## [4.10.4](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.10.3...vue-instantsearch@4.10.4) (2023-07-04)
 
+**Note:** Version bump only for package vue-instantsearch
 
-
-
-## [4.10.2](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.10.1...vue-instantsearch@4.10.2) (2023-06-13)
-
-
-### Bug Fixes
-
-* **createServerRootMixin:** forward i18n on option ([#5673](https://github.com/algolia/instantsearch/issues/5673)) ([d52b47f](https://github.com/algolia/instantsearch/commit/d52b47f58a9e723616ec59c9805c590e8079ba38))
-* **breadcrumb:** align vue component with specs ([#5672](https://github.com/algolia/instantsearch.js/issues/5672)) ([dbfed3a](https://github.com/algolia/instantsearch.js/commit/dbfed3ac25910013835c9bb36255b6dbd6d264ec))
-
-
-
-
-
-## [4.10.1](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.10.0...vue-instantsearch@4.10.1) (2023-05-30)
-
+## [4.10.3](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.10.2...vue-instantsearch@4.10.3) (2023-06-20)
 
 ### Bug Fixes
 
-* **insights:** send default click event when using auxiliary pointer button ([#5634](https://github.com/algolia/instantsearch.js/issues/5634)) ([7e4a216](https://github.com/algolia/instantsearch.js/commit/7e4a2162f87596a384b35c97efa51db9bb6f8973))
+- **dependencies:** update helper requirement ([#5676](https://github.com/algolia/instantsearch/issues/5676)) ([c289120](https://github.com/algolia/instantsearch/commit/c2891205c1125b1203b3b3db946d57e0fc4e4687)), closes [#5658](https://github.com/algolia/instantsearch/issues/5658)
 
-
-
-
-
-# [4.10.0](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.9.0...vue-instantsearch@4.10.0) (2023-05-16)
-
+## [4.10.2](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.10.1...vue-instantsearch@4.10.2) (2023-06-13)
 
 ### Bug Fixes
 
-* **rangeinput:** allow input of numbers with precision ([#5541](https://github.com/algolia/instantsearch.js/issues/5541)) ([fb48951](https://github.com/algolia/instantsearch.js/commit/fb489513a8550528f3e2867be30fb380229ad188))
+- **createServerRootMixin:** forward i18n on option ([#5673](https://github.com/algolia/instantsearch/issues/5673)) ([d52b47f](https://github.com/algolia/instantsearch/commit/d52b47f58a9e723616ec59c9805c590e8079ba38))
+- **breadcrumb:** align vue component with specs ([#5672](https://github.com/algolia/instantsearch/issues/5672)) ([dbfed3a](https://github.com/algolia/instantsearch/commit/dbfed3ac25910013835c9bb36255b6dbd6d264ec))
 
+## [4.10.1](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.10.0...vue-instantsearch@4.10.1) (2023-05-30)
+
+### Bug Fixes
+
+- **insights:** send default click event when using auxiliary pointer button ([#5634](https://github.com/algolia/instantsearch/issues/5634)) ([7e4a216](https://github.com/algolia/instantsearch/commit/7e4a2162f87596a384b35c97efa51db9bb6f8973))
+
+# [4.10.0](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.9.0...vue-instantsearch@4.10.0) (2023-05-16)
+
+### Bug Fixes
+
+- **rangeinput:** allow input of numbers with precision ([#5541](https://github.com/algolia/instantsearch/issues/5541)) ([fb48951](https://github.com/algolia/instantsearch/commit/fb489513a8550528f3e2867be30fb380229ad188))
 
 ### Features
 
-* **instantsearch:** make root indexName optional ([#5590](https://github.com/algolia/instantsearch.js/issues/5590)) ([80f309e](https://github.com/algolia/instantsearch.js/commit/80f309ed69b61534ca118b60c9c88691e0148fca))
+- **instantsearch:** make root indexName optional ([#5590](https://github.com/algolia/instantsearch/issues/5590)) ([80f309e](https://github.com/algolia/instantsearch/commit/80f309ed69b61534ca118b60c9c88691e0148fca))
 
-
-
-
-
-# [4.9.0](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.10...vue-instantsearch@4.9.0) (2023-04-24)
-
+# [4.9.0](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.10...vue-instantsearch@4.9.0) (2023-04-24)
 
 ### Features
 
+- **insights:** add insights option to InstantSearch ([#5488](https://github.com/algolia/instantsearch/issues/5488)) ([9031573](https://github.com/algolia/instantsearch/commit/9031573807fa6803dcfae9f33d61b8f111f68423)) ([#5578](https://github.com/algolia/instantsearch/issues/5578)) ([8fb517f](https://github.com/algolia/instantsearch/commit/8fb517f15381ecb32ea00cf4b01a0fd5e70e1d17)) ([#5545](https://github.com/algolia/instantsearch/issues/5545)) ([99a0972](https://github.com/algolia/instantsearch/commit/99a0972663b8f3284cac3b5621571ced7a33908f)) ([#5493](https://github.com/algolia/instantsearch/issues/5493)) ([cff723f](https://github.com/algolia/instantsearch/commit/cff723fc95a90ebb2ed14c46c51ab05764835a47))
+- **insights:** always pass Algolia credentials locally ([#5554](https://github.com/algolia/instantsearch/issues/5554)) ([654ab81](https://github.com/algolia/instantsearch/commit/654ab81e1669354c249710b6756610fba35d54b4)) ([#5558](https://github.com/algolia/instantsearch/issues/5558)) ([82144c0](https://github.com/algolia/instantsearch/commit/82144c0a0b18e6b47d6f508e5c670a9de274c121)) ([#5529](https://github.com/algolia/instantsearch/issues/5529)) ([8537f8f](https://github.com/algolia/instantsearch/commit/8537f8f7a10bcaf053ff62180c082e077b1b052d))
+- **insights:** annotate events with algoliaSource ([#5580](https://github.com/algolia/instantsearch/issues/5580)) ([c419307](https://github.com/algolia/instantsearch/commit/c419307a5f7fe46d5032c9437a17c8e3dad57fe5))
+- **insights:** automatically load search-insights if not passed ([#5484](https://github.com/algolia/instantsearch/issues/5484)) ([a85797b](https://github.com/algolia/instantsearch/commit/a85797b503edc94e001c5bfb3b754db6cb556943))
+- **insights:** enable default click events on hits and infinite hits ([#5522](https://github.com/algolia/instantsearch/issues/5522)) ([271bd12](https://github.com/algolia/instantsearch/commit/271bd12e34bc55656976bb53c90282193083eb86)) ([#5527](https://github.com/algolia/instantsearch/issues/5527)) ([0e55821](https://github.com/algolia/instantsearch/commit/0e558213c807cd17d592fadec052f3d1fc692e6c))
+- **insights:** prevent potential errors ([#5487](https://github.com/algolia/instantsearch/issues/5487)) ([33fe510](https://github.com/algolia/instantsearch/commit/33fe510307e4b382a5ba1153a0eaf160420acd11)) ([#5606](https://github.com/algolia/instantsearch/issues/5606)) ([bdd9290](https://github.com/algolia/instantsearch/commit/bdd92901b59ae4e5d7311eadfbf53ed656bbaf4a)) ([#5512](https://github.com/algolia/instantsearch/issues/5512)) ([85dfbc9](https://github.com/algolia/instantsearch/commit/85dfbc9ebd722fbe6a7e1bd056950fdbcc16d8d9))
+- **metadata:** register metadata around middleware ([#5492](https://github.com/algolia/instantsearch/issues/5492)) ([3e72ec8](https://github.com/algolia/instantsearch/commit/3e72ec82894a05a071328a4802d2f764233fe005))
 
-* **insights:** add insights option to InstantSearch ([#5488](https://github.com/algolia/instantsearch.js/issues/5488)) ([9031573](https://github.com/algolia/instantsearch.js/commit/9031573807fa6803dcfae9f33d61b8f111f68423)) ([#5578](https://github.com/algolia/instantsearch.js/issues/5578)) ([8fb517f](https://github.com/algolia/instantsearch.js/commit/8fb517f15381ecb32ea00cf4b01a0fd5e70e1d17)) ([#5545](https://github.com/algolia/instantsearch.js/issues/5545)) ([99a0972](https://github.com/algolia/instantsearch.js/commit/99a0972663b8f3284cac3b5621571ced7a33908f)) ([#5493](https://github.com/algolia/instantsearch.js/issues/5493)) ([cff723f](https://github.com/algolia/instantsearch.js/commit/cff723fc95a90ebb2ed14c46c51ab05764835a47))
-* **insights:** always pass Algolia credentials locally ([#5554](https://github.com/algolia/instantsearch.js/issues/5554)) ([654ab81](https://github.com/algolia/instantsearch.js/commit/654ab81e1669354c249710b6756610fba35d54b4)) ([#5558](https://github.com/algolia/instantsearch.js/issues/5558)) ([82144c0](https://github.com/algolia/instantsearch.js/commit/82144c0a0b18e6b47d6f508e5c670a9de274c121)) ([#5529](https://github.com/algolia/instantsearch.js/issues/5529)) ([8537f8f](https://github.com/algolia/instantsearch.js/commit/8537f8f7a10bcaf053ff62180c082e077b1b052d))
-* **insights:** annotate events with algoliaSource ([#5580](https://github.com/algolia/instantsearch.js/issues/5580)) ([c419307](https://github.com/algolia/instantsearch.js/commit/c419307a5f7fe46d5032c9437a17c8e3dad57fe5))
-* **insights:** automatically load search-insights if not passed ([#5484](https://github.com/algolia/instantsearch.js/issues/5484)) ([a85797b](https://github.com/algolia/instantsearch.js/commit/a85797b503edc94e001c5bfb3b754db6cb556943))
-* **insights:** enable default click events on hits and infinite hits ([#5522](https://github.com/algolia/instantsearch.js/issues/5522)) ([271bd12](https://github.com/algolia/instantsearch.js/commit/271bd12e34bc55656976bb53c90282193083eb86)) ([#5527](https://github.com/algolia/instantsearch.js/issues/5527)) ([0e55821](https://github.com/algolia/instantsearch.js/commit/0e558213c807cd17d592fadec052f3d1fc692e6c))
-* **insights:** prevent potential errors ([#5487](https://github.com/algolia/instantsearch.js/issues/5487)) ([33fe510](https://github.com/algolia/instantsearch.js/commit/33fe510307e4b382a5ba1153a0eaf160420acd11)) ([#5606](https://github.com/algolia/instantsearch.js/issues/5606)) ([bdd9290](https://github.com/algolia/instantsearch.js/commit/bdd92901b59ae4e5d7311eadfbf53ed656bbaf4a)) ([#5512](https://github.com/algolia/instantsearch.js/issues/5512)) ([85dfbc9](https://github.com/algolia/instantsearch.js/commit/85dfbc9ebd722fbe6a7e1bd056950fdbcc16d8d9))
-* **metadata:** register metadata around middleware ([#5492](https://github.com/algolia/instantsearch.js/issues/5492)) ([3e72ec8](https://github.com/algolia/instantsearch.js/commit/3e72ec82894a05a071328a4802d2f764233fe005))
-
-
-
-
-
-
-## [4.8.10](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.9...vue-instantsearch@4.8.10) (2023-04-11)
+## [4.8.10](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.9...vue-instantsearch@4.8.10) (2023-04-11)
 
 **Note:** Version bump only for package vue-instantsearch
 
-
-
-
-
-## [4.8.9](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.8...vue-instantsearch@4.8.9) (2023-03-28)
+## [4.8.9](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.8...vue-instantsearch@4.8.9) (2023-03-28)
 
 ### Features
 
-* **ais-instant-search**: warn when an unstable search client is detected ([#5572](https://github.com/algolia/instantsearch.js/issues/5572)) ([71296a4](https://github.com/algolia/instantsearch/commit/71296a4eaa6233d397d2fc3b7e635e12e521409c))
+- **ais-instant-search**: warn when an unstable search client is detected ([#5572](https://github.com/algolia/instantsearch/issues/5572)) ([71296a4](https://github.com/algolia/instantsearch/commit/71296a4eaa6233d397d2fc3b7e635e12e521409c))
 
-
-
-
-## [4.8.8](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.7...vue-instantsearch@4.8.8) (2023-03-21)
-
+## [4.8.8](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.7...vue-instantsearch@4.8.8) (2023-03-21)
 
 ### Bug Fixes
 
-* **searchbox:** add aria-hidden to svg icons ([#5547](https://github.com/algolia/instantsearch.js/issues/5547)) ([50344e3](https://github.com/algolia/instantsearch.js/commit/50344e3b14c22c886415c0e7d799aca778dc39ab)), closes [#5546](https://github.com/algolia/instantsearch.js/issues/5546)
-* **svg:** don't style width/height in attributes with unit ([#5550](https://github.com/algolia/instantsearch.js/issues/5550)) ([31b85a6](https://github.com/algolia/instantsearch.js/commit/31b85a6ad56993455adb201f88ab1d1ae2d96683))
+- **searchbox:** add aria-hidden to svg icons ([#5547](https://github.com/algolia/instantsearch/issues/5547)) ([50344e3](https://github.com/algolia/instantsearch/commit/50344e3b14c22c886415c0e7d799aca778dc39ab)), closes [#5546](https://github.com/algolia/instantsearch/issues/5546)
+- **svg:** don't style width/height in attributes with unit ([#5550](https://github.com/algolia/instantsearch/issues/5550)) ([31b85a6](https://github.com/algolia/instantsearch/commit/31b85a6ad56993455adb201f88ab1d1ae2d96683))
 
-
-
-
-
-## [4.8.7](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.5...vue-instantsearch@4.8.7) (2023-03-07)
+## [4.8.7](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.5...vue-instantsearch@4.8.7) (2023-03-07)
 
 **Note:** Version bump only for package vue-instantsearch
 
-
-
-
-
-## [4.8.6](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.5...vue-instantsearch@4.8.6) (2023-02-28)
+## [4.8.6](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.5...vue-instantsearch@4.8.6) (2023-02-28)
 
 **Note:** Version bump only for package vue-instantsearch
 
-
-
-
-
-## [4.8.5](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.4...vue-instantsearch@4.8.5) (2023-02-21)
-
+## [4.8.5](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.4...vue-instantsearch@4.8.5) (2023-02-21)
 
 ### Bug Fixes
 
-* **breadcrumb:** guard against undefined facets ([#5482](https://github.com/algolia/instantsearch.js/issues/5482)) ([3159afe](https://github.com/algolia/instantsearch.js/commit/3159afe57472fe2b669dceb5f1ee638b658f7f52))
+- **breadcrumb:** guard against undefined facets ([#5482](https://github.com/algolia/instantsearch/issues/5482)) ([3159afe](https://github.com/algolia/instantsearch/commit/3159afe57472fe2b669dceb5f1ee638b658f7f52))
 
-
-
-
-
-## [4.8.4](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.3...vue-instantsearch@4.8.4) (2023-02-14)
+## [4.8.4](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.3...vue-instantsearch@4.8.4) (2023-02-14)
 
 **Note:** Version bump only for package vue-instantsearch
 
-
-
-
-
-## [4.8.3](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.2...vue-instantsearch@4.8.3) (2023-02-07)
-
+## [4.8.3](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.2...vue-instantsearch@4.8.3) (2023-02-07)
 
 ### Bug Fixes
 
-* **HitsPerPage:** compute selected from isRefined ([#5469](https://github.com/algolia/instantsearch.js/issues/5469)) ([7dc16f4](https://github.com/algolia/instantsearch.js/commit/7dc16f479cdc88cf771199a74e33b3b175961fe7))
+- **HitsPerPage:** compute selected from isRefined ([#5469](https://github.com/algolia/instantsearch/issues/5469)) ([7dc16f4](https://github.com/algolia/instantsearch/commit/7dc16f479cdc88cf771199a74e33b3b175961fe7))
 
-
-
-
-
-## [4.8.2](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.1...vue-instantsearch@4.8.2) (2023-01-30)
-
+## [4.8.2](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.1...vue-instantsearch@4.8.2) (2023-01-30)
 
 ### Bug Fixes
 
-* **infiniteHits:** read cache correctly when search is loading ([#5461](https://github.com/algolia/instantsearch.js/issues/5461)) ([bfabe00](https://github.com/algolia/instantsearch.js/commit/bfabe002a26e15e13b33200c355379f4e3c60f21))
+- **infiniteHits:** read cache correctly when search is loading ([#5461](https://github.com/algolia/instantsearch/issues/5461)) ([bfabe00](https://github.com/algolia/instantsearch/commit/bfabe002a26e15e13b33200c355379f4e3c60f21))
 
-
-
-
-
-## [4.8.1](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.8.0...vue-instantsearch@4.8.1) (2023-01-26)
-
+## [4.8.1](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.8.0...vue-instantsearch@4.8.1) (2023-01-26)
 
 ### Bug Fixes
 
-* **HierarchicalMenu:** don't give --parent class if data is empty ([#5458](https://github.com/algolia/instantsearch.js/issues/5458)) ([1d1a209](https://github.com/algolia/instantsearch.js/commit/1d1a209992e86b720939607cd22e37a04e865195)), closes [/github.com/algolia/instantsearch/blob/f84c01b2f66ac279f7e33fafe5f1cd559436edef/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx#L175-L179](https://github.com//github.com/algolia/instantsearch/blob/f84c01b2f66ac279f7e33fafe5f1cd559436edef/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx/issues/L175-L179)
+- **HierarchicalMenu:** don't give --parent class if data is empty ([#5458](https://github.com/algolia/instantsearch/issues/5458)) ([1d1a209](https://github.com/algolia/instantsearch/commit/1d1a209992e86b720939607cd22e37a04e865195)), closes [/github.com/algolia/instantsearch/blob/f84c01b2f66ac279f7e33fafe5f1cd559436edef/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx#L175-L179](https://github.com//github.com/algolia/instantsearch/blob/f84c01b2f66ac279f7e33fafe5f1cd559436edef/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx/issues/L175-L179)
 
-
-
-
-
-# [4.8.0](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.7.2...vue-instantsearch@4.8.0) (2023-01-25)
-
+# [4.8.0](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.7.2...vue-instantsearch@4.8.0) (2023-01-25)
 
 ### Features
 
-* **rendering:** always render with current state ([#5429](https://github.com/algolia/instantsearch.js/issues/5429)) ([920e951](https://github.com/algolia/instantsearch.js/commit/920e951f03aada0e6a1ce16bc389a82a2f00b202))
-* **rendering:** revert search state on error ([#5438](https://github.com/algolia/instantsearch.js/issues/5438)) ([732fcac](https://github.com/algolia/instantsearch.js/commit/732fcac79ea1f51b19f62d5c4bf1fdf22619fa73))
+- **rendering:** always render with current state ([#5429](https://github.com/algolia/instantsearch/issues/5429)) ([920e951](https://github.com/algolia/instantsearch/commit/920e951f03aada0e6a1ce16bc389a82a2f00b202))
+- **rendering:** revert search state on error ([#5438](https://github.com/algolia/instantsearch/issues/5438)) ([732fcac](https://github.com/algolia/instantsearch/commit/732fcac79ea1f51b19f62d5c4bf1fdf22619fa73))
 
-
-
-
-
-## [4.7.2](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.7.1...vue-instantsearch@4.7.2) (2023-01-09)
-
+## [4.7.2](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.7.1...vue-instantsearch@4.7.2) (2023-01-09)
 
 ### Bug Fixes
 
-* **dependencies:** update helper requirement for minor PP vulnerability ([#5417](https://github.com/algolia/instantsearch.js/issues/5417)) ([254ef00](https://github.com/algolia/instantsearch.js/commit/254ef00439a9af48be15f22b4fd9902899610226))
+- **dependencies:** update helper requirement for minor PP vulnerability ([#5417](https://github.com/algolia/instantsearch/issues/5417)) ([254ef00](https://github.com/algolia/instantsearch/commit/254ef00439a9af48be15f22b4fd9902899610226))
 
-
-
-
-
-## [4.7.1](https://github.com/algolia/instantsearch.js/compare/vue-instantsearch@4.7.0...vue-instantsearch@4.7.1) (2023-01-03)
-
+## [4.7.1](https://github.com/algolia/instantsearch/compare/vue-instantsearch@4.7.0...vue-instantsearch@4.7.1) (2023-01-03)
 
 ### Bug Fixes
 
-* **vue-instantsearch:** compute initial state from helper instead of results ([#5403](https://github.com/algolia/instantsearch.js/issues/5403)) ([b03e7e3](https://github.com/algolia/instantsearch.js/commit/b03e7e3ad49f382bb341e180b88baac66e0b0b75))
-
-
-
-
+- **vue-instantsearch:** compute initial state from helper instead of results ([#5403](https://github.com/algolia/instantsearch/issues/5403)) ([b03e7e3](https://github.com/algolia/instantsearch/commit/b03e7e3ad49f382bb341e180b88baac66e0b0b75))
 
 # [4.7.0](https://github.com/algolia/vue-instantsearch/compare/v4.6.0...v4.7.0) (2022-12-21)
 
-
 ### Bug Fixes
 
-* **state-results:** provide rendering variables for initial render ([#1156](https://github.com/algolia/vue-instantsearch/issues/1156)) ([0d718d5](https://github.com/algolia/vue-instantsearch/commit/0d718d5e622fba69c5d8f8f389ea9fae1f8893dc)), closes [#1154](https://github.com/algolia/vue-instantsearch/issues/1154)
-
+- **state-results:** provide rendering variables for initial render ([#1156](https://github.com/algolia/vue-instantsearch/issues/1156)) ([0d718d5](https://github.com/algolia/vue-instantsearch/commit/0d718d5e622fba69c5d8f8f389ea9fae1f8893dc)), closes [#1154](https://github.com/algolia/vue-instantsearch/issues/1154)
 
 ### Features
 
-* update PoweredBy component logo ([#1158](https://github.com/algolia/vue-instantsearch/issues/1158)) ([751ffda](https://github.com/algolia/vue-instantsearch/commit/751ffda63ef32328429d5b73ec46dc443e771605))
-
-
+- update PoweredBy component logo ([#1158](https://github.com/algolia/vue-instantsearch/issues/1158)) ([751ffda](https://github.com/algolia/vue-instantsearch/commit/751ffda63ef32328429d5b73ec46dc443e771605))
 
 # [4.6.0](https://github.com/algolia/vue-instantsearch/compare/v4.5.0...v4.6.0) (2022-10-04)
 
-
 ### Features
 
-* **ais-hierarchical-menu:** add css class for link of selected menu item ([#1150](https://github.com/algolia/vue-instantsearch/issues/1150)) ([93dfdc1](https://github.com/algolia/vue-instantsearch/commit/93dfdc159d54fe8f3a5e31721e8533c7c0b6ca81))
-* **InstantSearch:** support onStateChange ([#1149](https://github.com/algolia/vue-instantsearch/issues/1149)) ([badf815](https://github.com/algolia/vue-instantsearch/commit/badf8154f0869ea6449091ac97738e1eb491412b)), closes [#1148](https://github.com/algolia/vue-instantsearch/issues/1148)
-* **StateResults:** give access to status and error ([#1151](https://github.com/algolia/vue-instantsearch/issues/1151)) ([03dea3a](https://github.com/algolia/vue-instantsearch/commit/03dea3a2c540ae05202e269dfa1b92cb7583af9b))
-
-
+- **ais-hierarchical-menu:** add css class for link of selected menu item ([#1150](https://github.com/algolia/vue-instantsearch/issues/1150)) ([93dfdc1](https://github.com/algolia/vue-instantsearch/commit/93dfdc159d54fe8f3a5e31721e8533c7c0b6ca81))
+- **InstantSearch:** support onStateChange ([#1149](https://github.com/algolia/vue-instantsearch/issues/1149)) ([badf815](https://github.com/algolia/vue-instantsearch/commit/badf8154f0869ea6449091ac97738e1eb491412b)), closes [#1148](https://github.com/algolia/vue-instantsearch/issues/1148)
+- **StateResults:** give access to status and error ([#1151](https://github.com/algolia/vue-instantsearch/issues/1151)) ([03dea3a](https://github.com/algolia/vue-instantsearch/commit/03dea3a2c540ae05202e269dfa1b92cb7583af9b))
 
 # [4.5.0](https://github.com/algolia/vue-instantsearch/compare/v4.4.2...v4.5.0) (2022-09-07)
 
-
 ### Bug Fixes
 
-* **nuxt:** only write $nuxt if it's writable ([#1117](https://github.com/algolia/vue-instantsearch/issues/1117)) ([bdecca9](https://github.com/algolia/vue-instantsearch/commit/bdecca9334322e9405ca21e6c6d51735d3ec042f)), closes [/github.com/algolia/vue-instantsearch/commit/acda29326475bd1b73f12b058a0c02df00b8b239#commitcomment-67430759](https://github.com//github.com/algolia/vue-instantsearch/commit/acda29326475bd1b73f12b058a0c02df00b8b239/issues/commitcomment-67430759)
-
+- **nuxt:** only write $nuxt if it's writable ([#1117](https://github.com/algolia/vue-instantsearch/issues/1117)) ([bdecca9](https://github.com/algolia/vue-instantsearch/commit/bdecca9334322e9405ca21e6c6d51735d3ec042f)), closes [/github.com/algolia/vue-instantsearch/commit/acda29326475bd1b73f12b058a0c02df00b8b239#commitcomment-67430759](https://github.com//github.com/algolia/vue-instantsearch/commit/acda29326475bd1b73f12b058a0c02df00b8b239/issues/commitcomment-67430759)
 
 ### Features
 
-* **can-refine:** provide `canRefine` for multiple widget slots ([#1141](https://github.com/algolia/vue-instantsearch/issues/1141)) ([424316d](https://github.com/algolia/vue-instantsearch/commit/424316d8c6e23d4573c0d6a63c56ef919da864e1))
-
-
+- **can-refine:** provide `canRefine` for multiple widget slots ([#1141](https://github.com/algolia/vue-instantsearch/issues/1141)) ([424316d](https://github.com/algolia/vue-instantsearch/commit/424316d8c6e23d4573c0d6a63c56ef919da864e1))
 
 ## [4.4.2](https://github.com/algolia/vue-instantsearch/compare/v4.4.1...v4.4.2) (2022-07-25)
 
-
 ### Bug Fixes
 
-* **SearchBox:** forward missing prop queryHook ([#1136](https://github.com/algolia/vue-instantsearch/issues/1136)) ([7f8754d](https://github.com/algolia/vue-instantsearch/commit/7f8754dad73542c976b5218bda9a2db0c21c36a1))
-* **VoiceSearch:** forward missing props language and additionalQueryParameters ([#1136](https://github.com/algolia/vue-instantsearch/issues/1136)) ([7f8754d](https://github.com/algolia/vue-instantsearch/commit/7f8754dad73542c976b5218bda9a2db0c21c36a1)), closes [#1135](https://github.com/algolia/vue-instantsearch/issues/1135)
-
-
+- **SearchBox:** forward missing prop queryHook ([#1136](https://github.com/algolia/vue-instantsearch/issues/1136)) ([7f8754d](https://github.com/algolia/vue-instantsearch/commit/7f8754dad73542c976b5218bda9a2db0c21c36a1))
+- **VoiceSearch:** forward missing props language and additionalQueryParameters ([#1136](https://github.com/algolia/vue-instantsearch/issues/1136)) ([7f8754d](https://github.com/algolia/vue-instantsearch/commit/7f8754dad73542c976b5218bda9a2db0c21c36a1)), closes [#1135](https://github.com/algolia/vue-instantsearch/issues/1135)
 
 ## [4.4.1](https://github.com/algolia/vue-instantsearch/compare/v4.4.0...v4.4.1) (2022-07-19)
 
-
 ### Bug Fixes
 
-* **searchbox:** prevent concurrent query updates from state while input is focused ([#1133](https://github.com/algolia/vue-instantsearch/issues/1133)) ([c468c0a](https://github.com/algolia/vue-instantsearch/commit/c468c0aee633358f3fb64e41d7aa73b14b344fd2))
-
-
+- **searchbox:** prevent concurrent query updates from state while input is focused ([#1133](https://github.com/algolia/vue-instantsearch/issues/1133)) ([c468c0a](https://github.com/algolia/vue-instantsearch/commit/c468c0aee633358f3fb64e41d7aa73b14b344fd2))
 
 # [4.4.0](https://github.com/algolia/vue-instantsearch/compare/v4.3.3...v4.4.0) (2022-06-28)
 
-
 ### Bug Fixes
 
-* **ais-hierarchical-menu:** show full hierarchical parent values ([#1126](https://github.com/algolia/vue-instantsearch/issues/1126)) ([51aadf0](https://github.com/algolia/vue-instantsearch/commit/51aadf076e7116637c2046ff903279cafc5222c7))
-* **pagination:** add page class for "page" item ([#1129](https://github.com/algolia/vue-instantsearch/issues/1129)) ([afacf8b](https://github.com/algolia/vue-instantsearch/commit/afacf8b3a9b8f3c99a15c9a31d2524f66142c67f))
-* **ssr:** allow component without mixins to be extended ([#1127](https://github.com/algolia/vue-instantsearch/issues/1127)) ([3b8b887](https://github.com/algolia/vue-instantsearch/commit/3b8b887e918b8f59d92c73b6c57bd6836a99b771))
-
+- **ais-hierarchical-menu:** show full hierarchical parent values ([#1126](https://github.com/algolia/vue-instantsearch/issues/1126)) ([51aadf0](https://github.com/algolia/vue-instantsearch/commit/51aadf076e7116637c2046ff903279cafc5222c7))
+- **pagination:** add page class for "page" item ([#1129](https://github.com/algolia/vue-instantsearch/issues/1129)) ([afacf8b](https://github.com/algolia/vue-instantsearch/commit/afacf8b3a9b8f3c99a15c9a31d2524f66142c67f))
+- **ssr:** allow component without mixins to be extended ([#1127](https://github.com/algolia/vue-instantsearch/issues/1127)) ([3b8b887](https://github.com/algolia/vue-instantsearch/commit/3b8b887e918b8f59d92c73b6c57bd6836a99b771))
 
 ### Features
 
-* **core:** update instantsearch ([69a3aa8](https://github.com/algolia/vue-instantsearch/commit/69a3aa805a3e8f309d4a058c6c2a5c4534eed7ef))
-* **widgets:** pass $$widgetType ([#1121](https://github.com/algolia/vue-instantsearch/issues/1121)) ([7696acc](https://github.com/algolia/vue-instantsearch/commit/7696acc8a30c40c682f3b7df2e82803c388a377f))
-
-
+- **core:** update instantsearch ([69a3aa8](https://github.com/algolia/vue-instantsearch/commit/69a3aa805a3e8f309d4a058c6c2a5c4534eed7ef))
+- **widgets:** pass $$widgetType ([#1121](https://github.com/algolia/vue-instantsearch/issues/1121)) ([7696acc](https://github.com/algolia/vue-instantsearch/commit/7696acc8a30c40c682f3b7df2e82803c388a377f))
 
 ## [4.3.3](https://github.com/algolia/vue-instantsearch/compare/v4.3.2...v4.3.3) (2022-02-10)
 
-
 ### Bug Fixes
 
-* **esm:** mark esm exports as type: module ([#1111](https://github.com/algolia/vue-instantsearch/issues/1111)) ([71c25d4](https://github.com/algolia/vue-instantsearch/commit/71c25d460e1b077b62ca41a59a5c4df7b713ec56))
-* **nuxt3:** forward `$nuxt` on the instance by default ([#1112](https://github.com/algolia/vue-instantsearch/issues/1112)) ([acda293](https://github.com/algolia/vue-instantsearch/commit/acda29326475bd1b73f12b058a0c02df00b8b239))
-
-
+- **esm:** mark esm exports as type: module ([#1111](https://github.com/algolia/vue-instantsearch/issues/1111)) ([71c25d4](https://github.com/algolia/vue-instantsearch/commit/71c25d460e1b077b62ca41a59a5c4df7b713ec56))
+- **nuxt3:** forward `$nuxt` on the instance by default ([#1112](https://github.com/algolia/vue-instantsearch/issues/1112)) ([acda293](https://github.com/algolia/vue-instantsearch/commit/acda29326475bd1b73f12b058a0c02df00b8b239))
 
 ## [4.3.2](https://github.com/algolia/vue-instantsearch/compare/v4.3.1...v4.3.2) (2022-01-31)
 
-
 ### Bug Fixes
 
-* **ssr:** extend component correctly if at root (vue2) ([#1104](https://github.com/algolia/vue-instantsearch/issues/1104)) ([08b7124](https://github.com/algolia/vue-instantsearch/commit/08b71244c3bf7cf2cbd8183a671d1a589af75798)), closes [#1054](https://github.com/algolia/vue-instantsearch/issues/1054)
-
-
+- **ssr:** extend component correctly if at root (vue2) ([#1104](https://github.com/algolia/vue-instantsearch/issues/1104)) ([08b7124](https://github.com/algolia/vue-instantsearch/commit/08b71244c3bf7cf2cbd8183a671d1a589af75798)), closes [#1054](https://github.com/algolia/vue-instantsearch/issues/1054)
 
 ## [4.3.1](https://github.com/algolia/vue-instantsearch/compare/v4.3.0...v4.3.1) (2022-01-11)
 
-
 ### Bug Fixes
 
-* **dependencies:** update instantsearch.js requirement ([a36ae2b](https://github.com/algolia/vue-instantsearch/commit/a36ae2b964110f3e4bc98c39895dd31b79527701)), closes [#1096](https://github.com/algolia/vue-instantsearch/issues/1096)
-
-
+- **dependencies:** update instantsearch.js requirement ([a36ae2b](https://github.com/algolia/vue-instantsearch/commit/a36ae2b964110f3e4bc98c39895dd31b79527701)), closes [#1096](https://github.com/algolia/vue-instantsearch/issues/1096)
 
 # [4.3.0](https://github.com/algolia/vue-instantsearch/compare/v4.2.0...v4.3.0) (2021-12-16)
 
-
 ### Features
 
-* **dynamicWidgets:** pass parameters to connector ([#1093](https://github.com/algolia/vue-instantsearch/issues/1093)) ([247ed0f](https://github.com/algolia/vue-instantsearch/commit/247ed0f101b5dabd5eebf35a7b8c3a2504eef2e2))
-
-
+- **dynamicWidgets:** pass parameters to connector ([#1093](https://github.com/algolia/vue-instantsearch/issues/1093)) ([247ed0f](https://github.com/algolia/vue-instantsearch/commit/247ed0f101b5dabd5eebf35a7b8c3a2504eef2e2))
 
 # [4.2.0](https://github.com/algolia/vue-instantsearch/compare/v4.1.1...v4.2.0) (2021-12-13)
 
-
 ### Features
 
-* **dynamicWidgets:** release as production ([#1086](https://github.com/algolia/vue-instantsearch/issues/1086)) ([9e0902b](https://github.com/algolia/vue-instantsearch/commit/9e0902bc7a3afe3eb2211b78e681e65b3677dd78))
-* **instantsearch:** update version ([dbf485f](https://github.com/algolia/vue-instantsearch/commit/dbf485f6263d9821aaf169e682ff1ab94157d15f))
-* **ssr:** prevent initial network request ([#1090](https://github.com/algolia/vue-instantsearch/issues/1090)) ([d97eea2](https://github.com/algolia/vue-instantsearch/commit/d97eea21fbd059b0ca0634a6984a6a8b02acdd3d))
-
-
+- **dynamicWidgets:** release as production ([#1086](https://github.com/algolia/vue-instantsearch/issues/1086)) ([9e0902b](https://github.com/algolia/vue-instantsearch/commit/9e0902bc7a3afe3eb2211b78e681e65b3677dd78))
+- **instantsearch:** update version ([dbf485f](https://github.com/algolia/vue-instantsearch/commit/dbf485f6263d9821aaf169e682ff1ab94157d15f))
+- **ssr:** prevent initial network request ([#1090](https://github.com/algolia/vue-instantsearch/issues/1090)) ([d97eea2](https://github.com/algolia/vue-instantsearch/commit/d97eea21fbd059b0ca0634a6984a6a8b02acdd3d))
 
 ## [4.1.1](https://github.com/algolia/vue-instantsearch/compare/v4.1.0...v4.1.1) (2021-10-27)
 
-
 ### Bug Fixes
 
-* **vue3:** disable automatic plugin registration ([#1081](https://github.com/algolia/vue-instantsearch/issues/1081)) ([6077413](https://github.com/algolia/vue-instantsearch/commit/607741312db620242b62a1fa2181563d87e69705))
-
-
+- **vue3:** disable automatic plugin registration ([#1081](https://github.com/algolia/vue-instantsearch/issues/1081)) ([6077413](https://github.com/algolia/vue-instantsearch/commit/607741312db620242b62a1fa2181563d87e69705))
 
 # [4.1.0](https://github.com/algolia/vue-instantsearch/compare/v4.0.1...v4.1.0) (2021-10-26)
 
-
 ### Features
 
-* **dependencies:** update downstream ([#1075](https://github.com/algolia/vue-instantsearch/issues/1075)) ([ede11a5](https://github.com/algolia/vue-instantsearch/commit/ede11a5aa907f33123df7f19013680633228d0cf))
-
-
+- **dependencies:** update downstream ([#1075](https://github.com/algolia/vue-instantsearch/issues/1075)) ([ede11a5](https://github.com/algolia/vue-instantsearch/commit/ede11a5aa907f33123df7f19013680633228d0cf))
 
 ## [4.0.1](https://github.com/algolia/vue-instantsearch/compare/v4.0.0...v4.0.1) (2021-09-15)
 
-
 ### Bug Fixes
 
-* **dynamic-widgets:** use non-experimental connector ([5629957](https://github.com/algolia/vue-instantsearch/commit/56299575f1fdd1d8cd777358f77543d5b0211b18))
-* **ssr:** pass parent index to render in __forceRender ([25284aa](https://github.com/algolia/vue-instantsearch/commit/25284aafdb95f4684387744953c2a38241da7ad1))
-
-
+- **dynamic-widgets:** use non-experimental connector ([5629957](https://github.com/algolia/vue-instantsearch/commit/56299575f1fdd1d8cd777358f77543d5b0211b18))
+- **ssr:** pass parent index to render in \_\_forceRender ([25284aa](https://github.com/algolia/vue-instantsearch/commit/25284aafdb95f4684387744953c2a38241da7ad1))
 
 # [4.0.0](https://github.com/algolia/vue-instantsearch/compare/v3.8.1...v4.0.0) (2021-08-23)
 
@@ -424,298 +261,222 @@ It has a few breaking changes that you can easily migrate. You can read [the upg
 
 You can try these examples:
 
-* Vue 3 + Vue CLI: [GitHub](https://github.com/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/vue3-vue-cli) | [CodeSandbox](codesandbox.io/s/github/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/vue3-vue-cli)
-* Vue 3 + Vite: [GitHub](https://github.com/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/vue3-vite)
-* Vue 3 + SSR + Vue CLI: [GitHub](https://github.com/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/vue3-ssr-vue-cli)
-* Vue 3 + SSR + Vite: [GitHub](https://github.com/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/vue3-ssr-vite)
-
+- Vue 3 + Vue CLI: [GitHub](https://github.com/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/vue3-vue-cli) | [CodeSandbox](codesandbox.io/s/github/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/vue3-vue-cli)
+- Vue 3 + Vite: [GitHub](https://github.com/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/vue3-vite)
+- Vue 3 + SSR + Vue CLI: [GitHub](https://github.com/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/vue3-ssr-vue-cli)
+- Vue 3 + SSR + Vite: [GitHub](https://github.com/algolia/doc-code-samples/tree/master/Vue%20InstantSearch/vue3-ssr-vite)
 
 ## [3.8.1](https://github.com/algolia/vue-instantsearch/compare/v3.8.0...v3.8.1) (2021-07-12)
 
-
 ### Features
 
-* **props:** remove defaults ([#1016](https://github.com/algolia/vue-instantsearch/issues/1016)) ([1029500](https://github.com/algolia/vue-instantsearch/commit/102950021792b1dda4a5109717861e409a9060ec))
-
-
+- **props:** remove defaults ([#1016](https://github.com/algolia/vue-instantsearch/issues/1016)) ([1029500](https://github.com/algolia/vue-instantsearch/commit/102950021792b1dda4a5109717861e409a9060ec))
 
 # [3.8.0](https://github.com/algolia/vue-instantsearch/compare/v3.7.0...v3.8.0) (2021-07-12)
 
 ### Features
 
-* **dynamic-widgets**: add the `ais-experimental-dynamic-widgets` ([#922](https://github.com/algolia/vue-instantsearch/issues/922))
-* **facet ordering**: apply result from facet ordering in facet widgets ([#922](https://github.com/algolia/vue-instantsearch/issues/922))
+- **dynamic-widgets**: add the `ais-experimental-dynamic-widgets` ([#922](https://github.com/algolia/vue-instantsearch/issues/922))
+- **facet ordering**: apply result from facet ordering in facet widgets ([#922](https://github.com/algolia/vue-instantsearch/issues/922))
 
 # [3.7.0](https://github.com/algolia/vue-instantsearch/compare/v3.6.0...v3.7.0) (2021-04-27)
 
-
 ### Features
 
-* **insights:** expose `send-event` in widgets ([#953](https://github.com/algolia/vue-instantsearch/issues/953)) ([e2e42a4](https://github.com/algolia/vue-instantsearch/commit/e2e42a4180796728cff5d7b02949b857e5918d3c))
-* **middlewares:** add middlewares prop to ais-instant-search ([#939](https://github.com/algolia/vue-instantsearch/issues/939)) ([513017a](https://github.com/algolia/vue-instantsearch/commit/513017a47d38ccddd0557c01ce732e6e5e7648d6))
-
-
+- **insights:** expose `send-event` in widgets ([#953](https://github.com/algolia/vue-instantsearch/issues/953)) ([e2e42a4](https://github.com/algolia/vue-instantsearch/commit/e2e42a4180796728cff5d7b02949b857e5918d3c))
+- **middlewares:** add middlewares prop to ais-instant-search ([#939](https://github.com/algolia/vue-instantsearch/issues/939)) ([513017a](https://github.com/algolia/vue-instantsearch/commit/513017a47d38ccddd0557c01ce732e6e5e7648d6))
 
 # [3.6.0](https://github.com/algolia/vue-instantsearch/compare/v3.5.0...v3.6.0) (2021-03-31)
 
-
 ### Bug Fixes
 
-* **ssr:** correctly pass scopedResults.results ([#943](https://github.com/algolia/vue-instantsearch/issues/943)) ([118e0a3](https://github.com/algolia/vue-instantsearch/commit/118e0a39b8a047930520220da757ff0175cec12d)), closes [#940](https://github.com/algolia/vue-instantsearch/issues/940)
-
+- **ssr:** correctly pass scopedResults.results ([#943](https://github.com/algolia/vue-instantsearch/issues/943)) ([118e0a3](https://github.com/algolia/vue-instantsearch/commit/118e0a39b8a047930520220da757ff0175cec12d)), closes [#940](https://github.com/algolia/vue-instantsearch/issues/940)
 
 ### Features
 
-* **ssr:** expose clone component ([#937](https://github.com/algolia/vue-instantsearch/issues/937)) ([4741c7b](https://github.com/algolia/vue-instantsearch/commit/4741c7b64be92d70745fa36b55c2f7e8690347bd)), closes [#936](https://github.com/algolia/vue-instantsearch/issues/936)
-
-
+- **ssr:** expose clone component ([#937](https://github.com/algolia/vue-instantsearch/issues/937)) ([4741c7b](https://github.com/algolia/vue-instantsearch/commit/4741c7b64be92d70745fa36b55c2f7e8690347bd)), closes [#936](https://github.com/algolia/vue-instantsearch/issues/936)
 
 # [3.5.0](https://github.com/algolia/vue-instantsearch/compare/v3.4.3...v3.5.0) (2021-03-03)
 
-
 ### Bug Fixes
 
-* **ratingMenu:** correct URL ([3c3f7e2](https://github.com/algolia/vue-instantsearch/commit/3c3f7e21a0c19852eefc0e37f38cdad2683c900d))
-
+- **ratingMenu:** correct URL ([3c3f7e2](https://github.com/algolia/vue-instantsearch/commit/3c3f7e21a0c19852eefc0e37f38cdad2683c900d))
 
 ### Features
 
-* **ais-relevant-sort:** add widget ([#918](https://github.com/algolia/vue-instantsearch/issues/918)) ([4fe5745](https://github.com/algolia/vue-instantsearch/commit/4fe5745c3dc8b95a8952b272f3e139295fb42820))
-
-
+- **ais-relevant-sort:** add widget ([#918](https://github.com/algolia/vue-instantsearch/issues/918)) ([4fe5745](https://github.com/algolia/vue-instantsearch/commit/4fe5745c3dc8b95a8952b272f3e139295fb42820))
 
 ## [3.4.3](https://github.com/algolia/vue-instantsearch/compare/v3.4.2...v3.4.3) (2020-12-22)
 
-
 ### Bug Fixes
 
-* **ssr:** forward slots of the AisInstantSearchSsr component ([#898](https://github.com/algolia/vue-instantsearch/issues/898)) ([60b595e](https://github.com/algolia/vue-instantsearch/commit/60b595e4b806dd52c66e9f3c82772deb9c67b770))
-
-
+- **ssr:** forward slots of the AisInstantSearchSsr component ([#898](https://github.com/algolia/vue-instantsearch/issues/898)) ([60b595e](https://github.com/algolia/vue-instantsearch/commit/60b595e4b806dd52c66e9f3c82772deb9c67b770))
 
 ## [3.4.2](https://github.com/algolia/vue-instantsearch/compare/v3.4.1...v3.4.2) (2020-10-05)
 
-
 ### Bug Fixes
 
-* **panel:** safely access state in mapStateToCanRefine ([#876](https://github.com/algolia/vue-instantsearch/issues/876)) ([435c7d3](https://github.com/algolia/vue-instantsearch/commit/435c7d3d890a0c78d5a37670a926abf29e0f8bff)), closes [#874](https://github.com/algolia/vue-instantsearch/issues/874)
-
-
+- **panel:** safely access state in mapStateToCanRefine ([#876](https://github.com/algolia/vue-instantsearch/issues/876)) ([435c7d3](https://github.com/algolia/vue-instantsearch/commit/435c7d3d890a0c78d5a37670a926abf29e0f8bff)), closes [#874](https://github.com/algolia/vue-instantsearch/issues/874)
 
 ## [3.4.1](https://github.com/algolia/vue-instantsearch/compare/v3.3.0...v3.4.1) (2020-09-30)
 
-
 ### Bug Fixes
 
-* **panel:** react to changes on initial render ([#871](https://github.com/algolia/vue-instantsearch/issues/871)) ([56917a0](https://github.com/algolia/vue-instantsearch/commit/56917a079a1e48d4cce1a509d1caefec60f203fe))
+- **panel:** react to changes on initial render ([#871](https://github.com/algolia/vue-instantsearch/issues/871)) ([56917a0](https://github.com/algolia/vue-instantsearch/commit/56917a079a1e48d4cce1a509d1caefec60f203fe))
 
 ### Features
 
-* **ssr:** forward propsData to recreated component ([#865](https://github.com/algolia/vue-instantsearch/issues/865)) ([6c18a10](https://github.com/algolia/vue-instantsearch/commit/6c18a100558ae48e059c660262da32d420891d0d)), closes [/github.com/vuejs/vue/blob/7912f75c5eb09e0aef3e4bfd8a3bb78cad7540d7/src/core/util/options.js#L34-L44](https://github.com//github.com/vuejs/vue/blob/7912f75c5eb09e0aef3e4bfd8a3bb78cad7540d7/src/core/util/options.js/issues/L34-L44)
-
-
+- **ssr:** forward propsData to recreated component ([#865](https://github.com/algolia/vue-instantsearch/issues/865)) ([6c18a10](https://github.com/algolia/vue-instantsearch/commit/6c18a100558ae48e059c660262da32d420891d0d)), closes [/github.com/vuejs/vue/blob/7912f75c5eb09e0aef3e4bfd8a3bb78cad7540d7/src/core/util/options.js#L34-L44](https://github.com//github.com/vuejs/vue/blob/7912f75c5eb09e0aef3e4bfd8a3bb78cad7540d7/src/core/util/options.js/issues/L34-L44)
 
 # [3.3.0](https://github.com/algolia/vue-instantsearch/compare/v3.2.0...v3.3.0) (2020-09-28)
 
-
 ### Bug Fixes
 
-* **RatingMenu:** use unique keys ([80ff944](https://github.com/algolia/vue-instantsearch/commit/80ff94480ff3e9759ccf4dad8b1da28821b9c254))
-* **Tree Shaking:** allow modern bundlers to remove parts of Vue InstantSearch which aren't used ([(#866)](https://github.com/algolia/vue-instantsearch/pulls/866))
+- **RatingMenu:** use unique keys ([80ff944](https://github.com/algolia/vue-instantsearch/commit/80ff94480ff3e9759ccf4dad8b1da28821b9c254))
+- **Tree Shaking:** allow modern bundlers to remove parts of Vue InstantSearch which aren't used ([(#866)](https://github.com/algolia/vue-instantsearch/pulls/866))
 
 ### Features
 
-* **ssr:** forward router instance to findResultsState clone ([#863](https://github.com/algolia/vue-instantsearch/issues/863)) ([84f79eb](https://github.com/algolia/vue-instantsearch/commit/84f79eb54a6f32ac3981d9fbf8504ddc4a319e03))
-* **ssr:** forward vuex instance to findResultsState clone ([#864](https://github.com/algolia/vue-instantsearch/issues/864)) ([986a992](https://github.com/algolia/vue-instantsearch/commit/986a992a564d409522252536fd653a3b86cda82b))
-
-
+- **ssr:** forward router instance to findResultsState clone ([#863](https://github.com/algolia/vue-instantsearch/issues/863)) ([84f79eb](https://github.com/algolia/vue-instantsearch/commit/84f79eb54a6f32ac3981d9fbf8504ddc4a319e03))
+- **ssr:** forward vuex instance to findResultsState clone ([#864](https://github.com/algolia/vue-instantsearch/issues/864)) ([986a992](https://github.com/algolia/vue-instantsearch/commit/986a992a564d409522252536fd653a3b86cda82b))
 
 # [3.2.0](https://github.com/algolia/vue-instantsearch/compare/v3.1.0...v3.2.0) (2020-08-12)
 
-
 ### Bug Fixes
 
-* **highlight:** don't remove whitespace-only nodes ([#827](https://github.com/algolia/vue-instantsearch/issues/827)) ([1358b6a](https://github.com/algolia/vue-instantsearch/commit/1358b6a0a0faa8a530afd02c0342d59f9e3078d2)), closes [#826](https://github.com/algolia/vue-instantsearch/issues/826)
-* **range-input:** fix range input min and max values fallbacks ([#835](https://github.com/algolia/vue-instantsearch/issues/835)) ([0e900ef](https://github.com/algolia/vue-instantsearch/commit/0e900ef2175108ee18f0562fe0b8d1e07f8b23af)), closes [#833](https://github.com/algolia/vue-instantsearch/issues/833)
-* **routing:** do not warn when `router` or `stateMapping` is missing ([#809](https://github.com/algolia/vue-instantsearch/issues/809)) ([a9335c1](https://github.com/algolia/vue-instantsearch/commit/a9335c112807046ff21ed73d24d449850691bb3b))
-* **ssr:** fix missing scopedResults during render ([#830](https://github.com/algolia/vue-instantsearch/issues/830)) ([74cf685](https://github.com/algolia/vue-instantsearch/commit/74cf685d9856904d8edbc1b7de3a86ea96cc3557)), closes [#829](https://github.com/algolia/vue-instantsearch/issues/829)
-* **widgetMixin:** remove when InstantSearch is not yet started ([e94af00](https://github.com/algolia/vue-instantsearch/commit/e94af00af0eb5a57feac907566333510b996313e)), closes [#502](https://github.com/algolia/vue-instantsearch/issues/502)
-
-
+- **highlight:** don't remove whitespace-only nodes ([#827](https://github.com/algolia/vue-instantsearch/issues/827)) ([1358b6a](https://github.com/algolia/vue-instantsearch/commit/1358b6a0a0faa8a530afd02c0342d59f9e3078d2)), closes [#826](https://github.com/algolia/vue-instantsearch/issues/826)
+- **range-input:** fix range input min and max values fallbacks ([#835](https://github.com/algolia/vue-instantsearch/issues/835)) ([0e900ef](https://github.com/algolia/vue-instantsearch/commit/0e900ef2175108ee18f0562fe0b8d1e07f8b23af)), closes [#833](https://github.com/algolia/vue-instantsearch/issues/833)
+- **routing:** do not warn when `router` or `stateMapping` is missing ([#809](https://github.com/algolia/vue-instantsearch/issues/809)) ([a9335c1](https://github.com/algolia/vue-instantsearch/commit/a9335c112807046ff21ed73d24d449850691bb3b))
+- **ssr:** fix missing scopedResults during render ([#830](https://github.com/algolia/vue-instantsearch/issues/830)) ([74cf685](https://github.com/algolia/vue-instantsearch/commit/74cf685d9856904d8edbc1b7de3a86ea96cc3557)), closes [#829](https://github.com/algolia/vue-instantsearch/issues/829)
+- **widgetMixin:** remove when InstantSearch is not yet started ([e94af00](https://github.com/algolia/vue-instantsearch/commit/e94af00af0eb5a57feac907566333510b996313e)), closes [#502](https://github.com/algolia/vue-instantsearch/issues/502)
 
 # [3.1.0](https://github.com/algolia/vue-instantsearch/compare/v3.0.3...v3.1.0) (2020-07-02)
 
-
 ### Bug Fixes
 
-* **ssr:** allow getWidgetState to be empty for createURL ([#805](https://github.com/algolia/vue-instantsearch/issues/805)) ([0528b55](https://github.com/algolia/vue-instantsearch/commit/0528b55999099aee4981f745027f175a0df49094))
-
+- **ssr:** allow getWidgetState to be empty for createURL ([#805](https://github.com/algolia/vue-instantsearch/issues/805)) ([0528b55](https://github.com/algolia/vue-instantsearch/commit/0528b55999099aee4981f745027f175a0df49094))
 
 ### Features
 
-* **ais-toggle-refinement:** allow multiple values for "on" and "off" ([#780](https://github.com/algolia/vue-instantsearch/issues/780)) ([6ee1404](https://github.com/algolia/vue-instantsearch/commit/6ee140485825619f80709587fd6ce2f2f9ebb98d))
-* **InfiniteHits:** support cache ([#804](https://github.com/algolia/vue-instantsearch/issues/804)) ([918c92d](https://github.com/algolia/vue-instantsearch/commit/918c92d0d73edb9790e98cfeed3b9ed58b948df7))
-
-
+- **ais-toggle-refinement:** allow multiple values for "on" and "off" ([#780](https://github.com/algolia/vue-instantsearch/issues/780)) ([6ee1404](https://github.com/algolia/vue-instantsearch/commit/6ee140485825619f80709587fd6ce2f2f9ebb98d))
+- **InfiniteHits:** support cache ([#804](https://github.com/algolia/vue-instantsearch/issues/804)) ([918c92d](https://github.com/algolia/vue-instantsearch/commit/918c92d0d73edb9790e98cfeed3b9ed58b948df7))
 
 ## [3.0.3](https://github.com/algolia/vue-instantsearch/compare/v3.0.1...v3.0.3) (2020-06-12)
 
-
 ### Bug Fixes
 
-* **server:** make vue-server-renderer not a dependency unless you're using it ([#801](https://github.com/algolia/vue-instantsearch/issues/801)) ([1acc3df](https://github.com/algolia/vue-instantsearch/commit/1acc3df))
-
-
+- **server:** make vue-server-renderer not a dependency unless you're using it ([#801](https://github.com/algolia/vue-instantsearch/issues/801)) ([1acc3df](https://github.com/algolia/vue-instantsearch/commit/1acc3df))
 
 # [3.0.1](https://github.com/algolia/vue-instantsearch/compare/v3.0.0...v3.0.1) (2020-06-11)
 
-
 ### Bug Fixes
 
-* make vue-server-renderer temporarily a dependency ([84fc47c](https://github.com/algolia/vue-instantsearch/commit/84fc47c))
+- make vue-server-renderer temporarily a dependency ([84fc47c](https://github.com/algolia/vue-instantsearch/commit/84fc47c))
 
 # [3.0.0](https://github.com/algolia/vue-instantsearch/compare/v2.7.1...v3.0.0) (2020-06-11)
 
-
 ### Features
 
-* **index:** add multi-index widget ([#745](https://github.com/algolia/vue-instantsearch/issues/745)) ([3c32cfe](https://github.com/algolia/vue-instantsearch/commit/3c32cfe))
-* **server side rendering:** support ais-index ([#764](https://github.com/algolia/vue-instantsearch/issues/764)) ([3e74a8c](https://github.com/algolia/vue-instantsearch/commit/3e74a8c)), closes [#784](https://github.com/algolia/vue-instantsearch/issues/784)
-* **widgets:** introduce `ConfigureRelatedItems` as experimental ([#751](https://github.com/algolia/vue-instantsearch/issues/751)) ([f00513e](https://github.com/algolia/vue-instantsearch/commit/f00513e))
-
+- **index:** add multi-index widget ([#745](https://github.com/algolia/vue-instantsearch/issues/745)) ([3c32cfe](https://github.com/algolia/vue-instantsearch/commit/3c32cfe))
+- **server side rendering:** support ais-index ([#764](https://github.com/algolia/vue-instantsearch/issues/764)) ([3e74a8c](https://github.com/algolia/vue-instantsearch/commit/3e74a8c)), closes [#784](https://github.com/algolia/vue-instantsearch/issues/784)
+- **widgets:** introduce `ConfigureRelatedItems` as experimental ([#751](https://github.com/algolia/vue-instantsearch/issues/751)) ([f00513e](https://github.com/algolia/vue-instantsearch/commit/f00513e))
 
 ### BREAKING CHANGES
 
-* **index:** this introduces the dependency on InstantSearch v4, which has its own breaking changes you might see if you're using methods on helper. See more here: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/js/#upgrade-from-v3-to-v4
-* **server-side rendering:** the API has changed to avoid having to repeat information between template & fetching. See more here: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/vue/
-
+- **index:** this introduces the dependency on InstantSearch v4, which has its own breaking changes you might see if you're using methods on helper. See more here: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/js/#upgrade-from-v3-to-v4
+- **server-side rendering:** the API has changed to avoid having to repeat information between template & fetching. See more here: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/vue/
 
 ## [2.7.1](https://github.com/algolia/vue-instantsearch/compare/v2.7.0...v2.7.1) (2020-06-10)
 
-
 ### Bug Fixes
 
-* **Highlight, Snippet:** prevent XSS via routing ([#783](https://github.com/algolia/vue-instantsearch/issues/783)) ([f35446b](https://github.com/algolia/vue-instantsearch/commit/f35446b))
-* **RangeInput:** refine correctly when start is given ([#777](https://github.com/algolia/vue-instantsearch/issues/777)) ([6eb46c8](https://github.com/algolia/vue-instantsearch/commit/6eb46c8))
-
-
+- **Highlight, Snippet:** prevent XSS via routing ([#783](https://github.com/algolia/vue-instantsearch/issues/783)) ([f35446b](https://github.com/algolia/vue-instantsearch/commit/f35446b))
+- **RangeInput:** refine correctly when start is given ([#777](https://github.com/algolia/vue-instantsearch/issues/777)) ([6eb46c8](https://github.com/algolia/vue-instantsearch/commit/6eb46c8))
 
 # [2.7.0](https://github.com/algolia/vue-instantsearch/compare/v2.6.0...v2.7.0) (2020-01-23)
 
-
 ### Features
 
-* **algoliasearch:** add support for algoliasearch v4 ([#756](https://github.com/algolia/vue-instantsearch/issues/756)) ([571b1fc](https://github.com/algolia/vue-instantsearch/commit/571b1fc))
-* **StateResults:** give access to search parameters ([#627](https://github.com/algolia/vue-instantsearch/issues/627)) ([9870e85](https://github.com/algolia/vue-instantsearch/commit/9870e85))
-
-
+- **algoliasearch:** add support for algoliasearch v4 ([#756](https://github.com/algolia/vue-instantsearch/issues/756)) ([571b1fc](https://github.com/algolia/vue-instantsearch/commit/571b1fc))
+- **StateResults:** give access to search parameters ([#627](https://github.com/algolia/vue-instantsearch/issues/627)) ([9870e85](https://github.com/algolia/vue-instantsearch/commit/9870e85))
 
 # [2.6.0](https://github.com/algolia/vue-instantsearch/compare/v2.5.0...v2.6.0) (2019-10-14)
 
-
 ### Bug Fixes
 
-* **Snippet:** switch tag replacement to mark ([#729](https://github.com/algolia/vue-instantsearch/issues/729)) ([7f30331](https://github.com/algolia/vue-instantsearch/commit/7f30331)), closes [#727](https://github.com/algolia/vue-instantsearch/issues/727)
-
+- **Snippet:** switch tag replacement to mark ([#729](https://github.com/algolia/vue-instantsearch/issues/729)) ([7f30331](https://github.com/algolia/vue-instantsearch/commit/7f30331)), closes [#727](https://github.com/algolia/vue-instantsearch/issues/727)
 
 ### Features
 
-* **core:** expose source files ([#726](https://github.com/algolia/vue-instantsearch/issues/726)) ([ede5852](https://github.com/algolia/vue-instantsearch/commit/ede5852))
-
-
+- **core:** expose source files ([#726](https://github.com/algolia/vue-instantsearch/issues/726)) ([ede5852](https://github.com/algolia/vue-instantsearch/commit/ede5852))
 
 # [2.5.0](https://github.com/algolia/vue-instantsearch/compare/v2.4.0...v2.5.0) (2019-09-18)
 
-
 ### Features
 
-* expose `createSuitMixin` to use for class names in custom widgets ([#721](https://github.com/algolia/vue-instantsearch/issues/721)) ([5063ce1](https://github.com/algolia/vue-instantsearch/commit/5063ce1))
-
-
+- expose `createSuitMixin` to use for class names in custom widgets ([#721](https://github.com/algolia/vue-instantsearch/issues/721)) ([5063ce1](https://github.com/algolia/vue-instantsearch/commit/5063ce1))
 
 # [2.4.0](https://github.com/algolia/vue-instantsearch/compare/v2.3.0...v2.4.0) (2019-09-03)
 
-
 ### Features
 
-* **searchbox:** Adds events to hook on to focus, blur, and reset ([#711](https://github.com/algolia/vue-instantsearch/issues/711)) ([0149d2f](https://github.com/algolia/vue-instantsearch/commit/0149d2f))
-
-
+- **searchbox:** Adds events to hook on to focus, blur, and reset ([#711](https://github.com/algolia/vue-instantsearch/issues/711)) ([0149d2f](https://github.com/algolia/vue-instantsearch/commit/0149d2f))
 
 # [2.3.0](https://github.com/algolia/vue-instantsearch/compare/v2.2.2...v2.3.0) (2019-07-30)
 
-
 ### Bug Fixes
 
-* **core:** prevent duplicating facet values ([#705](https://github.com/algolia/vue-instantsearch/issues/705)) ([7573be1](https://github.com/algolia/vue-instantsearch/commit/7573be1)), closes [#663](https://github.com/algolia/vue-instantsearch/issues/663)
-* **error:** correct suggestion ([44f2d9c](https://github.com/algolia/vue-instantsearch/commit/44f2d9c))
-* **ssr:** clearer error message when using ssr without the component ([#698](https://github.com/algolia/vue-instantsearch/issues/698)) ([20c2153](https://github.com/algolia/vue-instantsearch/commit/20c2153)), closes [#697](https://github.com/algolia/vue-instantsearch/issues/697)
-
+- **core:** prevent duplicating facet values ([#705](https://github.com/algolia/vue-instantsearch/issues/705)) ([7573be1](https://github.com/algolia/vue-instantsearch/commit/7573be1)), closes [#663](https://github.com/algolia/vue-instantsearch/issues/663)
+- **error:** correct suggestion ([44f2d9c](https://github.com/algolia/vue-instantsearch/commit/44f2d9c))
+- **ssr:** clearer error message when using ssr without the component ([#698](https://github.com/algolia/vue-instantsearch/issues/698)) ([20c2153](https://github.com/algolia/vue-instantsearch/commit/20c2153)), closes [#697](https://github.com/algolia/vue-instantsearch/issues/697)
 
 ### Features
 
-* **RefinementList:** forward class names to input ([#696](https://github.com/algolia/vue-instantsearch/issues/696)) ([793eaf2](https://github.com/algolia/vue-instantsearch/commit/793eaf2)), closes [#644](https://github.com/algolia/vue-instantsearch/issues/644)
-
-
+- **RefinementList:** forward class names to input ([#696](https://github.com/algolia/vue-instantsearch/issues/696)) ([793eaf2](https://github.com/algolia/vue-instantsearch/commit/793eaf2)), closes [#644](https://github.com/algolia/vue-instantsearch/issues/644)
 
 ## [2.2.2](https://github.com/algolia/vue-instantsearch/compare/v2.2.1...v2.2.2) (2019-07-11)
 
-
 ### Bug Fixes
 
-* **highlight:** change expected tag to replace ([#679](https://github.com/algolia/vue-instantsearch/issues/679)) ([4aa06fb](https://github.com/algolia/vue-instantsearch/commit/4aa06fb))
-
-
+- **highlight:** change expected tag to replace ([#679](https://github.com/algolia/vue-instantsearch/issues/679)) ([4aa06fb](https://github.com/algolia/vue-instantsearch/commit/4aa06fb))
 
 # [2.2.1](https://github.com/algolia/vue-instantsearch/compare/v2.1.0...v2.2.1) (2019-05-21)
 
-
 ### Features
 
-* **panel:** provide hasRefinement scope to slots ([#670](https://github.com/algolia/vue-instantsearch/issues/670)) ([2a21b52](https://github.com/algolia/vue-instantsearch/commit/2a21b52)), closes [#347](https://github.com/algolia/vue-instantsearch/issues/347)
-* **voiceSearch:** add voice search component ([#668](https://github.com/algolia/vue-instantsearch/issues/668)) ([84efffc](https://github.com/algolia/vue-instantsearch/commit/84efffc))
-
-
+- **panel:** provide hasRefinement scope to slots ([#670](https://github.com/algolia/vue-instantsearch/issues/670)) ([2a21b52](https://github.com/algolia/vue-instantsearch/commit/2a21b52)), closes [#347](https://github.com/algolia/vue-instantsearch/issues/347)
+- **voiceSearch:** add voice search component ([#668](https://github.com/algolia/vue-instantsearch/issues/668)) ([84efffc](https://github.com/algolia/vue-instantsearch/commit/84efffc))
 
 # [2.1.0](https://github.com/algolia/vue-instantsearch/compare/v2.0.1...v2.1.0) (2019-04-30)
 
-
 ### Bug Fixes
 
-* **stories:** update range slider component to v3 ([#648](https://github.com/algolia/vue-instantsearch/issues/648)) ([e3010f6](https://github.com/algolia/vue-instantsearch/commit/e3010f6)), closes [#647](https://github.com/algolia/vue-instantsearch/issues/647)
-* **toggle-refinement:** display label ([#649](https://github.com/algolia/vue-instantsearch/issues/649)) ([84c909d](https://github.com/algolia/vue-instantsearch/commit/84c909d))
-* **ua:** change the User-Agent to use the new specs lib (version) ([#650](https://github.com/algolia/vue-instantsearch/issues/650)) ([6942979](https://github.com/algolia/vue-instantsearch/commit/6942979))
-
+- **stories:** update range slider component to v3 ([#648](https://github.com/algolia/vue-instantsearch/issues/648)) ([e3010f6](https://github.com/algolia/vue-instantsearch/commit/e3010f6)), closes [#647](https://github.com/algolia/vue-instantsearch/issues/647)
+- **toggle-refinement:** display label ([#649](https://github.com/algolia/vue-instantsearch/issues/649)) ([84c909d](https://github.com/algolia/vue-instantsearch/commit/84c909d))
+- **ua:** change the User-Agent to use the new specs lib (version) ([#650](https://github.com/algolia/vue-instantsearch/issues/650)) ([6942979](https://github.com/algolia/vue-instantsearch/commit/6942979))
 
 ### Features
 
-* **infiniteHits:** add previous button ([#659](https://github.com/algolia/vue-instantsearch/issues/659)) ([3d2eec9](https://github.com/algolia/vue-instantsearch/commit/3d2eec9))
-* **insights:** add insights support to Hits widget ([#665](https://github.com/algolia/vue-instantsearch/issues/665)) ([2efa8c0](https://github.com/algolia/vue-instantsearch/commit/2efa8c0))
-* **insights:** add insights support to InfiniteHits widget ([#666](https://github.com/algolia/vue-instantsearch/issues/666)) ([b3302cf](https://github.com/algolia/vue-instantsearch/commit/b3302cf))
-* **insights:** add insightsClient support on storybook ([#664](https://github.com/algolia/vue-instantsearch/issues/664)) ([5ad4d3e](https://github.com/algolia/vue-instantsearch/commit/5ad4d3e))
-* **query-rules:** add new widgets ([#652](https://github.com/algolia/vue-instantsearch/issues/652)) ([cec815d](https://github.com/algolia/vue-instantsearch/commit/cec815d))
-
-
+- **infiniteHits:** add previous button ([#659](https://github.com/algolia/vue-instantsearch/issues/659)) ([3d2eec9](https://github.com/algolia/vue-instantsearch/commit/3d2eec9))
+- **insights:** add insights support to Hits widget ([#665](https://github.com/algolia/vue-instantsearch/issues/665)) ([2efa8c0](https://github.com/algolia/vue-instantsearch/commit/2efa8c0))
+- **insights:** add insights support to InfiniteHits widget ([#666](https://github.com/algolia/vue-instantsearch/issues/666)) ([b3302cf](https://github.com/algolia/vue-instantsearch/commit/b3302cf))
+- **insights:** add insightsClient support on storybook ([#664](https://github.com/algolia/vue-instantsearch/issues/664)) ([5ad4d3e](https://github.com/algolia/vue-instantsearch/commit/5ad4d3e))
+- **query-rules:** add new widgets ([#652](https://github.com/algolia/vue-instantsearch/issues/652)) ([cec815d](https://github.com/algolia/vue-instantsearch/commit/cec815d))
 
 ## [2.0.1](https://github.com/algolia/vue-instantsearch/compare/v2.0.0...v2.0.1) (2019-03-13)
 
-
 ### Bug Fixes
 
-* **umd:** prevent inclusion of Vue in bundle ([#635](https://github.com/algolia/vue-instantsearch/issues/635)) ([a90cbce](https://github.com/algolia/vue-instantsearch/commit/a90cbce))
-
-
+- **umd:** prevent inclusion of Vue in bundle ([#635](https://github.com/algolia/vue-instantsearch/issues/635)) ([a90cbce](https://github.com/algolia/vue-instantsearch/commit/a90cbce))
 
 <a name="2.0.0"></a>
-# [2.0.0](https://github.com/algolia/vue-instantsearch/compare/v2.0.0-beta.3...v2.0.0) (2019-02-18)
 
+# [2.0.0](https://github.com/algolia/vue-instantsearch/compare/v2.0.0-beta.3...v2.0.0) (2019-02-18)
 
 ### Features
 
-* **core:** update to InstantSearch.js v3 ([#612](https://github.com/algolia/vue-instantsearch/issues/612)) ([fbf818e](https://github.com/algolia/vue-instantsearch/commit/fbf818e)), closes [#619](https://github.com/algolia/vue-instantsearch/issues/619)
-* **deps:** remove transitive dependencies ([6fa3169](https://github.com/algolia/vue-instantsearch/commit/6fa3169))
-
-
+- **core:** update to InstantSearch.js v3 ([#612](https://github.com/algolia/vue-instantsearch/issues/612)) ([fbf818e](https://github.com/algolia/vue-instantsearch/commit/fbf818e)), closes [#619](https://github.com/algolia/vue-instantsearch/issues/619)
+- **deps:** remove transitive dependencies ([6fa3169](https://github.com/algolia/vue-instantsearch/commit/6fa3169))
 
 <a name="2.0.0-beta.3"></a>
 
@@ -729,7 +490,7 @@ You can try these examples:
 
 ### Features
 
-- server side rendering ([#596](https://github.com/algolia/vue-instantsearch/issues/596)) ([a875bd9](https://github.com/algolia/vue-instantsearch/commit/a875bd9)), closes [#603](https://github.com/algolia/vue-instantsearch/issues/603) [#605](https://github.com/algolia/vue-instantsearch/issues/605) [#607](https://github.com/algolia/vue-instantsearch/issues/607) [algolia/instantsearch.js#3415](https://github.com/algolia/instantsearch.js/issues/3415)
+- server side rendering ([#596](https://github.com/algolia/vue-instantsearch/issues/596)) ([a875bd9](https://github.com/algolia/vue-instantsearch/commit/a875bd9)), closes [#603](https://github.com/algolia/vue-instantsearch/issues/603) [#605](https://github.com/algolia/vue-instantsearch/issues/605) [#607](https://github.com/algolia/vue-instantsearch/issues/607) [algolia/instantsearch#3415](https://github.com/algolia/instantsearch/issues/3415)
 
 <a name="2.0.0-beta.2"></a>
 
@@ -947,8 +708,7 @@ You can try these examples:
 
 ### BREAKING CHANGES
 
-- **store:** if you previously used the `store.searchParameters` getters and setters of the store,
-  you should now use `store.queryParameters` instead.
+- **store:** if you previously used the `store.searchParameters` getters and setters of the store, you should now use `store.queryParameters` instead.
 
 <a name="0.6.0"></a>
 
@@ -975,9 +735,7 @@ You can try these examples:
 
 ### BREAKING CHANGES
 
-- **store:** using `store.start()` will no longer trigger an Algolia call.
-  if you were using `store.stop()`/`store.start()` you should now
-  also call `store.refresh()` if you want your store to stay in sync with Algolia.
+- **store:** using `store.start()` will no longer trigger an Algolia call. if you were using `store.stop()`/`store.start()` you should now also call `store.refresh()` if you want your store to stay in sync with Algolia.
 
 <a name="0.5.0"></a>
 
@@ -1052,9 +810,7 @@ Update the readme on npm website.
 
 ### BREAKING CHANGES
 
-- Highlight and Snippet components no longer accept `tag-name` nor `escape-html`
-  as props. Highlighted values are now escaped as responses are received.
-  The highlighting tags can now be configured on the store itself.
+- Highlight and Snippet components no longer accept `tag-name` nor `escape-html` as props. Highlighted values are now escaped as responses are received. The highlighting tags can now be configured on the store itself.
 
 <a name="0.2.1"></a>
 

--- a/packages/vue-instantsearch/README.md
+++ b/packages/vue-instantsearch/README.md
@@ -1,6 +1,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+**Table of Contents** _generated with [DocToc](https://github.com/thlorenz/doctoc)_
 
 - [Vue InstantSearch](#vue-instantsearch)
 - [Documentation](#documentation)
@@ -12,12 +13,7 @@
 
 [![Vue InstantSearch logo][logo]][website]
 
-InstantSearch projects: **Vue InstantSearch**
-| [InstantSearch.js][instantsearch.js-github]
-| [React InstantSearch][react-instantsearch-github]
-| [Angular InstantSearch][angular-instantsearch-github]
-| [InstantSearch Android][instantsearch-android-github]
-| [InstantSearch iOS][instantsearch-ios-github].
+InstantSearch projects: **Vue InstantSearch** | [InstantSearch.js][instantsearch-github] | [React InstantSearch][instantsearch-github] | [Angular InstantSearch][angular-instantsearch-github] | [InstantSearch Android][instantsearch-android-github] | [InstantSearch iOS][instantsearch-ios-github].
 
 ## Vue InstantSearch
 
@@ -51,16 +47,13 @@ Encountering an issue? Before reaching out to support, we recommend heading to o
 
 ## Contributing, dev, release
 
-We welcome all contributors, from casual to regular. You are only
-one command away to start the developer environment,
-[read our CONTRIBUTING guide](CONTRIBUTING.md).
+We welcome all contributors, from casual to regular. You are only one command away to start the developer environment, [read our CONTRIBUTING guide](CONTRIBUTING.md).
 
 [logo]: vue-instantsearch-readme.png
 [website]: https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/vue/
 [getting-started-guide]: https://www.algolia.com/doc/guides/building-search-ui/getting-started/vue/
 [algolia-website]: https://www.algolia.com/
-[instantsearch.js-github]: https://github.com/algolia/instantsearch.js
-[react-instantsearch-github]: https://github.com/algolia/react-instantsearch
+[instantsearch-github]: https://github.com/algolia/instantsearch
 [instantsearch-android-github]: https://github.com/algolia/instantsearch-android
 [instantsearch-ios-github]: https://github.com/algolia/instantsearch-ios
 [angular-instantsearch-github]: https://github.com/algolia/angular-instantsearch

--- a/packages/vue-instantsearch/package.json
+++ b/packages/vue-instantsearch/package.json
@@ -25,7 +25,7 @@
   "main": "vue2/cjs",
   "module": "vue2/es",
   "sideEffects": false,
-  "repository": "https://github.com/algolia/instantsearch.js",
+  "repository": "https://github.com/algolia/instantsearch",
   "scripts": {
     "prebuild": "rm -rf vue2 vue3",
     "build": "rollup -c",

--- a/packages/vue-instantsearch/src/components/__tests__/InstantSearch.js
+++ b/packages/vue-instantsearch/src/components/__tests__/InstantSearch.js
@@ -334,7 +334,7 @@ it.skip('Does not allow a change in `routing`', async () => {
   ).rejects.toMatchInlineSnapshot(`
 [Error: routing configuration can not be changed dynamically at this point.
 
-Please open a new issue: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage%2cLibrary%3A+Vue+InstantSearch&title=Feature%20request%3A%20dynamic%20props]
+Please open a new issue: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage%2cLibrary%3A+Vue+InstantSearch&title=Feature%20request%3A%20dynamic%20props]
 `);
 });
 

--- a/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
+++ b/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
@@ -34,14 +34,14 @@ export const createInstantSearchComponent = (component) =>
           throw new Error(
             'routing configuration can not be changed dynamically at this point.' +
               '\n\n' +
-              'Please open a new issue: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage%2cLibrary%3A+Vue+InstantSearch&title=Feature%20request%3A%20dynamic%20props'
+              'Please open a new issue: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage%2cLibrary%3A+Vue+InstantSearch&title=Feature%20request%3A%20dynamic%20props'
           );
         },
         onStateChange() {
           throw new Error(
             'onStateChange configuration can not be changed dynamically at this point.' +
               '\n\n' +
-              'Please open a new issue: https://github.com/algolia/instantsearch.js/discussions/new?category=ideas&labels=triage%2cLibrary%3A+Vue+InstantSearch&title=Feature%20request%3A%20dynamic%20props'
+              'Please open a new issue: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage%2cLibrary%3A+Vue+InstantSearch&title=Feature%20request%3A%20dynamic%20props'
           );
         },
         searchFunction(searchFunction) {

--- a/specs/CHANGELOG.md
+++ b/specs/CHANGELOG.md
@@ -1,31 +1,20 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## 0.1.3 (2023-08-07)
 
-
 ### Bug Fixes
 
-* **searchbox:** add aria-hidden to svg icons ([#5547](https://github.com/algolia/instantsearch.js/issues/5547)) ([50344e3](https://github.com/algolia/instantsearch.js/commit/50344e3b14c22c886415c0e7d799aca778dc39ab)), closes [#5546](https://github.com/algolia/instantsearch.js/issues/5546)
-* **svg:** don't style width/height in attributes with unit ([#5550](https://github.com/algolia/instantsearch.js/issues/5550)) ([31b85a6](https://github.com/algolia/instantsearch.js/commit/31b85a6ad56993455adb201f88ab1d1ae2d96683))
-
-
-
-
+- **searchbox:** add aria-hidden to svg icons ([#5547](https://github.com/algolia/instantsearch/issues/5547)) ([50344e3](https://github.com/algolia/instantsearch/commit/50344e3b14c22c886415c0e7d799aca778dc39ab)), closes [#5546](https://github.com/algolia/instantsearch/issues/5546)
+- **svg:** don't style width/height in attributes with unit ([#5550](https://github.com/algolia/instantsearch/issues/5550)) ([31b85a6](https://github.com/algolia/instantsearch/commit/31b85a6ad56993455adb201f88ab1d1ae2d96683))
 
 ## 0.1.2 (2023-03-21)
 
-
 ### Bug Fixes
 
-* **searchbox:** add aria-hidden to svg icons ([#5547](https://github.com/algolia/instantsearch.js/issues/5547)) ([50344e3](https://github.com/algolia/instantsearch.js/commit/50344e3b14c22c886415c0e7d799aca778dc39ab)), closes [#5546](https://github.com/algolia/instantsearch.js/issues/5546)
-* **svg:** don't style width/height in attributes with unit ([#5550](https://github.com/algolia/instantsearch.js/issues/5550)) ([31b85a6](https://github.com/algolia/instantsearch.js/commit/31b85a6ad56993455adb201f88ab1d1ae2d96683))
-
-
-
-
+- **searchbox:** add aria-hidden to svg icons ([#5547](https://github.com/algolia/instantsearch/issues/5547)) ([50344e3](https://github.com/algolia/instantsearch/commit/50344e3b14c22c886415c0e7d799aca778dc39ab)), closes [#5546](https://github.com/algolia/instantsearch/issues/5546)
+- **svg:** don't style width/height in attributes with unit ([#5550](https://github.com/algolia/instantsearch/issues/5550)) ([31b85a6](https://github.com/algolia/instantsearch/commit/31b85a6ad56993455adb201f88ab1d1ae2d96683))
 
 ## 0.1.1 (2023-01-03)
 

--- a/specs/package.json
+++ b/specs/package.json
@@ -5,7 +5,7 @@
   "description": "The specs website for InstantSearch.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/algolia/instantsearch.js"
+    "url": "https://github.com/algolia/instantsearch"
   },
   "license": "MIT",
   "author": "Algolia <support@algolia.com>",

--- a/specs/src/components/Header.astro
+++ b/specs/src/components/Header.astro
@@ -15,7 +15,7 @@ const { BASE_URL } = import.meta.env;
         <li><a href={`${BASE_URL}demo/`}>Demo</a></li>
         <li>
           <a
-            href="https://github.com/algolia/instantsearch.js/edit/master/packages/instantsearch.css"
+            href="https://github.com/algolia/instantsearch/edit/master/packages/instantsearch.css"
           >
             View on Github
           </a>

--- a/specs/src/config.ts
+++ b/specs/src/config.ts
@@ -1,1 +1,1 @@
-export const GITHUB_EDIT_URL = `https://github.com/algolia/instantsearch.js/edit/master/packages/instantsearch.css`;
+export const GITHUB_EDIT_URL = `https://github.com/algolia/instantsearch/edit/master/packages/instantsearch.css`;

--- a/tests/common/widgets/hits/insights.ts
+++ b/tests/common/widgets/hits/insights.ts
@@ -131,7 +131,7 @@ export function createInsightsTests(
         });
 
         // @TODO: This is a bug, we should not send a view event when the results are the same.
-        // see: https://github.com/algolia/instantsearch.js/issues/5442
+        // see: https://github.com/algolia/instantsearch/issues/5442
         expect(window.aa).toHaveBeenCalledTimes(2);
       }
     });

--- a/tests/common/widgets/infinite-hits/insights.ts
+++ b/tests/common/widgets/infinite-hits/insights.ts
@@ -131,7 +131,7 @@ export function createInsightsTests(
         });
 
         // @TODO: This is a bug, we should not send a view event when the results are the same.
-        // see: https://github.com/algolia/instantsearch.js/issues/5442
+        // see: https://github.com/algolia/instantsearch/issues/5442
         expect(window.aa).toHaveBeenCalledTimes(2);
       }
     });


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

leftover from the monorepo migration, also some changes in the readmes to fix links more precise for vue and react

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- readme files have right links
- all algolia/instantsearch.js links replaced

One thing I couldn't find is where we configure conventional-changelog to add algolia/instantsearch.js URLs, because that still seems to be the case recently?
