### PR TITLE
test: `hydrateSearchClient` to make sure it caches results

### DIFF
--- a/packages/instantsearch.js/src/lib/utils/__tests__/hydrateSearchClient-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/hydrateSearchClient-test.ts
@@ -1,0 +1,74 @@
+import { hydrateSearchClient } from '../hydrateSearchClient';
+
+import type { SearchClient, InitialResults } from '../../../types';
+
+describe('hydrateSearchClient', () => {
+  let client: SearchClient & {
+    _cacheHydrated?: boolean;
+    _useCache?: boolean;
+    cache?: Record<string, string>;
+  };
+  const initialResults = {
+    instant_search: {
+      results: [{ index: 'instant_search', params: 'params', nbHits: 1000 }],
+      state: {},
+      rawResults: [{ index: 'instant_search', params: 'params', nbHits: 1000 }],
+    },
+  } as unknown as InitialResults;
+
+  it('should not hydrate the client if no results are provided', () => {
+    client = {} as unknown as SearchClient;
+    hydrateSearchClient(client, undefined);
+
+    expect(client._cacheHydrated).not.toBeDefined();
+  });
+
+  it('should not hydrate the client if the cache is disabled', () => {
+    client = { _useCache: false } as unknown as SearchClient;
+
+    hydrateSearchClient(client, initialResults);
+
+    expect(client._cacheHydrated).not.toBeDefined();
+  });
+
+  it('should not hydrate the client if `addAlgoliaAgent` is missing', () => {
+    client = { addAlgoliaAgent: undefined } as unknown as SearchClient;
+
+    hydrateSearchClient(client, initialResults);
+
+    expect(client._cacheHydrated).not.toBeDefined();
+  });
+
+  it('should hydrate the client for >= v4 if the cache is enabled and the Algolia agent is present', () => {
+    const setCache = jest.fn();
+    client = {
+      transporter: { responsesCache: { set: setCache } },
+      addAlgoliaAgent: jest.fn(),
+    } as unknown as SearchClient;
+
+    hydrateSearchClient(client, initialResults);
+
+    expect(setCache).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: [[{ indexName: 'instant_search', params: 'params' }]],
+        method: 'search',
+      }),
+      expect.objectContaining({
+        results: [{ index: 'instant_search', params: 'params', nbHits: 1000 }],
+      })
+    );
+    expect(client._cacheHydrated).toBe(true);
+    expect(client.search).toBeDefined();
+  });
+
+  it('should populate the cache for < v4 if there is no transporter object', () => {
+    client = {
+      addAlgoliaAgent: jest.fn(),
+      _useCache: true,
+    } as unknown as SearchClient;
+
+    hydrateSearchClient(client, initialResults);
+
+    expect(client.cache).toBeDefined();
+  });
+});

