### PR TITLE
fix(next-app-router): using wrong initial results when mounting on client

### DIFF
--- a/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
+++ b/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
@@ -54,6 +54,10 @@ export function InstantSearchNext<
   const isMounting = useRef(true);
   useEffect(() => {
     isMounting.current = false;
+    return () => {
+      // This is to make sure that they're not reused if mounting again on a different route
+      delete window[InstantSearchInitialResults];
+    };
   }, []);
 
   const promiseRef = useRef<PromiseWithState<void> | null>(null);


### PR DESCRIPTION
**Summary**

Fixes #6086

**Result**

Starting from Next 14, pressing the back button to go back to a different page does not cause a server-side render, so `InstantSearchNext` would read the `initialResults` again even if the route has changed.
The easiest way to fix this is to delete them from window when disposing (not after reading as this may cause issues in strict mode)