### PR TITLE
feat(insights): update default version to support `authenticatedUserToken`

### DIFF
--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -38,7 +38,7 @@
     "htm": "^3.0.0",
     "preact": "^10.10.0",
     "qs": "^6.5.1 < 6.10",
-    "search-insights": "^2.6.0"
+    "search-insights": "^2.13.0"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.1 < 6"

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -608,7 +608,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
     });
 
     test('insights: options passes options to middleware', () => {
-      const insightsClient = Object.assign(jest.fn(), { version: '2.6.0' });
+      const insightsClient = Object.assign(jest.fn(), { version: '2.13.0' });
       const search = new InstantSearch({
         searchClient: createSearchClientWithAutomaticInsightsOptedIn(),
         indexName: 'test',

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -183,7 +183,7 @@ describe('insights', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.13.0/dist/search-insights.min.js"
           />
         </body>
       `);
@@ -226,7 +226,7 @@ describe('insights', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.13.0/dist/search-insights.min.js"
           />
         </body>
       `);
@@ -246,7 +246,7 @@ describe('insights', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.13.0/dist/search-insights.min.js"
           />
         </body>
       `);

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -40,7 +40,7 @@ export type InsightsProps<
   $$automatic?: boolean;
 };
 
-const ALGOLIA_INSIGHTS_VERSION = '2.6.0';
+const ALGOLIA_INSIGHTS_VERSION = '2.13.0';
 const ALGOLIA_INSIGHTS_SRC = `https://cdn.jsdelivr.net/npm/search-insights@${ALGOLIA_INSIGHTS_VERSION}/dist/search-insights.min.js`;
 
 export type InsightsClientWithGlobals = InsightsClient & {

--- a/packages/react-instantsearch-core/src/__tests__/insights.test.tsx
+++ b/packages/react-instantsearch-core/src/__tests__/insights.test.tsx
@@ -29,7 +29,7 @@ describe('insights', () => {
       <body>
         <div />
         <script
-          src="https://cdn.jsdelivr.net/npm/search-insights@2.6.0/dist/search-insights.min.js"
+          src="https://cdn.jsdelivr.net/npm/search-insights@2.13.0/dist/search-insights.min.js"
         />
       </body>
     `);

--- a/tests/common/shared/insights.ts
+++ b/tests/common/shared/insights.ts
@@ -25,7 +25,7 @@ export function createInsightsTests(
         const delay = 100;
         const margin = 10;
         const attribute = 'one';
-        window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+        window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
 
         const options = {
           instantSearchOptions: {
@@ -109,7 +109,7 @@ export function createInsightsTests(
         const delay = 100;
         const margin = 10;
         const attribute = 'one';
-        window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+        window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
 
         const options = {
           instantSearchOptions: {

--- a/tests/common/widgets/hits/insights.ts
+++ b/tests/common/widgets/hits/insights.ts
@@ -26,7 +26,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -140,7 +140,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 25;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -276,7 +276,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -358,7 +358,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -447,7 +447,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -533,7 +533,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -630,7 +630,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -712,7 +712,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',

--- a/tests/common/widgets/infinite-hits/insights.ts
+++ b/tests/common/widgets/infinite-hits/insights.ts
@@ -26,7 +26,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -140,7 +140,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 25;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -276,7 +276,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -358,7 +358,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -447,7 +447,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -533,7 +533,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -630,7 +630,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -712,7 +712,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.6.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',

--- a/tests/mocks/createInsightsClient.ts
+++ b/tests/mocks/createInsightsClient.ts
@@ -15,8 +15,8 @@ try {
   delete window.AlgoliaAnalyticsObject;
 } catch (error) {} // eslint-disable-line no-empty
 
-export function createInsights<TVersion extends string | undefined = '2.6.0'>({
-  forceVersion = '2.6.0',
+export function createInsights<TVersion extends string | undefined = '2.13.0'>({
+  forceVersion = '2.13.0',
 }: {
   forceVersion?: TVersion;
 } = {}) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -27972,10 +27972,10 @@ scule@^0.2.1:
   resolved "https://registry.yarnpkg.com/scule/-/scule-0.2.1.tgz#0c1dc847b18e07219ae9a3832f2f83224e2079dc"
   integrity sha512-M9gnWtn3J0W+UhJOHmBxBTwv8mZCan5i1Himp60t6vvZcor0wr+IM0URKmIglsWJ7bRujNAVVN77fp+uZaWoKg==
 
-search-insights@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.6.0.tgz#bb8771a73b83c4a0f1f207c2f64fea01acd3e7d0"
-  integrity sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw==
+search-insights@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.13.0.tgz#a79fdcf4b5dad2fba8975b06f2ebc37a865032b7"
+  integrity sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==
 
 section-matter@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Summary**

This PR sets updates the `search-insights` dependency and the version retrieved at runtime to the latest. This gives the ability to set `authenticatedUserToken` in Insights init props without requiring users to manually load the library.
