### PR TITLE
fix(routing): ensure UiState is cleaned up allowing "undefined" for values

### DIFF
--- a/packages/instantsearch.js/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/packages/instantsearch.js/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -244,13 +244,16 @@ const connectBreadcrumb: BreadcrumbConnector = function connectBreadcrumb(
           hierarchicalFacetName
         );
 
-        return removeEmptyRefinementsFromUiState({
-          ...uiState,
-          hierarchicalMenu: {
-            ...uiState.hierarchicalMenu,
-            [hierarchicalFacetName]: path,
+        return removeEmptyRefinementsFromUiState(
+          {
+            ...uiState,
+            hierarchicalMenu: {
+              ...uiState.hierarchicalMenu,
+              [hierarchicalFacetName]: path,
+            },
           },
-        });
+          hierarchicalFacetName
+        );
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
@@ -333,29 +336,23 @@ function shiftItemsValues(array: BreadcrumbConnectorParamsItem[]) {
   }));
 }
 
-function removeEmptyRefinementsFromUiState(indexUiState: IndexUiState) {
-  const { hierarchicalMenu, ...indexUiStateBase } = indexUiState;
-
-  if (!hierarchicalMenu) {
+function removeEmptyRefinementsFromUiState(
+  indexUiState: IndexUiState,
+  attribute: string
+): IndexUiState {
+  if (!indexUiState.hierarchicalMenu) {
     return indexUiState;
   }
 
-  const connectorUiState = Object.keys(hierarchicalMenu).reduce(
-    (acc, key) => ({
-      ...acc,
-      ...(hierarchicalMenu[key].length > 0
-        ? { [key]: hierarchicalMenu[key] }
-        : {}),
-    }),
-    {}
-  );
+  if (indexUiState.hierarchicalMenu[attribute] === undefined) {
+    delete indexUiState.hierarchicalMenu[attribute];
+  }
 
-  return {
-    ...indexUiStateBase,
-    ...(Object.keys(connectorUiState).length > 0
-      ? { hierarchicalMenu: connectorUiState }
-      : {}),
-  };
+  if (Object.keys(indexUiState.hierarchicalMenu).length === 0) {
+    delete indexUiState.hierarchicalMenu;
+  }
+
+  return indexUiState;
 }
 
 export default connectBreadcrumb;

--- a/packages/instantsearch.js/src/connectors/breadcrumb/connectBreadcrumb.ts
+++ b/packages/instantsearch.js/src/connectors/breadcrumb/connectBreadcrumb.ts
@@ -344,7 +344,10 @@ function removeEmptyRefinementsFromUiState(
     return indexUiState;
   }
 
-  if (indexUiState.hierarchicalMenu[attribute] === undefined) {
+  if (
+    !indexUiState.hierarchicalMenu[attribute] ||
+    !indexUiState.hierarchicalMenu[attribute].length
+  ) {
     delete indexUiState.hierarchicalMenu[attribute];
   }
 

--- a/packages/instantsearch.js/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
+++ b/packages/instantsearch.js/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
@@ -490,7 +490,10 @@ function removeEmptyRefinementsFromUiState(
     return indexUiState;
   }
 
-  if (indexUiState.hierarchicalMenu[attribute] === undefined) {
+  if (
+    !indexUiState.hierarchicalMenu[attribute] ||
+    indexUiState.hierarchicalMenu[attribute].length === 0
+  ) {
     delete indexUiState.hierarchicalMenu[attribute];
   }
 

--- a/packages/instantsearch.js/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
+++ b/packages/instantsearch.js/src/connectors/hierarchical-menu/connectHierarchicalMenu.ts
@@ -397,13 +397,16 @@ const connectHierarchicalMenu: HierarchicalMenuConnector =
             hierarchicalFacetName
           );
 
-          return removeEmptyRefinementsFromUiState({
-            ...uiState,
-            hierarchicalMenu: {
-              ...uiState.hierarchicalMenu,
-              [hierarchicalFacetName]: path,
+          return removeEmptyRefinementsFromUiState(
+            {
+              ...uiState,
+              hierarchicalMenu: {
+                ...uiState.hierarchicalMenu,
+                [hierarchicalFacetName]: path,
+              },
             },
-          });
+            hierarchicalFacetName
+          );
         },
 
         getWidgetSearchParameters(searchParameters, { uiState }) {
@@ -479,29 +482,23 @@ As this is not supported, please make sure to remove this other widget or this H
     };
   };
 
-function removeEmptyRefinementsFromUiState(indexUiState: IndexUiState) {
-  const { hierarchicalMenu, ...indexUiStateBase } = indexUiState;
-
-  if (!hierarchicalMenu) {
+function removeEmptyRefinementsFromUiState(
+  indexUiState: IndexUiState,
+  attribute: string
+): IndexUiState {
+  if (!indexUiState.hierarchicalMenu) {
     return indexUiState;
   }
 
-  const connectorUiState = Object.keys(hierarchicalMenu).reduce(
-    (acc, key) => ({
-      ...acc,
-      ...(hierarchicalMenu[key].length > 0
-        ? { [key]: hierarchicalMenu[key] }
-        : {}),
-    }),
-    {}
-  );
+  if (indexUiState.hierarchicalMenu[attribute] === undefined) {
+    delete indexUiState.hierarchicalMenu[attribute];
+  }
 
-  return {
-    ...indexUiStateBase,
-    ...(Object.keys(connectorUiState).length > 0
-      ? { hierarchicalMenu: connectorUiState }
-      : {}),
-  };
+  if (Object.keys(indexUiState.hierarchicalMenu).length === 0) {
+    delete indexUiState.hierarchicalMenu;
+  }
+
+  return indexUiState;
 }
 
 export default connectHierarchicalMenu;

--- a/packages/instantsearch.js/src/connectors/menu/connectMenu.ts
+++ b/packages/instantsearch.js/src/connectors/menu/connectMenu.ts
@@ -334,13 +334,16 @@ const connectMenu: MenuConnector = function connectMenu(
         const [value] =
           searchParameters.getHierarchicalFacetBreadcrumb(attribute);
 
-        return removeEmptyRefinementsFromUiState({
-          ...uiState,
-          menu: {
-            ...uiState.menu,
-            [attribute]: value,
+        return removeEmptyRefinementsFromUiState(
+          {
+            ...uiState,
+            menu: {
+              ...uiState.menu,
+              [attribute]: value,
+            },
           },
-        });
+          attribute
+        );
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
@@ -397,27 +400,23 @@ As this is not supported, please make sure to remove this other widget or this M
   };
 };
 
-function removeEmptyRefinementsFromUiState(indexUiState: IndexUiState) {
-  const { menu, ...indexUiStateBase } = indexUiState;
-
-  if (!menu) {
+function removeEmptyRefinementsFromUiState(
+  indexUiState: IndexUiState,
+  attribute: string
+): IndexUiState {
+  if (!indexUiState.menu) {
     return indexUiState;
   }
 
-  const connectorUiState = Object.keys(menu).reduce(
-    (acc, key) => ({
-      ...acc,
-      ...(menu[key]?.length > 0 ? { [key]: menu[key] } : {}),
-    }),
-    {}
-  );
+  if (indexUiState.menu[attribute] === undefined) {
+    delete indexUiState.menu[attribute];
+  }
 
-  return {
-    ...indexUiStateBase,
-    ...(Object.keys(connectorUiState).length > 0
-      ? { menu: connectorUiState }
-      : {}),
-  };
+  if (Object.keys(indexUiState.menu).length === 0) {
+    delete indexUiState.menu;
+  }
+
+  return indexUiState;
 }
 
 export default connectMenu;

--- a/packages/instantsearch.js/src/connectors/numeric-menu/connectNumericMenu.ts
+++ b/packages/instantsearch.js/src/connectors/numeric-menu/connectNumericMenu.ts
@@ -235,13 +235,16 @@ const connectNumericMenu: NumericMenuConnector = function connectNumericMenu(
         const min = (values['>='] && values['>='][0]) || '';
         const max = (values['<='] && values['<='][0]) || '';
 
-        return removeEmptyRefinementsFromUiState({
-          ...uiState,
-          numericMenu: {
-            ...uiState.numericMenu,
-            [attribute]: `${min}:${max}`,
+        return removeEmptyRefinementsFromUiState(
+          {
+            ...uiState,
+            numericMenu: {
+              ...uiState.numericMenu,
+              [attribute]: `${min}:${max}`,
+            },
           },
-        });
+          attribute
+        );
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
@@ -483,27 +486,23 @@ function hasNumericRefinement(
   );
 }
 
-function removeEmptyRefinementsFromUiState(indexUiState: IndexUiState) {
-  const { numericMenu, ...indexUiStateBase } = indexUiState;
-
-  if (!numericMenu) {
+function removeEmptyRefinementsFromUiState(
+  indexUiState: IndexUiState,
+  attribute: string
+): IndexUiState {
+  if (!indexUiState.numericMenu) {
     return indexUiState;
   }
 
-  const connectorUiState = Object.keys(numericMenu).reduce(
-    (acc, key) => ({
-      ...acc,
-      ...(numericMenu[key] !== ':' ? { [key]: numericMenu[key] } : {}),
-    }),
-    {}
-  );
+  if (indexUiState.numericMenu[attribute] === ':') {
+    delete indexUiState.numericMenu[attribute];
+  }
 
-  return {
-    ...indexUiStateBase,
-    ...(Object.keys(connectorUiState).length > 0
-      ? { numericMenu: connectorUiState }
-      : {}),
-  };
+  if (Object.keys(indexUiState.numericMenu).length === 0) {
+    delete indexUiState.numericMenu;
+  }
+
+  return indexUiState;
 }
 
 export default connectNumericMenu;

--- a/packages/instantsearch.js/src/connectors/rating-menu/connectRatingMenu.ts
+++ b/packages/instantsearch.js/src/connectors/rating-menu/connectRatingMenu.ts
@@ -479,16 +479,16 @@ function removeEmptyRefinementsFromUiState(
   indexUiState: IndexUiState,
   attribute: string
 ): IndexUiState {
-  if (!indexUiState.numericMenu) {
+  if (!indexUiState.ratingMenu) {
     return indexUiState;
   }
 
-  if (typeof indexUiState.numericMenu[attribute] !== 'number') {
-    delete indexUiState.numericMenu[attribute];
+  if (typeof indexUiState.ratingMenu[attribute] !== 'number') {
+    delete indexUiState.ratingMenu[attribute];
   }
 
-  if (Object.keys(indexUiState.numericMenu).length === 0) {
-    delete indexUiState.numericMenu;
+  if (Object.keys(indexUiState.ratingMenu).length === 0) {
+    delete indexUiState.ratingMenu;
   }
 
   return indexUiState;

--- a/packages/instantsearch.js/src/connectors/rating-menu/connectRatingMenu.ts
+++ b/packages/instantsearch.js/src/connectors/rating-menu/connectRatingMenu.ts
@@ -439,13 +439,16 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
       getWidgetUiState(uiState, { searchParameters }) {
         const value = getRefinedStar(searchParameters);
 
-        return removeEmptyRefinementsFromUiState({
-          ...uiState,
-          ratingMenu: {
-            ...uiState.ratingMenu,
-            [attribute]: typeof value === 'number' ? value : undefined,
+        return removeEmptyRefinementsFromUiState(
+          {
+            ...uiState,
+            ratingMenu: {
+              ...uiState.ratingMenu,
+              [attribute]: typeof value === 'number' ? value : undefined,
+            },
           },
-        });
+          attribute
+        );
       },
 
       getWidgetSearchParameters(searchParameters, { uiState }) {
@@ -472,29 +475,23 @@ const connectRatingMenu: RatingMenuConnector = function connectRatingMenu(
   };
 };
 
-function removeEmptyRefinementsFromUiState(indexUiState: IndexUiState) {
-  const { ratingMenu, ...indexUiStateBase } = indexUiState;
-
-  if (!ratingMenu) {
+function removeEmptyRefinementsFromUiState(
+  indexUiState: IndexUiState,
+  attribute: string
+): IndexUiState {
+  if (!indexUiState.numericMenu) {
     return indexUiState;
   }
 
-  const connectorUiState = Object.keys(ratingMenu).reduce(
-    (acc, key) => ({
-      ...acc,
-      ...(typeof ratingMenu[key] === 'number'
-        ? { [key]: ratingMenu[key] }
-        : {}),
-    }),
-    {}
-  );
+  if (typeof indexUiState.numericMenu[attribute] !== 'number') {
+    delete indexUiState.numericMenu[attribute];
+  }
 
-  return {
-    ...indexUiStateBase,
-    ...(Object.keys(connectorUiState).length > 0
-      ? { ratingMenu: connectorUiState }
-      : {}),
-  };
+  if (Object.keys(indexUiState.numericMenu).length === 0) {
+    delete indexUiState.numericMenu;
+  }
+
+  return indexUiState;
 }
 
 export default connectRatingMenu;

--- a/packages/instantsearch.js/src/connectors/refinement-list/connectRefinementList.ts
+++ b/packages/instantsearch.js/src/connectors/refinement-list/connectRefinementList.ts
@@ -570,7 +570,10 @@ function removeEmptyRefinementsFromUiState(
     return indexUiState;
   }
 
-  if (indexUiState.refinementList[attribute] === undefined) {
+  if (
+    !indexUiState.refinementList[attribute] ||
+    indexUiState.refinementList[attribute].length === 0
+  ) {
     delete indexUiState.refinementList[attribute];
   }
 

--- a/packages/instantsearch.js/src/connectors/refinement-list/connectRefinementList.ts
+++ b/packages/instantsearch.js/src/connectors/refinement-list/connectRefinementList.ts
@@ -476,13 +476,16 @@ const connectRefinementList: RefinementListConnector =
               ? searchParameters.getDisjunctiveRefinements(attribute)
               : searchParameters.getConjunctiveRefinements(attribute);
 
-          return removeEmptyRefinementsFromUiState({
-            ...uiState,
-            refinementList: {
-              ...uiState.refinementList,
-              [attribute]: values,
+          return removeEmptyRefinementsFromUiState(
+            {
+              ...uiState,
+              refinementList: {
+                ...uiState.refinementList,
+                [attribute]: values,
+              },
             },
-          });
+            attribute
+          );
         },
 
         getWidgetSearchParameters(searchParameters, { uiState }) {
@@ -559,27 +562,23 @@ As this is not supported, please make sure to only use this attribute with one o
     };
   };
 
-function removeEmptyRefinementsFromUiState(indexUiState: IndexUiState) {
-  const { refinementList, ...indexUiStateBase } = indexUiState;
-
-  if (!refinementList) {
+function removeEmptyRefinementsFromUiState(
+  indexUiState: IndexUiState,
+  attribute: string
+): IndexUiState {
+  if (!indexUiState.refinementList) {
     return indexUiState;
   }
 
-  const connectorUiState = Object.keys(refinementList).reduce(
-    (acc, key) => ({
-      ...acc,
-      ...(refinementList[key].length > 0 ? { [key]: refinementList[key] } : {}),
-    }),
-    {}
-  );
+  if (indexUiState.refinementList[attribute] === undefined) {
+    delete indexUiState.refinementList[attribute];
+  }
 
-  return {
-    ...indexUiStateBase,
-    ...(Object.keys(connectorUiState).length > 0
-      ? { refinementList: connectorUiState }
-      : {}),
-  };
+  if (Object.keys(indexUiState.refinementList).length === 0) {
+    delete indexUiState.refinementList;
+  }
+
+  return indexUiState;
 }
 
 export default connectRefinementList;

--- a/tests/common/common.ts
+++ b/tests/common/common.ts
@@ -69,7 +69,7 @@ export function runTestSuites<
   testSetups: TestSetupsMap<TTestSuites>;
   testOptions: TestOptionsMap<TTestSuites>;
 }) {
-  test.skip('has all the tests', () => {
+  test('has all the tests', () => {
     expect(Object.keys(testSetups).sort()).toEqual(
       Object.keys(testSuites).sort()
     );

--- a/tests/common/common.ts
+++ b/tests/common/common.ts
@@ -31,6 +31,9 @@ export type TestOptions = {
   skippedTests?: SkippedTests;
 };
 
+export type SetupOptions<TSetup extends TestSetup<any, any>> =
+  Parameters<TSetup>[0];
+
 export type AnyTestSuite = (
   setup: TestSetup<Record<string, unknown>, any>,
   options: TestOptions
@@ -66,7 +69,7 @@ export function runTestSuites<
   testSetups: TestSetupsMap<TTestSuites>;
   testOptions: TestOptionsMap<TTestSuites>;
 }) {
-  test('has all the tests', () => {
+  test.skip('has all the tests', () => {
     expect(Object.keys(testSetups).sort()).toEqual(
       Object.keys(testSuites).sort()
     );

--- a/tests/common/connectors/current-refinements/routing.ts
+++ b/tests/common/connectors/current-refinements/routing.ts
@@ -11,7 +11,7 @@ import { simple } from 'instantsearch.js/es/lib/stateMappings';
 import { skippableDescribe } from '../../common';
 
 import type { CurrentRefinementsConnectorSetup } from '.';
-import type { TestOptions } from '../../common';
+import type { SetupOptions, TestOptions } from '../../common';
 
 export function createRoutingTests(
   setup: CurrentRefinementsConnectorSetup,
@@ -30,7 +30,7 @@ export function createRoutingTests(
         const delay = 100;
         const margin = 10;
         const router = history();
-        const options = {
+        const options: SetupOptions<CurrentRefinementsConnectorSetup> = {
           instantSearchOptions: {
             indexName: 'indexName',
             routing: {
@@ -119,7 +119,7 @@ export function createRoutingTests(
         const delay = 100;
         const margin = 10;
         const router = history();
-        const options = {
+        const options: SetupOptions<CurrentRefinementsConnectorSetup> = {
           instantSearchOptions: {
             indexName: 'indexName',
             routing: {

--- a/tests/common/connectors/hierarchical-menu/routing.ts
+++ b/tests/common/connectors/hierarchical-menu/routing.ts
@@ -10,7 +10,7 @@ import { history } from 'instantsearch.js/es/lib/routers';
 import { simple } from 'instantsearch.js/es/lib/stateMappings';
 
 import type { HierarchicalMenuConnectorSetup } from '.';
-import type { TestOptions } from '../../common';
+import type { SetupOptions, TestOptions } from '../../common';
 
 export function createRoutingTests(
   setup: HierarchicalMenuConnectorSetup,
@@ -30,7 +30,7 @@ export function createRoutingTests(
         const margin = 10;
         const attributes = ['1', '2'];
         const router = history();
-        const options = {
+        const options: SetupOptions<HierarchicalMenuConnectorSetup> = {
           instantSearchOptions: {
             indexName: 'indexName',
             routing: {
@@ -197,6 +197,82 @@ export function createRoutingTests(
             'href',
             router.createURL({})
           );
+        }
+      });
+
+      test('works with unsafe "routeToState" implementation', async () => {
+        const delay = 100;
+        const attributes = ['brand'];
+        const router = history();
+        const options: SetupOptions<HierarchicalMenuConnectorSetup> = {
+          instantSearchOptions: {
+            indexName: 'indexName',
+            routing: {
+              stateMapping: {
+                stateToRoute(uiState) {
+                  return uiState;
+                },
+                // @ts-expect-error returning undefined instead of real UiState for attribute keys
+                routeToState(routeState) {
+                  return {
+                    ...routeState,
+                    indexName: {
+                      hierarchicalMenu: {
+                        other: routeState.indexName?.hierarchicalMenu?.other,
+                        [attributes[0]]:
+                          routeState.indexName?.hierarchicalMenu?.[
+                            attributes[0]
+                          ],
+                      },
+                    },
+                  };
+                },
+              },
+              router,
+            },
+            searchClient: createSearchClient({
+              search: jest.fn(async (requests) => {
+                await wait(delay);
+                return createMultiSearchResponse(
+                  ...requests.map(() =>
+                    createSingleSearchResponse({
+                      facets: {
+                        [attributes[0]]: {
+                          Samsung: 100,
+                          Apple: 200,
+                        },
+                      },
+                    })
+                  )
+                );
+              }),
+            }),
+          },
+          widgetParams: { attributes },
+        };
+
+        await setup(options);
+
+        // Before widgets are completely mounted
+        {
+          // Vue doesn't render anything on first render, so we don't need
+          // to check that the URL is correct.
+          const link = document.querySelector(
+            '[data-testid="HierarchicalMenu-link"]'
+          );
+          if (link) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(link).toHaveAttribute(
+              'href',
+              router.createURL({
+                indexName: {
+                  hierarchicalMenu: {
+                    [attributes[0]]: ['value'],
+                  },
+                },
+              })
+            );
+          }
         }
       });
     });

--- a/tests/common/connectors/hits-per-page/routing.ts
+++ b/tests/common/connectors/hits-per-page/routing.ts
@@ -9,7 +9,7 @@ import { history } from 'instantsearch.js/es/lib/routers';
 import { simple } from 'instantsearch.js/es/lib/stateMappings';
 
 import type { HitsPerPageConnectorSetup } from '.';
-import type { TestOptions } from '../../common';
+import type { SetupOptions, TestOptions } from '../../common';
 
 export function createRoutingTests(
   setup: HitsPerPageConnectorSetup,
@@ -28,7 +28,7 @@ export function createRoutingTests(
         const delay = 100;
         const margin = 10;
         const router = history();
-        const options = {
+        const options: SetupOptions<HitsPerPageConnectorSetup> = {
           instantSearchOptions: {
             indexName: 'indexName',
             routing: {

--- a/tests/common/connectors/numeric-menu/routing.ts
+++ b/tests/common/connectors/numeric-menu/routing.ts
@@ -9,7 +9,7 @@ import { history } from 'instantsearch.js/es/lib/routers';
 import { simple } from 'instantsearch.js/es/lib/stateMappings';
 
 import type { NumericMenuConnectorSetup } from '.';
-import type { TestOptions } from '../../common';
+import type { SetupOptions, TestOptions } from '../../common';
 
 export function createRoutingTests(
   setup: NumericMenuConnectorSetup,
@@ -29,7 +29,7 @@ export function createRoutingTests(
         const margin = 10;
         const router = history();
         const attribute = 'price';
-        const options = {
+        const options: SetupOptions<NumericMenuConnectorSetup> = {
           instantSearchOptions: {
             indexName: 'indexName',
             routing: {
@@ -85,6 +85,74 @@ export function createRoutingTests(
               indexName: { numericMenu: { [attribute]: '500:' } },
             })
           );
+        }
+      });
+
+      test('works with unsafe "routeToState" implementation', async () => {
+        const delay = 100;
+        const attribute = 'range';
+        const router = history();
+        const options: SetupOptions<NumericMenuConnectorSetup> = {
+          instantSearchOptions: {
+            indexName: 'indexName',
+            routing: {
+              stateMapping: {
+                stateToRoute(uiState) {
+                  return uiState;
+                },
+                // @ts-expect-error returning undefined instead of real UiState for attribute keys
+                routeToState(routeState) {
+                  return {
+                    ...routeState,
+                    indexName: {
+                      numericMenu: {
+                        other: routeState.indexName?.numericMenu?.other,
+                        [attribute]:
+                          routeState.indexName?.numericMenu?.[attribute],
+                      },
+                    },
+                  };
+                },
+              },
+              router,
+            },
+            searchClient: createSearchClient({
+              search: jest.fn(async (requests) => {
+                await wait(delay);
+                return createMultiSearchResponse(
+                  requests.map(() => createSingleSearchResponse({}))
+                );
+              }),
+            }),
+          },
+          widgetParams: {
+            attribute,
+            items: [{ label: 'All' }, { label: 'Less than 500$', end: 500 }],
+          },
+        };
+
+        await setup(options);
+
+        // Before widgets are completely mounted
+        {
+          // Vue doesn't render anything on first render, so we don't need
+          // to check that the URL is correct.
+          const link = document.querySelector(
+            '[data-testid="NumericMenu-link"]'
+          );
+          if (link) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(link).toHaveAttribute(
+              'href',
+              router.createURL({
+                indexName: {
+                  numericMenu: {
+                    [attribute]: '500:',
+                  },
+                },
+              })
+            );
+          }
         }
       });
     });

--- a/tests/common/connectors/numeric-menu/routing.ts
+++ b/tests/common/connectors/numeric-menu/routing.ts
@@ -120,7 +120,7 @@ export function createRoutingTests(
               search: jest.fn(async (requests) => {
                 await wait(delay);
                 return createMultiSearchResponse(
-                  requests.map(() => createSingleSearchResponse({}))
+                  ...requests.map(() => createSingleSearchResponse({}))
                 );
               }),
             }),

--- a/tests/common/connectors/pagination/routing.ts
+++ b/tests/common/connectors/pagination/routing.ts
@@ -9,7 +9,7 @@ import { history } from 'instantsearch.js/es/lib/routers';
 import { simple } from 'instantsearch.js/es/lib/stateMappings';
 
 import type { PaginationConnectorSetup } from '.';
-import type { TestOptions } from '../../common';
+import type { SetupOptions, TestOptions } from '../../common';
 
 export function createRoutingTests(
   setup: PaginationConnectorSetup,
@@ -28,7 +28,7 @@ export function createRoutingTests(
         const delay = 100;
         const margin = 10;
         const router = history();
-        const options = {
+        const options: SetupOptions<PaginationConnectorSetup> = {
           instantSearchOptions: {
             indexName: 'indexName',
             routing: {

--- a/tests/common/connectors/rating-menu/routing.ts
+++ b/tests/common/connectors/rating-menu/routing.ts
@@ -10,7 +10,7 @@ import { history } from 'instantsearch.js/es/lib/routers';
 import { simple } from 'instantsearch.js/es/lib/stateMappings';
 
 import type { RatingMenuConnectorSetup } from '.';
-import type { TestOptions } from '../../common';
+import type { SetupOptions, TestOptions } from '../../common';
 
 export function createRoutingTests(
   setup: RatingMenuConnectorSetup,
@@ -30,7 +30,7 @@ export function createRoutingTests(
         const margin = 10;
         const router = history();
         const attribute = 'rating';
-        const options = {
+        const options: SetupOptions<RatingMenuConnectorSetup> = {
           instantSearchOptions: {
             indexName: 'indexName',
             routing: {
@@ -129,6 +129,82 @@ export function createRoutingTests(
               indexName: { ratingMenu: { [attribute]: 5 } },
             })
           );
+        }
+      });
+
+      test('works with unsafe "routeToState" implementation', async () => {
+        const delay = 100;
+        const attribute = 'free_shipping';
+        const router = history();
+        const options: SetupOptions<RatingMenuConnectorSetup> = {
+          instantSearchOptions: {
+            indexName: 'indexName',
+            routing: {
+              stateMapping: {
+                stateToRoute(uiState) {
+                  return uiState;
+                },
+                routeToState(routeState) {
+                  return {
+                    ...routeState,
+                    indexName: {
+                      ratingMenu: {
+                        other: routeState.indexName?.ratingMenu?.other,
+                        [attribute]:
+                          routeState.indexName?.ratingMenu?.[attribute],
+                      },
+                    },
+                  };
+                },
+              },
+              router,
+            },
+            searchClient: createSearchClient({
+              search: jest.fn(async (requests) => {
+                await wait(delay);
+                return createMultiSearchResponse(
+                  ...requests.map(() =>
+                    createSingleSearchResponse({
+                      facets: {
+                        [attribute]: {
+                          5: 4,
+                          4: 6,
+                          3: 2,
+                          2: 1,
+                          1: 3,
+                        },
+                      },
+                    })
+                  )
+                );
+              }),
+            }),
+          },
+          widgetParams: { attribute },
+        };
+
+        await setup(options);
+
+        // Before widgets are completely mounted
+        {
+          // Vue doesn't render anything on first render, so we don't need
+          // to check that the URL is correct.
+          const link = document.querySelector(
+            '[data-testid="RatingMenu-link"]'
+          );
+          if (link) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(link).toHaveAttribute(
+              'href',
+              router.createURL({
+                indexName: {
+                  ratingMenu: {
+                    [attribute]: 5,
+                  },
+                },
+              })
+            );
+          }
         }
       });
     });

--- a/tests/common/connectors/refinement-list/routing.ts
+++ b/tests/common/connectors/refinement-list/routing.ts
@@ -10,7 +10,7 @@ import { history } from 'instantsearch.js/es/lib/routers';
 import { simple } from 'instantsearch.js/es/lib/stateMappings';
 
 import type { RefinementListConnectorSetup } from '.';
-import type { TestOptions } from '../../common';
+import type { TestOptions, SetupOptions } from '../../common';
 
 export function createRoutingTests(
   setup: RefinementListConnectorSetup,
@@ -30,7 +30,7 @@ export function createRoutingTests(
         const margin = 10;
         const attribute = 'brand';
         const router = history();
-        const options = {
+        const options: SetupOptions<RefinementListConnectorSetup> = {
           instantSearchOptions: {
             indexName: 'indexName',
             routing: {
@@ -202,6 +202,80 @@ export function createRoutingTests(
             'href',
             router.createURL({})
           );
+        }
+      });
+
+      test('works with unsafe "routeToState" implementation', async () => {
+        const delay = 100;
+        const attribute = 'brand';
+        const router = history();
+        const options: SetupOptions<RefinementListConnectorSetup> = {
+          instantSearchOptions: {
+            indexName: 'indexName',
+            routing: {
+              stateMapping: {
+                stateToRoute(uiState) {
+                  return uiState;
+                },
+                // @ts-expect-error returning undefined instead of real UiState for attribute keys
+                routeToState(routeState) {
+                  return {
+                    ...routeState,
+                    indexName: {
+                      refinementList: {
+                        other: routeState.indexName?.refinementList?.other,
+                        [attribute]:
+                          routeState.indexName?.refinementList?.[attribute],
+                      },
+                    },
+                  };
+                },
+              },
+              router,
+            },
+            searchClient: createSearchClient({
+              search: jest.fn(async (requests) => {
+                await wait(delay);
+                return createMultiSearchResponse(
+                  ...requests.map(() =>
+                    createSingleSearchResponse({
+                      facets: {
+                        [attribute]: {
+                          Samsung: 100,
+                          Apple: 200,
+                        },
+                      },
+                    })
+                  )
+                );
+              }),
+            }),
+          },
+          widgetParams: { attribute },
+        };
+
+        await setup(options);
+
+        // Before widgets are completely mounted
+        {
+          // Vue doesn't render anything on first render, so we don't need
+          // to check that the URL is correct.
+          const link = document.querySelector(
+            '[data-testid="RefinementList-link"]'
+          );
+          if (link) {
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(link).toHaveAttribute(
+              'href',
+              router.createURL({
+                indexName: {
+                  refinementList: {
+                    [attribute]: ['value'],
+                  },
+                },
+              })
+            );
+          }
         }
       });
     });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Since #5912, we ensure to clean the UiState from empty values, however this was done in a slightly inefficient (looping over values) and unsafe (no checking for undefined) way, as the types implied that RouteState/UiState always is completely given (if you're using TypeScript that's actually the case, you'd get an error returning `undefined` for refinementList[attribute] for example).

**Result**

- Simplified the UiState cleaning
- ensure `undefined` doesn't cause issues
- add new test to each `connectors/*/routing` where relevant (pushed the tests separately to show they fail with current implementation: https://app.circleci.com/pipelines/github/algolia/instantsearch/9831/workflows/cba7210e-6955-4459-8c82-307d77319955/jobs/47848/tests)

fixes https://github.com/algolia/instantsearch/issues/5954

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
