### PR TITLE
feat(createInsightsMiddleware): support `authenticatedUserToken`

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "167.25 kB"
+      "maxSize": "167.5 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "65 kB"
+      "maxSize": "65.25 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -881,6 +881,166 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
       expect(instantSearchInstance.client.search).toHaveBeenCalledTimes(2);
     });
 
+    describe('authenticatedUserToken', () => {
+      describe('before `init`', () => {
+        it('uses the `authenticatedUserToken` as the `userToken` when defined', () => {
+          const { insightsClient, instantSearchInstance, getUserToken } =
+            createTestEnvironment();
+
+          insightsClient('setAuthenticatedUserToken', 'abc');
+
+          instantSearchInstance.use(
+            createInsightsMiddleware({ insightsClient })
+          );
+
+          expect(getUserToken()).toEqual('abc');
+        });
+
+        it('uses the `authenticatedUserToken` as the `userToken` when both are defined', () => {
+          const { insightsClient, instantSearchInstance, getUserToken } =
+            createTestEnvironment();
+
+          insightsClient('setUserToken', 'abc');
+          insightsClient('setAuthenticatedUserToken', 'def');
+
+          instantSearchInstance.use(
+            createInsightsMiddleware({ insightsClient })
+          );
+
+          expect(getUserToken()).toEqual('def');
+        });
+
+        it('reverts to the `userToken` when unsetting the `authenticatedUserToken`', () => {
+          const { insightsClient, instantSearchInstance, getUserToken } =
+            createTestEnvironment();
+
+          insightsClient('setUserToken', 'abc');
+          insightsClient('setAuthenticatedUserToken', 'def');
+          insightsClient('setAuthenticatedUserToken', undefined);
+
+          instantSearchInstance.use(
+            createInsightsMiddleware({ insightsClient })
+          );
+
+          expect(getUserToken()).toEqual('abc');
+        });
+      });
+
+      describe('after `init`', () => {
+        it('uses the `authenticatedUserToken` as the `userToken` when defined', async () => {
+          const { insightsClient, instantSearchInstance, getUserToken } =
+            createTestEnvironment();
+          instantSearchInstance.use(
+            createInsightsMiddleware({ insightsClient })
+          );
+
+          insightsClient('setAuthenticatedUserToken', 'abc');
+
+          await wait(0);
+
+          expect(getUserToken()).toEqual('abc');
+        });
+
+        it('uses the `authenticatedUserToken` as the `userToken` when both are defined', async () => {
+          const { insightsClient, instantSearchInstance, getUserToken } =
+            createTestEnvironment();
+          instantSearchInstance.use(
+            createInsightsMiddleware({ insightsClient })
+          );
+
+          insightsClient('setUserToken', 'abc');
+          insightsClient('setAuthenticatedUserToken', 'def');
+
+          await wait(0);
+
+          expect(getUserToken()).toEqual('def');
+        });
+
+        it('reverts to the `userToken` when unsetting the `authenticatedUserToken`', async () => {
+          const { insightsClient, instantSearchInstance, getUserToken } =
+            createTestEnvironment();
+          instantSearchInstance.use(
+            createInsightsMiddleware({ insightsClient })
+          );
+
+          insightsClient('setUserToken', 'abc');
+          insightsClient('setAuthenticatedUserToken', 'def');
+          insightsClient('setAuthenticatedUserToken', undefined);
+
+          await wait(0);
+
+          expect(getUserToken()).toEqual('abc');
+        });
+      });
+
+      describe('from queue', () => {
+        it('uses the `authenticatedUserToken` as the `userToken` when defined', () => {
+          const {
+            insightsClient,
+            libraryLoadedAndProcessQueue,
+            instantSearchInstance,
+            getUserToken,
+          } = createUmdTestEnvironment();
+
+          insightsClient('init', { appId: 'myAppId', apiKey: 'myApiKey' });
+          insightsClient('setAuthenticatedUserToken', 'abc');
+
+          instantSearchInstance.use(
+            createInsightsMiddleware({
+              insightsClient,
+            })
+          );
+          libraryLoadedAndProcessQueue();
+
+          expect(getUserToken()).toEqual('abc');
+        });
+
+        it('uses the `authenticatedUserToken` as the `userToken` when both are defined', () => {
+          const {
+            insightsClient,
+            libraryLoadedAndProcessQueue,
+            instantSearchInstance,
+            getUserToken,
+          } = createUmdTestEnvironment();
+
+          insightsClient('init', { appId: 'myAppId', apiKey: 'myApiKey' });
+          insightsClient('setUserToken', 'abc');
+          insightsClient('setAuthenticatedUserToken', 'def');
+
+          instantSearchInstance.use(
+            createInsightsMiddleware({
+              insightsClient,
+            })
+          );
+          libraryLoadedAndProcessQueue();
+
+          expect(getUserToken()).toEqual('def');
+        });
+
+        it('reverts to the `userToken` when unsetting the `authenticatedUserToken`', () => {
+          const {
+            insightsClient,
+            libraryLoadedAndProcessQueue,
+            instantSearchInstance,
+            getUserToken,
+          } = createUmdTestEnvironment();
+
+          insightsClient('setUserToken', 'abc');
+          insightsClient('setAuthenticatedUserToken', 'def');
+          insightsClient('setAuthenticatedUserToken', undefined);
+
+          instantSearchInstance.use(
+            createInsightsMiddleware({
+              insightsClient,
+            })
+          );
+          libraryLoadedAndProcessQueue();
+
+          expect(getUserToken()).toEqual('abc');
+        });
+      });
+    });
+
     describe('umd', () => {
       it('applies userToken from queue if exists', () => {
         const {

--- a/tests/common/shared/insights.ts
+++ b/tests/common/shared/insights.ts
@@ -76,7 +76,7 @@ export function createInsightsTests(
         });
 
         // initial calls because the middleware is attached
-        expect(window.aa).toHaveBeenCalledTimes(4);
+        expect(window.aa).toHaveBeenCalledTimes(6);
         expect(window.aa).toHaveBeenCalledWith(
           'addAlgoliaAgent',
           'insights-middleware'
@@ -151,7 +151,7 @@ export function createInsightsTests(
         await setup(options);
 
         // initial calls because the middleware is attached
-        expect(window.aa).toHaveBeenCalledTimes(3);
+        expect(window.aa).toHaveBeenCalledTimes(5);
         expect(window.aa).toHaveBeenCalledWith(
           'addAlgoliaAgent',
           'insights-middleware'
@@ -164,7 +164,7 @@ export function createInsightsTests(
         });
 
         // Once result is available
-        expect(window.aa).toHaveBeenCalledTimes(4);
+        expect(window.aa).toHaveBeenCalledTimes(6);
         expect(window.aa).toHaveBeenCalledWith(
           'viewedObjectIDs',
           {


### PR DESCRIPTION
This supports the new `authenticatedUserToken` from Search Insights.

When provided, it takes precedence over the `userToken`. When not, or when unset, the `userToken` is used.

> [!NOTE]  
> The code and tests are getting a bit more complicated than they could, but I didn't want to make a refactor in this PR to avoid complexifying the diffs. I'll do it in a separate one.

https://algolia.atlassian.net/browse/FX-2707