### PR TITLE
fix(react-instantsearch): properly add `noRefinementRoot` class on `<RefinementList>`

### DIFF
--- a/packages/react-instantsearch/src/ui/RefinementList.tsx
+++ b/packages/react-instantsearch/src/ui/RefinementList.tsx
@@ -102,7 +102,7 @@ export function RefinementList({
       className={cx(
         'ais-RefinementList',
         classNames.root,
-        !canRefine &&
+        items.length === 0 &&
           cx('ais-RefinementList--noRefinement', classNames.noRefinementRoot),
         className
       )}

--- a/packages/react-instantsearch/src/ui/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/RefinementList.test.tsx
@@ -625,7 +625,7 @@ describe('RefinementList', () => {
   test('accepts custom class names (empty)', () => {
     const props = createProps({
       canRefine: false,
-      items: undefined,
+      items: [],
       noResults: 'No results.',
       className: 'MyCustomRefinementList',
       classNames: {

--- a/packages/react-instantsearch/src/widgets/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/RefinementList.test.tsx
@@ -909,7 +909,7 @@ describe('RefinementList', () => {
       expect(container).toMatchInlineSnapshot(`
         <div>
           <div
-            class="ais-RefinementList"
+            class="ais-RefinementList ais-RefinementList--noRefinement"
           >
             <div
               class="ais-RefinementList-searchBox"


### PR DESCRIPTION
## Summary

When the `<RefinementList>` is searchable and a user searches for a facet value that doesn't exist, the root should have the class `.ais-RefinementList--noRefinement`. This was however not the case because we were relying on `canRefine` which remains `true` as long as the last search contains search results.

Now we're relying on the items returned from SFFV.

In the future, we may want to reconsider what `canRefine` means in the context of `connectRefinementList`, as the source of refinements comes from two places (main search _and_ SFFV), but this would be breaking right now so we can keep it for later.