### PR TITLE
fix(angular): update versions to avoid typescript errors

### DIFF
--- a/packages/create-instantsearch-app/src/templates/Angular InstantSearch/package.json
+++ b/packages/create-instantsearch-app/src/templates/Angular InstantSearch/package.json
@@ -10,14 +10,14 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "12.2.16",
-    "@angular/common": "12.2.16",
-    "@angular/compiler": "12.2.16",
-    "@angular/core": "12.2.16",
-    "@angular/forms": "12.2.16",
-    "@angular/platform-browser": "12.2.16",
-    "@angular/platform-browser-dynamic": "12.2.16",
-    "@angular/router": "12.2.16",
+    "@angular/animations": "15.2.10",
+    "@angular/common": "15.2.10",
+    "@angular/compiler": "15.2.10",
+    "@angular/core": "15.2.10",
+    "@angular/forms": "15.2.10",
+    "@angular/platform-browser": "15.2.10",
+    "@angular/platform-browser-dynamic": "15.2.10",
+    "@angular/router": "15.2.10",
     "algoliasearch": "4",
     "angular-instantsearch": "{{libraryVersion}}",
     "rxjs": "6.6.0",
@@ -25,9 +25,9 @@
     "zone.js": "0.11.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "12.2.16",
-    "@angular/cli": "12.2.16",
-    "@angular/compiler-cli": "12.2.16",
+    "@angular-devkit/build-angular": "15.2.10",
+    "@angular/cli": "15.2.10",
+    "@angular/compiler-cli": "15.2.10",
     "@types/jasmine": "3.8.0",
     "@types/node": "12.11.1",
     "jasmine-core": "3.8.0",
@@ -36,6 +36,6 @@
     "karma-coverage": "2.0.3",
     "karma-jasmine": "4.0.0",
     "karma-jasmine-html-reporter": "1.7.0",
-    "typescript": "4.3.5"
+    "typescript": "4.9.5"
   }
 }


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

update angular, typescript versions to avoid typescript errors

This isn't the latest Angular versions (as it requires Ivy, which isn't done), but this runs fine both built and served.

E2E templates test doesn't need to be updated, as dependencies are stripped out.

CR-5137 for the report.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

angular template now runs fine on node 16 and 18

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
