### PR TITLE
fix(vue-compat): Ensure getDefaultSlots works with @vue/compat & Vue 3

### DIFF
--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
@@ -49,5 +49,13 @@ export function renderCompat(fn) {
 }
 
 export function getDefaultSlot(component) {
-  return component.$slots.default && component.$slots.default();
+  const $slots = component.$slots || component.slots;
+
+  if (typeof $slots.default === 'function') {
+    // Vue 3
+    return $slots.default();
+  }
+
+  // Vue 3 with @vue/compat
+  return $slots.default;
 }


### PR DESCRIPTION
**Summary**

Fixes https://github.com/algolia/instantsearch/issues/6015

There is a compatibility issue when using the Vue3 version of the Algolia InstantSearch library alongside the [@vue/compat](https://www.npmjs.com/package/@vue/compat) module during a migration from Vue 2 to 3. When attempting to run the application with the InstantSearch library in a Vue 3 environment that utilises the [@vue/compat](https://www.npmjs.com/package/@vue/compat) module for backward compatibility, the application fails to initialise properly.

```
[Vue warn]: Unhandled error during execution of render function 
  at <AisInstantSearch search-client=index-name="instant_search" > 
```

**Live reproduction**

[https://codesandbox.io/p/devbox/black-glade-jrhmvc](https://codesandbox.io/p/devbox/black-glade-jrhmvc?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clrlwlzk000073b6h43wyezz1%2522%252C%2522sizes%2522%253A%255B100%252C0%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clrlwlzk000023b6hxd0r7jjz%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clrlwlzk000043b6hj2alh9sg%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clrlwlzk000063b6hgohhjnng%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clrlwlzk000023b6hxd0r7jjz%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clrlwlzk000013b6h181p0yk0%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clrlwnvov00023b6hberpqo4s%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A14%252C%2522startColumn%2522%253A17%252C%2522endLineNumber%2522%253A14%252C%2522endColumn%2522%253A17%257D%255D%252C%2522filepath%2522%253A%2522%252Fpackage.json%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clrlxt7uu00023b6hkwt1uhgp%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A11%252C%2522startColumn%2522%253A26%252C%2522endLineNumber%2522%253A11%252C%2522endColumn%2522%253A26%257D%255D%252C%2522filepath%2522%253A%2522%252Fvite.config.js%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522id%2522%253A%2522clrlwlzk000023b6hxd0r7jjz%2522%252C%2522activeTabId%2522%253A%2522clrlxt7uu00023b6hkwt1uhgp%2522%257D%252C%2522clrlwlzk000063b6hgohhjnng%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clrlwlzk000053b6hoalg5wpf%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_PORT%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522port%2522%253A3000%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clrlwlzk000063b6hgohhjnng%2522%252C%2522activeTabId%2522%253A%2522clrlwlzk000053b6hoalg5wpf%2522%257D%252C%2522clrlwlzk000043b6hj2alh9sg%2522%253A%257B%2522id%2522%253A%2522clrlwlzk000043b6hj2alh9sg%2522%252C%2522activeTabId%2522%253A%2522clrlwlzk000033b6hmp6oh1pm%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clrlwlzk000033b6hmp6oh1pm%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522dev%2522%257D%252C%257B%2522id%2522%253A%2522clrlwo65p002z3b6hq6oae1t4%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TERMINAL%2522%252C%2522shellId%2522%253A%2522clrlwo68c000we6d57wtf6vqo%2522%257D%255D%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Afalse%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)

**Result**
Fork of the Live reproduction with references updated to the build from this PR:
[https://codesandbox.io/p/devbox/awesome-shockley-5c3r4l](https://codesandbox.io/p/devbox/awesome-shockley-5c3r4l?file=%2Fpackage.json%3A16%2C5&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clrlwlzk000073b6h43wyezz1%2522%252C%2522sizes%2522%253A%255B60%252C40%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clrlwlzk000023b6hxd0r7jjz%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clrlwlzk000043b6hj2alh9sg%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clrlwlzk000063b6hgohhjnng%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B54.35274057896048%252C45.64725942103952%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clrlwlzk000023b6hxd0r7jjz%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clrlwlzk000013b6h181p0yk0%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clrlwnvov00023b6hberpqo4s%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A16%252C%2522startColumn%2522%253A5%252C%2522endLineNumber%2522%253A16%252C%2522endColumn%2522%253A5%257D%255D%252C%2522filepath%2522%253A%2522%252Fpackage.json%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clrlxt7uu00023b6hkwt1uhgp%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A11%252C%2522startColumn%2522%253A26%252C%2522endLineNumber%2522%253A11%252C%2522endColumn%2522%253A26%257D%255D%252C%2522filepath%2522%253A%2522%252Fvite.config.js%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522id%2522%253A%2522clrlwlzk000023b6hxd0r7jjz%2522%252C%2522activeTabId%2522%253A%2522clrlwnvov00023b6hberpqo4s%2522%257D%252C%2522clrlwlzk000063b6hgohhjnng%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clrlwlzk000053b6hoalg5wpf%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_PORT%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522port%2522%253A3000%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clrlwlzk000063b6hgohhjnng%2522%252C%2522activeTabId%2522%253A%2522clrlwlzk000053b6hoalg5wpf%2522%257D%252C%2522clrlwlzk000043b6hj2alh9sg%2522%253A%257B%2522id%2522%253A%2522clrlwlzk000043b6hj2alh9sg%2522%252C%2522activeTabId%2522%253A%2522clrm488ze01113b6h82ybl7kt%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clrlwo65p002z3b6hq6oae1t4%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TERMINAL%2522%252C%2522shellId%2522%253A%2522clrlwo68c000we6d57wtf6vqo%2522%257D%252C%257B%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522id%2522%253A%2522clrm488ze01113b6h82ybl7kt%2522%252C%2522mode%2522%253A%2522permanent%2522%257D%255D%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)

The app initialises as expected. All components in the example project except [Highlighter](https://github.com/algolia/instantsearch/blob/332933c5265e4c59e460be3a3a1cdfc5e8e026e3/packages/vue-instantsearch/src/components/Highlighter.vue#L18) work as expected. 