### PR TITLE
chore: update banner image url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/">
-    <img alt="InstantSearch.js" src=".github/banner.png">
+    <img alt="InstantSearch.js" src=".github/banner.png?raw=">
   </a>
 
   <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/">
-    <img alt="InstantSearch.js" src=".github/banner.png?raw=">
+    <img alt="InstantSearch.js" src=".github/banner.png">
   </a>
 
   <p align="center">

--- a/packages/instantsearch.js/README.md
+++ b/packages/instantsearch.js/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/">
-    <img alt="InstantSearch.js" src=".github/banner.png">
+    <img alt="InstantSearch.js" src="https://github.com/algolia/instantsearch/blob/master/.github/banner.png?raw=true">
   </a>
 
   <p align="center">

--- a/packages/react-instantsearch-core/README.md
+++ b/packages/react-instantsearch-core/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <a href="https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/">
+    <img alt="React InstantSearch" src="https://github.com/algolia/instantsearch/blob/master/.github/react-instantsearch-banner.png?raw=true">
+  </a>
+</p>
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 

--- a/packages/react-instantsearch/README.md
+++ b/packages/react-instantsearch/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <a href="https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/react/">
+    <img alt="React InstantSearch" src="https://github.com/algolia/instantsearch/blob/master/.github/react-instantsearch-banner.png?raw=true">
+  </a>
+</p>
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 


### PR DESCRIPTION
**Summary**

Banner in packages/instantsearch.js README is broken: https://github.com/algolia/instantsearch/tree/master/packages/instantsearch.js.

This PR updates the URL to correctly display it again: https://github.com/algolia/instantsearch/tree/chore/update-banner-image-url/packages/instantsearch.js.
