### PR TITLE
fix(current-refinements): clear with the `refine` function in each item

### DIFF
--- a/packages/react-instantsearch/src/ui/CurrentRefinements.tsx
+++ b/packages/react-instantsearch/src/ui/CurrentRefinements.tsx
@@ -2,18 +2,17 @@ import React from 'react';
 
 import { capitalize, cx, isModifierClick } from './lib';
 
-import type {
-  CurrentRefinementsConnectorParamsItem,
-  CurrentRefinementsConnectorParamsRefinement,
-} from 'instantsearch.js/es/connectors/current-refinements/connectCurrentRefinements';
+import type { CurrentRefinementsConnectorParamsItem } from 'instantsearch.js/es/connectors/current-refinements/connectCurrentRefinements';
 
 export type CurrentRefinementsProps = React.ComponentProps<'div'> & {
   classNames?: Partial<CurrentRefinementsClassNames>;
   items?: Array<
-    Pick<CurrentRefinementsConnectorParamsItem, 'label' | 'refinements'> &
+    Pick<
+      CurrentRefinementsConnectorParamsItem,
+      'label' | 'refinements' | 'refine'
+    > &
       Record<string, unknown>
   >;
-  onRemove?: (refinement: CurrentRefinementsConnectorParamsRefinement) => void;
   hasRefinements?: boolean;
 };
 
@@ -59,7 +58,6 @@ export type CurrentRefinementsClassNames = {
 export function CurrentRefinements({
   classNames = {},
   items = [],
-  onRemove = () => {},
   hasRefinements = false,
   ...props
 }: CurrentRefinementsProps) {
@@ -122,7 +120,7 @@ export function CurrentRefinements({
                       return;
                     }
 
-                    onRemove(refinement);
+                    item.refine(refinement);
                   }}
                   className={cx(
                     'ais-CurrentRefinements-delete',

--- a/packages/react-instantsearch/src/ui/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/CurrentRefinements.test.tsx
@@ -28,13 +28,14 @@ describe('CurrentRefinements', () => {
   });
 
   test('renders with clickable refinements', () => {
-    const onRemove = jest.fn();
+    const refine = jest.fn();
 
     const { container } = render(
       <CurrentRefinements
         items={[
           {
             label: 'Brand',
+            refine,
             refinements: [
               {
                 label: 'Apple',
@@ -52,7 +53,6 @@ describe('CurrentRefinements', () => {
           },
         ]}
         hasRefinements={true}
-        onRemove={onRemove}
       />
     );
 
@@ -116,7 +116,7 @@ describe('CurrentRefinements', () => {
 
     userEvent.click(button1);
 
-    expect(onRemove).toHaveBeenLastCalledWith({
+    expect(refine).toHaveBeenLastCalledWith({
       attribute: 'brand',
       label: 'Apple',
       type: 'facet',
@@ -125,13 +125,13 @@ describe('CurrentRefinements', () => {
 
     userEvent.click(button2);
 
-    expect(onRemove).toHaveBeenLastCalledWith({
+    expect(refine).toHaveBeenLastCalledWith({
       attribute: 'brand',
       label: 'Samsung',
       type: 'facet',
       value: 'Samsung',
     });
-    expect(onRemove).toHaveBeenCalledTimes(2);
+    expect(refine).toHaveBeenCalledTimes(2);
   });
 
   test('accepts custom class names', () => {
@@ -172,6 +172,7 @@ describe('CurrentRefinements', () => {
           items={[
             {
               label: 'brand',
+              refine: jest.fn(),
               refinements: [
                 {
                   attribute: 'brand',

--- a/packages/react-instantsearch/src/widgets/CurrentRefinements.tsx
+++ b/packages/react-instantsearch/src/widgets/CurrentRefinements.tsx
@@ -8,7 +8,7 @@ import type { UseCurrentRefinementsProps } from 'react-instantsearch-core';
 
 type UiProps = Pick<
   CurrentRefinementsUiComponentProps,
-  'items' | 'onRemove' | 'hasRefinements'
+  'items' | 'hasRefinements'
 >;
 
 export type CurrentRefinementsProps = Omit<
@@ -23,7 +23,7 @@ export function CurrentRefinements({
   transformItems,
   ...props
 }: CurrentRefinementsProps) {
-  const { items, refine, canRefine } = useCurrentRefinements(
+  const { items, canRefine } = useCurrentRefinements(
     {
       includedAttributes,
       excludedAttributes,
@@ -36,7 +36,6 @@ export function CurrentRefinements({
 
   const uiProps: UiProps = {
     items,
-    onRemove: refine,
     hasRefinements: canRefine,
   };
 

--- a/tests/common/widgets/current-refinements/options.ts
+++ b/tests/common/widgets/current-refinements/options.ts
@@ -315,6 +315,53 @@ export function createOptionsTests(
       ).toHaveLength(0);
     });
 
+    it('clears a refinement by calling the `refine` method in each item', async () => {
+      const refine = jest.fn();
+      await setup({
+        instantSearchOptions: {
+          searchClient,
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {
+              refinementList: {
+                brand: ['Apple', 'Samsung'],
+                feature: ['5G'],
+              },
+            },
+          },
+        },
+        widgetParams: {
+          transformItems: (items) =>
+            items.map((item) => ({
+              ...item,
+              refine(refinement) {
+                refine(refinement);
+                item.refine(refinement);
+              },
+            })),
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const container = document.querySelector<HTMLElement>(
+        '.ais-CurrentRefinements'
+      )!;
+
+      const [btn5G] = document.querySelectorAll(
+        '.ais-CurrentRefinements-delete'
+      );
+
+      await act(async () => {
+        userEvent.click(btn5G);
+        await wait(0);
+      });
+      expect(refine).toHaveBeenCalledTimes(1);
+      expect(queryByText(container, '5G')).toBeNull();
+    });
+
     it('does not trigger default event', async () => {
       await setup({
         instantSearchOptions: {


### PR DESCRIPTION
**Summary**

I noticed by working on a CR that our React InstantSearch implementation of CurrentRefinements differs from the other flavours. Specifically, we call the `refine()` method returned by the connector when we clear a refinement value, instead of using the `refine()` method available in each item.

One use-case for this is to modify the `refine()` method through `transformItems`, allowing for example to clear all numerical refinements of an attribute at once (ie: removing the min and max of a price range).

> **Note**  
> In React InstantSearch v6 both ranges would be cleared in a numerical refinement, but in React InstantSearch v7, because we rely on the JS implementation, ranges are cleared individually. This would allow customers to easily implement the legacy behaviour if they want it. 

**Result**

Refinements are cleared using the `refine()` method available in each item, unifying the behaviour of JS/React/Vue InstantSearch.