### PR TITLE
fix(config): don't accept non-arrays for attributesToDisplay

### DIFF
--- a/packages/create-instantsearch-app/src/cli/__tests__/postProcessAnswers.js
+++ b/packages/create-instantsearch-app/src/cli/__tests__/postProcessAnswers.js
@@ -281,3 +281,23 @@ test('removes `imageAttribute` from `attributesToDisplay`', async () => {
     })
   );
 });
+
+test('ignores invalid input', async () => {
+  expect(
+    await postProcessAnswers({
+      configuration: {},
+      templateConfig: {},
+      optionsFromArguments: {},
+      answers: {
+        attributesToDisplay: 'test',
+        attributesForFaceting: 'test',
+      },
+    })
+  ).toEqual(
+    expect.objectContaining({
+      attributesForFaceting: false,
+      attributesToDisplay: false,
+      flags: { autocomplete: false, dynamicWidgets: false, insights: false },
+    })
+  );
+});

--- a/packages/create-instantsearch-app/src/cli/postProcessAnswers.js
+++ b/packages/create-instantsearch-app/src/cli/postProcessAnswers.js
@@ -65,9 +65,11 @@ async function postProcessAnswers({
     template: templatePath,
     installation: optionsFromArguments.installation,
     currentYear: new Date().getFullYear(),
-    attributesToDisplay: combinedAnswers.attributesToDisplay?.filter(
-      (attribute) => attribute !== combinedAnswers.imageAttribute
-    ),
+    attributesToDisplay:
+      Array.isArray(combinedAnswers.attributesToDisplay) &&
+      combinedAnswers.attributesToDisplay.filter(
+        (attribute) => attribute !== combinedAnswers.imageAttribute
+      ),
     attributesForFaceting:
       Array.isArray(combinedAnswers.attributesForFaceting) &&
       combinedAnswers.attributesForFaceting.filter(


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This makes it consistent with `attributesForFaceting`. See  #6023 for more info, although it doesn't change that use case.


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

`attributesToDisplay` must be an array in config.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
