### PR TITLE
fix(hydration): generate cache with search parameters from server-side request

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "75.75 kB"
+      "maxSize": "76 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",

--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -277,8 +277,7 @@ describe('getInitialResults', () => {
     search.start();
 
     const requestParams = await waitForResults(search);
-
-    expect(getInitialResults(search.mainIndex, requestParams)).toEqual({
+    const expectedInitialResults = {
       indexName: expect.objectContaining({
         requestParams: expect.objectContaining({
           query: 'apple',
@@ -295,6 +294,16 @@ describe('getInitialResults', () => {
           hitsPerPage: 2,
         }),
       }),
-    });
+    };
+
+    expect(getInitialResults(search.mainIndex, requestParams)).toEqual(
+      expectedInitialResults
+    );
+
+    // Multiple calls to `getInitialResults()` with the same requestParams
+    // return the same results
+    expect(getInitialResults(search.mainIndex, requestParams)).toEqual(
+      expectedInitialResults
+    );
   });
 });

--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -25,7 +25,10 @@ describe('waitForResults', () => {
 
     searches[0].resolver();
 
-    await expect(output).resolves.toBeUndefined();
+    await expect(output).resolves.toEqual([
+      expect.objectContaining({ indexName: 'indexName' }),
+      expect.objectContaining({ indexName: 'indexName2' }),
+    ]);
   });
 
   test('throws on a search client error', async () => {
@@ -237,6 +240,45 @@ describe('getInitialResults', () => {
           },
         ],
       },
+    });
+  });
+
+  test('returns the current results with request params if specified', async () => {
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+      initialUiState: {
+        indexName: {
+          query: 'apple',
+        },
+        indexName2: {
+          query: 'samsung',
+        },
+      },
+    });
+
+    search.addWidgets([
+      connectSearchBox(() => {})({}),
+      index({ indexName: 'indexName2' }).addWidgets([
+        connectSearchBox(() => {})({}),
+      ]),
+    ]);
+
+    search.start();
+
+    const requestParams = await waitForResults(search);
+
+    expect(getInitialResults(search.mainIndex, requestParams)).toEqual({
+      indexName: expect.objectContaining({
+        requestParams: expect.objectContaining({
+          query: 'apple',
+        }),
+      }),
+      indexName2: expect.objectContaining({
+        requestParams: expect.objectContaining({
+          query: 'samsung',
+        }),
+      }),
     });
   });
 });

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -7,24 +7,22 @@ import type {
   SearchOptions,
 } from '../types';
 
