### PR TITLE
fix(InstantSearchNext): do not scroll on push

### DIFF
--- a/packages/react-instantsearch-nextjs/README.md
+++ b/packages/react-instantsearch-nextjs/README.md
@@ -58,7 +58,7 @@ export function Search() {
 }
 ```
 
-Import the `<InstantSearchNext>` component from the `react-instantsearch-nextjs` package, and replace the <%= widget_link('instantsearch', 'react') %> component with it, without changing the props.
+Import the `<InstantSearchNext>` component from the `react-instantsearch-nextjs` package, and replace the [`<InstantSearch>`](https://www.algolia.com/doc/api-reference/widgets/instantsearch/react/) component with it, without changing the props.
 
 
 ```diff

--- a/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
+++ b/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
@@ -91,7 +91,7 @@ export function InstantSearchNext<
       if (this.isDisposed) {
         return;
       }
-      router.push(url);
+      router.push(url, { scroll: false });
     };
 
     if (typeof passedRouting === 'object') {


### PR DESCRIPTION
**Summary**

`router.push` scrolls to the top by default, so I made this PR to disable that as we don't do this is in other flavors.
We could make it into an option but I think it's best to leave it like that, it probably makes more sense to scroll to the top depending on the widget, for example Pagination, whereas it wouldn't make sense with InfiniteHits.

Also included a small fix to the README file

