### PR TITLE
ci(github-actions): sync npm version from .nvmrc

### DIFF
--- a/.github/workflows/release-templates.yml
+++ b/.github/workflows/release-templates.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version-file: '.nvmrc'
 
       - name: 📦  install dependencies
         run: |


### PR DESCRIPTION
**Summary**

We recently updated the recommended node version we use in our monorepo and CI, but this change has not been repercuted to our CISA templates GitHub action. This PR changes how node version is determined, by referencing the **.nvmrc** file we use to store the version we rely on.
