### PR TITLE
fix(vue-instantsearch): properly add `noRefinement` class on `<ais-refinement-list>`

### DIFF
--- a/packages/instantsearch.js/src/connectors/refinement-list/connectRefinementList.ts
+++ b/packages/instantsearch.js/src/connectors/refinement-list/connectRefinementList.ts
@@ -126,6 +126,8 @@ export type RefinementListRenderState = {
   isFromSearch: boolean;
   /**
    * `true` if a refinement can be applied.
+   * @MAJOR: reconsider how `canRefine` is computed so it both accounts for the
+   * items returned in the main search and in SFFV.
    */
   canRefine: boolean;
   /**

--- a/packages/vue-instantsearch/src/components/RefinementList.vue
+++ b/packages/vue-instantsearch/src/components/RefinementList.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :class="[suit(), !state.canRefine && suit('', 'noRefinement')]"
+    :class="[suit(), items.length === 0 && suit('', 'noRefinement')]"
     v-if="state"
   >
     <slot


### PR DESCRIPTION
## Summary

When the <ais-refinement-list> is searchable and a user searches for a facet value that doesn't exist, the root should have the class .ais-RefinementList--noRefinement. This was however not the case because we were relying on `canRefine` which remains `true` as long as the last search contains search results.

Now we're relying on the items returned from SFFV.

In the future, we may want to reconsider what `canRefine` means in the context of `connectRefinementList`, as the source of refinements comes from two places (main search and SFFV), but this would be breaking right now so we can keep it for later.

## Note

This change doesn't update tests, because existing ones weren't testing this use case. This will be touched on in #6090.