### PR TITLE
feat(cisa): can now display images by picking an attribute

### DIFF
--- a/packages/create-instantsearch-app/README.md
+++ b/packages/create-instantsearch-app/README.md
@@ -71,6 +71,7 @@ $ create-instantsearch-app --help
     --api-key <apiKey>                                 The Algolia search API key
     --index-name <indexName>                           The main index of your search
     --attributes-to-display <attributesToDisplay>      The attributes of your index to display
+    --image-attribute <imageAttribute>                 The attribute of your index to use for image display
     --attributes-for-faceting <attributesForFaceting>  The attributes for faceting
     --template <template>                              The InstantSearch template to use
     --library-version <libraryVersion>                 The version of the library
@@ -114,6 +115,7 @@ The `config` flag is handy to automate app generations.
   "indexName": "MY_INDEX_NAME",
   "searchPlaceholder": "Search",
   "attributesToDisplay": ["name", "description"],
+  "imageAttribute": "image",
   "attributesForFaceting": ["brand", "location"],
   "enableInsights": true
 }
@@ -136,6 +138,7 @@ const app = createInstantSearchApp('~/lab/my-app', {
   template: 'InstantSearch.js',
   libraryVersion: '2.0.0',
   attributesToDisplay: ['name', 'description'],
+  imageAttribute: 'image',
   attributesForFaceting: ['keywords'],
   enableInsights: true,
 });

