### PR TITLE
fix(links): ensure cmd-click always opens in new tab

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -22,15 +22,15 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "64.5 kB"
+      "maxSize": "65 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "68 kB"
+      "maxSize": "68.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "68.5 kB"
+      "maxSize": "69 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",

--- a/packages/instantsearch.js/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/instantsearch.js/src/components/Breadcrumb/Breadcrumb.tsx
@@ -3,6 +3,7 @@
 import { cx } from 'instantsearch-ui-components';
 import { h } from 'preact';
 
+import { isSpecialClick } from '../../lib/utils';
 import Template from '../Template/Template';
 
 import type { BreadcrumbConnectorParamsItem } from '../../connectors/breadcrumb/connectBreadcrumb';
@@ -55,6 +56,9 @@ const Breadcrumb = ({
             className: cssClasses.link,
             href: createURL(null),
             onClick: (event: MouseEvent) => {
+              if (isSpecialClick(event)) {
+                return;
+              }
               event.preventDefault();
               refine(null);
             },
@@ -86,6 +90,9 @@ const Breadcrumb = ({
                 className={cssClasses.link}
                 href={createURL(item.value)}
                 onClick={(event) => {
+                  if (isSpecialClick(event)) {
+                    return;
+                  }
                   event.preventDefault();
                   refine(item.value);
                 }}

--- a/packages/react-instantsearch/src/ui/Menu.tsx
+++ b/packages/react-instantsearch/src/ui/Menu.tsx
@@ -1,6 +1,7 @@
 import { cx } from 'instantsearch-ui-components';
 import React from 'react';
 
+import { isModifierClick } from './lib/isModifierClick';
 import { ShowMoreButton } from './ShowMoreButton';
 
 import type { ShowMoreButtonTranslations } from './ShowMoreButton';
@@ -102,6 +103,9 @@ export function Menu({
               className={cx('ais-Menu-link', classNames.link)}
               href={createURL(item.value)}
               onClick={(event) => {
+                if (isModifierClick(event)) {
+                  return;
+                }
                 event.preventDefault();
                 onRefine(item);
               }}

--- a/packages/vue-instantsearch/src/components/Breadcrumb.vue
+++ b/packages/vue-instantsearch/src/components/Breadcrumb.vue
@@ -20,7 +20,7 @@
             v-if="Boolean(state.items.length)"
             :href="state.createURL()"
             :class="suit('link')"
-            @click.prevent="state.refine()"
+            @click.exact.left.prevent="state.refine()"
           >
             <slot name="rootLabel">Home</slot>
           </a>
@@ -28,7 +28,7 @@
             v-else
             :href="state.createURL(null)"
             :class="suit('link')"
-            @click.prevent="state.refine(null)"
+            @click.exact.left.prevent="state.refine(null)"
           >
             <slot name="rootLabel">Home</slot>
           </a>
@@ -44,7 +44,7 @@
             v-if="!isLastItem(index)"
             :href="state.createURL(item.value)"
             :class="suit('link')"
-            @click.prevent="state.refine(item.value)"
+            @click.exact.left.prevent="state.refine(item.value)"
             >{{ item.label }}</a
           >
           <template v-else>{{ item.label }}</template>

--- a/packages/vue-instantsearch/src/components/HierarchicalMenuList.vue
+++ b/packages/vue-instantsearch/src/components/HierarchicalMenuList.vue
@@ -19,7 +19,7 @@
       <a
         :href="createURL(item.value)"
         :class="[suit('link'), item.isRefined && suit('link', 'selected')]"
-        @click.prevent="refine(item.value)"
+        @click.exact.left.prevent="refine(item.value)"
       >
         <span :class="suit('label')">{{ item.label }}</span>
         <span :class="suit('count')">{{ item.count }}</span>

--- a/packages/vue-instantsearch/src/components/Menu.vue
+++ b/packages/vue-instantsearch/src/components/Menu.vue
@@ -22,7 +22,7 @@
           <a
             :href="state.createURL(item.value)"
             :class="suit('link')"
-            @click.prevent="state.refine(item.value)"
+            @click.exact.left.prevent="state.refine(item.value)"
           >
             <span :class="suit('label')">{{ item.label }}</span>
             <span :class="suit('count')">{{ item.count }}</span>
@@ -37,7 +37,7 @@
           !state.canToggleShowMore && suit('showMore', 'disabled'),
         ]"
         :disabled="!state.canToggleShowMore"
-        @click.prevent="state.toggleShowMore()"
+        @click.prevent="state.toggleShowMore"
       >
         <slot name="showMoreLabel" :is-showing-more="state.isShowingMore">{{
           state.isShowingMore ? 'Show less' : 'Show more'

--- a/packages/vue-instantsearch/src/components/RatingMenu.vue
+++ b/packages/vue-instantsearch/src/components/RatingMenu.vue
@@ -31,7 +31,7 @@
               :href="state.createURL(item.value)"
               :aria-label="`${item.value} & up`"
               :class="suit('link')"
-              @click.prevent="state.refine(item.value)"
+              @click.exact.left.prevent="state.refine(item.value)"
             >
               <template v-for="(full, n) in item.stars">
                 <svg

--- a/tests/common/widgets/breadcrumb/index.ts
+++ b/tests/common/widgets/breadcrumb/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptimisticUiTests } from './optimistic-ui';
 import { createOptionsTests } from './options';
 
@@ -22,5 +23,6 @@ export function createBreadcrumbWidgetTests(
   describe('Breadcrumb widget common tests', () => {
     createOptimisticUiTests(setup, { act, skippedTests });
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/breadcrumb/links.ts
+++ b/tests/common/widgets/breadcrumb/links.ts
@@ -1,0 +1,103 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import userEvent from '@testing-library/user-event';
+
+import type { BreadcrumbWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: BreadcrumbWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const attributes = ['1', '2'];
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {
+              hierarchicalMenu: {
+                [attributes[0]]: ['Cameras & Camcorders > Digital Cameras'],
+              },
+            },
+          },
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attributes[0]]: {
+                        'Cameras & Camcorders': 1369,
+                      },
+                      [attributes[1]]: {
+                        'Cameras & Camcorders > Digital Cameras': 170,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attributes },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-Breadcrumb')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(2);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+
+      // Click all links with a modifier
+      {
+        await act(async () => {
+          container.querySelectorAll('a').forEach((link) => {
+            userEvent.click(link, { ctrlKey: true });
+          });
+
+          await wait(0);
+          await wait(0);
+        });
+
+        // No UI has changed
+        expect(container.querySelectorAll('a')).toHaveLength(2);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(container.querySelectorAll('a')).toHaveLength(2);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/clear-refinements/index.ts
+++ b/tests/common/widgets/clear-refinements/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createClearRefinementsWidgetTests(
 
   describe('ClearRefinements widget common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/clear-refinements/links.ts
+++ b/tests/common/widgets/clear-refinements/links.ts
@@ -1,0 +1,49 @@
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { ClearRefinementsWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: ClearRefinementsWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {
+              refinementList: {
+                brand: ['Apple'],
+              },
+            },
+          },
+          searchClient: createSearchClient({}),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-ClearRefinements')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/current-refinements/index.ts
+++ b/tests/common/widgets/current-refinements/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createCurrentRefinementsWidgetTests(
 
   describe('CurrentRefinements widget common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/current-refinements/links.ts
+++ b/tests/common/widgets/current-refinements/links.ts
@@ -1,0 +1,56 @@
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { CurrentRefinementsWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: CurrentRefinementsWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {
+              refinementList: {
+                feature: ['5G', 'OLED Display'],
+                brand: ['Samsung', 'Apple'],
+              },
+              hierarchicalMenu: {
+                'hierarchicalCategories.lvl0': ['Cell Phones'],
+              },
+              range: {
+                price: '500:990',
+              },
+            },
+          },
+          searchClient: createSearchClient({}),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-CurrentRefinements')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/dynamic-widgets/index.ts
+++ b/tests/common/widgets/dynamic-widgets/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createDynamicWidgetsWidgetTests(
 
   describe('DynamicWidgets widget common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/dynamic-widgets/links.ts
+++ b/tests/common/widgets/dynamic-widgets/links.ts
@@ -1,0 +1,47 @@
+import { createSearchClient } from '@instantsearch/mocks';
+import { castToJestMock, wait } from '@instantsearch/testutils';
+
+import type { DynamicWidgetsWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: DynamicWidgetsWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({}),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-DynamicWidgets')!;
+
+      const baseDynamicWidgetsSearches =
+        // Vue: 2, React, JS: 1
+        castToJestMock(options.instantSearchOptions.searchClient.search).mock
+          .calls.length;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(baseDynamicWidgetsSearches);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/frequently-bought-together/index.ts
+++ b/tests/common/widgets/frequently-bought-together/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct, skippableDescribe } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -23,6 +24,7 @@ export function createFrequentlyBoughtTogetherWidgetTests(
     skippedTests,
     () => {
       createOptionsTests(setup, { act, skippedTests });
+      createLinksTests(setup, { act, skippedTests });
     }
   );
 }

--- a/tests/common/widgets/frequently-bought-together/links.ts
+++ b/tests/common/widgets/frequently-bought-together/links.ts
@@ -1,0 +1,45 @@
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
+import { wait } from '@instantsearch/testutils';
+
+import type { FrequentlyBoughtTogetherWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: FrequentlyBoughtTogetherWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const objectIDs = ['1'];
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createRecommendSearchClient(),
+        },
+        widgetParams: { objectIDs },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector(
+        '.ais-FrequentlyBoughtTogether'
+      )!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.getRecommendations
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/hierarchical-menu/index.ts
+++ b/tests/common/widgets/hierarchical-menu/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptimisticUiTests } from './optimistic-ui';
 import { createOptionsTests } from './options';
 
@@ -22,5 +23,6 @@ export function createHierarchicalMenuWidgetTests(
   describe('HierarchicalMenu widget common tests', () => {
     createOptimisticUiTests(setup, { act, skippedTests });
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/hierarchical-menu/links.ts
+++ b/tests/common/widgets/hierarchical-menu/links.ts
@@ -1,0 +1,105 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import userEvent from '@testing-library/user-event';
+
+import type { HierarchicalMenuWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: HierarchicalMenuWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const attributes = ['1', '2'];
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {
+              hierarchicalMenu: {
+                [attributes[0]]: ['Apple > iPhone'],
+              },
+            },
+          },
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attributes[0]]: {
+                        Samsung: 100,
+                        Apple: 200,
+                      },
+                      [attributes[1]]: {
+                        'Apple > iPad': 100,
+                        'Apple > iPhone': 100,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attributes },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-HierarchicalMenu')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(4);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+
+      // Click all links with a modifier
+      {
+        await act(async () => {
+          container.querySelectorAll('a').forEach((link) => {
+            userEvent.click(link, { ctrlKey: true });
+          });
+
+          await wait(0);
+          await wait(0);
+        });
+
+        // No UI has changed
+        expect(container.querySelectorAll('a')).toHaveLength(4);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(container.querySelectorAll('a')).toHaveLength(4);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/hits-per-page/index.ts
+++ b/tests/common/widgets/hits-per-page/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createHitsPerPageWidgetTests(
 
   describe('HitsPerPage widget common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/hits-per-page/links.ts
+++ b/tests/common/widgets/hits-per-page/links.ts
@@ -1,0 +1,57 @@
+import {
+  createMultiSearchResponse,
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { HitsPerPageWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: HitsPerPageWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async () => {
+              await wait(delay);
+              return createMultiSearchResponse(createSingleSearchResponse());
+            }),
+          }),
+        },
+        widgetParams: {
+          items: [
+            { value: 10, label: 'ten', default: true },
+            { value: 20, label: 'twenty' },
+            { value: 30, label: 'thirty' },
+          ],
+        },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-HitsPerPage')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/hits/index.ts
+++ b/tests/common/widgets/hits/index.ts
@@ -1,6 +1,7 @@
 import { fakeAct } from '../../common';
 
 import { createInsightsTests } from './insights';
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -22,5 +23,6 @@ export function createHitsWidgetTests(
   describe('Hits widget common tests', () => {
     createInsightsTests(setup, { act, skippedTests });
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/hits/links.ts
+++ b/tests/common/widgets/hits/links.ts
@@ -1,0 +1,62 @@
+import {
+  createMultiSearchResponse,
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { HitsWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: HitsWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(({ params }) =>
+                  createSingleSearchResponse({
+                    hits: Array.from(
+                      { length: params.hitsPerPage || 20 },
+                      (_, i) => ({
+                        objectID: `${i}`,
+                      })
+                    ) as any[],
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-Hits')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/infinite-hits/index.ts
+++ b/tests/common/widgets/infinite-hits/index.ts
@@ -1,6 +1,7 @@
 import { fakeAct } from '../../common';
 
 import { createInsightsTests } from './insights';
+import { createLinksTests } from './links';
 import { createOptimisticUiTests } from './optimistic-ui';
 import { createOptionsTests } from './options';
 
@@ -24,5 +25,6 @@ export function createInfiniteHitsWidgetTests(
     createOptimisticUiTests(setup, { act, skippedTests });
     createInsightsTests(setup, { act, skippedTests });
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/infinite-hits/links.ts
+++ b/tests/common/widgets/infinite-hits/links.ts
@@ -1,0 +1,62 @@
+import {
+  createMultiSearchResponse,
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { InfiniteHitsWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: InfiniteHitsWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(({ params }) =>
+                  createSingleSearchResponse({
+                    hits: Array.from(
+                      { length: params.hitsPerPage || 20 },
+                      (_, i) => ({
+                        objectID: `${i}`,
+                      })
+                    ) as any[],
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-InfiniteHits')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/looking-similar/index.ts
+++ b/tests/common/widgets/looking-similar/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct, skippableDescribe } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createLookingSimilarWidgetTests(
 
   skippableDescribe('LookingSimilar widget common tests', skippedTests, () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/looking-similar/links.ts
+++ b/tests/common/widgets/looking-similar/links.ts
@@ -1,0 +1,43 @@
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
+import { wait } from '@instantsearch/testutils';
+
+import type { LookingSimilarWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: LookingSimilarWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const objectIDs = ['1'];
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createRecommendSearchClient(),
+        },
+        widgetParams: { objectIDs },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-LookingSimilar')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.getRecommendations
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/menu-select/index.ts
+++ b/tests/common/widgets/menu-select/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct, skippableDescribe } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createMenuSelectWidgetTests(
 
   skippableDescribe('MenuSelect widget common tests', skippedTests, () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/menu-select/links.ts
+++ b/tests/common/widgets/menu-select/links.ts
@@ -1,0 +1,63 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { MenuSelectWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: MenuSelectWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const attribute = 'brand';
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attribute]: {
+                        Samsung: 100,
+                        Apple: 200,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attribute },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-MenuSelect')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/menu/index.ts
+++ b/tests/common/widgets/menu/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptimisticUiTests } from './optimistic-ui';
 import { createOptionsTests } from './options';
 
@@ -22,5 +23,6 @@ export function createMenuWidgetTests(
   describe('Menu widget common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
     createOptimisticUiTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/menu/links.ts
+++ b/tests/common/widgets/menu/links.ts
@@ -1,0 +1,94 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import userEvent from '@testing-library/user-event';
+
+import type { MenuWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: MenuWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const attribute = 'brand';
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attribute]: {
+                        Samsung: 100,
+                        Apple: 200,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attribute },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-Menu')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(2);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+
+      // Click all links with a modifier
+      {
+        await act(async () => {
+          container.querySelectorAll('a').forEach((link) => {
+            userEvent.click(link, { ctrlKey: true });
+          });
+
+          await wait(0);
+          await wait(0);
+        });
+
+        // No UI has changed
+        expect(container.querySelectorAll('a')).toHaveLength(2);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(container.querySelectorAll('a')).toHaveLength(2);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/numeric-menu/index.ts
+++ b/tests/common/widgets/numeric-menu/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct, skippableDescribe } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createNumericMenuWidgetTests(
 
   skippableDescribe('NumericMenu widget common tests', skippedTests, () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/numeric-menu/links.ts
+++ b/tests/common/widgets/numeric-menu/links.ts
@@ -1,0 +1,74 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { NumericMenuWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: NumericMenuWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const attribute = 'price';
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attribute]: {
+                        0: 100,
+                        1: 200,
+                      },
+                    },
+                    facets_stats: {
+                      [attribute]: {
+                        min: 0,
+                        max: 200,
+                        avg: 100,
+                        sum: 300,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: {
+          attribute,
+          items: [{ label: '>20', min: 20, default: true }],
+        },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-NumericMenu')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/pagination/index.ts
+++ b/tests/common/widgets/pagination/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptimisticUiTests } from './optimistic-ui';
 import { createOptionsTests } from './options';
 
@@ -22,5 +23,6 @@ export function createPaginationWidgetTests(
   describe('Pagination widget common tests', () => {
     createOptimisticUiTests(setup, { act, skippedTests });
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/pagination/links.ts
+++ b/tests/common/widgets/pagination/links.ts
@@ -1,0 +1,90 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import userEvent from '@testing-library/user-event';
+
+import type { PaginationWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: PaginationWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    hitsPerPage: 20,
+                    nbPages: 100,
+                    page: 5,
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-Pagination')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(9);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+
+      // Click all links with a modifier
+      {
+        await act(async () => {
+          container.querySelectorAll('a').forEach((link) => {
+            userEvent.click(link, { ctrlKey: true });
+          });
+
+          await wait(0);
+          await wait(0);
+        });
+
+        // No UI has changed
+        expect(container.querySelectorAll('a')).toHaveLength(9);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(container.querySelectorAll('a')).toHaveLength(9);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/powered-by/index.ts
+++ b/tests/common/widgets/powered-by/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -25,5 +26,6 @@ export function createPoweredByWidgetTests(
 
   describe('PoweredBy widget common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/powered-by/links.ts
+++ b/tests/common/widgets/powered-by/links.ts
@@ -1,0 +1,89 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { castToJestMock, wait } from '@instantsearch/testutils';
+import userEvent from '@testing-library/user-event';
+
+import type { PoweredByWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: PoweredByWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() => createSingleSearchResponse({}))
+              );
+            }),
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-PoweredBy')!;
+
+      const basePoweredBySearches =
+        // Vue: 0, React, JS: 1
+        castToJestMock(options.instantSearchOptions.searchClient.search).mock
+          .calls.length;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(1);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(basePoweredBySearches);
+      }
+
+      // Click all links with a modifier
+      {
+        await act(async () => {
+          container.querySelectorAll('a').forEach((link) => {
+            userEvent.click(link, { ctrlKey: true });
+          });
+
+          await wait(0);
+          await wait(0);
+        });
+
+        // No UI has changed
+        expect(container.querySelectorAll('a')).toHaveLength(1);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(basePoweredBySearches);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(container.querySelectorAll('a')).toHaveLength(1);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(basePoweredBySearches);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/range-input/index.ts
+++ b/tests/common/widgets/range-input/index.ts
@@ -1,6 +1,7 @@
 import { fakeAct } from '../../common';
 
 import { createBehaviourTests } from './behaviour';
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -22,5 +23,6 @@ export function createRangeInputWidgetTests(
   describe('RangeInput widget common tests', () => {
     createBehaviourTests(setup, { act, skippedTests });
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/range-input/links.ts
+++ b/tests/common/widgets/range-input/links.ts
@@ -1,0 +1,71 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { RangeInputWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: RangeInputWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const attribute = 'price';
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attribute]: {
+                        0: 100,
+                        1: 200,
+                      },
+                    },
+                    facets_stats: {
+                      [attribute]: {
+                        min: 0,
+                        max: 200,
+                        avg: 100,
+                        sum: 300,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attribute },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-RangeInput')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/rating-menu/index.ts
+++ b/tests/common/widgets/rating-menu/index.ts
@@ -1,6 +1,7 @@
 import { fakeAct, skippableDescribe } from '../../common';
 
 import { createBehaviourTests } from './behaviour';
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -22,5 +23,6 @@ export function createRatingMenuWidgetTests(
   skippableDescribe('RatingMenu widget common tests', skippedTests, () => {
     createBehaviourTests(setup, { act, skippedTests });
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/rating-menu/links.ts
+++ b/tests/common/widgets/rating-menu/links.ts
@@ -1,0 +1,105 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import userEvent from '@testing-library/user-event';
+
+import type { RatingMenuWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: RatingMenuWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const attribute = 'rating';
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attribute]: {
+                        1: 100,
+                        2: 100,
+                        3: 100,
+                        4: 100,
+                        5: 100,
+                      },
+                    },
+                    facets_stats: {
+                      [attribute]: {
+                        min: 0,
+                        max: 500,
+                        avg: 250,
+                        sum: 500,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attribute },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-RatingMenu')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(4);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+
+      // Click all links with a modifier
+      {
+        await act(async () => {
+          container.querySelectorAll('a').forEach((link) => {
+            userEvent.click(link, { ctrlKey: true });
+          });
+
+          await wait(0);
+          await wait(0);
+        });
+
+        // No UI has changed
+        expect(container.querySelectorAll('a')).toHaveLength(4);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+
+      // Wait for new results to come in
+      {
+        await act(async () => {
+          await wait(delay + margin);
+        });
+
+        expect(container.querySelectorAll('a')).toHaveLength(4);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/refinement-list/index.ts
+++ b/tests/common/widgets/refinement-list/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptimisticUiTests } from './optimistic-ui';
 import { createOptionsTests } from './options';
 
@@ -22,5 +23,6 @@ export function createRefinementListWidgetTests(
   describe('RefinementList widget common tests', () => {
     createOptimisticUiTests(setup, { act, skippedTests });
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/refinement-list/links.ts
+++ b/tests/common/widgets/refinement-list/links.ts
@@ -1,0 +1,63 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { RefinementListWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: RefinementListWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const attribute = 'brand';
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attribute]: {
+                        Samsung: 100,
+                        Apple: 200,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attribute },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-RefinementList')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/related-products/index.ts
+++ b/tests/common/widgets/related-products/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct, skippableDescribe } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createRelatedProductsWidgetTests(
 
   skippableDescribe('RelatedProducts widget common tests', skippedTests, () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/related-products/links.ts
+++ b/tests/common/widgets/related-products/links.ts
@@ -1,0 +1,43 @@
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
+import { wait } from '@instantsearch/testutils';
+
+import type { RelatedProductsWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: RelatedProductsWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const objectIDs = ['1'];
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createRecommendSearchClient(),
+        },
+        widgetParams: { objectIDs },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-RelatedProducts')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.getRecommendations
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/search-box/index.ts
+++ b/tests/common/widgets/search-box/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createSearchBoxWidgetTests(
 
   describe('SearchBox widget common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/search-box/links.ts
+++ b/tests/common/widgets/search-box/links.ts
@@ -1,0 +1,53 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { SearchBoxWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: SearchBoxWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() => createSingleSearchResponse({}))
+              );
+            }),
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-SearchBox')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/sort-by/index.ts
+++ b/tests/common/widgets/sort-by/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createSortByWidgetTests(
 
   describe('SortBy widget common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/sort-by/links.ts
+++ b/tests/common/widgets/sort-by/links.ts
@@ -1,0 +1,55 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { SortByWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: SortByWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() => createSingleSearchResponse({}))
+              );
+            }),
+          }),
+        },
+        widgetParams: {
+          items: [{ value: 'value', label: 'label', default: true }],
+        },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-SortBy')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/stats/index.ts
+++ b/tests/common/widgets/stats/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createStatsWidgetTests(
 
   describe('Stats widget common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/stats/links.ts
+++ b/tests/common/widgets/stats/links.ts
@@ -1,0 +1,53 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { StatsWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: StatsWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() => createSingleSearchResponse({}))
+              );
+            }),
+          }),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-Stats')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/toggle-refinement/links.ts
+++ b/tests/common/widgets/toggle-refinement/links.ts
@@ -1,0 +1,63 @@
+import {
+  createSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+
+import type { ToggleRefinementWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: ToggleRefinementWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const attribute = 'brand';
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient({
+            search: jest.fn(async (requests) => {
+              await wait(delay);
+              return createMultiSearchResponse(
+                ...requests.map(() =>
+                  createSingleSearchResponse({
+                    facets: {
+                      [attribute]: {
+                        Samsung: 100,
+                        Apple: 200,
+                      },
+                    },
+                  })
+                )
+              );
+            }),
+          }),
+        },
+        widgetParams: { attribute, on: 'Samsung', off: 'Apple' },
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-ToggleRefinement')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.search
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}

--- a/tests/common/widgets/trending-items/index.ts
+++ b/tests/common/widgets/trending-items/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct, skippableDescribe } from '../../common';
 
+import { createLinksTests } from './links';
 import { createOptionsTests } from './options';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -20,5 +21,6 @@ export function createTrendingItemsWidgetTests(
 
   skippableDescribe('TrendingItems widget common tests', skippedTests, () => {
     createOptionsTests(setup, { act, skippedTests });
+    createLinksTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/widgets/trending-items/links.ts
+++ b/tests/common/widgets/trending-items/links.ts
@@ -1,0 +1,42 @@
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
+import { wait } from '@instantsearch/testutils';
+
+import type { TrendingItemsWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createLinksTests(
+  setup: TrendingItemsWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('links', () => {
+    test("a click on a link with modifier doesn't search", async () => {
+      const delay = 100;
+      const margin = 10;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createRecommendSearchClient(),
+        },
+        widgetParams: {},
+      };
+
+      await setup(options);
+
+      // Wait for initial results to populate widgets with data
+      await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const container = document.querySelector('.ais-TrendingItems')!;
+
+      // Initial state, before interaction
+      {
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(
+          options.instantSearchOptions.searchClient.getRecommendations
+        ).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

You should be able to cmd-click on every link rendered by InstantSearch and open it in a new tab. The default behaviour should never be prevented if it's a modifier or special click.

**Result**

- Menu in React and Vue
- Breadcrumb in JS and Vue
- HierarchicalMenu in Vue
- RatingMenu in Vue
- every widget has a "links" test suite that control-clicks all links and ensures no search happened (thus prevent default wasn't called)