### PR TITLE
chore: generalize watch mode in packages and document process in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ Each flavor has a **getting-started** example which can be used for development 
 First, build the libraries and watch changes:
 
 ```sh
-yarn watch
+yarn watch:es
 ```
 
 Then start the server of the relevant example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,19 @@ Opening an issue is very effective way to contribute because many users might al
 
 Before reporting an issue, first check that there is not an already open issue for the same topic using the [issues page](https://github.com/algolia/instantsearch/issues). Don't hesitate to thumb up an issue that corresponds to the problem you have.
 
-Another element that will help us go faster at solving the issue is to provide a reproducible test case. We often recommend to [use this CodeSandbox template](https://codesandbox.io/s/github/algolia/instantsearch-templates/tree/master/src/InstantSearch.js).
+Another element that will help us go faster at solving the issue is to provide a reproducible test case. We often recommend to use one of the following CodeSandbox templates:
+
+<table>
+  <tr>
+    <td><a href="https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/instantsearch.js" target="_blank">InstantSearch.js</a></td>
+    <td><a href="https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/react-instantsearch" target="_blank">React InstantSearch</a></td>
+    <td><a href="https://codesandbox.io/s/github/algolia/instantsearch/tree/templates/vue-instantsearch" target="_blank">Vue InstantSearch</a></td>
+  </tr>
+</table>
 
 ## The code contribution process
 
-InstantSearch.js is developed in TypeScript.
+InstantSearch is developed in TypeScript.
 
 For any code contribution, you need to:
 
@@ -104,12 +112,28 @@ _Note that no new features will be developed or backported for the `vX` branches
 
 To run this project, you will need:
 
-- Node.js ≥ 14 (current stable version) – [nvm](https://github.com/creationix/nvm#install-script) is recommended
+- Node.js ≥ 20 (current stable version) – [nvm](https://github.com/creationix/nvm#install-script) is recommended
 - [Yarn](https://yarnpkg.com)
 
 ## Launch the dev environment
 
-We use [Storybook](https://github.com/storybooks/storybook) to create stories for widgets.
+Each flavor has a **getting-started** example which can be used for development purposes.
+
+First, build the libraries and watch changes:
+
+```sh
+yarn watch
+```
+
+Then start the server of the relevant example:
+
+```sh
+yarn --cwd examples/js/getting-started start
+```
+
+Finally, go to the URL displayed on the terminal (generally http://localhost:3000) to view the example in a browser.
+
+We also use [Storybook](https://github.com/storybooks/storybook) to create stories for widgets:
 
 ```sh
 yarn
@@ -126,10 +150,11 @@ Here are the main files and folders of the project.
 ```
 ▸ examples/                            << Examples, grouped per flavor
 ▸ packages/                            << Packages of the project
-  ▸ react-instantsearch/              << Bundled React InstantSearch library
-  ▸ react-instantsearch-core/         << Runtime-independent React InstantSearch version
-
-  ▸ instantsearch.js/                  << The InstantSearch.js library
+  ▸ instantsearch-ui-components/         << Shared UI components library across all flavors
+  ▸ react-instantsearch/                 << Bundled React InstantSearch library
+  ▸ react-instantsearch-core/            << Runtime-independent React InstantSearch version
+  ▸ instantsearch.js/                    << The InstantSearch.js library
+  ▸ vue-instantsearch/                   << Bundled Vue InstantSearch library
 ▸ tests/                               << The test utilites
   ▸ mocks/                             << Fake versions of the API, for testing
   ▸ utils/                             << Global utilities for the tests

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release": "shipjs prepare",
     "prepare": "lerna run prepare && patch-package",
     "prepare-vue3": "./scripts/prepare-vue3.js",
-    "watch": "lerna run watch --parallel --stream --ignore='example-*' --ignore='create-instantsearch-app'"
+    "watch:es": "lerna run watch:es --parallel --stream --ignore='example-*' --ignore='create-instantsearch-app'"
   },
   "devDependencies": {
     "@algolia/cache-common": "4.22.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test:v3": "lerna run test:v3",
     "release": "shipjs prepare",
     "prepare": "lerna run prepare && patch-package",
-    "prepare-vue3": "./scripts/prepare-vue3.js"
+    "prepare-vue3": "./scripts/prepare-vue3.js",
+    "watch": "lerna run watch --parallel --stream --ignore='example-*' --ignore='create-instantsearch-app'"
   },
   "devDependencies": {
     "@algolia/cache-common": "4.22.1",

--- a/packages/instantsearch-ui-components/package.json
+++ b/packages/instantsearch-ui-components/package.json
@@ -39,10 +39,12 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
-    "build:es": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet",
+    "build:es:base": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*'",
+    "build:es": "yarn build:es:base --quiet",
     "build:cjs": "BABEL_ENV=cjs babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/prepare-cjs.sh",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
-    "version": "./scripts/version.cjs"
+    "version": "./scripts/version.cjs",
+    "watch": "yarn --silent build:es:base --watch"
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2"

--- a/packages/instantsearch-ui-components/package.json
+++ b/packages/instantsearch-ui-components/package.json
@@ -44,7 +44,7 @@
     "build:cjs": "BABEL_ENV=cjs babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/prepare-cjs.sh",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
     "version": "./scripts/version.cjs",
-    "watch": "yarn --silent build:es:base --watch"
+    "watch:es": "yarn --silent build:es:base --watch"
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2"

--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -59,7 +59,7 @@
     "storybook:build": "NODE_OPTIONS=--openssl-legacy-provider build-storybook --quiet --output-dir ../../website/stories/js --static-dir .storybook/static",
     "test:exports": "node test/module/is-es-module.mjs && node test/module/is-cjs-module.cjs",
     "version": "./scripts/version/update-version.js",
-    "watch": "yarn --silent build:es:base --watch"
+    "watch:es": "yarn --silent build:es:base --watch"
   },
   "devDependencies": {
     "@algolia/recommend": "4.22.1",

--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -52,12 +52,14 @@
     "build": "yarn run build:cjs && yarn run build:es && yarn run build:umd && yarn run build:types",
     "build:umd": "rm -rf dist && BABEL_ENV=umd rollup --config ./scripts/rollup/rollup.config.js",
     "build:cjs": "rm -rf cjs && BABEL_ENV=cjs babel --root-mode upward src --extensions '.js,.ts,.tsx' --out-dir cjs/ --ignore 'src/index.es.ts','**/__tests__','**/__mocks__' --quiet",
-    "build:es": "rm -rf es && BABEL_ENV=es babel --root-mode upward src --extensions '.js,.ts,.tsx' --out-dir es/ --ignore 'src/index.es.ts','**/__tests__','**/__mocks__' --quiet && BABEL_ENV=es babel --root-mode upward src/index.es.ts --out-file es/index.js --quiet && echo '{\"type\":\"module\",\"sideEffects\":false}' > es/package.json",
+    "build:es:base": "BABEL_ENV=es babel --root-mode upward src --extensions '.js,.ts,.tsx' --out-dir es/ --ignore 'src/index.es.ts','**/__tests__','**/__mocks__'",
+    "build:es": "rm -rf es && yarn build:es:base --quiet && BABEL_ENV=es babel --root-mode upward src/index.es.ts --out-file es/index.js --quiet && echo '{\"type\":\"module\",\"sideEffects\":false}' > es/package.json",
     "build:types": "scripts/typescript/extract.js",
     "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook --quiet --port 6006 --ci --static-dir .storybook/static",
     "storybook:build": "NODE_OPTIONS=--openssl-legacy-provider build-storybook --quiet --output-dir ../../website/stories/js --static-dir .storybook/static",
     "test:exports": "node test/module/is-es-module.mjs && node test/module/is-cjs-module.cjs",
-    "version": "./scripts/version/update-version.js"
+    "version": "./scripts/version/update-version.js",
+    "watch": "yarn --silent build:es:base --watch"
   },
   "devDependencies": {
     "@algolia/recommend": "4.22.1",

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -37,14 +37,15 @@
   ],
   "scripts": {
     "clean": "rm -rf dist",
-    "watch": "yarn build:cjs --watch",
     "build": "yarn build:cjs && yarn build:es && yarn build:umd && yarn build:types",
     "build:cjs": "BABEL_ENV=cjs babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/prepare-cjs.sh",
-    "build:es": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet",
+    "build:es:base": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*'",
+    "build:es": "yarn build:es:base --quiet",
     "build:umd": "BABEL_ENV=rollup rollup -c rollup.config.js",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
     "test:exports": "node ./test/module/is-es-module.mjs && node ./test/module/is-cjs-module.cjs",
-    "version": "./scripts/version.cjs"
+    "version": "./scripts/version.cjs",
+    "watch": "yarn --silent build:es:base --watch"
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -45,7 +45,7 @@
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
     "test:exports": "node ./test/module/is-es-module.mjs && node ./test/module/is-cjs-module.cjs",
     "version": "./scripts/version.cjs",
-    "watch": "yarn --silent build:es:base --watch"
+    "watch:es": "yarn --silent build:es:base --watch"
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",

--- a/packages/react-instantsearch-nextjs/package.json
+++ b/packages/react-instantsearch-nextjs/package.json
@@ -42,9 +42,11 @@
     "clean": "rm -rf dist",
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "BABEL_ENV=cjs babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/prepare-cjs.sh",
-    "build:es": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet",
+    "build:es:base": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*'",
+    "build:es": "yarn build:es:base --quiet",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
-    "test:exports": "node ./__tests__/module/is-es-module.mjs && node ./__tests__/module/is-cjs-module.cjs"
+    "test:exports": "node ./__tests__/module/is-es-module.mjs && node ./__tests__/module/is-cjs-module.cjs",
+    "watch": "yarn --silent build:es:base --watch"
   },
   "devDependencies": {
     "instantsearch.js": "4.65.0",

--- a/packages/react-instantsearch-nextjs/package.json
+++ b/packages/react-instantsearch-nextjs/package.json
@@ -46,7 +46,7 @@
     "build:es": "yarn build:es:base --quiet",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
     "test:exports": "node ./__tests__/module/is-es-module.mjs && node ./__tests__/module/is-cjs-module.cjs",
-    "watch": "yarn --silent build:es:base --watch"
+    "watch:es": "yarn --silent build:es:base --watch"
   },
   "devDependencies": {
     "instantsearch.js": "4.65.0",

--- a/packages/react-instantsearch-router-nextjs/package.json
+++ b/packages/react-instantsearch-router-nextjs/package.json
@@ -40,12 +40,14 @@
     "clean": "rm -rf dist",
     "build": "yarn build:cjs && yarn build:es && yarn build:types",
     "build:cjs": "BABEL_ENV=cjs babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/prepare-cjs.sh",
-    "build:es": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet",
+    "build:es:base": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*'",
+    "build:es": "yarn build:es:base --quiet",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
     "test:exports": "node ./__tests__/module/is-es-module.mjs && node ./__tests__/module/is-cjs-module.cjs",
     "test:start-server": "yarn workspace example-react-instantsearch-next-routing-example build && yarn workspace example-react-instantsearch-next-routing-example start",
     "test:e2e": "start-server-and-test test:start-server 3000 'wdio run ./wdio.conf.cjs'",
-    "test:e2e:saucelabs": "start-server-and-test test:start-server 3000 'wdio run ./wdio.saucelabs.conf.cjs'"
+    "test:e2e:saucelabs": "start-server-and-test test:start-server 3000 'wdio run ./wdio.saucelabs.conf.cjs'",
+    "watch": "yarn --silent build:es:base --watch"
   },
   "dependencies": {
     "instantsearch.js": "4.65.0",

--- a/packages/react-instantsearch-router-nextjs/package.json
+++ b/packages/react-instantsearch-router-nextjs/package.json
@@ -47,7 +47,7 @@
     "test:start-server": "yarn workspace example-react-instantsearch-next-routing-example build && yarn workspace example-react-instantsearch-next-routing-example start",
     "test:e2e": "start-server-and-test test:start-server 3000 'wdio run ./wdio.conf.cjs'",
     "test:e2e:saucelabs": "start-server-and-test test:start-server 3000 'wdio run ./wdio.saucelabs.conf.cjs'",
-    "watch": "yarn --silent build:es:base --watch"
+    "watch:es": "yarn --silent build:es:base --watch"
   },
   "dependencies": {
     "instantsearch.js": "4.65.0",

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -37,13 +37,14 @@
   ],
   "scripts": {
     "clean": "rm -rf dist",
-    "watch": "yarn build:cjs --watch",
     "build": "yarn build:cjs && yarn build:es && yarn build:umd && yarn build:types",
     "build:cjs": "BABEL_ENV=cjs babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/cjs --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet && ../../scripts/prepare-cjs.sh",
-    "build:es": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*' --quiet",
+    "build:es:base": "BABEL_ENV=es babel src --root-mode upward --extensions '.js,.ts,.tsx' --out-dir dist/es --ignore '**/__tests__/**/*','**/__mocks__/**/*'",
+    "build:es": "yarn build:es:base --quiet",
     "build:umd": "BABEL_ENV=rollup rollup -c rollup.config.js",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
-    "test:exports": "node ./test/module/is-es-module.mjs && node ./test/module/is-cjs-module.cjs"
+    "test:exports": "node ./test/module/is-es-module.mjs && node ./test/module/is-cjs-module.cjs",
+    "watch": "yarn --silent build:es:base --watch"
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -44,7 +44,7 @@
     "build:umd": "BABEL_ENV=rollup rollup -c rollup.config.js",
     "build:types": "tsc -p ./tsconfig.declaration.json --outDir ./dist/es",
     "test:exports": "node ./test/module/is-es-module.mjs && node ./test/module/is-cjs-module.cjs",
-    "watch": "yarn --silent build:es:base --watch"
+    "watch:es": "yarn --silent build:es:base --watch"
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",

--- a/packages/vue-instantsearch/package.json
+++ b/packages/vue-instantsearch/package.json
@@ -33,7 +33,7 @@
     "storybook:build": "NODE_OPTIONS=--openssl-legacy-provider build-storybook -c .storybook -o ../../website/stories/vue",
     "test:exports": "node ./test/module/vue2/is-es-module.mjs && node ./test/module/vue2/is-cjs-module.cjs",
     "test:exports:vue3": "node ./test/module/vue3/is-es-module.mjs && node ./test/module/vue3/is-cjs-module.cjs",
-    "watch": "yarn --silent build --watch"
+    "watch:es": "yarn --silent build --watch"
   },
   "dependencies": {
     "instantsearch.js": "4.65.0",

--- a/packages/vue-instantsearch/package.json
+++ b/packages/vue-instantsearch/package.json
@@ -32,7 +32,8 @@
     "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006 -c .storybook",
     "storybook:build": "NODE_OPTIONS=--openssl-legacy-provider build-storybook -c .storybook -o ../../website/stories/vue",
     "test:exports": "node ./test/module/vue2/is-es-module.mjs && node ./test/module/vue2/is-cjs-module.cjs",
-    "test:exports:vue3": "node ./test/module/vue3/is-es-module.mjs && node ./test/module/vue3/is-cjs-module.cjs"
+    "test:exports:vue3": "node ./test/module/vue3/is-es-module.mjs && node ./test/module/vue3/is-cjs-module.cjs",
+    "watch": "yarn --silent build --watch"
   },
   "dependencies": {
     "instantsearch.js": "4.65.0",

--- a/packages/vue-instantsearch/rollup.config.js
+++ b/packages/vue-instantsearch/rollup.config.js
@@ -45,6 +45,8 @@ const aliasVueCompat = (vueVersion) => ({
   },
 });
 
+const isWatching = process.env.ROLLUP_WATCH;
+
 function outputs(vueVersion) {
   const vuePlugin = vueVersion === 'vue3' ? vueV3 : vueV2;
 
@@ -160,7 +162,11 @@ export * from './src/instantsearch.js';`
     ],
   };
 
+  if (isWatching) {
+    return [esm];
+  }
+
   return [cjs, esm, umd];
 }
 
-export default [...outputs('vue2'), ...outputs('vue3')];
+export default [...outputs('vue2'), ...(isWatching ? [] : outputs('vue3'))];


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR adds a `watch` script on almose all relevant packages in the monorepo and allows them to be run in parallel using lerna. It also updates the CONTRIBUTING.md guidelines with a description of the process.

> [!NOTE]
> **algoliasearch-helper** is omitted from this PR as it would a more significant refactoring of its build script to make it work properly in watch mode