### PR TITLE
refactor(core): move options diff to core

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -844,15 +844,12 @@ See documentation: ${createDocumentationLink({
 
   /**
    * Update the parameters passed to the InstantSearch constructor.
-   * @returns true if anything has been updated
    */
   public update(
     props: Partial<InstantSearchOptions<TUiState, TRouteState>>
-  ): boolean {
-    let hasUpdated = false;
+  ): void {
     if (this.indexName !== props.indexName) {
       this.helper!.setIndex(props.indexName || '').search();
-      hasUpdated = true;
     }
 
     if (this.client !== props.searchClient) {
@@ -881,12 +878,10 @@ See documentation: ${createDocumentationLink({
       // ]);
 
       this.mainHelper!.setClient(props.searchClient).search();
-      hasUpdated = true;
     }
 
     if (this.onStateChange !== props.onStateChange) {
       this.onStateChange = props.onStateChange;
-      hasUpdated = true;
     }
 
     if (this._searchFunction !== props.searchFunction) {
@@ -899,13 +894,11 @@ See documentation: ${createDocumentationLink({
         ((helper) => {
           helper.search();
         });
-      hasUpdated = true;
     }
 
     if (this._stalledSearchDelay !== props.stalledSearchDelay) {
       this._stalledSearchDelay =
         props.stalledSearchDelay ?? INSTANTSEARCH_STALLED_SEARCH_DEFAULTS;
-      hasUpdated = true;
     }
 
     // TODO: move dequal to a shared package?
@@ -914,7 +907,6 @@ See documentation: ${createDocumentationLink({
     //     ...INSTANTSEARCH_FUTURE_DEFAULTS,
     //     ...props.future,
     //   };
-    //   hasUpdated = true;
     // }
 
     // TODO: insights option
@@ -927,8 +919,6 @@ See documentation: ${createDocumentationLink({
     // it privately on the InstantSearch instance. Another way would be to
     // manually inject the routing middleware in this library, and not rely
     // on the provided `routing` prop.
-
-    return hasUpdated;
   }
 }
 

--- a/packages/react-instantsearch-core/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-core/src/lib/useInstantSearchApi.ts
@@ -59,7 +59,6 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
   const serverState = useInstantSearchSSRContext<TUiState, TRouteState>();
   const waitingForResultsRef = useRSCContext();
   const initialResults = serverState?.initialResults;
-  const prevPropsRef = useRef(props);
 
   const shouldRenderAtOnce =
     serverContext || initialResults || waitingForResultsRef;
@@ -131,16 +130,7 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
     searchRef.current = search;
   }
 
-  {
-    const search = searchRef.current;
-    // TODO: is this still needed? (was it even ever needed, we could have read the private InstantSearch values)
-    // const prevProps = prevPropsRef.current;
-    const nextProps = props;
-    const updated = search.update(nextProps);
-    if (updated) {
-      prevPropsRef.current = nextProps;
-    }
-  }
+  searchRef.current.update(props);
 
   const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const store = useSyncExternalStore<InstantSearch<TUiState, TRouteState>>(

--- a/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
+++ b/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
@@ -18,21 +18,18 @@ export const createInstantSearchComponent = (component) =>
       },
       watch: {
         searchClient(searchClient) {
-          warn(
-            false,
-            'The `search-client` prop of `<ais-instant-search>` changed between renders, which may cause more search requests than necessary. If this is an unwanted behavior, please provide a stable reference: https://www.algolia.com/doc/api-reference/widgets/instantsearch/vue/#widget-param-search-client'
-          );
-
-          this.instantSearchInstance.helper.setClient(searchClient).search();
+          this.instantSearchInstance.update({ searchClient });
         },
         indexName(indexName) {
-          this.instantSearchInstance.helper.setIndex(indexName || '').search();
+          this.instantSearchInstance.update({ indexName });
         },
         stalledSearchDelay(stalledSearchDelay) {
-          // private InstantSearch.js API:
-          this.instantSearchInstance._stalledSearchDelay = stalledSearchDelay;
+          this.instantSearchInstance.update({ stalledSearchDelay });
         },
         routing() {
+          // TODO: in React this is ignored, in Vue an error
+          // How do we get a consistent behaviour?
+          // Nobody ever opened these issues, implying error is right behaviour?
           throw new Error(
             'routing configuration can not be changed dynamically at this point.' +
               '\n\n' +
@@ -47,9 +44,10 @@ export const createInstantSearchComponent = (component) =>
           );
         },
         searchFunction(searchFunction) {
-          // private InstantSearch.js API:
-          this.instantSearchInstance._searchFunction = searchFunction;
+          this.instantSearchInstance.update({ searchFunction });
         },
+        // TODO: insights
+        // TODO: should this be an InstantSearch API? maybe not
         middlewares: {
           immediate: true,
           handler(next, prev) {
@@ -67,10 +65,7 @@ export const createInstantSearchComponent = (component) =>
           },
         },
         future(future) {
-          this.instantSearchInstance.future = Object.assign(
-            INSTANTSEARCH_FUTURE_DEFAULTS,
-            future
-          );
+          this.instantSearchInstance.update({ future });
         },
       },
       created() {


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

We deal with updating of parameters of InstantSearch in both React InstantSearch and Vue InstantSearch, in different ways. This PR aims to fix that, by moving the updating to core.

**Result**

`search.update(props: Partial<Options>)`

Still open questions:
- how to do `insights` (does middleware need update option too?) (do we handle anything other than init props)
- how to warn/error for routing/onStateChange (or do we handle it?)
- test that it works properly of course
- should some of the code in constructor be moved to update?

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
