### PR TITLE
feat(vue-instantsearch): render loading indicator in `<ais-refinement-list>`

### DIFF
--- a/packages/vue-instantsearch/src/components/RefinementList.vue
+++ b/packages/vue-instantsearch/src/components/RefinementList.vue
@@ -19,6 +19,7 @@
       <div :class="suit('searchBox')" v-if="searchable">
         <search-input
           v-model="searchForFacetValues"
+          :show-loading-indicator="true"
           :placeholder="searchablePlaceholder"
           :class-names="classNames"
         />

--- a/packages/vue-instantsearch/src/components/__tests__/__snapshots__/RefinementList.js.snap
+++ b/packages/vue-instantsearch/src/components/__tests__/__snapshots__/RefinementList.js.snap
@@ -47,6 +47,43 @@ exports[`allows search bar classes override when it's searchable 1`] = `
           </path>
         </svg>
       </button>
+      <span class="ais-SearchBox-loadingIndicator"
+            hidden="hidden"
+      >
+        <svg aria-hidden="true"
+             aria-label="Results are loading"
+             class="ais-SearchBox-loadingIcon"
+             height="16"
+             stroke="#444"
+             viewbox="0 0 38 38"
+             width="16"
+        >
+          <g fill="none"
+             fill-rule="evenodd"
+          >
+            <g stroke-width="2"
+               transform="translate(1 1)"
+            >
+              <circle cx="18"
+                      cy="18"
+                      r="18"
+                      stroke-opacity=".5"
+              >
+              </circle>
+              <path d="M36 18c0-9.94-8.06-18-18-18">
+                <animateTransform attributename="transform"
+                                  dur="1s"
+                                  from="0 18 18"
+                                  repeatcount="indefinite"
+                                  to="360 18 18"
+                                  type="rotate"
+                >
+                </animateTransform>
+              </path>
+            </g>
+          </g>
+        </svg>
+      </span>
     </form>
   </div>
   <ul class="ais-RefinementList-list">
@@ -296,6 +333,43 @@ exports[`renders correctly when it's searchable 1`] = `
           </path>
         </svg>
       </button>
+      <span class="ais-SearchBox-loadingIndicator"
+            hidden="hidden"
+      >
+        <svg aria-hidden="true"
+             aria-label="Results are loading"
+             class="ais-SearchBox-loadingIcon"
+             height="16"
+             stroke="#444"
+             viewbox="0 0 38 38"
+             width="16"
+        >
+          <g fill="none"
+             fill-rule="evenodd"
+          >
+            <g stroke-width="2"
+               transform="translate(1 1)"
+            >
+              <circle cx="18"
+                      cy="18"
+                      r="18"
+                      stroke-opacity=".5"
+              >
+              </circle>
+              <path d="M36 18c0-9.94-8.06-18-18-18">
+                <animateTransform attributename="transform"
+                                  dur="1s"
+                                  from="0 18 18"
+                                  repeatcount="indefinite"
+                                  to="360 18 18"
+                                  type="rotate"
+                >
+                </animateTransform>
+              </path>
+            </g>
+          </g>
+        </svg>
+      </span>
     </form>
   </div>
   <ul class="ais-RefinementList-list">


### PR DESCRIPTION
## Summary

In all flavors but Vue InstantSearch, we render a loading indicator when the refinement list is searchable. Note that it actually never renders anything on screen as we don't have information about SFFV being stalled, but the markup updates.

This change intends to harmonize markup across flavors for common testing purposes.

In a later iteration, we could work on actually displaying the loading indicator when SFFV is stalled.

## Note

This change doesn't update tests, because this will be done in https://github.com/algolia/instantsearch/pull/6090.