### PR TITLE
poc: batch recommend requests and prevent rerender

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -79,6 +79,11 @@ module.exports = (api) => {
             // false positive (babel doesn't know types)
             // this is actually only called on arrays
             'String.prototype.includes',
+
+            // Just for the PoC
+            'Array.prototype.flatMap',
+            'Object.entries',
+            'Object.fromEntries',
           ];
           if (defaultShouldInject && !exclude.includes(name)) {
             throw new Error(

--- a/examples/js/multi-clients/index.html
+++ b/examples/js/multi-clients/index.html
@@ -33,6 +33,9 @@
       </p>
     </header>
 
+    <div id="fbt"></div>
+    <div id="fbt2"></div>
+
     <div class="container">
       <div class="search-panel">
         <div class="search-panel__filters">

--- a/examples/js/multi-clients/src/app.js
+++ b/examples/js/multi-clients/src/app.js
@@ -5,10 +5,11 @@ import {
   panel,
   refinementList,
   searchBox,
+  frequentlyBoughtTogether,
 } from 'instantsearch.js/es/widgets';
 
 import { search } from './search';
-import { hitItem } from './templates';
+import { hitItem, recommendItem } from './templates';
 
 search.addWidgets([
   configure({
@@ -32,6 +33,60 @@ search.addWidgets([
   }),
   pagination({
     container: '#pagination',
+  }),
+  frequentlyBoughtTogether({
+    container: '#fbt',
+    objectIDs: ['M0E20000000EAAK'],
+    cssClasses: { list: 'grid gap-2 grid-cols-3 lg:grid-cols-6' },
+    templates: {
+      item: ({ item, html, sendEvent }) => {
+        return recommendItem({
+          item,
+          html,
+          onAddToCart() {
+            sendEvent('conversion', item, 'Added To Cart', {
+              eventSubtype: 'addToCart',
+              objectData: [
+                {
+                  discount: 0,
+                  price: item.price.value,
+                  quantity: 1,
+                },
+              ],
+              value: item.price.value,
+              currency: item.price.currency,
+            });
+          },
+        });
+      },
+    },
+  }),
+  frequentlyBoughtTogether({
+    container: '#fbt2',
+    objectIDs: ['M0E20000000E1HU'],
+    cssClasses: { list: 'grid gap-2 grid-cols-3 lg:grid-cols-6' },
+    templates: {
+      item: ({ item, html, sendEvent }) => {
+        return recommendItem({
+          item,
+          html,
+          onAddToCart() {
+            sendEvent('conversion', item, 'Added To Cart', {
+              eventSubtype: 'addToCart',
+              objectData: [
+                {
+                  discount: 0,
+                  price: item.price.value,
+                  quantity: 1,
+                },
+              ],
+              value: item.price.value,
+              currency: item.price.currency,
+            });
+          },
+        });
+      },
+    },
   }),
 ]);
 

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -216,6 +216,8 @@ type RequiredUiStateLifeCycle<TWidgetDescription extends WidgetDescription> = {
       >;
     }
   ) => SearchParameters;
+
+  getWidgetRecommendParameters?: any;
 };
 
 type UiStateLifeCycle<TWidgetDescription extends WidgetDescription> =

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -331,6 +331,17 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
           _uiState: localUiState,
         });
 
+        localInstantSearchInstance.registerRecommend(
+          indexName,
+          localWidgets.reduce(
+            (acc, widget) =>
+              widget.getWidgetRecommendParameters
+                ? widget.getWidgetRecommendParameters(acc)
+                : acc,
+            { frequentlyBoughtTogether: [] }
+          )
+        );
+
         // We compute the render state before calling `init` in a separate loop
         // to construct the whole render state object that is then passed to
         // `init`.
@@ -366,6 +377,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         });
 
         localInstantSearchInstance.scheduleSearch();
+        localInstantSearchInstance.scheduleRecommend();
       }
 
       return this;
@@ -454,6 +466,16 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
           index: indexName,
         }),
       });
+      instantSearchInstance.registerRecommend(
+        indexName,
+        localWidgets.reduce(
+          (acc, widget) =>
+            widget.getWidgetRecommendParameters
+              ? widget.getWidgetRecommendParameters(acc)
+              : acc,
+          { frequentlyBoughtTogether: [] }
+        )
+      );
 
       // This Helper is only used for state management we do not care about the
       // `searchClient`. Only the "main" Helper created at the `InstantSearch`


### PR DESCRIPTION
This is a dirty solution but it allows batching of recommend requests across multiple indices, and prevents rerenders when results are the same