### PR TITLE
feat(instantsearch): make `insights` undefined by default

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -229,7 +229,7 @@ Use \`InstantSearch.status === "stalled"\` instead.`
       numberLocale,
       initialUiState = {} as TUiState,
       routing = null,
-      insights = false,
+      insights = undefined,
       searchFunction,
       stalledSearchDelay = 200,
       searchClient = null,

--- a/packages/vue-instantsearch/src/components/InstantSearch.js
+++ b/packages/vue-instantsearch/src/components/InstantSearch.js
@@ -42,7 +42,11 @@ export default createInstantSearchComponent({
     insights: {
       default: undefined,
       validator(value) {
-        return typeof value === 'boolean' || typeof value === 'object';
+        return (
+          typeof value === 'undefined' ||
+          typeof value === 'boolean' ||
+          typeof value === 'object'
+        );
       },
     },
     stalledSearchDelay: {


### PR DESCRIPTION
This will prepare for the addition of insights in response to a dashboard setting.

FX-2641
