### PR TITLE
chore(toMatchNormalizedInlineSnapshot): normalize whole element

### DIFF
--- a/tests/utils/matchers/toMatchNormalizedInlineSnapshot.ts
+++ b/tests/utils/matchers/toMatchNormalizedInlineSnapshot.ts
@@ -6,10 +6,14 @@ export function toMatchNormalizedInlineSnapshot(
   normalizeFn: (html: string) => string,
   snapshot: string = ''
 ): jest.CustomMatcherResult {
-  const normalizedElement = received.cloneNode() as Element;
-  normalizedElement.innerHTML = normalizeFn(received.innerHTML);
+  const normalizedElement = document.createElement('div');
+  normalizedElement.innerHTML = normalizeFn(received.outerHTML);
 
-  return toMatchInlineSnapshot.call(this, normalizedElement, snapshot);
+  return toMatchInlineSnapshot.call(
+    this,
+    normalizedElement.firstChild,
+    snapshot
+  );
 }
 
 declare global {


### PR DESCRIPTION
This updates the `toMatchNormalizedInlineSnapshot` matcher so we can normalize the root element itself as well, not just its children. This is useful when the root have inconsistencies across flavors.