### PR TITLE
fix(vue-instantsearch): only render list in `<refinement-list>` when it has items

### DIFF
--- a/packages/vue-instantsearch/src/components/RefinementList.vue
+++ b/packages/vue-instantsearch/src/components/RefinementList.vue
@@ -30,7 +30,7 @@
       >
         <div :class="suit('noResults')">No results.</div>
       </slot>
-      <ul :class="suit('list')">
+      <ul v-if="items.length > 0" :class="suit('list')">
         <li
           :class="[suit('item'), item.isRefined && suit('item', 'selected')]"
           v-for="item in items"

--- a/packages/vue-instantsearch/src/components/__tests__/__snapshots__/RefinementList.js.snap
+++ b/packages/vue-instantsearch/src/components/__tests__/__snapshots__/RefinementList.js.snap
@@ -155,8 +155,6 @@ exports[`allows search bar classes override when it's searchable 1`] = `
 
 exports[`renders correctly (empty) 1`] = `
 <div class="ais-RefinementList ais-RefinementList--noRefinement">
-  <ul class="ais-RefinementList-list">
-  </ul>
 </div>
 `;
 


### PR DESCRIPTION
## Summary

Vue InstantSearch renders an empty `<ul>` when `<refinement-list>` has no items.

This fixes it by not rendering the list at all unless there are items.