### PR TITLE
fix: require @babel/runtime dependency

### DIFF
--- a/packages/instantsearch-ui-components/package.json
+++ b/packages/instantsearch-ui-components/package.json
@@ -43,5 +43,8 @@
     "build:cjs": "BABEL_ENV=cjs babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/prepare-cjs.sh",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
     "version": "./scripts/version.cjs"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.1.2"
   }
 }


### PR DESCRIPTION
**Summary**

The **instantsearch-ui-components** package is currently transformed during build to rely on babel runtime helpers.

This causes an issue when using **instantsearch.js** or **vue-instantsearch** with a build system, as we don't explicitly require **@babel/runtime** as a dependency.

This PR lists the dependency correctly.

Fixes #6060