### PR TITLE
feat(dynamicWidgets): accept strings for `facets`

### DIFF
--- a/packages/instantsearch.js/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/packages/instantsearch.js/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -882,5 +882,34 @@ describe('connectDynamicWidgets', () => {
         })
       );
     });
+
+    test('adds to existing facets', () => {
+      const dynamicWidgets = connectDynamicWidgets(() => {})({
+        facets: ['facet1', 'facet2'],
+        transformItems() {
+          return ['test1'];
+        },
+        widgets: [
+          connectMenu(() => {})({ attribute: 'test1' }),
+          connectHierarchicalMenu(() => {})({ attributes: ['test2', 'test3'] }),
+        ],
+      });
+
+      expect(
+        dynamicWidgets.getWidgetSearchParameters!(
+          new SearchParameters({
+            facets: ['existing'],
+          }),
+          {
+            uiState: {},
+          }
+        )
+      ).toEqual(
+        new SearchParameters({
+          facets: ['existing', 'facet1', 'facet2'],
+          maxValuesPerFacet: 20,
+        })
+      );
+    });
   });
 });

--- a/packages/instantsearch.js/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
+++ b/packages/instantsearch.js/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts
@@ -58,30 +58,40 @@ describe('connectDynamicWidgets', () => {
       ).not.toThrow();
     });
 
-    it('fails when a non-star facet is given', () => {
+    it('fails when widgets is not an array', () => {
       expect(() =>
-        connectDynamicWidgets(() => {})(
+        connectDynamicWidgets(() => {})({
           // @ts-expect-error
-          { widgets: [], facets: ['lol'] }
-        )
+          widgets: {},
+        })
       ).toThrowErrorMatchingInlineSnapshot(`
-        "The \`facets\` option only accepts [] or [\\"*\\"], you passed [\\"lol\\"]
+        "The \`widgets\` option expects an array of widgets.
 
         See documentation: https://www.algolia.com/doc/api-reference/widgets/dynamic-widgets/js/#connector"
       `);
     });
 
-    it('fails when a multiple star facets are given', () => {
+    it('fails when facets is not an array', () => {
       expect(() =>
-        connectDynamicWidgets(() => {})(
+        connectDynamicWidgets(() => {})({
+          widgets: [],
           // @ts-expect-error
-          { widgets: [], facets: ['*', '*'] }
-        )
+          facets: {},
+        })
       ).toThrowErrorMatchingInlineSnapshot(`
-        "The \`facets\` option only accepts [] or [\\"*\\"], you passed [\\"*\\",\\"*\\"]
+        "The \`facets\` option only accepts an array of facets, you passed {}
 
         See documentation: https://www.algolia.com/doc/api-reference/widgets/dynamic-widgets/js/#connector"
       `);
+    });
+
+    it('does not fail when only some facets are given', () => {
+      expect(() =>
+        connectDynamicWidgets(() => {})({
+          widgets: [],
+          facets: ['a', 'b', 'c'],
+        })
+      ).not.toThrow();
     });
 
     it('does not fail when only star facet is given', () => {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This can be useful for when you want to ensure certain facets are already requested, or know the exact list of facets to request (maximally, in the right order), to still have the advantages of request deduplication without using `*`.

Idea came up as a simplification when writing https://github.com/algolia/doc/pull/8659

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

dynamicWidgets accepts all arrays for `facets`, and sets those values by default.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
