### PR TITLE
feat(instantsearch-ui-components): update build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -121,6 +121,19 @@ module.exports = (api) => {
           ],
         ],
       },
+      {
+        test: 'packages/instantsearch-ui-components',
+        plugins: [
+          [
+            '@babel/plugin-transform-runtime',
+            {
+              corejs: false,
+              helpers: true,
+              regenerator: true,
+            },
+          ],
+        ],
+      },
     ],
     // jsx is transpiled, so the comment should no longer be present in the final files
     shouldPrintComment: (value) => value !== '* @jsx h ',

--- a/babel.config.js
+++ b/babel.config.js
@@ -129,7 +129,7 @@ module.exports = (api) => {
             {
               corejs: false,
               helpers: true,
-              regenerator: true,
+              regenerator: false,
             },
           ],
         ],

--- a/packages/instantsearch-ui-components/package.json
+++ b/packages/instantsearch-ui-components/package.json
@@ -4,11 +4,12 @@
   "description": "Common UI components for InstantSearch.",
   "source": "src/index.ts",
   "types": "dist/es/index.d.ts",
-  "main": "dist/es/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
   "type": "module",
   "exports": {
     "types": "./dist/es/index.d.ts",
+    "require": "./dist/cjs/index.js",
     "default": "./dist/es/index.js"
   },
   "sideEffects": false,
@@ -38,8 +39,9 @@
   ],
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "yarn build:es && yarn build:types",
+    "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:es": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet",
+    "build:cjs": "BABEL_ENV=cjs babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/prepare-cjs.sh",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
     "version": "./scripts/version.cjs"
   }

--- a/packages/instantsearch.js/scripts/rollup/rollup.config.js
+++ b/packages/instantsearch.js/scripts/rollup/rollup.config.js
@@ -23,6 +23,7 @@ const plugins = [
   }),
   babel({
     rootMode: 'upward',
+    runtimeHelpers: true,
     exclude: /node_modules|algoliasearch-helper/,
     extensions: ['.js', '.ts', '.tsx'],
   }),


### PR DESCRIPTION
## Summary

This modifies the build for `instantsearch-ui-components`:

- Includes runtime helpers as in the original `@algolia/ui-components`. This notably avoids issues with inlined helpers that currently cause our polyfill checker to fail.
- Includes a CJS bundle, which is necessary for the CJS bundles of each flavor.