--- a/packages/create-instantsearch-app/e2e/__snapshots__/templates.test.js.snap
+++ b/packages/create-instantsearch-app/e2e/__snapshots__/templates.test.js.snap
@@ -2576,6 +2576,7 @@ search.addWidgets([
     templates: {
       item: (hit, { html, components }) => html\`
         <article>
+          <img src=\${hit.imageAttribute} alt=\${hit.attribute1} />
           <h1>\${components.Highlight({ hit, attribute: 'attribute1' })}</h1>
           <p>\${components.Highlight({ hit, attribute: 'attribute2' })}</p>
         </article>
@@ -4182,6 +4183,7 @@ function renderHits(query) {
             (hit) =>
               \`<li class=\\"ais-hits--item\\">
                 <article>
+                  <img src=\\"\${hit.imageAttribute}\\" alt=\\"\${hit.attribute1}\\" />
                   <h1>\${hit._highlightResult.attribute1.value}</h1>
                   <p>\${hit._highlightResult.attribute2.value}</p>
                 </article>
@@ -4496,6 +4498,7 @@ helper.on('result', ({ results }) => {
           (hit) =>
             \`<li class=\\"ais-hits--item\\">
               <article>
+                <img src=\\"\${hit.imageAttribute}\\" alt=\\"\${hit.attribute1}\\" />
                 <h1>\${hit._highlightResult.attribute1.value}</h1>
                 <p>\${hit._highlightResult.attribute2.value}</p>
               </article>
@@ -4778,7 +4781,7 @@ export function App() {
           <Configure hitsPerPage={8} />
           <div className=\\"search-panel\\">
             <div className=\\"search-panel__filters\\">
-              <DynamicWidgets fallback={RefinementList}>
+              <DynamicWidgets fallbackComponent={RefinementList}>
                 <Panel header=\\"facet1\\">
                   <RefinementList attribute=\\"facet1\\" />
                 </Panel>
@@ -4813,6 +4816,7 @@ type HitProps = {
 function Hit({ hit }: HitProps) {
   return (
     <article>
+      <img src={hit.imageAttribute} alt={hit.attribute1} />
       <h1>
         <Highlight attribute=\\"attribute1\\" hit={hit} />
       </h1>
@@ -5504,6 +5508,7 @@ exports[`Templates Vue InstantSearch File content: src/App.vue 1`] = `
             <ais-hits>
               <template slot=\\"item\\" slot-scope=\\"{ item }\\">
                 <article>
+                  <img :src=\\"item.imageAttribute\\" :alt=\\"item.attribute1\\" />
                   <h1>
                     <ais-highlight :hit=\\"item\\" attribute=\\"attribute1\\" />
                   </h1>
@@ -5799,6 +5804,7 @@ exports[`Templates Vue InstantSearch with Vue 3 File content: src/App.vue 1`] = 
             <ais-hits>
               <template v-slot:item=\\"{ item }\\">
                 <article>
+                  <img :src=\\"item.imageAttribute\\" :alt=\\"item.attribute1\\" />
                   <h1>
                     <ais-highlight :hit=\\"item\\" attribute=\\"attribute1\\" />
                   </h1>

--- a/packages/create-instantsearch-app/e2e/templates.test.js
+++ b/packages/create-instantsearch-app/e2e/templates.test.js
@@ -53,6 +53,7 @@ describe('Templates', () => {
           indexName: 'indexName',
           searchPlaceholder: 'Search placeholder',
           attributesToDisplay: ['attribute1', 'attribute2'],
+          imageAttribute: 'imageAttribute',
           attributesForFaceting: ['ais.dynamicWidgets', 'facet1', 'facet2'],
           organization: 'algolia',
           enableInsights: true,

--- a/packages/create-instantsearch-app/src/cli/__tests__/postProcessAnswers.js
+++ b/packages/create-instantsearch-app/src/cli/__tests__/postProcessAnswers.js
@@ -263,3 +263,21 @@ describe('flags', () => {
     });
   });
 });
+
+test('removes `imageAttribute` from `attributesToDisplay`', async () => {
+  expect(
+    await postProcessAnswers({
+      configuration: {},
+      templateConfig: {},
+      optionsFromArguments: {},
+      answers: {
+        attributesToDisplay: ['test', 'image'],
+        imageAttribute: 'image',
+      },
+    })
+  ).toEqual(
+    expect.objectContaining({
+      attributesToDisplay: ['test'],
+    })
+  );
+});

--- a/packages/create-instantsearch-app/src/cli/getPotentialImageAttributes.js
+++ b/packages/create-instantsearch-app/src/cli/getPotentialImageAttributes.js
@@ -1,0 +1,43 @@
+const getInformationFromIndex = require('./getInformationFromIndex');
+
+module.exports = async function getPotentialImageAttributes({
+  appId,
+  apiKey,
+  indexName,
+} = {}) {
+  try {
+    const { hits } = await getInformationFromIndex({
+      appId,
+      apiKey,
+      indexName,
+    });
+    const [firstHit] = hits;
+    const highlightedAttributes = Object.keys(firstHit._highlightResult);
+    return Object.entries(firstHit)
+      .filter(
+        ([key, value]) =>
+          typeof value === 'string' &&
+          !/[\s]+/.test(value) &&
+          !highlightedAttributes.includes(key) &&
+          key !== 'objectID'
+      )
+      .map(([key]) => key)
+      .sort((a, b) => {
+        const regex = /image|img/;
+        const aIncludesImage = regex.test(a);
+        const bIncludesImage = regex.test(b);
+
+        if (aIncludesImage && !bIncludesImage) {
+          return -1;
+        }
+
+        if (!aIncludesImage && bIncludesImage) {
+          return 1;
+        }
+
+        return 0;
+      });
+  } catch (err) {
+    return [];
+  }
+};

--- a/packages/create-instantsearch-app/src/cli/index.js
+++ b/packages/create-instantsearch-app/src/cli/index.js
@@ -24,6 +24,7 @@ const getAnswersDefaultValues = require('./getAnswersDefaultValues');
 const getAttributesFromIndex = require('./getAttributesFromIndex');
 const getConfiguration = require('./getConfiguration');
 const getFacetsFromIndex = require('./getFacetsFromIndex');
+const getPotentialImageAttributes = require('./getPotentialImageAttributes');
 const isQuestionAsked = require('./isQuestionAsked');
 const postProcessAnswers = require('./postProcessAnswers');
 
@@ -43,6 +44,10 @@ program
     '--attributes-to-display <attributesToDisplay>',
     'The attributes of your index to display in hits',
     splitArray
+  )
+  .option(
+    '--image-attribute <imageAttribute>',
+    'The attribute for image display in hits'
   )
   .option(
     '--attributes-for-faceting <attributesForFaceting>',
@@ -158,6 +163,36 @@ const getQuestions = ({ appName }) => ({
       filter: (attributes) => attributes.filter(Boolean),
       when: ({ appId, apiKey, indexName }) =>
         attributesToDisplay.length === 0 && appId && apiKey && indexName,
+    },
+    {
+      type: 'list',
+      name: 'imageAttribute',
+      message: 'Attribute for image display',
+      suffix: `\n  ${chalk.gray(
+        'Used to display images in the default result template'
+      )}`,
+      pageSize: 10,
+      choices: async (answers) => [
+        {
+          name: 'None',
+          value: undefined,
+        },
+        new inquirer.Separator(),
+        new inquirer.Separator('From your index'),
+        ...(await getPotentialImageAttributes(answers)),
+      ],
+      when: ({
+        appId,
+        apiKey,
+        indexName,
+        imageAttribute,
+        attributesToDisplay: selectedAttributes,
+      }) =>
+        selectedAttributes.length > 0 &&
+        !imageAttribute &&
+        appId &&
+        apiKey &&
+        indexName,
     },
     {
       type: 'checkbox',

--- a/packages/create-instantsearch-app/src/cli/postProcessAnswers.js
+++ b/packages/create-instantsearch-app/src/cli/postProcessAnswers.js
@@ -65,6 +65,9 @@ async function postProcessAnswers({
     template: templatePath,
     installation: optionsFromArguments.installation,
     currentYear: new Date().getFullYear(),
+    attributesToDisplay: combinedAnswers.attributesToDisplay?.filter(
+      (attribute) => attribute !== combinedAnswers.imageAttribute
+    ),
     attributesForFaceting:
       Array.isArray(combinedAnswers.attributesForFaceting) &&
       combinedAnswers.attributesForFaceting.filter(

--- a/packages/create-instantsearch-app/src/templates/InstantSearch.js/src/app.js.hbs
+++ b/packages/create-instantsearch-app/src/templates/InstantSearch.js/src/app.js.hbs
@@ -39,6 +39,9 @@ search.addWidgets([
     templates: {
       item: (hit, { html, components }) => html`
 <article>
+  {{#if imageAttribute}}
+  <img src=${ hit.{{imageAttribute}} } alt=${ hit.{{attributesToDisplay.[0]}} } />
+  {{/if}}
   <h1>${components.Highlight({hit, attribute: "{{attributesToDisplay.[0]}}"})}</h1>
   {{#each attributesToDisplay}}
   {{#unless @first}}

--- a/packages/create-instantsearch-app/src/templates/JavaScript Client/src/app.js.hbs
+++ b/packages/create-instantsearch-app/src/templates/JavaScript Client/src/app.js.hbs
@@ -17,6 +17,9 @@ function renderHits(query) {
               `<li class="ais-hits--item">
                 <article>
                 {{#if attributesToDisplay}}
+                  {{#if imageAttribute}}
+                  <img src="${ hit.{{imageAttribute}} }" alt="${ hit.{{attributesToDisplay.[0]}} }" />
+                  {{/if}}
                   <h1>${hit._highlightResult.{{attributesToDisplay.[0]}}.value}</h1>
                   {{#each attributesToDisplay}}
                   {{#unless @first}}

--- a/packages/create-instantsearch-app/src/templates/JavaScript Helper/src/app.js.hbs
+++ b/packages/create-instantsearch-app/src/templates/JavaScript Helper/src/app.js.hbs
@@ -23,6 +23,9 @@ helper.on('result', ({ results }) => {
             `<li class="ais-hits--item">
               <article>
               {{#if attributesToDisplay}}
+                {{#if imageAttribute}}
+                <img src="${ hit.{{imageAttribute}} }" alt="${ hit.{{attributesToDisplay.[0]}} }" />
+                {{/if}}
                 <h1>${hit._highlightResult.{{attributesToDisplay.[0]}}.value}</h1>
                 {{#each attributesToDisplay}}
                 {{#unless @first}}

--- a/packages/create-instantsearch-app/src/templates/React InstantSearch/src/App.tsx.hbs
+++ b/packages/create-instantsearch-app/src/templates/React InstantSearch/src/App.tsx.hbs
@@ -54,7 +54,7 @@ export function App() {
           <div className="search-panel">
             <div className="search-panel__filters">
               {{#if flags.dynamicWidgets}}
-              <DynamicWidgets fallback={RefinementList}>
+              <DynamicWidgets fallbackComponent={RefinementList}>
                 {{#each attributesForFaceting}}
                 <Panel header="{{this}}">
                   <RefinementList attribute="{{this}}" />
@@ -93,6 +93,9 @@ function Hit({ hit }: HitProps) {
   return (
     <article>
       {{#if attributesToDisplay}}
+      {{#if imageAttribute}}
+      <img src={ hit.{{imageAttribute}} } alt={ hit.{{attributesToDisplay.[0]}} } />
+      {{/if}}
       <h1>
         <Highlight attribute="{{attributesToDisplay.[0]}}" hit={hit} />
       </h1>

--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch with Vue 3/src/App.vue
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch with Vue 3/src/App.vue
@@ -49,6 +49,9 @@
             <ais-hits>
               <template v-slot:item="{ item }">
                 <article>
+                  {{#if imageAttribute}}
+                  <img :src="item.{{imageAttribute}}" :alt="item.{{attributesToDisplay.[0]}}" />
+                  {{/if}}
                   <h1>
                     <ais-highlight
                       :hit="item"

--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch/src/App.vue
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch/src/App.vue
@@ -50,6 +50,9 @@
             <ais-hits>
               <template slot="item" slot-scope="{ item }">
                 <article>
+                  {{#if imageAttribute}}
+                  <img :src="item.{{imageAttribute}}" :alt="item.{{attributesToDisplay.[0]}}" />
+                  {{/if}}
                   <h1>
                     <ais-highlight
                       :hit="item"


### PR DESCRIPTION
**Summary**

### [FX-2610](https://algolia.atlassian.net/browse/FX-2610)

**Result**

- New `imageAttribute` option, takes a single string
  - From the CLI it can either be a root key, or something like `images.default` or `images[0]`
  - For the sake of simplicity, in interactive mode we only let them choose from root attributes with values that are strings without whitespace. Attribute keys containing `image` or `img` will be on top of the list.
  - We remove `imageAttribute` from `attributesToDisplay` if it was specified in CLI, although it wouldn't make sense as `attributesToDisplay` should be in `_highlightResults`
  - Templates have been updated to add a simple `img` tag with corresponding `src`, and `alt` is `attributesToDisplay[0]` as it's also mapped to a `h1` tag.
- Fixed a bug in the React InstantSearch template which was setting a `fallback` prop to `DynamicWidgets` instead of `fallbackComponent`


[FX-2610]: https://algolia.atlassian.net/browse/FX-2610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