### PR TITLE
chore(examples): add react types dev dependencies

### DIFF
--- a/examples/react/default-theme/package.json
+++ b/examples/react/default-theme/package.json
@@ -17,6 +17,7 @@
     "@parcel/core": "2.10.0",
     "@parcel/packager-raw-url": "2.10.0",
     "@parcel/transformer-webmanifest": "2.10.0",
+    "@types/react": "^18.0.9",
     "parcel": "2.10.0",
     "typescript": "5.1.3"
   }

--- a/examples/react/e-commerce/package.json
+++ b/examples/react/e-commerce/package.json
@@ -20,6 +20,7 @@
     "@parcel/core": "2.10.0",
     "@parcel/packager-raw-url": "2.10.0",
     "@parcel/transformer-webmanifest": "2.10.0",
+    "@types/react": "^18.0.9",
     "parcel": "2.10.0",
     "typescript": "5.1.3"
   }

--- a/examples/react/getting-started/package.json
+++ b/examples/react/getting-started/package.json
@@ -17,6 +17,7 @@
     "@parcel/core": "2.10.0",
     "@parcel/packager-raw-url": "2.10.0",
     "@parcel/transformer-webmanifest": "2.10.0",
+    "@types/react": "^18.0.9",
     "parcel": "2.10.0",
     "typescript": "5.1.3"
   }

--- a/examples/react/recommend/package.json
+++ b/examples/react/recommend/package.json
@@ -18,6 +18,7 @@
     "@parcel/core": "2.10.0",
     "@parcel/packager-raw-url": "2.10.0",
     "@parcel/transformer-webmanifest": "2.10.0",
+    "@types/react": "^18.0.9",
     "parcel": "2.10.0",
     "typescript": "5.1.3"
   }


### PR DESCRIPTION
**Summary**

This PR adds the `@types/react` dev dependency on relevant React InstantSearch examples so Codesandbox properly interprets JSX markup in the editor.
