### PR TITLE
fix(insights): use init method params type from Search Insights

### DIFF
--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -28,13 +28,7 @@ export type InsightsProps<
   TInsightsClient extends ProvidedInsightsClient = ProvidedInsightsClient
 > = {
   insightsClient?: TInsightsClient;
-  insightsInitParams?: {
-    userHasOptedOut?: boolean;
-    useCookie?: boolean;
-    anonymousUserToken?: boolean;
-    cookieDuration?: number;
-    region?: 'de' | 'us';
-  };
+  insightsInitParams?: Omit<InsightsMethodMap['init'][0], 'appId' | 'apiKey'>;
   onEvent?: (event: InsightsEvent, insightsClient: TInsightsClient) => void;
   /**
    * @internal indicator for the default insights middleware

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -28,7 +28,7 @@ export type InsightsProps<
   TInsightsClient extends ProvidedInsightsClient = ProvidedInsightsClient
 > = {
   insightsClient?: TInsightsClient;
-  insightsInitParams?: Omit<InsightsMethodMap['init'][0], 'appId' | 'apiKey'>;
+  insightsInitParams?: Partial<InsightsMethodMap['init'][0]>;
   onEvent?: (event: InsightsEvent, insightsClient: TInsightsClient) => void;
   /**
    * @internal indicator for the default insights middleware


### PR DESCRIPTION
This fixes a typing issue in the Insights middleware (and the `insights` prop of InstantSearch) where the init params type was out of sync with Search Insights. Specifically, the `userToken` param was missing.

In my case, I do need to provide `userToken` at this level because it comes from my app. If I don't provide it, then InstantSearch sends automatic events with a random user token, which is different than the one for my queries.

This is now accepted by the typings:

```tsx
<InstantSearch
  searchClient={searchClient}
  indexName={indexName}
  insights={{
    insightsInitParams: {
      userToken,
    },
  }}
>
  {/* ... */}
</InstantSearch>
```

The `InitParams` type isn't exported by Search Insights, so I inferred the init params from the `InsightsMethodMap` type.