### PR TITLE
feat(instantsearch): allow the insights middleware to be added in answer to a server setting

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "56.25 kB"
+      "maxSize": "56.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
@@ -30,7 +30,7 @@
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "63.5 kB"
+      "maxSize": "63.75 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "63 kB"
+      "maxSize": "63.25 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",

--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1317,7 +1317,7 @@ declare namespace algoliasearchHelper {
      */
     facets: SearchResults.Facet[];
 
-    _automaticInsights?: boolean;
+    _automaticInsights?: true;
 
     _rawResults: Array<SearchResponse<T>>;
     _state: SearchParameters;

--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1317,6 +1317,8 @@ declare namespace algoliasearchHelper {
      */
     facets: SearchResults.Facet[];
 
+    _automaticInsights?: boolean;
+
     _rawResults: Array<SearchResponse<T>>;
     _state: SearchParameters;
 

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -682,7 +682,10 @@ See documentation: ${createDocumentationLink({
           .some(({ results }) => results?._automaticInsights);
         if (hasAutomaticInsights) {
           this.use(
-            createInsightsMiddleware({ $$internal: true, $$automatic: true })
+            createInsightsMiddleware({
+              $$internal: true,
+              $$clickAnalytics: false,
+            })
           );
         }
       });

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -677,10 +677,10 @@ See documentation: ${createDocumentationLink({
     // Any user-provided middleware will be added later and override this one.
     if (typeof this._insights === 'undefined') {
       mainHelper.derivedHelpers[0].once('result', () => {
-        const hasQueryID = this.mainIndex
+        const hasAutomaticInsights = this.mainIndex
           .getScopedResults()
-          .some(({ results }) => results?.queryID !== undefined);
-        if (hasQueryID) {
+          .some(({ results }) => results?._automaticInsights === true);
+        if (hasAutomaticInsights) {
           this.use(
             createInsightsMiddleware({ $$internal: true, $$automatic: true })
           );

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -679,7 +679,7 @@ See documentation: ${createDocumentationLink({
       mainHelper.derivedHelpers[0].once('result', () => {
         const hasAutomaticInsights = this.mainIndex
           .getScopedResults()
-          .some(({ results }) => results?._automaticInsights === true);
+          .some(({ results }) => results?._automaticInsights);
         if (hasAutomaticInsights) {
           this.use(
             createInsightsMiddleware({ $$internal: true, $$automatic: true })

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -207,6 +207,7 @@ class InstantSearch<
   public _createURL: CreateURL<TUiState>;
   public _searchFunction?: InstantSearchOptions['searchFunction'];
   public _mainHelperSearch?: AlgoliaSearchHelper['search'];
+  public _insights: InstantSearchOptions['insights'];
   public middleware: Array<{
     creator: Middleware<TUiState>;
     instance: MiddlewareDefinition<TUiState>;
@@ -342,6 +343,8 @@ See documentation: ${createDocumentationLink({
     this._initialUiState = initialUiState as TUiState;
     this._initialResults = null;
 
+    this._insights = insights;
+
     if (searchFunction) {
       warning(
         false,
@@ -358,8 +361,9 @@ See documentation: ${createDocumentationLink({
       this.use(createRouterMiddleware(routerOptions));
     }
 
-    // This is the default middleware,
-    // any user-provided middleware will be added later and override this one.
+    // This is the default Insights middleware,
+    // added when `insights` is set to true by the user.
+    // Any user-provided middleware will be added later and override this one.
     if (insights) {
       const insightsOptions = typeof insights === 'boolean' ? {} : insights;
       insightsOptions.$$internal = true;
@@ -667,6 +671,22 @@ See documentation: ${createDocumentationLink({
     this.middleware.forEach(({ instance }) => {
       instance.started();
     });
+
+    // This is the automatic Insights middleware,
+    // added when `insights` is unset and the initial results possess `queryID`.
+    // Any user-provided middleware will be added later and override this one.
+    if (typeof this._insights === 'undefined') {
+      mainHelper.derivedHelpers[0].once('result', () => {
+        const hasQueryID = this.mainIndex
+          .getScopedResults()
+          .some(({ results }) => results?.queryID !== undefined);
+        if (hasQueryID) {
+          this.use(
+            createInsightsMiddleware({ $$internal: true, $$automatic: true })
+          );
+        }
+      });
+    }
   }
 
   /**

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -500,11 +500,11 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
       });
     const mapMiddlewares = (middlewares: InstantSearch['middleware']) =>
       middlewares.map(
-        // @ts-ignore: $$automatic is only applicable to insights middleware
-        ({ instance: { $$type, $$internal, $$automatic } }) => ({
+        // @ts-ignore: $$clickAnalytics is only applicable to insights middleware
+        ({ instance: { $$type, $$internal, $$clickAnalytics } }) => ({
           $$type,
           $$internal,
-          $$automatic,
+          $$clickAnalytics,
         })
       );
 
@@ -545,7 +545,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
         {
           $$type: 'ais.insights',
           $$internal: true,
-          $$automatic: true,
+          $$clickAnalytics: false,
         },
       ]);
     });
@@ -561,7 +561,28 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
         {
           $$type: 'ais.insights',
           $$internal: true,
-          $$automatic: false,
+          $$clickAnalytics: true,
+        },
+      ]);
+    });
+
+    test('insights: true adds only one insights middleware when `_automaticInsights: true` is also set', async () => {
+      const search = new InstantSearch({
+        searchClient: createSearchClientWithAutomaticInsightsOptedIn(),
+        indexName: 'indexNameWithAutomaticInsights',
+        insights: true,
+      });
+
+      search.addWidgets([virtualSearchBox({})]);
+      search.start();
+
+      await wait(0);
+
+      expect(mapMiddlewares(search.middleware)).toEqual([
+        {
+          $$type: 'ais.insights',
+          $$internal: true,
+          $$clickAnalytics: true,
         },
       ]);
     });
@@ -581,7 +602,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
         {
           $$type: 'ais.insights',
           $$internal: true,
-          $$automatic: false,
+          $$clickAnalytics: true,
         },
       ]);
     });
@@ -601,7 +622,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
         {
           $$type: 'ais.insights',
           $$internal: true,
-          $$automatic: false,
+          $$clickAnalytics: true,
         },
       ]);
 
@@ -666,7 +687,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
         {
           $$type: 'ais.insights',
           $$internal: false,
-          $$automatic: false,
+          $$clickAnalytics: true,
         },
       ]);
     });

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -476,7 +476,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
   });
 
   describe('insights middleware', () => {
-    const createSearchClientWithInsights = () =>
+    const createSearchClientWithAutomaticInsightsOptedIn = () =>
       createSearchClient({
         search: jest.fn((requests) => {
           return Promise.resolve(
@@ -511,7 +511,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
     test('insights: undefined does not add the insights middleware if `_automaticInsights: true` is not found in initial response', async () => {
       const search = new InstantSearch({
         indexName: 'indexName',
-        searchClient: createSearchClientWithInsights(),
+        searchClient: createSearchClientWithAutomaticInsightsOptedIn(),
       });
 
       search.addWidgets([
@@ -526,7 +526,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
     });
 
     test('insights: undefined adds the insights middleware if `_automaticInsights: true` is found in at least one index in initial response', async () => {
-      const searchClient = createSearchClientWithInsights();
+      const searchClient = createSearchClientWithAutomaticInsightsOptedIn();
       const search = new InstantSearch({
         indexName: 'indexNameWithAutomaticInsights',
         searchClient,
@@ -552,7 +552,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
 
     test('insights: true adds only one insights middleware', () => {
       const search = new InstantSearch({
-        searchClient: createSearchClientWithInsights(),
+        searchClient: createSearchClientWithAutomaticInsightsOptedIn(),
         indexName: 'test',
         insights: true,
       });
@@ -568,7 +568,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
 
     test('insights: options adds only one insights middleware', () => {
       const search = new InstantSearch({
-        searchClient: createSearchClientWithInsights(),
+        searchClient: createSearchClientWithAutomaticInsightsOptedIn(),
         indexName: 'test',
         insights: {
           insightsInitParams: {
@@ -589,7 +589,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
     test('insights: options passes options to middleware', () => {
       const insightsClient = Object.assign(jest.fn(), { version: '2.6.0' });
       const search = new InstantSearch({
-        searchClient: createSearchClientWithInsights(),
+        searchClient: createSearchClientWithAutomaticInsightsOptedIn(),
         indexName: 'test',
         insights: {
           insightsClient,
@@ -631,7 +631,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
 
     test('insights: false disables default insights', () => {
       const search = new InstantSearch({
-        searchClient: createSearchClientWithInsights(),
+        searchClient: createSearchClientWithAutomaticInsightsOptedIn(),
         indexName: 'test',
         insights: false,
       });
@@ -641,7 +641,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
 
     test('insights: false does not add Insights middleware even if `_automaticInsights: true` is set', async () => {
       const search = new InstantSearch({
-        searchClient: createSearchClientWithInsights(),
+        searchClient: createSearchClientWithAutomaticInsightsOptedIn(),
         indexName: 'indexNameWithAutomaticInsights',
         insights: false,
       });

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -522,13 +522,16 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
       expect(mapMiddlewares(search.middleware)).toEqual([]);
     });
 
-    test('insights: undefined adds the insights middleware if `queryID` is found in at least one index in initial response', async () => {
+    test('insights: undefined adds the insights middleware if `_automaticInsights` is found in at least one index in initial response', async () => {
       const searchClient = createSearchClient({
         search: jest.fn((requests) => {
           return Promise.resolve(
             createMultiSearchResponse(
               ...requests.map((request) => {
                 return createSingleSearchResponse<any>({
+                  ...(request.indexName === 'indexNameWithQueryID'
+                    ? { _automaticInsights: true }
+                    : undefined),
                   index: request.indexName,
                   query: request.query,
                   ...(request.indexName === 'indexNameWithQueryID'

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -483,12 +483,12 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
             createMultiSearchResponse(
               ...requests.map((request) => {
                 return createSingleSearchResponse<any>({
-                  ...(request.indexName === 'indexNameWithQueryID'
+                  ...(request.indexName === 'indexNameWithAutomaticInsights'
                     ? { _automaticInsights: true }
                     : undefined),
                   index: request.indexName,
                   query: request.query,
-                  ...(request.indexName === 'indexNameWithQueryID'
+                  ...(request.indexName === 'indexNameWithAutomaticInsights'
                     ? { queryID: 'queryID' }
                     : undefined),
                   hits: [{ objectID: `${request.indexName}-objectID1` }],
@@ -508,7 +508,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
         })
       );
 
-    test('insights: undefined does not add the insights middleware if `queryID` is not found in initial response', async () => {
+    test('insights: undefined does not add the insights middleware if `_automaticInsights: true` is not found in initial response', async () => {
       const search = new InstantSearch({
         indexName: 'indexName',
         searchClient: createSearchClientWithInsights(),
@@ -528,7 +528,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
     test('insights: undefined adds the insights middleware if `_automaticInsights: true` is found in at least one index in initial response', async () => {
       const searchClient = createSearchClientWithInsights();
       const search = new InstantSearch({
-        indexName: 'indexNameWithQueryID',
+        indexName: 'indexNameWithAutomaticInsights',
         searchClient,
       });
 
@@ -642,7 +642,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
     test('insights: false does not add Insights middleware even if `_automaticInsights: true` is set', async () => {
       const search = new InstantSearch({
         searchClient: createSearchClientWithInsights(),
-        indexName: 'indexNameWithQueryID',
+        indexName: 'indexNameWithAutomaticInsights',
         insights: false,
       });
 

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -468,7 +468,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
       );
     });
 
-    it('applies clickAnalytics', () => {
+    it('applies clickAnalytics if $$automatic: false', () => {
       const { insightsClient, instantSearchInstance } = createTestEnvironment();
       instantSearchInstance.use(
         createInsightsMiddleware({
@@ -476,6 +476,19 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
         })
       );
       expect(instantSearchInstance.mainHelper!.state.clickAnalytics).toBe(true);
+    });
+
+    it('does not apply clickAnalytics if $$automatic: true', () => {
+      const { insightsClient, instantSearchInstance } = createTestEnvironment();
+      instantSearchInstance.use(
+        createInsightsMiddleware({
+          insightsClient,
+          $$automatic: true,
+        })
+      );
+      expect(
+        instantSearchInstance.helper!.state.clickAnalytics
+      ).toBeUndefined();
     });
 
     it("doesn't reset page", () => {
@@ -516,6 +529,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
+              "$$automatic": false,
               "$$internal": true,
               "$$type": "ais.insights",
               "onStateChange": [Function],
@@ -538,6 +552,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
+              "$$automatic": false,
               "$$internal": false,
               "$$type": "ais.insights",
               "onStateChange": [Function],
@@ -558,6 +573,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
+              "$$automatic": false,
               "$$internal": false,
               "$$type": "ais.insights",
               "onStateChange": [Function],
@@ -569,6 +585,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
+              "$$automatic": false,
               "$$internal": false,
               "$$type": "ais.insights",
               "onStateChange": [Function],
@@ -596,6 +613,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
+              "$$automatic": false,
               "$$internal": true,
               "$$type": "ais.insights",
               "onStateChange": [Function],
@@ -631,6 +649,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
+              "$$automatic": false,
               "$$internal": true,
               "$$type": "ais.insights",
               "onStateChange": [Function],

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -468,7 +468,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
       );
     });
 
-    it('applies clickAnalytics if $$automatic: false', () => {
+    it('applies clickAnalytics if $$clickAnalytics: undefined', () => {
       const { insightsClient, instantSearchInstance } = createTestEnvironment();
       instantSearchInstance.use(
         createInsightsMiddleware({
@@ -478,12 +478,23 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
       expect(instantSearchInstance.mainHelper!.state.clickAnalytics).toBe(true);
     });
 
-    it('does not apply clickAnalytics if $$automatic: true', () => {
+    it('applies clickAnalytics if $$clickAnalytics: true', () => {
       const { insightsClient, instantSearchInstance } = createTestEnvironment();
       instantSearchInstance.use(
         createInsightsMiddleware({
           insightsClient,
-          $$automatic: true,
+          $$clickAnalytics: true,
+        })
+      );
+      expect(instantSearchInstance.mainHelper!.state.clickAnalytics).toBe(true);
+    });
+
+    it('does not apply clickAnalytics if $$clickAnalytics: false', () => {
+      const { insightsClient, instantSearchInstance } = createTestEnvironment();
+      instantSearchInstance.use(
+        createInsightsMiddleware({
+          insightsClient,
+          $$clickAnalytics: false,
         })
       );
       expect(
@@ -529,7 +540,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
-              "$$automatic": false,
+              "$$clickAnalytics": true,
               "$$internal": true,
               "$$type": "ais.insights",
               "onStateChange": [Function],
@@ -552,7 +563,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
-              "$$automatic": false,
+              "$$clickAnalytics": true,
               "$$internal": false,
               "$$type": "ais.insights",
               "onStateChange": [Function],
@@ -573,7 +584,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
-              "$$automatic": false,
+              "$$clickAnalytics": true,
               "$$internal": false,
               "$$type": "ais.insights",
               "onStateChange": [Function],
@@ -585,7 +596,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
-              "$$automatic": false,
+              "$$clickAnalytics": true,
               "$$internal": false,
               "$$type": "ais.insights",
               "onStateChange": [Function],
@@ -613,7 +624,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
-              "$$automatic": false,
+              "$$clickAnalytics": true,
               "$$internal": true,
               "$$type": "ais.insights",
               "onStateChange": [Function],
@@ -649,7 +660,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           {
             "creator": [Function],
             "instance": {
-              "$$automatic": false,
+              "$$clickAnalytics": true,
               "$$internal": true,
               "$$type": "ais.insights",
               "onStateChange": [Function],

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -157,6 +157,7 @@ export function createInsightsMiddleware<
     return {
       $$type: 'ais.insights',
       $$internal,
+      $$automatic,
       onStateChange() {},
       subscribe() {
         if (!insightsClient.shouldAddScript) return;

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -34,6 +34,10 @@ export type InsightsProps<
    * @internal indicator for the default insights middleware
    */
   $$internal?: boolean;
+  /**
+   * @internal indicator for the automatic insights middleware
+   */
+  $$automatic?: boolean;
 };
 
 const ALGOLIA_INSIGHTS_VERSION = '2.6.0';
@@ -54,6 +58,7 @@ export function createInsightsMiddleware<
     insightsInitParams,
     onEvent,
     $$internal = false,
+    $$automatic = false,
   } = props;
 
   let potentialInsightsClient: ProvidedInsightsClient = _insightsClient;
@@ -183,10 +188,13 @@ export function createInsightsMiddleware<
           clickAnalytics: helper.state.clickAnalytics,
         };
 
-        helper.overrideStateWithoutTriggeringChangeEvent({
-          ...helper.state,
-          clickAnalytics: true,
-        });
+        if (!$$automatic) {
+          helper.overrideStateWithoutTriggeringChangeEvent({
+            ...helper.state,
+            clickAnalytics: true,
+          });
+        }
+
         if (!$$internal) {
           instantSearchInstance.scheduleSearch();
         }

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -35,9 +35,9 @@ export type InsightsProps<
    */
   $$internal?: boolean;
   /**
-   * @internal indicator for the automatic insights middleware
+   * @internal indicator for sending the `clickAnalytics` search parameter
    */
-  $$automatic?: boolean;
+  $$clickAnalytics?: boolean;
 };
 
 const ALGOLIA_INSIGHTS_VERSION = '2.6.0';
@@ -58,7 +58,7 @@ export function createInsightsMiddleware<
     insightsInitParams,
     onEvent,
     $$internal = false,
-    $$automatic = false,
+    $$clickAnalytics = true,
   } = props;
 
   let potentialInsightsClient: ProvidedInsightsClient = _insightsClient;
@@ -157,7 +157,7 @@ export function createInsightsMiddleware<
     return {
       $$type: 'ais.insights',
       $$internal,
-      $$automatic,
+      $$clickAnalytics,
       onStateChange() {},
       subscribe() {
         if (!insightsClient.shouldAddScript) return;
@@ -189,7 +189,7 @@ export function createInsightsMiddleware<
           clickAnalytics: helper.state.clickAnalytics,
         };
 
-        if (!$$automatic) {
+        if ($$clickAnalytics) {
           helper.overrideStateWithoutTriggeringChangeEvent({
             ...helper.state,
             clickAnalytics: true,

--- a/packages/instantsearch.js/test/createInstantSearch.ts
+++ b/packages/instantsearch.js/test/createInstantSearch.ts
@@ -43,6 +43,7 @@ export const createInstantSearch = (
     _initialUiState: {},
     _initialResults: null,
     _createURL: jest.fn(() => '#'),
+    _insights: undefined,
     onStateChange: null,
     setUiState: jest.fn(),
     getUiState: jest.fn(() => ({})),


### PR DESCRIPTION
**Summary**

When `insights` is undefined, the Insights middleware can be initialized in answer to a server setting, received with the initial results.

FX-2643