### PR TITLE
fix(build): do not use babel runtime helpers in ui components

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -75,6 +75,7 @@ module.exports = (api) => {
 
             // we require polyfills for this already
             'Array.prototype.includes',
+            'Object.assign',
 
             // false positive (babel doesn't know types)
             // this is actually only called on arrays
@@ -117,19 +118,6 @@ module.exports = (api) => {
               helpers: true,
               regenerator: false,
               useESModules: isES || isRollup,
-            },
-          ],
-        ],
-      },
-      {
-        test: 'packages/instantsearch-ui-components',
-        plugins: [
-          [
-            '@babel/plugin-transform-runtime',
-            {
-              corejs: false,
-              helpers: true,
-              regenerator: false,
             },
           ],
         ],


### PR DESCRIPTION
**Summary**

The **instantsearch-ui-components** package is currently transformed during build to rely on babel runtime helpers (ie:  `extends` and `objectWithoutProperties`).

This is problematic as we don't set **@babel/runtime** as a dependency in instantsearch.js, which causes issues either during build with module bundlers, or at runtime with UMD.

This PR stops relying on this package and insteads reverts to inline these helper methods in each relevant component file.

> [!NOTE]
> A side-effect of this, is because `_objectWithoutProperties` calls `Object.assign()`, it needs to be excluded from the polyfill check we run. But this should pose no problem, we already recommend using polyfills for IE11 [in our documentation](https://www.algolia.com/doc/guides/building-search-ui/installation/js/#supported-browsers).

**Result**

InstantSearch.js does not trigger an error during build because of a missing **@babel/runtime** dependency.


Fixes #6060 