### PR TITLE
feat(hierarchical-menu): persist refined root level count with a future flag

### DIFF
--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1392,6 +1392,7 @@ declare namespace algoliasearchHelper {
       opts: {
         sortBy?: any;
         facetOrdering?: boolean;
+        persistHierarchicalRootCount?: boolean;
       }
     ): SearchResults.FacetValue[] | SearchResults.HierarchicalFacet | undefined;
 

--- a/packages/algoliasearch-helper/src/SearchResults/index.js
+++ b/packages/algoliasearch-helper/src/SearchResults/index.js
@@ -587,24 +587,7 @@ function SearchResults(state, results, options) {
           return;
         }
 
-        // when we always get root levels, if the hits refinement is `beers > IPA` (count: 5),
-        // then the disjunctive values will be `beers` (count: 100),
-        // but we do not want to display
-        //   | beers (100)
-        //     > IPA (5)
-        // We want
-        //   | beers (5)
-        //     > IPA (5)
-        var defaultData = {};
-
-        if (currentRefinement.length > 0) {
-          var root = currentRefinement[0].split(separator)[0];
-          defaultData[root] =
-            self.hierarchicalFacets[position][attributeIndex].data[root];
-        }
-
         self.hierarchicalFacets[position][attributeIndex].data = defaultsPure(
-          defaultData,
           facetResults,
           self.hierarchicalFacets[position][attributeIndex].data
         );
@@ -673,9 +656,14 @@ SearchResults.prototype.getFacetByName = function (name) {
  * @private
  * @param {SearchResults} results the search results to search in
  * @param {string} attribute name of the faceted attribute to search for
+ * @param {string} persistHierarchicalRootCount whether to replace the count of a refined root level with the count of the actively refined parent level
  * @return {array|object} facet values. For the hierarchical facets it is an object.
  */
-function extractNormalizedFacetValues(results, attribute) {
+function extractNormalizedFacetValues(
+  results,
+  attribute,
+  persistHierarchicalRootCount
+) {
   function predicate(facet) {
     return facet.name === attribute;
   }
@@ -730,6 +718,24 @@ function extractNormalizedFacetValues(results, attribute) {
     currentRefinementSplit.unshift(attribute);
 
     setIsRefined(hierarchicalFacetValues, currentRefinementSplit, 0);
+
+    // @MAJOR: remove this legacy behaviour in next major version
+    if (
+      currentRefinementSplit.length > 2 &&
+      hierarchicalFacetValues.data &&
+      !persistHierarchicalRootCount
+    ) {
+      var rootRefinement = hierarchicalFacetValues.data.find(function (item) {
+        return item.name === currentRefinementSplit[1];
+      });
+      var parentRefinement = getHierarchicalRefinement(
+        results._state,
+        attribute,
+        currentRefinementSplit.slice(1, -1).join(separator),
+        results.hierarchicalFacets
+      );
+      rootRefinement.count = parentRefinement.count;
+    }
 
     return hierarchicalFacetValues;
   }
@@ -909,17 +915,23 @@ function getFacetOrdering(results, attribute) {
  * });
  */
 SearchResults.prototype.getFacetValues = function (attribute, opts) {
-  var facetValues = extractNormalizedFacetValues(this, attribute);
-  if (!facetValues) {
-    return undefined;
-  }
-
   var options = defaultsPure({}, opts, {
     sortBy: SearchResults.DEFAULT_SORT,
     // if no sortBy is given, attempt to sort based on facetOrdering
     // if it is given, we still allow to sort via facet ordering first
     facetOrdering: !(opts && opts.sortBy),
+    persistHierarchicalRootCount: false,
   });
+
+  var facetValues = extractNormalizedFacetValues(
+    this,
+    attribute,
+    options.persistHierarchicalRootCount
+  );
+
+  if (!facetValues) {
+    return undefined;
+  }
 
   // eslint-disable-next-line consistent-this
   var results = this;

--- a/packages/instantsearch.js/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
+++ b/packages/instantsearch.js/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
@@ -353,6 +353,8 @@ const connectHierarchicalMenu: HierarchicalMenuConnector =
           if (results) {
             const facetValues = results.getFacetValues(hierarchicalFacetName, {
               sortBy,
+              persistHierarchicalRootCount:
+                instantSearchInstance.future.persistHierarchicalRootCount,
               facetOrdering: sortBy === DEFAULT_SORT,
             });
             const facetItems =

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -171,6 +171,17 @@ export type InstantSearchOptions<
      */
     // @MAJOR: Remove legacy behaviour
     preserveSharedStateOnUnmount?: boolean;
+    /**
+     * Changes the way root levels of hierarchical facets have their count displayed.
+     *
+     * If `false` (by default), the count of the refined root level is updated to match the count of the actively refined parent level.
+     *
+     * If `true`, the count of the root level stays the same as the count of all children levels.
+     *
+     * @default false
+     */
+    // @MAJOR: Remove legacy behaviour here and in algoliasearch-helper
+    persistHierarchicalRootCount?: boolean;
   };
 };
 
@@ -178,7 +189,10 @@ export type InstantSearchStatus = 'idle' | 'loading' | 'stalled' | 'error';
 
 export const INSTANTSEARCH_FUTURE_DEFAULTS: Required<
   InstantSearchOptions['future']
-> = { preserveSharedStateOnUnmount: false };
+> = {
+  preserveSharedStateOnUnmount: false,
+  persistHierarchicalRootCount: false,
+};
 
 /**
  * The actual implementation of the InstantSearch. This is


### PR DESCRIPTION
**Summary**

The current design of hierarchical facets in InstantSearch is to show the count of the active refined parent level next to its root level. This is not necessarily what current users of InstantSearch expect, so this PR provides an option in the form a future flag, to allow them to switch to a new behaviour where the root level count is not modified in answer to refinement changes.

**Result**

Users can now choose whether they want a hierarchical facet parent count reflected in the root level, or leave the root count untouched.

FX-2671