### PR TITLE
fix(packaging): remove non-exposed "source" key

### DIFF
--- a/packages/instantsearch-ui-components/package.json
+++ b/packages/instantsearch-ui-components/package.json
@@ -2,7 +2,6 @@
   "name": "instantsearch-ui-components",
   "version": "0.2.0",
   "description": "Common UI components for InstantSearch.",
-  "source": "src/index.ts",
   "types": "dist/es/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -2,7 +2,6 @@
   "name": "react-instantsearch-core",
   "version": "7.5.5",
   "description": "⚡ Lightning-fast search for React, by Algolia",
-  "source": "src/index.ts",
   "types": "dist/es/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/packages/react-instantsearch-nextjs/package.json
+++ b/packages/react-instantsearch-nextjs/package.json
@@ -2,7 +2,6 @@
   "name": "react-instantsearch-nextjs",
   "version": "0.1.12",
   "description": "React InstantSearch SSR utilities for Next.js",
-  "source": "src/index.ts",
   "types": "dist/es/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/packages/react-instantsearch-router-nextjs/package.json
+++ b/packages/react-instantsearch-router-nextjs/package.json
@@ -2,7 +2,6 @@
   "name": "react-instantsearch-router-nextjs",
   "version": "7.5.5",
   "description": "React InstantSearch Router for Next.js",
-  "source": "src/index.ts",
   "types": "dist/es/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -2,7 +2,6 @@
   "name": "react-instantsearch",
   "version": "7.5.5",
   "description": "⚡ Lightning-fast search for React, by Algolia",
-  "source": "src/index.ts",
   "types": "dist/es/index.d.ts",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This is what currently causes the `createElement is not defined` error. Basically the example builds "from source", but something in the build (minification) renames `createElement` to `e` and thus everything breaks.

In this PR I remove the `source` key to ensure no building is happening from source, everything (mainly our examples) will use the built code.

This has no (except possibly positive) impact for customers, as in all these packages `src` is not published (only dist is in `files`), so the source refers to a non-existing file.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- examples are runnable again.
- "dead" source key is removed from package.jsons