### PR TITLE
feat(instantsearch-ui-components): initialize the package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
             - packages/react-instantsearch-nextjs/dist
             - packages/vue-instantsearch/vue2
             - packages/vue-instantsearch/vue3
-
+            - packages/instantsearch-ui-components/dist
   test metadata:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,7 @@ jobs:
             - packages/vue-instantsearch/vue2
             - packages/vue-instantsearch/vue3
             - packages/instantsearch-ui-components/dist
+
   test metadata:
     <<: *defaults
     steps:

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -13,7 +13,8 @@
     "packages/react-instantsearch-core",
     "packages/react-instantsearch-nextjs",
     "packages/vue-instantsearch",
-    "packages/instantsearch.css"
+    "packages/instantsearch.css",
+    "packages/instantsearch-ui-components"
   ],
   "node": "16"
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,6 +43,8 @@ const config = {
     '^instantsearch.js$': '<rootDir>/packages/instantsearch.js/src/',
     '^instantsearch.js/es(.*)$': '<rootDir>/packages/instantsearch.js/src$1',
     '^instantsearch.js/(.*)$': '<rootDir>/packages/instantsearch.js/$1',
+    '^instantsearch-ui-components/(.*)$':
+      '<rootDir>/packages/instantsearch-ui-components/$1',
   },
   modulePathIgnorePatterns: [
     '<rootDir>/packages/create-instantsearch-app/src/templates',

--- a/packages/instantsearch-ui-components/README.md
+++ b/packages/instantsearch-ui-components/README.md
@@ -1,0 +1,44 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [instantsearch-ui-components](#instantsearch-ui-components)
+  - [Contributing](#contributing)
+  - [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# instantsearch-ui-components
+
+InstantSearch UI Components is an open-source UI library used by InstantSearch to build UI for search and discovery interfaces. It exports UI components that are compatible with InstantSearch.js, React InstantSearch, and Vue InstantSearch.
+
+> Note: `instantsearch-ui-components` exists for internal usage and isn't designed for public consumption.
+
+## Contributing
+
+We welcome all contributors, from casual to regular 💙
+
+- **Bug report**. Is something not working as expected? [Send a bug report][contributing-bugreport].
+- **Feature request**. Would you like to add something to the library? [Send a feature request][contributing-featurerequest].
+- **Documentation**. Did you find a typo in the doc? [Open an issue][contributing-newissue] and we'll take care of it.
+- **Development**. If you don't know where to start, you can check the open issues that are [tagged easy][contributing-label-easy], the [bugs][contributing-label-bug] or [chores][contributing-label-chore].
+
+To start contributing to code, you need to:
+
+1.  [Fork the project](https://help.github.com/articles/fork-a-repo/)
+1.  [Clone the repository](https://help.github.com/articles/cloning-a-repository/)
+1.  Install the dependencies: `yarn`
+
+Please read [our contribution process](https://github.com/algolia/instantsearch/blob/master/CONTRIBUTING.md) to learn more.
+
+## License
+
+InstantSearch UI Components is [MIT licensed](../../LICENSE).
+
+<!-- Links -->
+
+[contributing-bugreport]: https://github.com/algolia/instantsearch/issues/new?template=BUG_REPORT.yml&labels=triage,Library%3A%20React+InstantSearch
+[contributing-featurerequest]: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage,Library%3A%20React+InstantSearch&title=Feature%20request%3A%20
+[contributing-newissue]: https://github.com/algolia/instantsearch/issues/new?labels=triage,Library%3A%20React+InstantSearch
+[contributing-label-easy]: https://github.com/algolia/instantsearch/issues?q=is%3Aopen+is%3Aissue+label%3A%22Difficulty%3A+Easy%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-label-bug]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Bug%22+label%3A%22Library%3A%20React+InstantSearch%22
+[contributing-label-chore]: https://github.com/algolia/instantsearch/issues?q=is%3Aissue+is%3Aopen+label%3A%22Type%3A+Chore%22+label%3A%22Library%3A%20React+InstantSearch%22

--- a/packages/instantsearch-ui-components/package.json
+++ b/packages/instantsearch-ui-components/package.json
@@ -9,7 +9,6 @@
   "type": "module",
   "exports": {
     "types": "./dist/es/index.d.ts",
-    "require": "./dist/cjs/index.js",
     "default": "./dist/es/index.js"
   },
   "sideEffects": false,

--- a/packages/instantsearch-ui-components/package.json
+++ b/packages/instantsearch-ui-components/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "instantsearch-ui-components",
+  "version": "0.1.0",
+  "description": "Common UI components for InstantSearch.",
+  "source": "src/index.ts",
+  "types": "dist/es/index.d.ts",
+  "main": "dist/es/index.js",
+  "module": "dist/es/index.js",
+  "type": "module",
+  "exports": {
+    "types": "./dist/es/index.d.ts",
+    "require": "./dist/cjs/index.js",
+    "default": "./dist/es/index.js"
+  },
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/algolia/instantsearch"
+  },
+  "author": {
+    "name": "Algolia, Inc.",
+    "url": "https://www.algolia.com"
+  },
+  "keywords": [
+    "algolia",
+    "components",
+    "fast",
+    "instantsearch",
+    "react",
+    "search",
+    "jsx",
+    "vdom",
+    "hyperscript"
+  ],
+  "files": [
+    "README.md",
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "yarn build:es && yarn build:types",
+    "build:es": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet",
+    "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
+    "version": "./scripts/version.cjs"
+  }
+}

--- a/packages/instantsearch-ui-components/scripts/version.cjs
+++ b/packages/instantsearch-ui-components/scripts/version.cjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const version = require('../package.json').version;
+
+fs.writeFileSync(
+  path.resolve(__dirname, '../src/version.ts'),
+  `export default '${version}';\n`
+);

--- a/packages/instantsearch-ui-components/src/version.ts
+++ b/packages/instantsearch-ui-components/src/version.ts
@@ -1,0 +1,1 @@
+export default '0.1.0';

--- a/packages/instantsearch-ui-components/tsconfig.declaration.json
+++ b/packages/instantsearch-ui-components/tsconfig.declaration.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.declaration"
+}

--- a/tests/versions/index.js
+++ b/tests/versions/index.js
@@ -58,6 +58,11 @@ let hasError = false;
       versionFile: 'src/version.js',
       format: 'cjs',
     },
+    {
+      name: 'instantsearch-ui-components',
+      versionFile: 'src/version.ts',
+      format: 'esm',
+    },
   ];
 
   const results = versions.map(({ name, versionFile, format }) => {


### PR DESCRIPTION
## Summary

This initializes the `instantsearch-ui-components` package with the bare minimum.

https://algolia.atlassian.net/browse/FX-2744

## Notes

- I only export the ES module since this is designed for our usage only, at least for now.
- Not sure what version we want to start with, so I started with `0.1.0` ([why?](https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase)). Again, it's an internal package so we should be okay with breaking things as we need to, while sending the signal for anyone still willing to use it in their app that it's not stable.