### PR TITLE
chore(cisa): add note about insights option in templates

### DIFF
--- a/packages/create-instantsearch-app/README.md
+++ b/packages/create-instantsearch-app/README.md
@@ -50,6 +50,10 @@ cd my-app
 yarn start
 ```
 
+> **Important**
+> Selecting 'Y' when being prompted to ‘Enable user events’ activates the [`insights`](https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/#widget-param-insights) option for compatible templates, allowing Algolia to process your user Events. Events can unlock powerful features, enhancing your application's effectiveness and we encourage you to consider enabling this valuable functionality. Please review our [API reference](https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/#widget-param-insights) for more details about Events collection and settings.
+
+
 ## Usage
 
 This package comes with the module `createInstantSearchApp(path, options?)` and the command-line tool `create-instantsearch-app`.
@@ -110,7 +114,8 @@ The `config` flag is handy to automate app generations.
   "indexName": "MY_INDEX_NAME",
   "searchPlaceholder": "Search",
   "attributesToDisplay": ["name", "description"],
-  "attributesForFaceting": ["brand", "location"]
+  "attributesForFaceting": ["brand", "location"],
+  "enableInsights": true
 }
 ```
 
@@ -132,6 +137,7 @@ const app = createInstantSearchApp('~/lab/my-app', {
   libraryVersion: '2.0.0',
   attributesToDisplay: ['name', 'description'],
   attributesForFaceting: ['keywords'],
+  enableInsights: true,
 });
 
 app.create().then(() => console.log('App generated!'));


### PR DESCRIPTION
**Summary**

This PR updates CISA readme with a message informing users about the effects of enabling events during template creation.

FX-2658

[**Preview →**](https://github.com/algolia/instantsearch/blob/60f1ac29ae616d80db875445a8374e6d1ddf1b1a/packages/create-instantsearch-app/README.md#get-started)
