### PR TITLE
feat(instantsearch-ui-components): introduce `Highlight` component

### DIFF
--- a/packages/instantsearch-ui-components/src/components/Highlight.tsx
+++ b/packages/instantsearch-ui-components/src/components/Highlight.tsx
@@ -1,0 +1,126 @@
+/** @jsx createElement */
+import { cx } from '../lib';
+
+import type {
+  ComponentChildren,
+  ComponentProps,
+  ElementType,
+  Renderer,
+} from '../types';
+
+type HighlightPartProps = {
+  children: ComponentChildren;
+  classNames: Partial<HighlightClassNames>;
+  highlightedTagName: ElementType;
+  nonHighlightedTagName: ElementType;
+  isHighlighted: boolean;
+};
+
+function createHighlightPartComponent({ createElement }: Renderer) {
+  return function HighlightPart({
+    classNames,
+    children,
+    highlightedTagName,
+    isHighlighted,
+    nonHighlightedTagName,
+  }: HighlightPartProps) {
+    const TagName = isHighlighted ? highlightedTagName : nonHighlightedTagName;
+
+    return (
+      <TagName
+        className={
+          isHighlighted ? classNames.highlighted : classNames.nonHighlighted
+        }
+      >
+        {children}
+      </TagName>
+    );
+  };
+}
+
+type HighlightedPart = {
+  isHighlighted: boolean;
+  value: string;
+};
+
+export type HighlightClassNames = {
+  /**
+   * Class names to apply to the root element
+   */
+  root: string;
+  /**
+   * Class names to apply to the highlighted parts
+   */
+  highlighted: string;
+  /**
+   * Class names to apply to the non-highlighted parts
+   */
+  nonHighlighted: string;
+  /**
+   * Class names to apply to the separator between highlighted parts
+   */
+  separator: string;
+};
+
+export type HighlightProps = ComponentProps<'span'> & {
+  classNames?: Partial<HighlightClassNames>;
+  highlightedTagName?: ElementType;
+  nonHighlightedTagName?: ElementType;
+  separator?: ComponentChildren;
+  parts: HighlightedPart[][];
+};
+
+export function createHighlightComponent({
+  createElement,
+  Fragment,
+}: Renderer) {
+  const HighlightPart = createHighlightPartComponent({
+    createElement,
+    Fragment,
+  });
+
+  return function Highlight(userProps: HighlightProps) {
+    // Not destructured in function signature, to make sure it's not exposed in
+    // the type definition.
+    const {
+      parts,
+      highlightedTagName = 'mark',
+      nonHighlightedTagName = 'span',
+      separator = ', ',
+      className,
+      classNames = {},
+      ...props
+    } = userProps;
+
+    return (
+      <span {...props} className={cx(classNames.root, className)}>
+        {parts.map((part, partIndex) => {
+          const isLastPart = partIndex === parts.length - 1;
+
+          return (
+            <Fragment key={partIndex}>
+              {part.map((subPart, subPartIndex) => (
+                <HighlightPart
+                  key={subPartIndex}
+                  classNames={classNames}
+                  highlightedTagName={highlightedTagName}
+                  nonHighlightedTagName={nonHighlightedTagName}
+                  isHighlighted={subPart.isHighlighted}
+                >
+                  {subPart.value}
+                </HighlightPart>
+              ))}
+
+              {!isLastPart && (
+                <span className={classNames.separator}>
+                  {/* @ts-ignore-next-line */}
+                  {separator}
+                </span>
+              )}
+            </Fragment>
+          );
+        })}
+      </span>
+    );
+  };
+}

--- a/packages/instantsearch-ui-components/src/components/__tests__/Highlight.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Highlight.test.tsx
@@ -6,6 +6,7 @@ import { render } from '@testing-library/preact';
 import { createElement, Fragment } from 'preact';
 
 import { createHighlightComponent } from '../Highlight';
+import { ComponentChildren } from '../../types';
 
 const Highlight = createHighlightComponent({ createElement, Fragment });
 
