### PR TITLE
fix(cache-hydration): normalize params returned from response

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "64.25 kB"
+      "maxSize": "64.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "64.75 kB"
+      "maxSize": "65 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",

--- a/packages/instantsearch.js/src/lib/utils/__tests__/hydrateSearchClient-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/hydrateSearchClient-test.ts
@@ -50,7 +50,7 @@ describe('hydrateSearchClient', () => {
 
     expect(setCache).toHaveBeenCalledWith(
       expect.objectContaining({
-        args: [[{ indexName: 'instant_search', params: 'params' }]],
+        args: [[{ indexName: 'instant_search', params: 'params=' }]],
         method: 'search',
       }),
       expect.objectContaining({

--- a/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
@@ -62,7 +62,7 @@ export function hydrateSearchClient(
         params: serializeQueryParameters(request.params!),
       }));
 
-      return (client as ClientV3_4).transporter.responsesCache.get(
+      return (client as unknown as ClientV3_4).transporter.responsesCache.get(
         {
           method: 'search',
           args: [requestsWithSerializedParams, ...methodArgs],
@@ -73,7 +73,7 @@ export function hydrateSearchClient(
       );
     };
 
-    (client as ClientV3_4).transporter.responsesCache.set(
+    (client as unknown as ClientV3_4).transporter.responsesCache.set(
       {
         method: 'search',
         args: cachedRequest,

--- a/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
@@ -1,10 +1,18 @@
-// @ts-nocheck (types to be fixed during actual implementation)
-import qs from 'qs';
+import type {
+  SearchClient,
+  InitialResults,
+  ClientV3_4,
+  SearchOptions,
+  SearchResponse,
+} from '../../types';
 
-import type { InitialResults, SearchClient } from '../../types';
+type ClientWithCache = SearchClient & { cache: Record<string, string> };
 
 export function hydrateSearchClient(
-  client: SearchClient,
+  client: SearchClient & {
+    _cacheHydrated?: boolean;
+    _useCache?: boolean;
+  },
   results?: InitialResults
 ) {
   if (!results) {
@@ -16,11 +24,26 @@ export function hydrateSearchClient(
   // - Third party clients (detected by the `addAlgoliaAgent` function missing)
 
   if (
-    (!client.transporter || client._cacheHydrated) &&
+    (!('transporter' in client) || client._cacheHydrated) &&
     (!client._useCache || typeof client.addAlgoliaAgent !== 'function')
   ) {
     return;
   }
+
+  const cachedRequest = Object.keys(results).map((key) =>
+    results[key].results.map((result) => ({
+      indexName: result.index,
+      // We normalize the params received from the server as they can
+      // be serialized differently depending on the engine.
+      params: serializeQueryParameters(
+        deserializeQueryParameters(result.params)
+      ),
+    }))
+  );
+  const cachedResults = Object.keys(results).reduce<Array<SearchResponse<any>>>(
+    (acc, key) => acc.concat(results[key].results),
+    []
+  );
 
   // Algoliasearch API Client >= v4
   // To hydrate the client we need to populate the cache with the data from
@@ -29,17 +52,17 @@ export function hydrateSearchClient(
   // for us to compute the key the same way as `algoliasearch-client` we need
   // to populate it on a custom key and override the `search` method to
   // search on it first.
-  if (client.transporter && !client._cacheHydrated) {
+  if ('transporter' in client && !client._cacheHydrated) {
     client._cacheHydrated = true;
 
     const baseMethod = client.search;
     client.search = (requests, ...methodArgs) => {
       const requestsWithSerializedParams = requests.map((request) => ({
         ...request,
-        params: serializeQueryParameters(request.params),
+        params: serializeQueryParameters(request.params!),
       }));
 
-      return client.transporter.responsesCache.get(
+      return (client as ClientV3_4).transporter.responsesCache.get(
         {
           method: 'search',
           args: [requestsWithSerializedParams, ...methodArgs],
@@ -50,30 +73,13 @@ export function hydrateSearchClient(
       );
     };
 
-    // Populate the cache with the data from the server
-    client.transporter.responsesCache.set(
+    (client as ClientV3_4).transporter.responsesCache.set(
       {
         method: 'search',
-        args: [
-          Object.keys(results).reduce(
-            (acc, key) =>
-              acc.concat(
-                results[key].results.map((result) => ({
-                  indexName: result.index,
-                  // We normalize the params received from the server as they can
-                  // be serialized differently depending on the engine.
-                  params: serializeQueryParameters(qs.parse(result.params)),
-                }))
-              ),
-            []
-          ),
-        ],
+        args: cachedRequest,
       },
       {
-        results: Object.keys(results).reduce(
-          (acc, key) => acc.concat(results[key].results),
-          []
-        ),
+        results: cachedResults,
       }
     );
   }
@@ -84,40 +90,36 @@ export function hydrateSearchClient(
   // a single-index result. You can find more information about the
   // computation of the key inside the client (see link below).
   // https://github.com/algolia/algoliasearch-client-javascript/blob/c27e89ff92b2a854ae6f40dc524bffe0f0cbc169/src/AlgoliaSearchCore.js#L232-L240
-  if (!client.transporter) {
+  if (!('transporter' in client)) {
     const cacheKey = `/1/indexes/*/queries_body_${JSON.stringify({
-      requests: Object.keys(results).reduce(
-        (acc, key) =>
-          acc.concat(
-            results[key].rawResults.map((result) => ({
-              indexName: result.index,
-              params: serializeQueryParameters(qs.parse(result.params)),
-            }))
-          ),
-        []
-      ),
+      requests: cachedRequest,
     })}`;
 
-    client.cache = {
-      ...client.cache,
+    (client as ClientWithCache).cache = {
+      ...(client as ClientWithCache).cache,
       [cacheKey]: JSON.stringify({
-        results: Object.keys(results).reduce(
-          (acc, key) => acc.concat(results[key].rawResults),
-          []
-        ),
+        results: Object.keys(results).map((key) => results[key].results),
       }),
     };
   }
 }
 
+function deserializeQueryParameters(parameters: string) {
+  return parameters.split('&').reduce<Record<string, any>>((acc, parameter) => {
+    const [key, value] = parameter.split('=');
+    acc[key] = value ? decodeURIComponent(value) : '';
+    return acc;
+  }, {});
+}
+
 // This function is copied from the algoliasearch v4 API Client. If modified,
 // consider updating it also in `serializeQueryParameters` from `@algolia/transporter`.
-function serializeQueryParameters(parameters) {
-  const isObjectOrArray = (value) =>
+function serializeQueryParameters(parameters: SearchOptions) {
+  const isObjectOrArray = (value: any) =>
     Object.prototype.toString.call(value) === '[object Object]' ||
     Object.prototype.toString.call(value) === '[object Array]';
 
-  const encode = (format, ...args) => {
+  const encode = (format: string, ...args: [string, any]) => {
     let i = 0;
     return format.replace(/%s/g, () => encodeURIComponent(args[i++]));
   };
@@ -127,9 +129,9 @@ function serializeQueryParameters(parameters) {
       encode(
         '%s=%s',
         key,
-        isObjectOrArray(parameters[key])
-          ? JSON.stringify(parameters[key])
-          : parameters[key]
+        isObjectOrArray(parameters[key as keyof SearchOptions])
+          ? JSON.stringify(parameters[key as keyof SearchOptions])
+          : parameters[key as keyof SearchOptions]
       )
     )
     .join('&');

--- a/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
@@ -1,4 +1,6 @@
 // @ts-nocheck (types to be fixed during actual implementation)
+import qs from 'qs';
+
 import type { InitialResults, SearchClient } from '../../types';
 
 export function hydrateSearchClient(
@@ -58,7 +60,9 @@ export function hydrateSearchClient(
               acc.concat(
                 results[key].results.map((request) => ({
                   indexName: request.index,
-                  params: request.params,
+                  // We normalize the params received from the server as they can
+                  // be serialized differently depending on the engine.
+                  params: serializeQueryParameters(qs.parse(request.params)),
                 }))
               ),
             []

--- a/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
@@ -58,11 +58,11 @@ export function hydrateSearchClient(
           Object.keys(results).reduce(
             (acc, key) =>
               acc.concat(
-                results[key].results.map((request) => ({
-                  indexName: request.index,
+                results[key].results.map((result) => ({
+                  indexName: result.index,
                   // We normalize the params received from the server as they can
                   // be serialized differently depending on the engine.
-                  params: serializeQueryParameters(qs.parse(request.params)),
+                  params: serializeQueryParameters(qs.parse(result.params)),
                 }))
               ),
             []
@@ -89,9 +89,9 @@ export function hydrateSearchClient(
       requests: Object.keys(results).reduce(
         (acc, key) =>
           acc.concat(
-            results[key].rawResults.map((request) => ({
-              indexName: request.index,
-              params: request.params,
+            results[key].rawResults.map((result) => ({
+              indexName: result.index,
+              params: serializeQueryParameters(qs.parse(result.params)),
             }))
           ),
         []


### PR DESCRIPTION
**Summary**

There are discrepancies between how different versions of the search engine serialize query parameters.
This makes it so this caching solution does not work with all engines.

**Result**

We can normalize the params returned from the request so that it matches the same format as the one used by the search client.
