### PR TITLE
fix(rsc): wait for results in `useSearchResults`

### DIFF
--- a/packages/react-instantsearch-core/src/lib/useSearchResults.ts
+++ b/packages/react-instantsearch-core/src/lib/useSearchResults.ts
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
 
 import { getIndexSearchResults } from './getIndexSearchResults';
+import { use } from './use';
 import { useIndexContext } from './useIndexContext';
 import { useInstantSearchContext } from './useInstantSearchContext';
+import { useRSCContext } from './useRSCContext';
 
 import type { SearchResults } from 'algoliasearch-helper';
 import type { ScopedResult } from 'instantsearch.js';
@@ -13,6 +15,7 @@ export type SearchResultsApi = {
 };
 
 export function useSearchResults(): SearchResultsApi {
+  const waitingForResultsRef = useRSCContext();
   const search = useInstantSearchContext();
   const searchIndex = useIndexContext();
   const [searchResults, setSearchResults] = useState(() =>
@@ -40,6 +43,10 @@ export function useSearchResults(): SearchResultsApi {
       search.removeListener('render', handleRender);
     };
   }, [search, searchIndex]);
+
+  if (typeof window === 'undefined' && waitingForResultsRef?.current) {
+    use(waitingForResultsRef.current);
+  }
 
   return searchResults;
 }


### PR DESCRIPTION
**Summary**

Getting results from `useInstantSearch` does not work in server-side RSC because we don't wait for the results like we do in `useWidget`.

**Result**

This will result in re-mounting the hook once results are received, so that users can have access to results and display things related to it in SSR.
