### PR TITLE
fix(perf): improve speed of setQueryParameters

### DIFF
--- a/packages/algoliasearch-helper/src/SearchParameters/index.js
+++ b/packages/algoliasearch-helper/src/SearchParameters/index.js
@@ -300,7 +300,7 @@ SearchParameters._parseNumbers = function (partialState) {
     numbers.numericRefinements = numericRefinements;
   }
 
-  return merge({}, partialState, numbers);
+  return merge(partialState, numbers);
 };
 
 /**

--- a/packages/algoliasearch-helper/src/requestBuilder.js
+++ b/packages/algoliasearch-helper/src/requestBuilder.js
@@ -277,9 +277,12 @@ var requestBuilder = {
       .sort()
       .forEach(function (facetName) {
         var facetValues = facetsRefinements[facetName] || [];
-        facetValues.sort().forEach(function (facetValue) {
-          facetFilters.push(facetName + ':' + facetValue);
-        });
+        facetValues
+          .slice()
+          .sort()
+          .forEach(function (facetValue) {
+            facetFilters.push(facetName + ':' + facetValue);
+          });
       });
 
     var facetsExcludes = state.facetsExcludes || {};
@@ -302,9 +305,12 @@ var requestBuilder = {
         }
         var orFilters = [];
 
-        facetValues.sort().forEach(function (facetValue) {
-          orFilters.push(facetName + ':' + facetValue);
-        });
+        facetValues
+          .slice()
+          .sort()
+          .forEach(function (facetValue) {
+            orFilters.push(facetName + ':' + facetValue);
+          });
 
         facetFilters.push(orFilters);
       });

--- a/packages/algoliasearch-helper/test/datasets/SearchParameters/search.dataset.js
+++ b/packages/algoliasearch-helper/test/datasets/SearchParameters/search.dataset.js
@@ -188,7 +188,8 @@ function getData() {
     index: 'test_hotels-node',
     disjunctiveFacets: ['city'],
     disjunctiveFacetsRefinements: {
-      city: ['New York', 'Paris'],
+      // Note: these are in the same order as the refinements above, not sorted
+      city: ['Paris', 'New York'],
     },
   });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

inside setQueryParameters (used in many cases), we have _parseNumbers, which is always used with the arguments of setQueryParameters or new SearchParameters. This therefore means we don't need to make a safe copy of the parameters, everything should be fine using the arguments instead.


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

Note, this PR requires #6007 to be merged _before_ it. The failing test is related to that change.

better perf:

before|after
---|---
<img width="549" alt="Screenshot 2024-01-17 at 11 35 45" src="https://github.com/algolia/instantsearch/assets/6270048/3aa6b679-ec42-4d67-af1b-1463efc88976"> | <img width="679" alt="Screenshot 2024-01-17 at 11 36 12" src="https://github.com/algolia/instantsearch/assets/6270048/74cada70-7af3-463c-b2e6-1f311a4a31ac">


<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
