### PR TITLE
feat(useInstantSearch): expose renderState

### DIFF
--- a/packages/react-instantsearch-core/src/hooks/__tests__/useInstantSearch.test.tsx
+++ b/packages/react-instantsearch-core/src/hooks/__tests__/useInstantSearch.test.tsx
@@ -53,7 +53,7 @@ describe('useInstantSearch', () => {
     });
   });
 
-  describe('state', () => {
+  describe('ui state', () => {
     test('returns the ui state', () => {
       const wrapper = createInstantSearchTestWrapper();
       const { result } = renderHook(() => useInstantSearch(), { wrapper });
@@ -168,6 +168,130 @@ describe('useInstantSearch', () => {
 
       await waitFor(() => {
         expect(button).toHaveTextContent('new query');
+      });
+    });
+  });
+
+  describe('render state', () => {
+    test('returns the render state', async () => {
+      function App() {
+        const { renderState } = useInstantSearch();
+
+        return (
+          <>
+            <button
+              type="button"
+              data-testid="button"
+              onClick={() => {
+                renderState.indexName?.searchBox?.refine('new query');
+              }}
+            >
+              {renderState.indexName?.searchBox?.query}
+            </button>
+            <pre data-testid="renderState">{JSON.stringify(renderState)}</pre>
+            <SearchBox />
+          </>
+        );
+      }
+
+      const { getByTestId } = render(
+        <InstantSearchTestWrapper>
+          <App />
+        </InstantSearchTestWrapper>
+      );
+      const button = getByTestId('button');
+      const renderState = getByTestId('renderState');
+
+      await waitFor(() => {
+        expect(button).toHaveTextContent('');
+        expect(renderState).toHaveTextContent(
+          JSON.stringify({
+            indexName: {
+              searchBox: {
+                query: '',
+                widgetParams: {},
+                isSearchStalled: false,
+              },
+            },
+          })
+        );
+      });
+
+      userEvent.click(button);
+
+      await waitFor(() => {
+        expect(button).toHaveTextContent('new query');
+        expect(renderState).toHaveTextContent(
+          JSON.stringify({
+            indexName: {
+              searchBox: {
+                query: 'new query',
+                widgetParams: {},
+                isSearchStalled: false,
+              },
+            },
+          })
+        );
+      });
+    });
+
+    test('returns the index render state', async () => {
+      function App() {
+        const { indexRenderState } = useInstantSearch();
+
+        return (
+          <>
+            <button
+              type="button"
+              data-testid="button"
+              onClick={() => {
+                indexRenderState.searchBox?.refine('new query');
+              }}
+            >
+              {indexRenderState.searchBox?.query}
+            </button>
+            <pre data-testid="indexRenderState">
+              {JSON.stringify(indexRenderState)}
+            </pre>
+            <SearchBox />
+          </>
+        );
+      }
+
+      const { getByTestId } = render(
+        <InstantSearchTestWrapper>
+          <App />
+        </InstantSearchTestWrapper>
+      );
+      const button = getByTestId('button');
+      const indexRenderState = getByTestId('indexRenderState');
+
+      await waitFor(() => {
+        expect(button).toHaveTextContent('');
+        expect(indexRenderState).toHaveTextContent(
+          JSON.stringify({
+            searchBox: {
+              query: '',
+              widgetParams: {},
+              isSearchStalled: false,
+            },
+          })
+        );
+      });
+
+      userEvent.click(button);
+
+      await waitFor(() => {
+        expect(button).toHaveTextContent('new query');
+        expect(indexRenderState).toHaveTextContent(
+          JSON.stringify({
+            searchBox: {
+              query: 'new query',
+              widgetParams: {},
+              isSearchStalled: false,
+            },
+          })
+        );
       });
     });
   });

--- a/packages/react-instantsearch-core/src/hooks/useInstantSearch.ts
+++ b/packages/react-instantsearch-core/src/hooks/useInstantSearch.ts
@@ -45,8 +45,14 @@ export function useInstantSearch<TUiState extends UiState = UiState>({
   catchError,
 }: UseInstantSearchProps = {}): InstantSearchApi<TUiState> {
   const search = useInstantSearchContext<TUiState>();
-  const { uiState, setUiState, indexUiState, setIndexUiState } =
-    useSearchState<TUiState>();
+  const {
+    uiState,
+    setUiState,
+    indexUiState,
+    setIndexUiState,
+    renderState,
+    indexRenderState,
+  } = useSearchState<TUiState>();
   const { results, scopedResults } = useSearchResults();
 
   const addMiddlewares: InstantSearchApi<TUiState>['addMiddlewares'] =
@@ -81,6 +87,8 @@ export function useInstantSearch<TUiState extends UiState = UiState>({
     setUiState,
     indexUiState,
     setIndexUiState,
+    renderState,
+    indexRenderState,
     addMiddlewares,
     refresh,
     status: search.status,

--- a/packages/react-instantsearch-core/src/lib/__tests__/useSearchState.test.tsx
+++ b/packages/react-instantsearch-core/src/lib/__tests__/useSearchState.test.tsx
@@ -33,6 +33,8 @@ describe('useSearchState', () => {
       indexUiState: {},
       setUiState: expect.any(Function),
       setIndexUiState: expect.any(Function),
+      renderState: expect.any(Object),
+      indexRenderState: expect.any(Object),
     });
 
     const setUiState = result.current.setUiState;
@@ -47,6 +49,8 @@ describe('useSearchState', () => {
       indexUiState: {},
       setUiState,
       setIndexUiState,
+      renderState: expect.any(Object),
+      indexRenderState: expect.any(Object),
     });
   });
 
@@ -67,6 +71,8 @@ describe('useSearchState', () => {
       indexUiState: { query: 'iphone' },
       setUiState: expect.any(Function),
       setIndexUiState: expect.any(Function),
+      renderState: expect.any(Object),
+      indexRenderState: expect.any(Object),
     });
   });
 
@@ -265,6 +271,126 @@ describe('useSearchState', () => {
       expect(button).toHaveTextContent('undefined added added');
       expect(indexUiState).toHaveTextContent(
         JSON.stringify({ query: 'undefined added added' })
+      );
+    });
+  });
+
+  test('returns the render state', async () => {
+    function App() {
+      const { renderState } = useSearchState();
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              renderState.indexName?.searchBox?.refine('new query');
+            }}
+          >
+            {renderState.indexName?.searchBox?.query}
+          </button>
+          <pre data-testid="renderState">{JSON.stringify(renderState)}</pre>
+          <SearchBox />
+        </>
+      );
+    }
+
+    const { getByRole, getByTestId } = render(
+      <InstantSearchTestWrapper>
+        <App />
+      </InstantSearchTestWrapper>
+    );
+    const button = getByRole('button');
+    const renderState = getByTestId('renderState');
+
+    await waitFor(() => {
+      expect(button).toHaveTextContent('');
+      expect(renderState).toHaveTextContent(
+        JSON.stringify({
+          indexName: {
+            searchBox: {
+              query: '',
+              widgetParams: {},
+              isSearchStalled: false,
+            },
+          },
+        })
+      );
+    });
+
+    userEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toHaveTextContent('new query');
+      expect(renderState).toHaveTextContent(
+        JSON.stringify({
+          indexName: {
+            searchBox: {
+              query: 'new query',
+              widgetParams: {},
+              isSearchStalled: false,
+            },
+          },
+        })
+      );
+    });
+  });
+
+  test('returns the index render state', async () => {
+    function App() {
+      const { indexRenderState } = useSearchState();
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              indexRenderState.searchBox?.refine('new query');
+            }}
+          >
+            {indexRenderState.searchBox?.query}
+          </button>
+          <pre data-testid="indexRenderState">
+            {JSON.stringify(indexRenderState)}
+          </pre>
+          <SearchBox />
+        </>
+      );
+    }
+
+    const { getByRole, getByTestId } = render(
+      <InstantSearchTestWrapper>
+        <App />
+      </InstantSearchTestWrapper>
+    );
+    const button = getByRole('button');
+    const indexRenderState = getByTestId('indexRenderState');
+
+    await waitFor(() => {
+      expect(button).toHaveTextContent('');
+      expect(indexRenderState).toHaveTextContent(
+        JSON.stringify({
+          searchBox: {
+            query: '',
+            widgetParams: {},
+            isSearchStalled: false,
+          },
+        })
+      );
+    });
+
+    userEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toHaveTextContent('new query');
+      expect(indexRenderState).toHaveTextContent(
+        JSON.stringify({
+          searchBox: {
+            query: 'new query',
+            widgetParams: {},
+            isSearchStalled: false,
+          },
+        })
       );
     });
   });

