### PR TITLE
ci: split e2e tests jobs by browser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,9 @@ workflows:
           context: fx-libraries
           requires:
             - examples
+          matrix:
+            parameters:
+              browser: [chrome, firefox, internet explorer]
           filters:
             branches:
               only:
@@ -128,6 +131,9 @@ workflows:
           context: fx-libraries
           requires:
             - examples
+          matrix:
+            parameters:
+              browser: [chrome, firefox, internet explorer]
       - e2e tests router nextjs:
           context: fx-libraries
           requires:
@@ -284,6 +290,11 @@ jobs:
 
   e2e tests:
     <<: *defaults
+    parameters:
+      browser:
+        type: string
+    environment:
+      E2E_BROWSER: << parameters.browser >>
     resource_class: large
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,6 +328,10 @@ jobs:
                     {
                       "type": "mrkdwn",
                       "text": "*Project*: $CIRCLE_PROJECT_REPONAME"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Browser*: << parameters.browser >>"
                     }
                   ]
                 },

--- a/tests/e2e/CONTRIBUTING.md
+++ b/tests/e2e/CONTRIBUTING.md
@@ -15,6 +15,24 @@ yarn test:e2e # Run the test suite on Chrome browser on your local machine
 yarn test:e2e:saucelabs # Run the test suite on multiple browsers on the Sauce Labs service
 ```
 
+The tests are run on the **e-commerce** example built for every flavor (with the addition of an UMD build for InstantSearch.js). You can filter on a single flavor by setting the `E2E_FLAVOR` environment variable:
+
+```sh
+E2E_FLAVOR="react" yarn test:e2e
+# Possible values: js, js-umd, react, vue
+```
+
+When using the Sauce Labs service, tests are run on multiple browsers. To run a Sauce Labs test on a single browser, you can set the `E2E_BROWSER` environment variable:
+
+```sh
+E2E_BROWSER="internet explorer" yarn test:e2e:saucelabs
+# Possible values: chrome, firefox, internet explorer
+```
+
+> [!NOTE]
+> When running a Sauce Labs test locally, make sure examples are built with `yarn website:examples` and set the appropriate Sauce Labs environment variables: `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY`.
+> Additionally, the Sauce Connect proxy doesn't support macOS in its latest version (4.9.2 in Jan. 2024). You can fix it to the previous version by setting the `SAUCE_CONNECT_VERSION=4.9.1` variable.
+
 You can also run the tests with [WebdriverIO](https://webdriver.io) options. For example, to run a specific test in watch mode:
 
 ```sh

--- a/tests/e2e/CONTRIBUTING.md
+++ b/tests/e2e/CONTRIBUTING.md
@@ -30,8 +30,8 @@ E2E_BROWSER="internet explorer" yarn test:e2e:saucelabs
 ```
 
 > [!NOTE]
-> When running a Sauce Labs test locally, make sure examples are built with `yarn website:examples` and set the appropriate Sauce Labs environment variables: `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY`.
-> Additionally, the Sauce Connect proxy doesn't support macOS in its latest version (4.9.2 in Jan. 2024). You can fix it to the previous version by setting the `SAUCE_CONNECT_VERSION=4.9.1` variable.
+> To run tests locally with Sauce Labs, make sure examples are built with `yarn website:examples` and set the appropriate Sauce Labs environment variables: `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY`.
+> Additionally, the latest version of the Sauce Connect v4 tunnel (4.9.2) [doesn't support macOS](https://docs.saucelabs.com/secure-connections/sauce-connect/installation/#downloading-sauce-connect-proxy). You can pin it to the previous version by setting the `SAUCE_CONNECT_VERSION=4.9.1` variable.
 
 You can also run the tests with [WebdriverIO](https://webdriver.io) options. For example, to run a specific test in watch mode:
 

--- a/tests/e2e/flavors.js
+++ b/tests/e2e/flavors.js
@@ -1,3 +1,7 @@
 module.exports = {
-  flavors: ['js', 'js-umd', 'react', 'vue'],
+  flavors: ['js', 'js-umd', 'react', 'vue'].filter(
+    !process.env.E2E_FLAVOR
+      ? Boolean
+      : (flavor) => flavor === process.env.E2E_FLAVOR
+  ),
 };

--- a/tests/e2e/helpers/setSearchBoxValue.ts
+++ b/tests/e2e/helpers/setSearchBoxValue.ts
@@ -25,7 +25,10 @@ browser.addCommand('setSearchBoxValue', async (value: string) => {
   // Changing the URL will also change the page element IDs in Internet Explorer
   // Not waiting for the URL to be properly updated before continuing can make the next tests fail
   await browser.waitUntil(
-    async () => (await browser.getUrl()) !== oldUrl,
+    async () => {
+      const newUrl = await browser.getUrl();
+      return newUrl !== oldUrl && newUrl.includes(value);
+    },
     undefined,
     `URL was not updated after setting searchbox value to "${value}"`
   );

--- a/tests/e2e/wdio.saucelabs.conf.js
+++ b/tests/e2e/wdio.saucelabs.conf.js
@@ -120,5 +120,9 @@ module.exports = {
         requireWindowFocus: true,
       },
     },
-  ],
+  ].filter(
+    !process.env.E2E_BROWSER
+      ? Boolean
+      : ({ browserName }) => browserName === process.env.E2E_BROWSER
+  ),
 };

--- a/tests/e2e/wdio.saucelabs.conf.js
+++ b/tests/e2e/wdio.saucelabs.conf.js
@@ -60,6 +60,10 @@ module.exports = {
      */
     connectRetries: 2,
     connectRetryTimeout: 10000,
+    tunnelIdentifier: ['instantsearch-e2e', process.env.E2E_BROWSER]
+      .filter(Boolean)
+      .join('-')
+      .replace(/ /g, ''),
   },
   /*
    * Sauce Labs Open Source offer has a maximum of 5 concurrent session


### PR DESCRIPTION
**Summary**

This PR separates the e2e jobs into 3, so each browser target can be retried separately when there are flaky tests.

It also provides more information on how to run e2e tests locally using Sauce labs in the contributing guidelines.

<a href="https://app.circleci.com/pipelines/github/algolia/instantsearch/10250/workflows/bfd91628-69c4-49be-8fe0-03d9601855d7"><img width="1018" alt="CleanShot 2024-02-19 at 16 07 12@2x" src="https://github.com/algolia/instantsearch/assets/154633/3500713a-4f3a-4cdd-ae46-c5a8128d950a"></a>
