### PR TITLE
chore(examples): update links in next example

### DIFF
--- a/examples/react/next-routing/pages/index.tsx
+++ b/examples/react/next-routing/pages/index.tsx
@@ -33,7 +33,7 @@ type HitProps = {
 function Hit({ hit }: HitProps) {
   return (
     <>
-      <Link href="/other-page" passHref className="Hit-label">
+      <Link href="/other-page" className="Hit-label">
         <Highlight hit={hit} attribute="name" />
       </Link>
       <span className="Hit-price">${hit.price}</span>
@@ -54,9 +54,7 @@ export default function HomePage({ serverState, url }: HomePageProps) {
       </Head>
 
       {/* If you have navigation links outside of InstantSearch */}
-      <Link href="/?instant_search%5Bquery%5D=apple" passHref>
-        Prefilled query
-      </Link>
+      <Link href="/?instant_search%5Bquery%5D=apple">Prefilled query</Link>
 
       <InstantSearch
         searchClient={client}

--- a/examples/react/next-routing/pages/index.tsx
+++ b/examples/react/next-routing/pages/index.tsx
@@ -34,9 +34,7 @@ function Hit({ hit }: HitProps) {
   return (
     <>
       <Link href="/other-page" passHref className="Hit-label">
-        <a>
-          <Highlight hit={hit} attribute="name" />
-        </a>
+        <Highlight hit={hit} attribute="name" />
       </Link>
       <span className="Hit-price">${hit.price}</span>
     </>
@@ -57,7 +55,7 @@ export default function HomePage({ serverState, url }: HomePageProps) {
 
       {/* If you have navigation links outside of InstantSearch */}
       <Link href="/?instant_search%5Bquery%5D=apple" passHref>
-        <a>Prefilled query</a>
+        Prefilled query
       </Link>
 
       <InstantSearch


### PR DESCRIPTION
Next.js 13 changes how `<Link>` are rendered by having themselves an `<a>` tag, making implementations where `<a>` is in the userland code invalid.

This PR updates the references to `<Link>` in our examples to make them satisfy the new behaviour.

See: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor