### PR TITLE
fix(examples): remove unused package

### DIFF
--- a/examples/react/next-app-router/package.json
+++ b/examples/react/next-app-router/package.json
@@ -15,8 +15,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-instantsearch": "7.6.0",
-    "react-instantsearch-nextjs": "0.1.13",
-    "react-instantsearch-router-nextjs": "7.6.0"
+    "react-instantsearch-nextjs": "0.1.13"
   },
   "devDependencies": {
     "@types/node": "17.0.40",


### PR DESCRIPTION
**Summary**

Remove `react-instantsearch-router-nextjs` from **package.json** to avoid confusion for users and developers, as it's not utilized in this context.

**Result**
This package usage in the example won't cause confusion for users and developers.