### PR TITLE
fix(instantsearch-ui-components): fix Pragma

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -136,6 +136,6 @@ module.exports = (api) => {
       },
     ],
     // jsx is transpiled, so the comment should no longer be present in the final files
-    shouldPrintComment: (value) => value !== '* @jsx h ',
+    shouldPrintComment: (value) => !value.startsWith('* @jsx'),
   };
 };


### PR DESCRIPTION
## Summary

This updates the build so that the `@jsx` comment is properly stripped.