### PR TITLE
test(versions): add "insights" test

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:ci": "./scripts/retry.sh 3 'jest --maxWorkers=4 --ci' && lerna run test --concurrency=1",
     "test:size": "bundlesize",
     "test:exports": "lerna run test:exports",
-    "test:versions": "./tests/versions/index.js",
+    "test:versions": "./tests/versions/index.mjs",
     "test:e2e": "yarn test:e2e:local",
     "test:e2e:local": "wdio scripts/wdio/local.conf.js",
     "test:e2e:saucelabs": "wdio scripts/wdio/saucelabs.conf.js",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Ensure that search-insights is always on the latest version on CI

requires #5958 of course to pass CI

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

We are warned in CI if there's a newer search-insights version available

example failing run: https://app.circleci.com/pipelines/github/algolia/instantsearch/9868/workflows/c1d28ba1-bcfd-4c1e-920c-b91e33ccf86a/jobs/47989
example passing run: https://app.circleci.com/pipelines/github/algolia/instantsearch/9872/workflows/0c60a622-0070-4dd9-a45b-d9a0e68a91bc/jobs/48022


(note: you can ignore netlify failure, it ran correctly here: https://app.netlify.com/sites/instantsearchjs/deploys/65784298cf0a014abe7cfd9e, seems like just the GitHub status didn't work)

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
