### PR TITLE
fix(requestBuilder): sort facet refinements in a non-mutating manner

### DIFF
--- a/packages/algoliasearch-helper/src/requestBuilder.js
+++ b/packages/algoliasearch-helper/src/requestBuilder.js
@@ -277,9 +277,12 @@ var requestBuilder = {
       .sort()
       .forEach(function (facetName) {
         var facetValues = facetsRefinements[facetName] || [];
-        facetValues.sort().forEach(function (facetValue) {
-          facetFilters.push(facetName + ':' + facetValue);
-        });
+        facetValues
+          .slice()
+          .sort()
+          .forEach(function (facetValue) {
+            facetFilters.push(facetName + ':' + facetValue);
+          });
       });
 
     var facetsExcludes = state.facetsExcludes || {};
@@ -302,9 +305,12 @@ var requestBuilder = {
         }
         var orFilters = [];
 
-        facetValues.sort().forEach(function (facetValue) {
-          orFilters.push(facetName + ':' + facetValue);
-        });
+        facetValues
+          .slice()
+          .sort()
+          .forEach(function (facetValue) {
+            orFilters.push(facetName + ':' + facetValue);
+          });
 
         facetFilters.push(orFilters);
       });

--- a/packages/algoliasearch-helper/test/datasets/SearchParameters/search.dataset.js
+++ b/packages/algoliasearch-helper/test/datasets/SearchParameters/search.dataset.js
@@ -188,7 +188,8 @@ function getData() {
     index: 'test_hotels-node',
     disjunctiveFacets: ['city'],
     disjunctiveFacetsRefinements: {
-      city: ['New York', 'Paris'],
+      // Note: these are in the same order as the refinements above, not sorted
+      city: ['Paris', 'New York'],
     },
   });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

introduced in https://github.com/algolia/instantsearch/pull/5764, but wasn't an issue until merge/setQueryParameters doesn't make a new copy constantly of the parameters.

Essentially what's going on:
- when you build the requests, it's sorting the facet values
- this then gets updated in the parameters as well as it's the same object
- with this fix, the sorting is done non-mutating (similar to .toSorted) to avoid the sorting of the parameters for cache to have a potential impact on the UI

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

tests that fail in #6006 are now passing. This commit can be reviewed separately, but really needs to be merged before.
