### PR TITLE
chore(examples): remove env files

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -31,7 +31,7 @@ module.exports = (api) => {
     'babel-plugin-transform-react-pure-class-to-function',
     './scripts/babel/wrap-warning-with-dev-check',
     isRollup && 'babel-plugin-transform-react-remove-prop-types',
-    (isCJS || isES) && [
+    (isCJS || isES || isParcel) && [
       'inline-replace-variables',
       {
         __DEV__: {

--- a/examples/js/calendar-widget/env.js
+++ b/examples/js/calendar-widget/env.js
@@ -1,6 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-global.__DEV__ = process.env.NODE_ENV !== 'production';
-global.__TEST__ = false;

--- a/examples/js/calendar-widget/index.html
+++ b/examples/js/calendar-widget/index.html
@@ -47,7 +47,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment.min.js"></script>
     <script src="https://unpkg.com/BaremetricsCalendar@1.0.11/public/js/Calendar.js"></script>
-    <script type="module" src="env.js"></script>
     <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/examples/js/e-commerce-umd/index.html
+++ b/examples/js/e-commerce-umd/index.html
@@ -119,7 +119,6 @@
     </aside>
 
     <script src="/packages/instantsearch.js/dist/instantsearch.production.min.js"></script>
-    <script type="module" src="./src/env.js"></script>
     <script type="module" src="./src/app.ts"></script>
   </body>
 </html>

--- a/examples/js/e-commerce-umd/src/env.js
+++ b/examples/js/e-commerce-umd/src/env.js
@@ -1,6 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-global.__DEV__ = process.env.NODE_ENV !== 'production';
-global.__TEST__ = false;

--- a/examples/js/e-commerce/index.html
+++ b/examples/js/e-commerce/index.html
@@ -118,7 +118,6 @@
       </button>
     </aside>
 
-    <script type="module" src="./src/env.js"></script>
     <script type="module" src="./src/app.ts"></script>
   </body>
 </html>

--- a/examples/js/e-commerce/src/env.js
+++ b/examples/js/e-commerce/src/env.js
@@ -1,6 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-global.__DEV__ = process.env.NODE_ENV !== 'production';
-global.__TEST__ = false;

--- a/examples/js/getting-started/index.html
+++ b/examples/js/getting-started/index.html
@@ -47,7 +47,6 @@
       </div>
     </div>
 
-    <script type="module" src="./src/env.js"></script>
     <script type="module" src="./src/app.js"></script>
   </body>
 </html>

--- a/examples/js/getting-started/src/env.js
+++ b/examples/js/getting-started/src/env.js
@@ -1,6 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-global.__DEV__ = process.env.NODE_ENV !== 'production';
-global.__TEST__ = false;

--- a/examples/js/media/index.html
+++ b/examples/js/media/index.html
@@ -227,7 +227,6 @@
       </div>
     </footer>
 
-    <script type="module" src="./src/env.ts"></script>
     <script type="module" src="./src/app.ts"></script>
   </body>
 </html>

--- a/examples/js/media/src/env.ts
+++ b/examples/js/media/src/env.ts
@@ -1,8 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-(global as any).__DEV__ = process.env.NODE_ENV !== 'production';
-(global as any).__TEST__ = false;
-
-export {};

--- a/examples/js/recommend/index.html
+++ b/examples/js/recommend/index.html
@@ -47,7 +47,6 @@
       </div>
     </div>
 
-    <script type="module" src="./src/env.js"></script>
     <script type="module" src="./src/app.js"></script>
   </body>
 </html>

--- a/examples/js/recommend/src/env.js
+++ b/examples/js/recommend/src/env.js
@@ -1,6 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-global.__DEV__ = process.env.NODE_ENV !== 'production';
-global.__TEST__ = false;

--- a/examples/js/tourism/env.js
+++ b/examples/js/tourism/env.js
@@ -1,6 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-global.__DEV__ = process.env.NODE_ENV !== 'production';
-global.__TEST__ = false;

--- a/examples/js/tourism/index.html
+++ b/examples/js/tourism/index.html
@@ -82,7 +82,6 @@
     </div>
 
     <script src="https://maps.googleapis.com/maps/api/js?v=weekly&key=AIzaSyBawL8VbstJDdU5397SUX7pEt9DslAwWgQ"></script>
-    <script type="module" src="env.js"></script>
     <script type="module" src="search.js"></script>
   </body>
 </html>

--- a/examples/react/default-theme/index.html
+++ b/examples/react/default-theme/index.html
@@ -24,7 +24,6 @@
 
     <div id="root"></div>
 
-    <script type="module" src="src/env.js"></script>
     <script type="module" src="src/index.tsx"></script>
   </body>
 </html>

--- a/examples/react/default-theme/src/env.js
+++ b/examples/react/default-theme/src/env.js
@@ -1,6 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-global.__DEV__ = process.env.NODE_ENV !== 'production';
-global.__TEST__ = false;

--- a/examples/react/e-commerce/env.js
+++ b/examples/react/e-commerce/env.js
@@ -1,6 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-global.__DEV__ = process.env.NODE_ENV !== 'production';
-global.__TEST__ = false;

--- a/examples/react/e-commerce/index.html
+++ b/examples/react/e-commerce/index.html
@@ -32,7 +32,6 @@
 
     <div id="root"></div>
 
-    <script type="module" src="env.js"></script>
     <script type="module" src="index.tsx"></script>
   </body>
 </html>

--- a/examples/react/getting-started/index.html
+++ b/examples/react/getting-started/index.html
@@ -26,7 +26,6 @@
 
     <div id="root"></div>
 
-    <script type="module" src="src/env.js"></script>
     <script type="module" src="src/index.tsx"></script>
   </body>
 </html>

--- a/examples/react/getting-started/src/env.js
+++ b/examples/react/getting-started/src/env.js
@@ -1,6 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-global.__DEV__ = process.env.NODE_ENV !== 'production';
-global.__TEST__ = false;

--- a/examples/react/recommend/index.html
+++ b/examples/react/recommend/index.html
@@ -26,7 +26,6 @@
 
     <div id="root"></div>
 
-    <script type="module" src="src/env.js"></script>
     <script type="module" src="src/index.tsx"></script>
   </body>
 </html>

--- a/examples/react/recommend/src/env.js
+++ b/examples/react/recommend/src/env.js
@@ -1,6 +1,0 @@
-// Parcel picks the `source` field of the monorepo packages and thus doesn't
-// apply the Babel config. We therefore need to manually override the constants
-// in the app.
-// See https://twitter.com/devongovett/status/1134231234605830144
-global.__DEV__ = process.env.NODE_ENV !== 'production';
-global.__TEST__ = false;


### PR DESCRIPTION
**Summary**

This PR makes the **env.js** files in our examples unnecessary by replacing the `__DEV__` references in the InstantSearch codebase with a Babel plugin.

The main goal is to have the non Next.js React examples working again with Parcel.

I have manually tested all affected examples successfully, and the e-commerce examples still pass e2e tests.

There's still an issue with Parcel's HMR and React examples, where the Websocket receives the update command and the console is cleared, but a manual refresh is needed to see changes. If someone has an idea 🙇 .