### PR TITLE
chore(connectSearchBox): don't use `searchMetadata`

### DIFF
--- a/packages/instantsearch.js/src/connectors/search-box/__tests__/connectSearchBox-test.ts
+++ b/packages/instantsearch.js/src/connectors/search-box/__tests__/connectSearchBox-test.ts
@@ -7,6 +7,7 @@ import algoliasearchHelper, {
   SearchParameters,
 } from 'algoliasearch-helper';
 
+import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
   createDisposeOptions,
   createInitOptions,
@@ -486,7 +487,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
 
       const renderState = searchBox.getRenderState(
         {},
-        createRenderOptions({ searchMetadata: { isSearchStalled: true } })
+        createRenderOptions({
+          instantSearchInstance: createInstantSearch({ status: 'stalled' }),
+        })
       );
 
       expect(renderState.searchBox).toEqual({
@@ -573,7 +576,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/search-box/
       searchBox.init!(createInitOptions());
 
       const renderState = searchBox.getWidgetRenderState(
-        createRenderOptions({ searchMetadata: { isSearchStalled: true } })
+        createRenderOptions({
+          instantSearchInstance: createInstantSearch({ status: 'stalled' }),
+        })
       );
 
       expect(renderState).toEqual({

--- a/packages/instantsearch.js/src/connectors/search-box/connectSearchBox.ts
+++ b/packages/instantsearch.js/src/connectors/search-box/connectSearchBox.ts
@@ -133,7 +133,7 @@ const connectSearchBox: SearchBoxConnector = function connectSearchBox(
         };
       },
 
-      getWidgetRenderState({ helper, searchMetadata, state }) {
+      getWidgetRenderState({ helper, instantSearchInstance, state }) {
         if (!_refine) {
           _refine = (query) => {
             queryHook(query, (q) => helper.setQuery(q).search());
@@ -149,7 +149,7 @@ const connectSearchBox: SearchBoxConnector = function connectSearchBox(
           refine: _refine,
           clear: _clear,
           widgetParams,
-          isSearchStalled: searchMetadata.isSearchStalled,
+          isSearchStalled: instantSearchInstance.status === 'stalled',
         };
       },
 


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

searchMetadata is deprecated, so we shouldn't read it anymore. Further here we should probably also deprecate `isSearchStalled` in the render method, but not sure how to `stalled` in React then

I do wonder if all widgets should have access to `instantSearchInstance` in the render function in React after all to be able to access these global information without also using `useInstantSearch`, but that's a different conversation


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

`isSearchStalled` doesn't use `searchMetadata` anymore in search box connector

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