-type RequestParams = SearchOptions | undefined;
-
 /**
  * Waits for the results from the search instance to coordinate the next steps
  * in `getServerState()`.
  */
 export function waitForResults(
   search: InstantSearch
-): Promise<RequestParams[]> {
+): Promise<SearchOptions[]> {
   const helper = search.mainHelper!;
 
   // Extract search parameters from the search client to use them
   // later during hydration.
-  let requestParamsList: RequestParams[];
+  let requestParamsList: SearchOptions[];
   const client = helper.getClient();
   helper.setClient({
     search(queries) {
-      requestParamsList = queries.map(({ params }) => params);
+      requestParamsList = queries.map(({ params }) => params!);
       return client.search(queries);
     },
   });
@@ -63,7 +61,7 @@ export function getInitialResults(
    * Search parameters sent to the search client,
    * returned by `waitForResults()`.
    */
-  requestParamsList?: RequestParams[]
+  requestParamsList?: SearchOptions[]
 ): InitialResults {
   const initialResults: InitialResults = {};
 

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -23,9 +23,9 @@ export function waitForResults(
   let requestParamsList: RequestParams[];
   const client = helper.getClient();
   helper.setClient({
-    search(queries, requestOptions) {
-      requestParamsList = queries.map(({ params }) => params);
-      return client.search(queries, requestOptions);
+    search(...args) {
+      requestParamsList = args[0].map(({ params }) => params);
+      return client.search(...args);
     },
   });
 

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -60,19 +60,19 @@ export function waitForResults(
 export function getInitialResults(
   rootIndex: IndexWidget,
   /**
-   * Search parameters sent to the search client, usually
+   * Search parameters sent to the search client,
    * returned by `waitForResults()`.
    */
   requestParamsList?: RequestParams[]
 ): InitialResults {
   const initialResults: InitialResults = {};
 
+  let requestParamsIndex = 0;
   walkIndex(rootIndex, (widget) => {
     const searchResults = widget.getResults();
     if (searchResults) {
-      const indexId = widget.getIndexId();
-      const requestParams = requestParamsList?.shift();
-      initialResults[indexId] = {
+      const requestParams = requestParamsList?.[requestParamsIndex++];
+      initialResults[widget.getIndexId()] = {
         // We convert the Helper state to a plain object to pass parsable data
         // structures from server to client.
         state: { ...searchResults._state },

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -23,9 +23,9 @@ export function waitForResults(
   let requestParamsList: RequestParams[];
   const client = helper.getClient();
   helper.setClient({
-    search(...args) {
-      requestParamsList = args[0].map(({ params }) => params);
-      return client.search(...args);
+    search(queries) {
+      requestParamsList = queries.map(({ params }) => params);
+      return client.search(queries);
     },
   });
 

--- a/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
@@ -37,7 +37,7 @@ export function hydrateSearchClient(
   const cachedRequest = Object.keys(results).map((key) => {
     const { state, requestParams, results: serverResults } = results[key];
     return serverResults.map((result) => ({
-      indexName: result.index || state.index,
+      indexName: state.index || result.index,
       // We normalize the params received from the server as they can
       // be serialized differently depending on the engine.
       // We use search parameters from the server request to craft the cache

--- a/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
@@ -34,16 +34,24 @@ export function hydrateSearchClient(
     return;
   }
 
-  const cachedRequest = Object.keys(results).map((key) =>
-    results[key].results.map((result) => ({
-      indexName: result.index,
+  const cachedRequest = Object.keys(results).map((key) => {
+    const { state, requestParams, results: serverResults } = results[key];
+    return serverResults.map((result) => ({
+      indexName: result.index || state.index,
       // We normalize the params received from the server as they can
       // be serialized differently depending on the engine.
-      params: serializeQueryParameters(
-        deserializeQueryParameters(result.params)
-      ),
-    }))
-  );
+      // We use search parameters from the server request to craft the cache
+      // if possible, and fallback to those from results if not.
+      ...(requestParams || result.params
+        ? {
+            params: serializeQueryParameters(
+              requestParams || deserializeQueryParameters(result.params)
+            ),
+          }
+        : {}),
+    }));
+  });
+
   const cachedResults = Object.keys(results).reduce<Array<SearchResponse<any>>>(
     (acc, key) => acc.concat(results[key].results),
     []

--- a/packages/instantsearch.js/src/types/results.ts
+++ b/packages/instantsearch.js/src/types/results.ts
@@ -1,3 +1,4 @@
+import type { SearchOptions } from './algoliasearch';
 import type {
   PlainSearchParameters,
   SearchForFacetValues,
@@ -94,6 +95,7 @@ export type Refinement = FacetRefinement | NumericRefinement;
 type InitialResult = {
   state: PlainSearchParameters;
   results: SearchResults['_rawResults'];
+  requestParams?: SearchOptions;
 };
 
 export type InitialResults = Record<string, InitialResult>;

--- a/packages/react-instantsearch-core/src/server/__tests__/__snapshots__/getServerState.test.tsx.snap
+++ b/packages/react-instantsearch-core/src/server/__tests__/__snapshots__/getServerState.test.tsx.snap
@@ -71,19 +71,15 @@ exports[`getServerState returns initialResults 1`] = `
   },
   "instant_search_price_asc": {
     "requestParams": {
-      "facetFilters": [
-        [
-          "brand:Apple",
-        ],
-      ],
-      "facets": [
-        "brand",
-      ],
+      "analytics": false,
+      "clickAnalytics": false,
+      "facets": "brand",
       "highlightPostTag": "__/ais-highlight__",
       "highlightPreTag": "__ais-highlight__",
+      "hitsPerPage": 0,
       "maxValuesPerFacet": 10,
+      "page": 0,
       "query": "iphone",
-      "tagFilters": "",
     },
     "results": [
       {
@@ -130,19 +126,15 @@ exports[`getServerState returns initialResults 1`] = `
   },
   "instant_search_price_desc": {
     "requestParams": {
-      "facetFilters": [
-        [
-          "brand:Apple",
-        ],
-      ],
-      "facets": [
-        "brand",
-      ],
+      "analytics": false,
+      "clickAnalytics": false,
+      "facets": "brand",
       "highlightPostTag": "__/ais-highlight__",
       "highlightPreTag": "__ais-highlight__",
+      "hitsPerPage": 0,
       "maxValuesPerFacet": 10,
+      "page": 0,
       "query": "iphone",
-      "tagFilters": "",
     },
     "results": [
       {

--- a/packages/react-instantsearch-core/src/server/__tests__/__snapshots__/getServerState.test.tsx.snap
+++ b/packages/react-instantsearch-core/src/server/__tests__/__snapshots__/getServerState.test.tsx.snap
@@ -3,6 +3,21 @@
 exports[`getServerState returns initialResults 1`] = `
 {
   "instant_search": {
+    "requestParams": {
+      "facetFilters": [
+        [
+          "brand:Apple",
+        ],
+      ],
+      "facets": [
+        "brand",
+      ],
+      "highlightPostTag": "__/ais-highlight__",
+      "highlightPreTag": "__ais-highlight__",
+      "maxValuesPerFacet": 10,
+      "query": "iphone",
+      "tagFilters": "",
+    },
     "results": [
       {
         "exhaustiveFacetsCount": true,
@@ -55,6 +70,21 @@ exports[`getServerState returns initialResults 1`] = `
     },
   },
   "instant_search_price_asc": {
+    "requestParams": {
+      "facetFilters": [
+        [
+          "brand:Apple",
+        ],
+      ],
+      "facets": [
+        "brand",
+      ],
+      "highlightPostTag": "__/ais-highlight__",
+      "highlightPreTag": "__ais-highlight__",
+      "maxValuesPerFacet": 10,
+      "query": "iphone",
+      "tagFilters": "",
+    },
     "results": [
       {
         "exhaustiveFacetsCount": true,
@@ -99,6 +129,21 @@ exports[`getServerState returns initialResults 1`] = `
     },
   },
   "instant_search_price_desc": {
+    "requestParams": {
+      "facetFilters": [
+        [
+          "brand:Apple",
+        ],
+      ],
+      "facets": [
+        "brand",
+      ],
+      "highlightPostTag": "__/ais-highlight__",
+      "highlightPreTag": "__ais-highlight__",
+      "maxValuesPerFacet": 10,
+      "query": "iphone",
+      "tagFilters": "",
+    },
     "results": [
       {
         "exhaustiveFacetsCount": true,
@@ -143,6 +188,21 @@ exports[`getServerState returns initialResults 1`] = `
     },
   },
   "instant_search_rating_desc": {
+    "requestParams": {
+      "facetFilters": [
+        [
+          "brand:Apple",
+        ],
+      ],
+      "facets": [
+        "brand",
+      ],
+      "highlightPostTag": "__/ais-highlight__",
+      "highlightPreTag": "__ais-highlight__",
+      "maxValuesPerFacet": 10,
+      "query": "iphone",
+      "tagFilters": "",
+    },
     "results": [
       {
         "exhaustiveFacetsCount": true,

--- a/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
@@ -222,115 +222,112 @@ describe('getServerState', () => {
     await getServerState(<App />, { renderToString });
 
     expect(spiedSearch).toHaveBeenCalledTimes(1);
-    expect(spiedSearch).toHaveBeenCalledWith(
-      [
-        {
-          indexName: 'instant_search',
-          params: {
-            facetFilters: [['brand:Apple']],
-            facets: ['brand'],
-            highlightPostTag: '__/ais-highlight__',
-            highlightPreTag: '__ais-highlight__',
-            maxValuesPerFacet: 10,
-            query: 'iphone',
-            tagFilters: '',
-          },
+    expect(spiedSearch).toHaveBeenCalledWith([
+      {
+        indexName: 'instant_search',
+        params: {
+          facetFilters: [['brand:Apple']],
+          facets: ['brand'],
+          highlightPostTag: '__/ais-highlight__',
+          highlightPreTag: '__ais-highlight__',
+          maxValuesPerFacet: 10,
+          query: 'iphone',
+          tagFilters: '',
         },
-        {
-          indexName: 'instant_search',
-          params: {
-            analytics: false,
-            clickAnalytics: false,
-            facets: 'brand',
-            highlightPostTag: '__/ais-highlight__',
-            highlightPreTag: '__ais-highlight__',
-            hitsPerPage: 0,
-            maxValuesPerFacet: 10,
-            query: 'iphone',
-            page: 0,
-          },
+      },
+      {
+        indexName: 'instant_search',
+        params: {
+          analytics: false,
+          clickAnalytics: false,
+          facets: 'brand',
+          highlightPostTag: '__/ais-highlight__',
+          highlightPreTag: '__ais-highlight__',
+          hitsPerPage: 0,
+          maxValuesPerFacet: 10,
+          query: 'iphone',
+          page: 0,
         },
-        {
-          indexName: 'instant_search_price_asc',
-          params: {
-            facetFilters: [['brand:Apple']],
-            facets: ['brand'],
-            highlightPostTag: '__/ais-highlight__',
-            highlightPreTag: '__ais-highlight__',
-            maxValuesPerFacet: 10,
-            query: 'iphone',
-            tagFilters: '',
-          },
+      },
+      {
+        indexName: 'instant_search_price_asc',
+        params: {
+          facetFilters: [['brand:Apple']],
+          facets: ['brand'],
+          highlightPostTag: '__/ais-highlight__',
+          highlightPreTag: '__ais-highlight__',
+          maxValuesPerFacet: 10,
+          query: 'iphone',
+          tagFilters: '',
         },
-        {
-          indexName: 'instant_search_price_asc',
-          params: {
-            analytics: false,
-            clickAnalytics: false,
-            facets: 'brand',
-            highlightPostTag: '__/ais-highlight__',
-            highlightPreTag: '__ais-highlight__',
-            hitsPerPage: 0,
-            maxValuesPerFacet: 10,
-            page: 0,
-            query: 'iphone',
-          },
+      },
+      {
+        indexName: 'instant_search_price_asc',
+        params: {
+          analytics: false,
+          clickAnalytics: false,
+          facets: 'brand',
+          highlightPostTag: '__/ais-highlight__',
+          highlightPreTag: '__ais-highlight__',
+          hitsPerPage: 0,
+          maxValuesPerFacet: 10,
+          page: 0,
+          query: 'iphone',
         },
-        {
-          indexName: 'instant_search_rating_desc',
-          params: {
-            facetFilters: [['brand:Apple']],
-            facets: ['brand'],
-            highlightPostTag: '__/ais-highlight__',
-            highlightPreTag: '__ais-highlight__',
-            maxValuesPerFacet: 10,
-            query: 'iphone',
-            tagFilters: '',
-          },
+      },
+      {
+        indexName: 'instant_search_rating_desc',
+        params: {
+          facetFilters: [['brand:Apple']],
+          facets: ['brand'],
+          highlightPostTag: '__/ais-highlight__',
+          highlightPreTag: '__ais-highlight__',
+          maxValuesPerFacet: 10,
+          query: 'iphone',
+          tagFilters: '',
         },
-        {
-          indexName: 'instant_search_rating_desc',
-          params: {
-            analytics: false,
-            clickAnalytics: false,
-            facets: 'brand',
-            highlightPostTag: '__/ais-highlight__',
-            highlightPreTag: '__ais-highlight__',
-            hitsPerPage: 0,
-            maxValuesPerFacet: 10,
-            page: 0,
-            query: 'iphone',
-          },
+      },
+      {
+        indexName: 'instant_search_rating_desc',
+        params: {
+          analytics: false,
+          clickAnalytics: false,
+          facets: 'brand',
+          highlightPostTag: '__/ais-highlight__',
+          highlightPreTag: '__ais-highlight__',
+          hitsPerPage: 0,
+          maxValuesPerFacet: 10,
+          page: 0,
+          query: 'iphone',
         },
-        {
-          indexName: 'instant_search_price_desc',
-          params: {
-            facetFilters: [['brand:Apple']],
-            facets: ['brand'],
-            highlightPostTag: '__/ais-highlight__',
-            highlightPreTag: '__ais-highlight__',
-            maxValuesPerFacet: 10,
-            query: 'iphone',
-            tagFilters: '',
-          },
+      },
+      {
+        indexName: 'instant_search_price_desc',
+        params: {
+          facetFilters: [['brand:Apple']],
+          facets: ['brand'],
+          highlightPostTag: '__/ais-highlight__',
+          highlightPreTag: '__ais-highlight__',
+          maxValuesPerFacet: 10,
+          query: 'iphone',
+          tagFilters: '',
         },
-        {
-          indexName: 'instant_search_price_desc',
-          params: {
-            analytics: false,
-            clickAnalytics: false,
-            facets: 'brand',
-            highlightPostTag: '__/ais-highlight__',
-            highlightPreTag: '__ais-highlight__',
-            hitsPerPage: 0,
-            maxValuesPerFacet: 10,
-            page: 0,
-            query: 'iphone',
-          },
+      },
+      {
+        indexName: 'instant_search_price_desc',
+        params: {
+          analytics: false,
+          clickAnalytics: false,
+          facets: 'brand',
+          highlightPostTag: '__/ais-highlight__',
+          highlightPreTag: '__ais-highlight__',
+          hitsPerPage: 0,
+          maxValuesPerFacet: 10,
+          page: 0,
+          query: 'iphone',
         },
-      ],
-      undefined
-    );
+      },
+    ]);
   });
 
   test('returns initialResults', async () => {

--- a/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
@@ -222,112 +222,115 @@ describe('getServerState', () => {
     await getServerState(<App />, { renderToString });
 
     expect(spiedSearch).toHaveBeenCalledTimes(1);
-    expect(spiedSearch).toHaveBeenCalledWith([
-      {
-        indexName: 'instant_search',
-        params: {
-          facetFilters: [['brand:Apple']],
-          facets: ['brand'],
-          highlightPostTag: '__/ais-highlight__',
-          highlightPreTag: '__ais-highlight__',
-          maxValuesPerFacet: 10,
-          query: 'iphone',
-          tagFilters: '',
+    expect(spiedSearch).toHaveBeenCalledWith(
+      [
+        {
+          indexName: 'instant_search',
+          params: {
+            facetFilters: [['brand:Apple']],
+            facets: ['brand'],
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            maxValuesPerFacet: 10,
+            query: 'iphone',
+            tagFilters: '',
+          },
         },
-      },
-      {
-        indexName: 'instant_search',
-        params: {
-          analytics: false,
-          clickAnalytics: false,
-          facets: 'brand',
-          highlightPostTag: '__/ais-highlight__',
-          highlightPreTag: '__ais-highlight__',
-          hitsPerPage: 0,
-          maxValuesPerFacet: 10,
-          query: 'iphone',
-          page: 0,
+        {
+          indexName: 'instant_search',
+          params: {
+            analytics: false,
+            clickAnalytics: false,
+            facets: 'brand',
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            hitsPerPage: 0,
+            maxValuesPerFacet: 10,
+            query: 'iphone',
+            page: 0,
+          },
         },
-      },
-      {
-        indexName: 'instant_search_price_asc',
-        params: {
-          facetFilters: [['brand:Apple']],
-          facets: ['brand'],
-          highlightPostTag: '__/ais-highlight__',
-          highlightPreTag: '__ais-highlight__',
-          maxValuesPerFacet: 10,
-          query: 'iphone',
-          tagFilters: '',
+        {
+          indexName: 'instant_search_price_asc',
+          params: {
+            facetFilters: [['brand:Apple']],
+            facets: ['brand'],
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            maxValuesPerFacet: 10,
+            query: 'iphone',
+            tagFilters: '',
+          },
         },
-      },
-      {
-        indexName: 'instant_search_price_asc',
-        params: {
-          analytics: false,
-          clickAnalytics: false,
-          facets: 'brand',
-          highlightPostTag: '__/ais-highlight__',
-          highlightPreTag: '__ais-highlight__',
-          hitsPerPage: 0,
-          maxValuesPerFacet: 10,
-          page: 0,
-          query: 'iphone',
+        {
+          indexName: 'instant_search_price_asc',
+          params: {
+            analytics: false,
+            clickAnalytics: false,
+            facets: 'brand',
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            hitsPerPage: 0,
+            maxValuesPerFacet: 10,
+            page: 0,
+            query: 'iphone',
+          },
         },
-      },
-      {
-        indexName: 'instant_search_rating_desc',
-        params: {
-          facetFilters: [['brand:Apple']],
-          facets: ['brand'],
-          highlightPostTag: '__/ais-highlight__',
-          highlightPreTag: '__ais-highlight__',
-          maxValuesPerFacet: 10,
-          query: 'iphone',
-          tagFilters: '',
+        {
+          indexName: 'instant_search_rating_desc',
+          params: {
+            facetFilters: [['brand:Apple']],
+            facets: ['brand'],
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            maxValuesPerFacet: 10,
+            query: 'iphone',
+            tagFilters: '',
+          },
         },
-      },
-      {
-        indexName: 'instant_search_rating_desc',
-        params: {
-          analytics: false,
-          clickAnalytics: false,
-          facets: 'brand',
-          highlightPostTag: '__/ais-highlight__',
-          highlightPreTag: '__ais-highlight__',
-          hitsPerPage: 0,
-          maxValuesPerFacet: 10,
-          page: 0,
-          query: 'iphone',
+        {
+          indexName: 'instant_search_rating_desc',
+          params: {
+            analytics: false,
+            clickAnalytics: false,
+            facets: 'brand',
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            hitsPerPage: 0,
+            maxValuesPerFacet: 10,
+            page: 0,
+            query: 'iphone',
+          },
         },
-      },
-      {
-        indexName: 'instant_search_price_desc',
-        params: {
-          facetFilters: [['brand:Apple']],
-          facets: ['brand'],
-          highlightPostTag: '__/ais-highlight__',
-          highlightPreTag: '__ais-highlight__',
-          maxValuesPerFacet: 10,
-          query: 'iphone',
-          tagFilters: '',
+        {
+          indexName: 'instant_search_price_desc',
+          params: {
+            facetFilters: [['brand:Apple']],
+            facets: ['brand'],
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            maxValuesPerFacet: 10,
+            query: 'iphone',
+            tagFilters: '',
+          },
         },
-      },
-      {
-        indexName: 'instant_search_price_desc',
-        params: {
-          analytics: false,
-          clickAnalytics: false,
-          facets: 'brand',
-          highlightPostTag: '__/ais-highlight__',
-          highlightPreTag: '__ais-highlight__',
-          hitsPerPage: 0,
-          maxValuesPerFacet: 10,
-          page: 0,
-          query: 'iphone',
+        {
+          indexName: 'instant_search_price_desc',
+          params: {
+            analytics: false,
+            clickAnalytics: false,
+            facets: 'brand',
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            hitsPerPage: 0,
+            maxValuesPerFacet: 10,
+            page: 0,
+            query: 'iphone',
+          },
         },
-      },
-    ]);
+      ],
+      undefined
+    );
   });
 
   test('returns initialResults', async () => {

--- a/packages/react-instantsearch-core/src/server/getServerState.tsx
+++ b/packages/react-instantsearch-core/src/server/getServerState.tsx
@@ -129,9 +129,12 @@ function execute({
 
       return waitForResults(searchRef.current);
     })
-    .then(() => {
+    .then((requestParams) => {
       return {
-        initialResults: getInitialResults(searchRef.current!.mainIndex),
+        initialResults: getInitialResults(
+          searchRef.current!.mainIndex,
+          requestParams
+        ),
       };
     });
 }

--- a/packages/react-instantsearch-core/src/server/getServerState.tsx
+++ b/packages/react-instantsearch-core/src/server/getServerState.tsx
@@ -129,11 +129,11 @@ function execute({
 
       return waitForResults(searchRef.current);
     })
-    .then((requestParams) => {
+    .then((requestParamsList) => {
       return {
         initialResults: getInitialResults(
           searchRef.current!.mainIndex,
-          requestParams
+          requestParamsList
         ),
       };
     });

--- a/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
@@ -8,6 +8,8 @@ import {
   wrapPromiseWithState,
 } from 'react-instantsearch-core';
 
+import type { SearchClient } from 'instantsearch.js';
+
 export function InitializePromise() {
   const search = useInstantSearchContext();
   const waitForResultsRef = useRSCContext();
@@ -16,6 +18,16 @@ export function InitializePromise() {
     (() => {
       throw new Error('Missing ServerInsertedHTMLContext');
     });
+
+  // Extract search parameters from the search client to use them
+  // later during hydration.
+  let requestParams: Parameters<SearchClient['search']>[0];
+  search.mainHelper!.setClient({
+    search(queries, requestOptions) {
+      requestParams = queries;
+      return search.client.search(queries, requestOptions);
+    },
+  });
 
   const waitForResults = () =>
     new Promise<void>((resolve) => {
@@ -26,7 +38,7 @@ export function InitializePromise() {
 
   const injectInitialResults = () => {
     let inserted = false;
-    const results = getInitialResults(search.mainIndex);
+    const results = getInitialResults(search.mainIndex, requestParams);
     insertHTML(() => {
       if (inserted) {
         return <></>;

--- a/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
@@ -21,10 +21,10 @@ export function InitializePromise() {
 
   // Extract search parameters from the search client to use them
   // later during hydration.
-  let requestParamsList: Array<SearchOptions | undefined>;
+  let requestParamsList: SearchOptions[];
   search.mainHelper!.setClient({
     search(queries) {
-      requestParamsList = queries.map(({ params }) => params);
+      requestParamsList = queries.map(({ params }) => params!);
       return search.client.search(queries);
     },
   });

--- a/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
@@ -23,9 +23,9 @@ export function InitializePromise() {
   // later during hydration.
   let requestParamsList: Array<SearchOptions | undefined>;
   search.mainHelper!.setClient({
-    search(queries, requestOptions) {
-      requestParamsList = queries.map(({ params }) => params);
-      return search.client.search(queries, requestOptions);
+    search(...args) {
+      requestParamsList = args[0].map(({ params }) => params);
+      return search.client.search(...args);
     },
   });
 

--- a/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
@@ -23,9 +23,9 @@ export function InitializePromise() {
   // later during hydration.
   let requestParamsList: Array<SearchOptions | undefined>;
   search.mainHelper!.setClient({
-    search(...args) {
-      requestParamsList = args[0].map(({ params }) => params);
-      return search.client.search(...args);
+    search(queries) {
+      requestParamsList = queries.map(({ params }) => params);
+      return search.client.search(queries);
     },
   });
 

--- a/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
@@ -8,7 +8,7 @@ import {
   wrapPromiseWithState,
 } from 'react-instantsearch-core';
 
-import type { SearchClient } from 'instantsearch.js';
+import type { SearchOptions } from 'instantsearch.js';
 
 export function InitializePromise() {
   const search = useInstantSearchContext();
@@ -21,10 +21,10 @@ export function InitializePromise() {
 
   // Extract search parameters from the search client to use them
   // later during hydration.
-  let requestParams: Parameters<SearchClient['search']>[0];
+  let requestParamsList: Array<SearchOptions | undefined>;
   search.mainHelper!.setClient({
     search(queries, requestOptions) {
-      requestParams = queries;
+      requestParamsList = queries.map(({ params }) => params);
       return search.client.search(queries, requestOptions);
     },
   });
@@ -38,7 +38,7 @@ export function InitializePromise() {
 
   const injectInitialResults = () => {
     let inserted = false;
-    const results = getInitialResults(search.mainIndex, requestParams);
+    const results = getInitialResults(search.mainIndex, requestParamsList);
     insertHTML(() => {
       if (inserted) {
         return <></>;

--- a/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
+++ b/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
@@ -317,6 +317,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
               });
 
               expect(state.hello).toEqual({
+                requestParams: {
+                  facets: [],
+                  hitsPerPage: 100,
+                  query: '',
+                  tagFilters: '',
+                },
                 results: [
                   {
                     query: '',
@@ -340,6 +346,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
               // Parent's widgets state should not be merged into nested index state
               expect(state.nestedIndex).toEqual({
+                requestParams: {
+                  facets: [],
+                  hitsPerPage: 100,
+                  query: '',
+                  tagFilters: '',
+                },
                 results: [
                   {
                     query: '',

--- a/packages/vue-instantsearch/src/util/createServerRootMixin.js
+++ b/packages/vue-instantsearch/src/util/createServerRootMixin.js
@@ -116,8 +116,11 @@ function augmentInstantSearch(instantSearchOptions, cloneComponent) {
       })
       .then(() => renderToString(app))
       .then(() => waitForResults(instance))
-      .then(() => {
-        initialResults = getInitialResults(instance.mainIndex);
+      .then((requestParamsList) => {
+        initialResults = getInitialResults(
+          instance.mainIndex,
+          requestParamsList
+        );
         search.hydrate(initialResults);
         return search.getState();
       });


### PR DESCRIPTION
**Summary**

In an SSR context, the search request performed server-side is cached in the client-side search client to prevent sending an unnecessary duplicate request when the user interacts with refinements.

This is done by manually recomposing the cached results during hydration and adding it to the search client's cache mechanism. The key of a cached request uses the search parameters from the response, normally returned by Algolia, but customers can limit what fields are returned by setting the `responseFIelds` option. If `params` is omitted, than the app throws an error during hydration.

This PR changes slightly how the request key is crafted, by instead extracting the request search parameters from the server-side search request, and using it instead of the response search parameters.

**Result**

Hydration now works correctly and the server-side request is effectively cached whether fields are filtered using `responseFields` or not.

> [!NOTE]
> The issue of cache miss in implementations containing multiple indices is still unsolved and can be handled by FX-2720.
> Furthermore, if in those multiple indices there are multiples of the same `indexName` + `indexId`, the current implementation of `getInitialResults()` uses only the last instance for params and results, which might not be desirable.

Fixes #5964 
FX-2702