--- a/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
@@ -53,10 +53,10 @@ export function hydrateSearchClient(
       {
         method: 'search',
         args: [
-          Object.values(results).reduce(
-            (acc, result) =>
+          Object.keys(results).reduce(
+            (acc, key) =>
               acc.concat(
-                result.results.map((request) => ({
+                results[key].results.map((request) => ({
                   indexName: request.index,
                   params: request.params,
                 }))
@@ -66,8 +66,8 @@ export function hydrateSearchClient(
         ],
       },
       {
-        results: Object.values(results).reduce(
-          (acc, result) => acc.concat(result.results),
+        results: Object.keys(results).reduce(
+          (acc, key) => acc.concat(results[key].results),
           []
         ),
       }
@@ -81,11 +81,11 @@ export function hydrateSearchClient(
   // computation of the key inside the client (see link below).
   // https://github.com/algolia/algoliasearch-client-javascript/blob/c27e89ff92b2a854ae6f40dc524bffe0f0cbc169/src/AlgoliaSearchCore.js#L232-L240
   if (!client.transporter) {
-    const key = `/1/indexes/*/queries_body_${JSON.stringify({
-      requests: results.reduce(
-        (acc, result) =>
+    const cacheKey = `/1/indexes/*/queries_body_${JSON.stringify({
+      requests: Object.keys(results).reduce(
+        (acc, key) =>
           acc.concat(
-            result.rawResults.map((request) => ({
+            results[key].rawResults.map((request) => ({
               indexName: request.index,
               params: request.params,
             }))
@@ -96,9 +96,9 @@ export function hydrateSearchClient(
 
     client.cache = {
       ...client.cache,
-      [key]: JSON.stringify({
-        results: results.reduce(
-          (acc, result) => acc.concat(result.rawResults),
+      [cacheKey]: JSON.stringify({
+        results: Object.keys(results).reduce(
+          (acc, key) => acc.concat(results[key].rawResults),
           []
         ),
       }),

--- a/packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '@instantsearch/mocks';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import algoliasearch from 'algoliasearch';
 import { history } from 'instantsearch.js/es/lib/routers';
 import { simple } from 'instantsearch.js/es/lib/stateMappings';
 import React, { StrictMode } from 'react';
@@ -467,6 +468,69 @@ describe('InstantSearchSSRProvider', () => {
           }),
         },
       ]);
+    });
+  });
+
+  test('caches the initial results to avoid a client-side request', async () => {
+    const send = jest.fn(() =>
+      Promise.resolve({
+        content: JSON.stringify(createMultiSearchResponse()),
+        isTimedOut: false,
+        status: 200,
+      })
+    );
+    const searchClient = algoliasearch('appId', 'apiKey', {
+      requester: { send },
+    });
+    const initialResults = {
+      indexName: {
+        state: {},
+        results: [
+          {
+            exhaustiveFacetsCount: true,
+            exhaustiveNbHits: true,
+            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+            hitsPerPage: 20,
+            index: 'indexName',
+            nbHits: 0,
+            nbPages: 0,
+            page: 0,
+            params: '',
+            processingTimeMS: 0,
+            query: '',
+          },
+        ],
+      },
+    };
+
+    function App() {
+      return (
+        <StrictMode>
+          <InstantSearchSSRProvider initialResults={initialResults}>
+            <InstantSearch searchClient={searchClient} indexName="indexName">
+              <SearchBox />
+            </InstantSearch>
+          </InstantSearchSSRProvider>
+        </StrictMode>
+      );
+    }
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(send).toHaveBeenCalledTimes(0);
+    });
+
+    userEvent.type(screen.getByRole('searchbox'), 'i');
+
+    await waitFor(() => {
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    userEvent.clear(screen.getByRole('searchbox'));
+
+    await waitFor(() => {
+      expect(send).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx
@@ -213,6 +213,7 @@ describe('InstantSearchSSRProvider', () => {
         );
       }),
     });
+    const spiedSearch = jest.spyOn(searchClient, 'search');
     const initialResults = {
       indexName: {
         state: {
@@ -297,7 +298,7 @@ describe('InstantSearchSSRProvider', () => {
     const { getByRole } = render(<App />);
 
     await waitFor(() => {
-      expect(searchClient.search).toHaveBeenCalledTimes(0);
+      expect(spiedSearch).toHaveBeenCalledTimes(0);
       expect(getByRole('checkbox', { name: 'Apple 442' })).not.toBeChecked();
       expect(getByRole('checkbox', { name: 'Samsung 633' })).not.toBeChecked();
     });
@@ -305,7 +306,7 @@ describe('InstantSearchSSRProvider', () => {
     userEvent.click(getByRole('checkbox', { name: 'Apple 442' }));
 
     await waitFor(() => {
-      expect(searchClient.search).toHaveBeenCalledTimes(1);
+      expect(spiedSearch).toHaveBeenCalledTimes(1);
       expect(getByRole('checkbox', { name: 'Apple 442' })).toBeChecked();
       expect(getByRole('checkbox', { name: 'Samsung 633' })).not.toBeChecked();
     });
@@ -351,6 +352,7 @@ describe('InstantSearchSSRProvider', () => {
 
   test('does not trigger a network request with initialResults', async () => {
     const searchClient = createAlgoliaSearchClient({});
+    const spiedSearch = jest.spyOn(searchClient, 'search');
     const initialResults = {
       indexName: {
         state: {},
@@ -387,12 +389,13 @@ describe('InstantSearchSSRProvider', () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(searchClient.search).toHaveBeenCalledTimes(0);
+      expect(spiedSearch).toHaveBeenCalledTimes(0);
     });
   });
 
   test('recovers the state on rerender', async () => {
     const searchClient = createAlgoliaSearchClient({});
+    const spiedSearch = jest.spyOn(searchClient, 'search');
     const initialResults = {
       indexName: {
         state: {},
@@ -429,7 +432,7 @@ describe('InstantSearchSSRProvider', () => {
     const { rerender } = render(<App />);
 
     await waitFor(() => {
-      expect(searchClient.search).toHaveBeenCalledTimes(0);
+      expect(spiedSearch).toHaveBeenCalledTimes(0);
     });
 
     rerender(<App />);
@@ -437,8 +440,8 @@ describe('InstantSearchSSRProvider', () => {
     userEvent.type(screen.getByRole('searchbox'), 'iphone');
 
     await waitFor(() => {
-      expect(searchClient.search).toHaveBeenCalledTimes(6);
-      expect(searchClient.search).toHaveBeenLastCalledWith([
+      expect(spiedSearch).toHaveBeenCalledTimes(6);
+      expect(spiedSearch).toHaveBeenLastCalledWith([
         {
           indexName: 'indexName',
           params: expect.objectContaining({
@@ -455,8 +458,8 @@ describe('InstantSearchSSRProvider', () => {
     });
 
     await waitFor(() => {
-      expect(searchClient.search).toHaveBeenCalledTimes(11);
-      expect(searchClient.search).toHaveBeenLastCalledWith([
+      expect(spiedSearch).toHaveBeenCalledTimes(11);
+      expect(spiedSearch).toHaveBeenLastCalledWith([
         {
           indexName: 'indexName',
           params: expect.objectContaining({

--- a/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
@@ -216,12 +216,13 @@ describe('getServerState', () => {
 
   test('calls search with widgets search parameters', async () => {
     const searchClient = createSearchClient({});
+    const spiedSearch = jest.spyOn(searchClient, 'search');
     const { App } = createTestEnvironment({ searchClient });
 
     await getServerState(<App />, { renderToString });
 
-    expect(searchClient.search).toHaveBeenCalledTimes(1);
-    expect(searchClient.search).toHaveBeenCalledWith([
+    expect(spiedSearch).toHaveBeenCalledTimes(1);
+    expect(spiedSearch).toHaveBeenCalledWith([
       {
         indexName: 'instant_search',
         params: {
@@ -341,6 +342,7 @@ describe('getServerState', () => {
 
   test('searches twice (cached) with dynamic widgets', async () => {
     const searchClient = createAlgoliaSearchClient({});
+    const spiedSearch = jest.spyOn(searchClient, 'search');
     const { App } = createTestEnvironment({ searchClient, initialUiState: {} });
 
     await getServerState(
@@ -350,15 +352,14 @@ describe('getServerState', () => {
       { renderToString }
     );
 
-    expect(searchClient.search).toHaveBeenCalledTimes(2);
+    expect(spiedSearch).toHaveBeenCalledTimes(2);
     // both calls are the same, so they're cached
-    expect(searchClient.search.mock.calls[0][0]).toEqual(
-      searchClient.search.mock.calls[1][0]
-    );
+    expect(spiedSearch.mock.calls[0][0]).toEqual(spiedSearch.mock.calls[1][0]);
   });
 
   test('searches twice (cached) with dynamic widgets inside index', async () => {
     const searchClient = createAlgoliaSearchClient({});
+    const spiedSearch = jest.spyOn(searchClient, 'search');
     const { App } = createTestEnvironment({ searchClient, initialUiState: {} });
 
     await getServerState(
@@ -370,11 +371,9 @@ describe('getServerState', () => {
       { renderToString }
     );
 
-    expect(searchClient.search).toHaveBeenCalledTimes(2);
+    expect(spiedSearch).toHaveBeenCalledTimes(2);
     // both calls are the same, so they're cached
-    expect(searchClient.search.mock.calls[0][0]).toEqual(
-      searchClient.search.mock.calls[1][0]
-    );
+    expect(spiedSearch.mock.calls[0][0]).toEqual(spiedSearch.mock.calls[1][0]);
   });
 
   test('searches twice with dynamic widgets and a refinement', async () => {
@@ -391,6 +390,7 @@ describe('getServerState', () => {
         );
       }),
     });
+    const spiedSearch = jest.spyOn(searchClient, 'search');
     const { App } = createTestEnvironment({
       searchClient,
       initialUiState: {
@@ -409,10 +409,10 @@ describe('getServerState', () => {
       { renderToString }
     );
 
-    expect(searchClient.search).toHaveBeenCalledTimes(2);
+    expect(spiedSearch).toHaveBeenCalledTimes(2);
 
     // first query doesn't have the fallback widget mounted yet
-    expect(searchClient.search.mock.calls[0][0][0]).toEqual({
+    expect(spiedSearch.mock.calls[0][0][0]).toEqual({
       indexName: 'instant_search',
       params: {
         facets: ['*'],
@@ -425,7 +425,7 @@ describe('getServerState', () => {
     });
 
     // second query does have the fallback widget mounted, and thus also the refinement
-    expect(searchClient.search.mock.calls[1][0][0]).toEqual({
+    expect(spiedSearch.mock.calls[1][0][0]).toEqual({
       indexName: 'instant_search',
       params: {
         facetFilters: [['categories:refined!']],

--- a/tsconfig.v3.json
+++ b/tsconfig.v3.json
@@ -20,5 +20,7 @@
     "packages/instantsearch.js/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts",
     "packages/instantsearch.js/src/connectors/menu/__tests__/connectMenu-test.ts",
     "packages/instantsearch.js/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts",
+    // this test has specific code for v4
+    "packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx"
   ]
 }


### PR DESCRIPTION
**Summary**

#### [FX-2647](https://algolia.atlassian.net/browse/FX-2647)

I started making e2e tests with [wdio-intercept-service](https://webdriver.io/docs/wdio-intercept-service/) but due to limitations with selenium, there's no way to intercept requests made when the page loads reliably, only requests resulting from user actions can be tested :/

We would have to use Cypress or Puppeteer to test it then.

So this just tests the implementation itself, which is still better than nothing 😅
Also changed `Object.values` to `Object.keys` for it to build properly.

[FX-2647]: https://algolia.atlassian.net/browse/FX-2647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