### PR TITLE
fix(insights): use up-to-date index name when sending events

### DIFF
--- a/packages/instantsearch.js/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/packages/instantsearch.js/src/connectors/autocomplete/connectAutocomplete.ts
@@ -184,7 +184,7 @@ search.addWidgets([
 
           const sendEvent = createSendEventForHits({
             instantSearchInstance,
-            index: scopedResult.results.index,
+            getIndex: () => scopedResult.results.index,
             widgetType: this.$$type,
           });
 

--- a/packages/instantsearch.js/src/connectors/geo-search/connectGeoSearch.ts
+++ b/packages/instantsearch.js/src/connectors/geo-search/connectGeoSearch.ts
@@ -341,7 +341,7 @@ const connectGeoSearch: GeoSearchConnector = (renderFn, unmountFn = noop) => {
         if (!sendEvent) {
           sendEvent = createSendEventForHits({
             instantSearchInstance,
-            index: helper.getIndex(),
+            getIndex: () => helper.getIndex(),
             widgetType: $$type,
           });
         }

--- a/packages/instantsearch.js/src/connectors/hits/connectHits.ts
+++ b/packages/instantsearch.js/src/connectors/hits/connectHits.ts
@@ -129,14 +129,14 @@ const connectHits: HitsConnector = function connectHits(
         if (!sendEvent) {
           sendEvent = createSendEventForHits({
             instantSearchInstance,
-            index: helper.getIndex(),
+            getIndex: () => helper.getIndex(),
             widgetType: this.$$type,
           });
         }
 
         if (!bindEvent) {
           bindEvent = createBindEventForHits({
-            index: helper.getIndex(),
+            getIndex: () => helper.getIndex(),
             widgetType: this.$$type,
             instantSearchInstance,
           });

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -323,11 +323,11 @@ const connectInfiniteHits: InfiniteHitsConnector = function connectInfiniteHits(
           showMore = getShowMore(helper);
           sendEvent = createSendEventForHits({
             instantSearchInstance,
-            index: helper.getIndex(),
+            getIndex: () => helper.getIndex(),
             widgetType: this.$$type,
           });
           bindEvent = createBindEventForHits({
-            index: helper.getIndex(),
+            getIndex: () => helper.getIndex(),
             widgetType: this.$$type,
             instantSearchInstance,
           });

--- a/packages/instantsearch.js/src/lib/insights/__tests__/insights-listener-test.tsx
+++ b/packages/instantsearch.js/src/lib/insights/__tests__/insights-listener-test.tsx
@@ -128,7 +128,7 @@ describe('createInsightsEventHandler', () => {
       const payload = serializePayload(
         _buildEventPayloadsForHits({
           widgetType: 'ais.hits',
-          index: 'instant_search',
+          getIndex: () => 'instant_search',
           instantSearchInstance: createInstantSearch(),
           methodName: 'bindEvent',
           args: ['click', { objectID: '1', __position: 1 }, 'Hit Clicked'],
@@ -172,7 +172,7 @@ describe('createInsightsEventHandler', () => {
       const payload = serializePayload(
         _buildEventPayloadsForHits({
           widgetType: 'ais.hits',
-          index: 'instant_search',
+          getIndex: () => 'instant_search',
           instantSearchInstance: createInstantSearch(),
           methodName: 'bindEvent',
           args: ['click', { objectID: '1', __position: 1 }, 'Hit Clicked'],
@@ -246,7 +246,7 @@ describe('createInsightsEventHandler', () => {
       const modernPayload = serializePayload(
         _buildEventPayloadsForHits({
           widgetType: 'ais.hits',
-          index: 'instant_search',
+          getIndex: () => 'instant_search',
           instantSearchInstance: createInstantSearch(),
           methodName: 'bindEvent',
           args: ['click', { objectID: '1', __position: 1 }, 'Product Clicked'],

--- a/packages/instantsearch.js/src/lib/utils/__tests__/createSendEventForHits-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/createSendEventForHits-test.ts
@@ -541,6 +541,8 @@ describe('createSendEventForHits', () => {
       })
     );
 
+    // This is what happens when a user changes the active index
+    // using sortBy() for example.
     helper.setIndex('index2');
 
     sendEvent('view', hits, 'Products Viewed');

--- a/packages/instantsearch.js/src/lib/utils/createSendEventForHits.ts
+++ b/packages/instantsearch.js/src/lib/utils/createSendEventForHits.ts
@@ -30,14 +30,14 @@ function chunk<TItem>(arr: TItem[], chunkSize: number = 20): TItem[][] {
 }
 
 export function _buildEventPayloadsForHits({
-  index,
+  getIndex,
   widgetType,
   methodName,
   args,
   instantSearchInstance,
 }: {
   widgetType: string;
-  index: string;
+  getIndex: () => string;
   methodName: 'sendEvent' | 'bindEvent';
   args: any[];
   instantSearchInstance: InstantSearch;
@@ -101,7 +101,7 @@ export function _buildEventPayloadsForHits({
         eventType,
         payload: {
           eventName: eventName || 'Hits Viewed',
-          index,
+          index: getIndex(),
           objectIDs: objectIDsByChunk[i],
           ...additionalData,
         },
@@ -117,7 +117,7 @@ export function _buildEventPayloadsForHits({
         eventType,
         payload: {
           eventName: eventName || 'Hit Clicked',
-          index,
+          index: getIndex(),
           queryID,
           objectIDs: objectIDsByChunk[i],
           positions: positionsByChunk[i],
@@ -135,7 +135,7 @@ export function _buildEventPayloadsForHits({
         eventType,
         payload: {
           eventName: eventName || 'Hit Converted',
-          index,
+          index: getIndex(),
           queryID,
           objectIDs: objectIDsByChunk[i],
           ...additionalData,
@@ -155,11 +155,11 @@ export function _buildEventPayloadsForHits({
 
 export function createSendEventForHits({
   instantSearchInstance,
-  index,
+  getIndex,
   widgetType,
 }: {
   instantSearchInstance: InstantSearch;
-  index: string;
+  getIndex: () => string;
   widgetType: string;
 }): SendEventForHits {
   let sentEvents: Record<InsightsEvent['eventType'], boolean> = {};
@@ -168,7 +168,7 @@ export function createSendEventForHits({
   const sendEventForHits: SendEventForHits = (...args: any[]) => {
     const payloads = _buildEventPayloadsForHits({
       widgetType,
-      index,
+      getIndex,
       methodName: 'sendEvent',
       args,
       instantSearchInstance,
@@ -196,18 +196,18 @@ export function createSendEventForHits({
 }
 
 export function createBindEventForHits({
-  index,
+  getIndex,
   widgetType,
   instantSearchInstance,
 }: {
-  index: string;
+  getIndex: () => string;
   widgetType: string;
   instantSearchInstance: InstantSearch;
 }): BindEventForHits {
   const bindEventForHits: BindEventForHits = (...args: any[]) => {
     const payloads = _buildEventPayloadsForHits({
       widgetType,
-      index,
+      getIndex,
       methodName: 'bindEvent',
       args,
       instantSearchInstance,


### PR DESCRIPTION
**Summary**

When enabling insights, the event payloads include the index name from which the data comes from. Currently, this index name is provided as a string and can be incorrect when the index changes, due to a `sortBy()` for example.

This PR implements changes to always retrieve the index name during the payload creation so it always matches the current state of InstantSearch.

**Result**

Events sent always include the correct index name.

CR-5442