--- a/packages/react-instantsearch-core/src/lib/useSearchState.ts
+++ b/packages/react-instantsearch-core/src/lib/useSearchState.ts
@@ -10,6 +10,8 @@ export type SearchStateApi<TUiState extends UiState> = {
   setUiState: InstantSearch<TUiState>['setUiState'];
   indexUiState: TUiState[string];
   setIndexUiState: IndexWidget<TUiState>['setIndexUiState'];
+  renderState: InstantSearch<TUiState>['renderState'];
+  indexRenderState: InstantSearch<TUiState>['renderState'][string];
 };
 
 export function useSearchState<
@@ -20,6 +22,8 @@ export function useSearchState<
   const indexId = searchIndex.getIndexId();
   const [uiState, setLocalUiState] = useState(() => search.getUiState());
   const indexUiState = uiState[indexId] as TUiState[string];
+  const [renderState, setRenderState] = useState(() => search.renderState);
+  const indexRenderState = renderState[indexId] || {};
 
   const setUiState = useCallback<SearchStateApi<TUiState>['setUiState']>(
     (nextUiState) => {
@@ -39,6 +43,7 @@ export function useSearchState<
   useEffect(() => {
     function handleRender() {
       setLocalUiState(search.getUiState());
+      setRenderState(search.renderState);
     }
 
     search.addListener('render', handleRender);
@@ -53,5 +58,7 @@ export function useSearchState<
     setUiState,
     indexUiState,
     setIndexUiState,
+    renderState,
+    indexRenderState,
   };
 }


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

The renderState is useful for interacting with a different widget that you know / assume is also mounted. This is good for example for refining within a hit component without adding a second refinement widget (which could have side effects if hits is conditional, despite that impact being made smaller through #5123).

Can also be useful for a reusable widget that allows the user to pass their own options to e.g. refinementList, but still expects it to be mounted by the user.

An example use case:

```js
function Hits(props) {
  const { renderState } = useInstantSearch();
  const { hits } = useHits();

  return (
    <ol>
      {hits.map((hit) => (
        <li key={hit.objectID}>
          <button
            type="button"
            onClick={() => {
              indexRenderState.refinementList.keyword.refine(hit.keyword);
            }}
          >
            {hit.keyword}
            {indexRenderState.refinementList.keyword.items.find(
              (item) => item.label === hit.keyword
            )
              ? ' (refined)'
              : ''}
          </button>
        </li>
      ))}
    </ol>
  );
}
```

**Result**

[RFC-71](https://github.com/algolia/instantsearch-rfcs/blob/master/implemented/use-instantsearch.md) is implemented more completely

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