@@ -47,7 +48,7 @@ describe('Highlight', () => {
             st
           </span>
           <span>
-            , 
+            ,
           </span>
           <span>
             nothing
@@ -84,7 +85,7 @@ describe('Highlight', () => {
           </span>
           <span>
             <strong>
-               - 
+               -
             </strong>
           </span>
           <span>
@@ -122,7 +123,7 @@ describe('Highlight', () => {
             st
           </small>
           <span>
-            , 
+            ,
           </span>
           <small>
             nothing
@@ -133,10 +134,14 @@ describe('Highlight', () => {
   });
 
   test('renders with custom tag names as components', () => {
-    function Highlighted({ children }) {
+    type PropsWithChildren = {
+      children: ComponentChildren;
+    };
+
+    function Highlighted({ children }: PropsWithChildren) {
       return <strong>{children}</strong>;
     }
-    function NonHighlighted({ children }) {
+    function NonHighlighted({ children }: PropsWithChildren) {
       return <small>{children}</small>;
     }
 
@@ -166,7 +171,7 @@ describe('Highlight', () => {
             st
           </small>
           <span>
-            , 
+            ,
           </span>
           <small>
             nothing
@@ -214,7 +219,7 @@ describe('Highlight', () => {
           <span
             class="SEPARATOR"
           >
-            , 
+            ,
           </span>
           <span
             class="NON-HIGHLIGHTED"
@@ -254,7 +259,7 @@ describe('Highlight', () => {
             st
           </span>
           <span>
-            , 
+            ,
           </span>
           <span>
             nothing

--- a/packages/instantsearch-ui-components/src/components/__tests__/Highlight.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Highlight.test.tsx
@@ -49,7 +49,7 @@ describe('Highlight', () => {
             st
           </span>
           <span>
-            ,
+            , 
           </span>
           <span>
             nothing
@@ -86,7 +86,7 @@ describe('Highlight', () => {
           </span>
           <span>
             <strong>
-               -
+               - 
             </strong>
           </span>
           <span>
@@ -124,7 +124,7 @@ describe('Highlight', () => {
             st
           </small>
           <span>
-            ,
+            , 
           </span>
           <small>
             nothing
@@ -172,7 +172,7 @@ describe('Highlight', () => {
             st
           </small>
           <span>
-            ,
+            , 
           </span>
           <small>
             nothing
@@ -220,7 +220,7 @@ describe('Highlight', () => {
           <span
             class="SEPARATOR"
           >
-            ,
+            , 
           </span>
           <span
             class="NON-HIGHLIGHTED"
@@ -260,7 +260,7 @@ describe('Highlight', () => {
             st
           </span>
           <span>
-            ,
+            , 
           </span>
           <span>
             nothing

--- a/packages/instantsearch-ui-components/src/components/__tests__/Highlight.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Highlight.test.tsx
@@ -1,0 +1,277 @@
+/**
+ * @jest-environment jsdom
+ */
+/** @jsx createElement */
+import { render } from '@testing-library/preact';
+import { createElement, Fragment } from 'preact';
+
+import { createHighlightComponent } from '../Highlight';
+
+const Highlight = createHighlightComponent({ createElement, Fragment });
+
+describe('Highlight', () => {
+  test('renders only wrapper with empty match', () => {
+    const { container } = render(<Highlight parts={[]} />);
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class=""
+        />
+      </div>
+    `);
+  });
+
+  test('renders parts', () => {
+    const { container } = render(
+      <Highlight
+        parts={[
+          [
+            { isHighlighted: true, value: 'te' },
+            { isHighlighted: false, value: 'st' },
+          ],
+          [{ isHighlighted: false, value: 'nothing' }],
+        ]}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class=""
+        >
+          <mark>
+            te
+          </mark>
+          <span>
+            st
+          </span>
+          <span>
+            , 
+          </span>
+          <span>
+            nothing
+          </span>
+        </span>
+      </div>
+    `);
+  });
+
+  test('renders with custom separator', () => {
+    const { container } = render(
+      <Highlight
+        separator={<strong> - </strong>}
+        parts={[
+          [
+            { isHighlighted: true, value: 'te' },
+            { isHighlighted: false, value: 'st' },
+          ],
+          [{ isHighlighted: false, value: 'nothing' }],
+        ]}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class=""
+        >
+          <mark>
+            te
+          </mark>
+          <span>
+            st
+          </span>
+          <span>
+            <strong>
+               - 
+            </strong>
+          </span>
+          <span>
+            nothing
+          </span>
+        </span>
+      </div>
+    `);
+  });
+
+  test('renders with custom tag names as strings', () => {
+    const { container } = render(
+      <Highlight
+        highlightedTagName="strong"
+        nonHighlightedTagName="small"
+        parts={[
+          [
+            { isHighlighted: true, value: 'te' },
+            { isHighlighted: false, value: 'st' },
+          ],
+          [{ isHighlighted: false, value: 'nothing' }],
+        ]}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class=""
+        >
+          <strong>
+            te
+          </strong>
+          <small>
+            st
+          </small>
+          <span>
+            , 
+          </span>
+          <small>
+            nothing
+          </small>
+        </span>
+      </div>
+    `);
+  });
+
+  test('renders with custom tag names as components', () => {
+    function Highlighted({ children }) {
+      return <strong>{children}</strong>;
+    }
+    function NonHighlighted({ children }) {
+      return <small>{children}</small>;
+    }
+
+    const { container } = render(
+      <Highlight
+        highlightedTagName={Highlighted}
+        nonHighlightedTagName={NonHighlighted}
+        parts={[
+          [
+            { isHighlighted: true, value: 'te' },
+            { isHighlighted: false, value: 'st' },
+          ],
+          [{ isHighlighted: false, value: 'nothing' }],
+        ]}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class=""
+        >
+          <strong>
+            te
+          </strong>
+          <small>
+            st
+          </small>
+          <span>
+            , 
+          </span>
+          <small>
+            nothing
+          </small>
+        </span>
+      </div>
+    `);
+  });
+
+  test('accepts custom class names', () => {
+    const { container } = render(
+      <Highlight
+        parts={[
+          [
+            { isHighlighted: true, value: 'te' },
+            { isHighlighted: false, value: 'st' },
+          ],
+          [{ isHighlighted: false, value: 'nothing' }],
+        ]}
+        className="MyCustomHighlight"
+        classNames={{
+          root: 'ROOT',
+          highlighted: 'HIGHLIGHTED',
+          nonHighlighted: 'NON-HIGHLIGHTED',
+          separator: 'SEPARATOR',
+        }}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class="ROOT MyCustomHighlight"
+        >
+          <mark
+            class="HIGHLIGHTED"
+          >
+            te
+          </mark>
+          <span
+            class="NON-HIGHLIGHTED"
+          >
+            st
+          </span>
+          <span
+            class="SEPARATOR"
+          >
+            , 
+          </span>
+          <span
+            class="NON-HIGHLIGHTED"
+          >
+            nothing
+          </span>
+        </span>
+      </div>
+    `);
+  });
+
+  test('accepts partial custom class names', () => {
+    const { container } = render(
+      <Highlight
+        parts={[
+          [
+            { isHighlighted: true, value: 'te' },
+            { isHighlighted: false, value: 'st' },
+          ],
+          [{ isHighlighted: false, value: 'nothing' }],
+        ]}
+        classNames={{ root: 'ROOT', highlighted: 'HIGHLIGHTED' }}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <span
+          class="ROOT"
+        >
+          <mark
+            class="HIGHLIGHTED"
+          >
+            te
+          </mark>
+          <span>
+            st
+          </span>
+          <span>
+            , 
+          </span>
+          <span>
+            nothing
+          </span>
+        </span>
+      </div>
+    `);
+  });
+
+  test('forwards `div` props to the root element', () => {
+    const { container } = render(
+      <Highlight parts={[]} classNames={{ root: 'ROOT' }} aria-hidden="true" />
+    );
+
+    expect(container.querySelector('.ROOT')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+  });
+});

--- a/packages/instantsearch-ui-components/src/components/__tests__/Highlight.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Highlight.test.tsx
@@ -6,7 +6,8 @@ import { render } from '@testing-library/preact';
 import { createElement, Fragment } from 'preact';
 
 import { createHighlightComponent } from '../Highlight';
-import { ComponentChildren } from '../../types';
+
+import type { ComponentChildren } from '../../types';
 
 const Highlight = createHighlightComponent({ createElement, Fragment });
 

--- a/packages/instantsearch-ui-components/src/components/index.ts
+++ b/packages/instantsearch-ui-components/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './Highlight';

--- a/packages/instantsearch-ui-components/src/index.ts
+++ b/packages/instantsearch-ui-components/src/index.ts
@@ -1,0 +1,3 @@
+export * from './components';
+export * from './lib';
+export * from './types';

--- a/packages/instantsearch-ui-components/src/lib/cx.ts
+++ b/packages/instantsearch-ui-components/src/lib/cx.ts
@@ -1,0 +1,5 @@
+export function cx(
+  ...classNames: Array<string | number | boolean | undefined | null>
+) {
+  return classNames.filter(Boolean).join(' ');
+}

--- a/packages/instantsearch-ui-components/src/lib/index.ts
+++ b/packages/instantsearch-ui-components/src/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './cx';

--- a/packages/instantsearch-ui-components/src/types/Renderer.ts
+++ b/packages/instantsearch-ui-components/src/types/Renderer.ts
@@ -1,0 +1,76 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-empty-interface */
+
+// Ensure that the JSX namespace is available in this file and its dependents.
+declare global {
+  namespace JSX {
+    interface Element {}
+    interface IntrinsicElements {}
+  }
+}
+
+// For safety when there's no @types/react or preact, we don't directly use
+// JSX.IntrinsicElements
+type IntrinsicElements = keyof JSX.IntrinsicElements extends never
+  ? Record<string, unknown>
+  : JSX.IntrinsicElements;
+
+export type Pragma = (
+  type: any,
+  props: Record<string, any> | null,
+  ...children: ComponentChildren[]
+) => JSX.Element;
+
+export type PragmaFrag = any;
+
+type ComponentChild =
+  | VNode<any>
+  | object
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+
+export type ComponentChildren = ComponentChild[] | ComponentChild;
+
+type PropsWithChildren<TProps> = TProps & { children?: ComponentChildren };
+
+type FunctionComponent<TProps = Record<string, any>> = (
+  props: PropsWithChildren<TProps>,
+  context?: any
+) => JSX.Element;
+
+export type ElementType<TProps = any> =
+  | {
+      [TKey in keyof IntrinsicElements]: TProps extends IntrinsicElements[TKey]
+        ? TKey
+        : never;
+    }[keyof IntrinsicElements]
+  | FunctionComponent<TProps>;
+
+export type ComponentProps<TComponent extends keyof IntrinsicElements> =
+  IntrinsicElements[TComponent];
+
+export type VNode<TProps = any> = {
+  type: any;
+  props: TProps & {
+    children: ComponentChildren;
+    key?: string | number | null;
+  };
+};
+
+export type Renderer = {
+  /**
+   * The function to create virtual nodes.
+   *
+   * @default preact.createElement
+   */
+  createElement: Pragma;
+  /**
+   * The component to use to create fragments.
+   *
+   * @default preact.Fragment
+   */
+  Fragment: PragmaFrag;
+};

--- a/packages/instantsearch-ui-components/src/types/index.ts
+++ b/packages/instantsearch-ui-components/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './Renderer';


### PR DESCRIPTION
## Summary

This moves the `Highlight` component from `@algolia/ui-components` to the monorepo.

https://algolia.atlassian.net/browse/FX-2745