### PR TITLE
test(toggle): add explicit label test

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
@@ -375,12 +375,19 @@ const testSetups: TestSetupsMap<TestSuites> = {
       })
       .start();
   },
-  createToggleRefinementWidgetTests({ instantSearchOptions, widgetParams }) {
+  createToggleRefinementWidgetTests({
+    instantSearchOptions,
+    // @ts-expect-error `label` is not part of the props for InstantSearch.js, but is for the other flavors
+    widgetParams: { label, ...widgetParams },
+  }) {
     instantsearch(instantSearchOptions)
       .addWidgets([
         toggleRefinement({
           container: document.body.appendChild(document.createElement('div')),
           ...widgetParams,
+          templates: {
+            labelText: label,
+          },
         }),
       ])
       .on('error', () => {

--- a/packages/instantsearch.js/src/widgets/toggle-refinement/toggle-refinement.tsx
+++ b/packages/instantsearch.js/src/widgets/toggle-refinement/toggle-refinement.tsx
@@ -21,7 +21,6 @@ import type {
 import type {
   ToggleRefinementConnectorParams,
   ToggleRefinementWidgetDescription,
-  ToggleRefinementValue,
   ToggleRefinementRenderState,
 } from '../../connectors/toggle-refinement/connectToggleRefinement';
 import type { PreparedTemplateProps } from '../../lib/templating';
@@ -99,7 +98,7 @@ export type ToggleRefinementTemplates = Partial<{
   /**
    * the text that describes the toggle action
    */
-  labelText: Template<ToggleRefinementValue & { name: string }>;
+  labelText: Template<ToggleRefinementRenderState['value']>;
 }>;
 
 export type ToggleRefinementWidgetParams = {

--- a/packages/vue-instantsearch/src/components/ToggleRefinement.vue
+++ b/packages/vue-instantsearch/src/components/ToggleRefinement.vue
@@ -54,10 +54,6 @@ export default {
       type: String,
       required: true,
     },
-    label: {
-      type: String,
-      required: true,
-    },
     on: {
       type: [String, Number, Boolean, Array],
       required: false,
@@ -68,12 +64,15 @@ export default {
       required: false,
       default: undefined,
     },
+    label: {
+      type: String,
+      default: undefined,
+    },
   },
   computed: {
     widgetParams() {
       return {
         attribute: this.attribute,
-        label: this.label,
         on: this.on,
         off: this.off,
       };

--- a/packages/vue-instantsearch/src/components/__tests__/ToggleRefinement.js
+++ b/packages/vue-instantsearch/src/components/__tests__/ToggleRefinement.js
@@ -35,7 +35,9 @@ it('accepts a label prop', () => {
     propsData: defaultProps,
   });
 
-  expect(wrapper.vm.widgetParams.label).toBe('Free Shipping');
+  expect(wrapper.find('.ais-ToggleRefinement-labelText').text()).toBe(
+    'Free Shipping'
+  );
 });
 
 it('exposes send-event method for insights middleware', async () => {


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

- uses the `label` prop, casted to a template for the JS test
- fixes the type for the template in JS
- ensure the count in Vue (outlier) is tested and normalised
- remove "required" from Vue label prop (as it isn't actually required anymore since #5919)

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

ToggleRefinement label is tested

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
