### PR TITLE
feat(instantsearch): prepare index widget for recommend widgets

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "76.5 kB"
+      "maxSize": "76.75 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "168.5 kB"
+      "maxSize": "169 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
@@ -22,15 +22,15 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "58 kB"
+      "maxSize": "58.25 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "65.25 kB"
+      "maxSize": "65.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "65.75 kB"
+      "maxSize": "66 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",

--- a/packages/algoliasearch-helper/index.js
+++ b/packages/algoliasearch-helper/index.js
@@ -63,7 +63,7 @@ algoliasearchHelper.AlgoliaSearchHelper = AlgoliaSearchHelper;
 algoliasearchHelper.SearchParameters = SearchParameters;
 
 /**
- * Constructor for the object containing all the parameters for reocmmend.
+ * Constructor for the object containing all the parameters for Recommend.
  * @member module:algoliasearchHelper.RecommendParameters
  * @type {RecommendParameters}
  */

--- a/packages/algoliasearch-helper/index.js
+++ b/packages/algoliasearch-helper/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var AlgoliaSearchHelper = require('./src/algoliasearch.helper');
+var RecommendParameters = require('./src/RecommendParameters');
 var SearchParameters = require('./src/SearchParameters');
 var SearchResults = require('./src/SearchResults');
 
@@ -60,6 +61,13 @@ algoliasearchHelper.AlgoliaSearchHelper = AlgoliaSearchHelper;
  * @type {SearchParameters}
  */
 algoliasearchHelper.SearchParameters = SearchParameters;
+
+/**
+ * Constructor for the object containing all the parameters for reocmmend.
+ * @member module:algoliasearchHelper.RecommendParameters
+ * @type {RecommendParameters}
+ */
+algoliasearchHelper.RecommendParameters = RecommendParameters;
 
 /**
  * Constructor for the object containing the results of the search.

--- a/packages/instantsearch.js/src/lib/__tests__/RoutingManager-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/RoutingManager-test.ts
@@ -154,7 +154,7 @@ describe('RoutingManager', () => {
       const widget = createWidget({
         render: jest.fn(),
         getWidgetSearchParameters: jest.fn((searchParameters, { uiState }) =>
-          searchParameters.setQuery(uiState.query)
+          searchParameters.setQuery(uiState.query!)
         ),
       });
 

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -150,7 +150,7 @@ type SearchWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
 };
 
 type RecommendWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
-  dependsOn: 'recommend';
+  dependsOn?: 'recommend';
   getWidgetParameters: (
     state: RecommendParameters,
     widgetParametersOptions: {

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -7,6 +7,7 @@ import type {
   AlgoliaSearchHelper as Helper,
   SearchParameters,
   SearchResults,
+  RecommendParameters,
 } from 'algoliasearch-helper';
 
 export type ScopedResult = {
@@ -39,6 +40,8 @@ export type InitOptions = SharedRenderOptions & {
   uiState: UiState;
   results?: undefined;
 };
+
+export type ShouldRenderOptions = { instantSearchInstance: InstantSearch };
 
 export type RenderOptions = SharedRenderOptions & {
   results: SearchResults;
@@ -141,9 +144,18 @@ type RequiredWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
   $$type: TWidgetDescription['$$type'];
 
   /**
+   * Which API endpoint this connector relies on, `'search'` by default.
+   */
+  dependsOn?: 'search' | 'recommend';
+
+  /**
    * Called once before the first search.
    */
   init?: (options: InitOptions) => void;
+  /**
+   * Whether `render` should be called
+   */
+  shouldRender?: (options: ShouldRenderOptions) => boolean;
   /**
    * Called after each search response has been received.
    */
@@ -216,6 +228,15 @@ type RequiredUiStateLifeCycle<TWidgetDescription extends WidgetDescription> = {
       >;
     }
   ) => SearchParameters;
+
+  getWidgetParameters?: (
+    state: SearchParameters | RecommendParameters,
+    widgetSearchParametersOptions: {
+      uiState: Expand<
+        Partial<TWidgetDescription['indexUiState'] & IndexUiState>
+      >;
+    }
+  ) => SearchParameters | RecommendParameters;
 };
 
 type UiStateLifeCycle<TWidgetDescription extends WidgetDescription> =

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -137,16 +137,35 @@ export type WidgetDescription = {
   indexUiState?: Record<string, unknown>;
 };
 
+type SearchWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
+  dependsOn?: 'search';
+  getWidgetParameters?: (
+    state: SearchParameters,
+    widgetParametersOptions: {
+      uiState: Expand<
+        Partial<TWidgetDescription['indexUiState'] & IndexUiState>
+      >;
+    }
+  ) => SearchParameters;
+};
+
+type RecommendWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
+  dependsOn: 'recommend';
+  getWidgetParameters: (
+    state: RecommendParameters,
+    widgetParametersOptions: {
+      uiState: Expand<
+        Partial<TWidgetDescription['indexUiState'] & IndexUiState>
+      >;
+    }
+  ) => RecommendParameters;
+};
+
 type RequiredWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
   /**
    * Identifier for connectors and widgets.
    */
   $$type: TWidgetDescription['$$type'];
-
-  /**
-   * Which API endpoint this connector relies on, `'search'` by default.
-   */
-  dependsOn?: 'search' | 'recommend';
 
   /**
    * Called once before the first search.
@@ -228,16 +247,10 @@ type RequiredUiStateLifeCycle<TWidgetDescription extends WidgetDescription> = {
       >;
     }
   ) => SearchParameters;
-
-  getWidgetParameters?: (
-    state: SearchParameters | RecommendParameters,
-    widgetSearchParametersOptions: {
-      uiState: Expand<
-        Partial<TWidgetDescription['indexUiState'] & IndexUiState>
-      >;
-    }
-  ) => SearchParameters | RecommendParameters;
-};
+} & (
+  | SearchWidgetLifeCycle<TWidgetDescription>
+  | RecommendWidgetLifeCycle<TWidgetDescription>
+);
 
 type UiStateLifeCycle<TWidgetDescription extends WidgetDescription> =
   TWidgetDescription extends RequiredKeys<WidgetDescription, 'indexUiState'>

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -116,7 +116,7 @@ describe('index', () => {
         return parameters;
       }),
       ...args,
-    });
+    } as unknown as Widget);
 
   const virtualSearchBox = connectSearchBox(() => {});
   const virtualPagination = connectPagination(() => {});

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -272,6 +272,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         expect(fbt.getWidgetParameters).toHaveBeenCalledTimes(1);
       });
 
+      it('calls getWidgetParameters on widgets that depend on search and implement the function', () => {
+        const instance = index({ indexName: 'indexName' });
+
+        instance.init(createIndexInitOptions({ parent: null }));
+
+        const searchbox = createSearchBox({
+          dependsOn: 'search',
+          getWidgetParameters: jest.fn((searchParameters, { uiState }) => {
+            return searchParameters.setQueryParameter(
+              'query',
+              uiState.query || ''
+            );
+          }),
+        });
+        instance.addWidgets([searchbox]);
+
+        expect(searchbox.getWidgetParameters).toHaveBeenCalledTimes(1);
+      });
+
       it('calls `init` on the added widgets', () => {
         const instance = index({ indexName: 'indexName' });
         const instantSearchInstance = createInstantSearch();
@@ -1199,6 +1218,25 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       instance.init(createIndexInitOptions({ parent: null }));
 
       expect(fbt.getWidgetParameters).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls getWidgetParameters on widgets that depend on search and implement the function', () => {
+      const instance = index({ indexName: 'indexName' });
+
+      const searchbox = createSearchBox({
+        dependsOn: 'search',
+        getWidgetParameters: jest.fn((searchParameters, { uiState }) => {
+          return searchParameters.setQueryParameter(
+            'query',
+            uiState.query || ''
+          );
+        }),
+      });
+      instance.addWidgets([searchbox]);
+
+      instance.init(createIndexInitOptions({ parent: null }));
+
+      expect(searchbox.getWidgetParameters).toHaveBeenCalledTimes(1);
     });
 
     it('uses the index set by the widget for the queries', () => {

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -109,6 +109,15 @@ describe('index', () => {
       ...args,
     });
 
+  const createFrequentlyBoughtTogether = (args: Partial<Widget> = {}): Widget =>
+    createWidget({
+      dependsOn: 'recommend',
+      getWidgetParameters: jest.fn((parameters) => {
+        return parameters;
+      }),
+      ...args,
+    });
+
   const virtualSearchBox = connectSearchBox(() => {});
   const virtualPagination = connectPagination(() => {});
   const virtualRefinementList = connectRefinementList(() => {});
@@ -250,6 +259,17 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
             page: 5,
           })
         );
+      });
+
+      it('calls getWidgetParameters on widgets that depend on recommend', () => {
+        const instance = index({ indexName: 'indexName' });
+
+        instance.init(createIndexInitOptions({ parent: null }));
+
+        const fbt = createFrequentlyBoughtTogether({});
+        instance.addWidgets([fbt]);
+
+        expect(fbt.getWidgetParameters).toHaveBeenCalledTimes(1);
       });
 
       it('calls `init` on the added widgets', () => {
@@ -1168,6 +1188,17 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           },
         ])
       );
+    });
+
+    it('calls getWidgetParameters on widgets that depend on recommend', () => {
+      const instance = index({ indexName: 'indexName' });
+
+      const fbt = createFrequentlyBoughtTogether({});
+      instance.addWidgets([fbt]);
+
+      instance.init(createIndexInitOptions({ parent: null }));
+
+      expect(fbt.getWidgetParameters).toHaveBeenCalledTimes(1);
     });
 
     it('uses the index set by the widget for the queries', () => {
@@ -2633,6 +2664,75 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           },
         });
       });
+    });
+
+    it('calls `render` when `shouldRender` is undefined', async () => {
+      const instance = index({ indexName: 'indexName' });
+      const instantSearchInstance = createInstantSearch();
+
+      const fbt = createFrequentlyBoughtTogether({ shouldRender: undefined });
+      instance.addWidgets([fbt]);
+
+      instance.init(
+        createIndexInitOptions({
+          instantSearchInstance,
+          parent: null,
+        })
+      );
+      instance.getHelper()!.search();
+      await wait(0);
+
+      instance.render({
+        instantSearchInstance,
+      });
+
+      expect(fbt.render).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls `render` when `shouldRender` returns true', async () => {
+      const instance = index({ indexName: 'indexName' });
+      const instantSearchInstance = createInstantSearch();
+
+      const fbt = createFrequentlyBoughtTogether({ shouldRender: () => true });
+      instance.addWidgets([fbt]);
+
+      instance.init(
+        createIndexInitOptions({
+          instantSearchInstance,
+          parent: null,
+        })
+      );
+      instance.getHelper()!.search();
+      await wait(0);
+
+      instance.render({
+        instantSearchInstance,
+      });
+
+      expect(fbt.render).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call `render` when `shouldRender` returns false', async () => {
+      const instance = index({ indexName: 'indexName' });
+      const instantSearchInstance = createInstantSearch();
+
+      const fbt = createFrequentlyBoughtTogether({ shouldRender: () => false });
+      instance.addWidgets([fbt]);
+
+      instance.init(
+        createIndexInitOptions({
+          instantSearchInstance,
+          parent: null,
+        })
+      );
+      instance.getHelper()!.search();
+      await wait(0);
+
+      instance.render({
+        instantSearchInstance,
+      });
+
+      expect(fbt.render).toHaveBeenCalledTimes(0);
     });
 
     // https://github.com/algolia/instantsearch/pull/2623

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -261,7 +261,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         );
       });
 
-      it('calls getWidgetParameters on widgets that depend on recommend', () => {
+      it('calls getWidgetParameters after init on widgets that depend on recommend', () => {
         const instance = index({ indexName: 'indexName' });
 
         instance.init(createIndexInitOptions({ parent: null }));
@@ -272,7 +272,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         expect(fbt.getWidgetParameters).toHaveBeenCalledTimes(1);
       });
 
-      it('calls getWidgetParameters on widgets that depend on search and implement the function', () => {
+      it('calls getWidgetParameters after init on widgets that depend on search and implement the function', () => {
         const instance = index({ indexName: 'indexName' });
 
         instance.init(createIndexInitOptions({ parent: null }));

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -27,6 +27,7 @@ import type {
   SearchParameters,
   SearchResults,
   AlgoliaSearchHelper,
+  RecommendParameters,
 } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -53,6 +54,9 @@ type WidgetSearchParametersOptions = Parameters<
 >[1];
 type LocalWidgetSearchParametersOptions = WidgetSearchParametersOptions & {
   initialSearchParameters: SearchParameters;
+};
+type LocalWidgetRecommendParametersOptions = WidgetSearchParametersOptions & {
+  initialRecommendParameters: RecommendParameters;
 };
 
 export type IndexWidgetDescription = {
@@ -119,10 +123,12 @@ function privateHelperSetState(
   helper: AlgoliaSearchHelper,
   {
     state,
+    recommendState,
     isPageReset,
     _uiState,
   }: {
     state: SearchParameters;
+    recommendState: RecommendParameters;
     isPageReset?: boolean;
     _uiState?: IndexUiState;
   }
@@ -136,6 +142,13 @@ function privateHelperSetState(
       isPageReset,
       _uiState,
     });
+  }
+
+  if (recommendState !== helper.recommendState) {
+    helper.recommendState = recommendState;
+
+    // eslint-disable-next-line no-warning-comments
+    // TODO: emit "change" event when events for Recommend are implemented
   }
 }
 
@@ -182,6 +195,27 @@ function getLocalWidgetsSearchParameters(
     }, initialSearchParameters);
 }
 
+function getLocalWidgetsRecommendParameters(
+  widgets: Array<Widget | IndexWidget>,
+  widgetRecommendParametersOptions: LocalWidgetRecommendParametersOptions
+): RecommendParameters {
+  const { initialRecommendParameters, ...rest } =
+    widgetRecommendParametersOptions;
+
+  return widgets
+    .filter(
+      (widget) =>
+        !isIndexWidget(widget) &&
+        widget.getWidgetParameters &&
+        widget.dependsOn === 'recommend'
+    )
+    .reduce<RecommendParameters>(
+      (state, widget) =>
+        widget.getWidgetParameters!(state, rest) as RecommendParameters,
+      initialRecommendParameters
+    );
+}
+
 function resetPageFromWidgets(widgets: Array<Widget | IndexWidget>): void {
   const indexWidgets = widgets.filter(isIndexWidget);
 
@@ -194,6 +228,7 @@ function resetPageFromWidgets(widgets: Array<Widget | IndexWidget>): void {
 
     privateHelperSetState(widgetHelper, {
       state: widgetHelper.state.resetPage(),
+      recommendState: widgetHelper.recommendState,
       isPageReset: true,
     });
 
@@ -328,6 +363,10 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
             uiState: localUiState,
             initialSearchParameters: helper!.state,
           }),
+          recommendState: getLocalWidgetsRecommendParameters(localWidgets, {
+            uiState: localUiState,
+            initialRecommendParameters: helper!.recommendState,
+          }),
           _uiState: localUiState,
         });
 
@@ -454,6 +493,14 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
           index: indexName,
         }),
       });
+      const recommendParameters = getLocalWidgetsRecommendParameters(
+        localWidgets,
+        {
+          uiState: localUiState,
+          initialRecommendParameters:
+            new algoliasearchHelper.RecommendParameters(),
+        }
+      );
 
       // This Helper is only used for state management we do not care about the
       // `searchClient`. Only the "main" Helper created at the `InstantSearch`
@@ -463,6 +510,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         parameters.index,
         parameters
       );
+      helper.recommendState = recommendParameters;
 
       // We forward the call to `search` to the "main" instance of the Helper
       // which is responsible for managing the queries (it's the only one that is
@@ -641,9 +689,17 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
 
       // We only render index widgets if there are no results.
       // This makes sure `render` is never called with `results` being `null`.
-      const widgetsToRender = this.getResults()
+      let widgetsToRender = this.getResults()
         ? localWidgets
         : localWidgets.filter(isIndexWidget);
+
+      widgetsToRender = widgetsToRender.filter((widget) => {
+        if (!widget.shouldRender) {
+          return true;
+        }
+
+        return widget.shouldRender({ instantSearchInstance });
+      });
 
       widgetsToRender.forEach((widget) => {
         if (widget.getRenderState) {

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -202,18 +202,16 @@ function getLocalWidgetsRecommendParameters(
   const { initialRecommendParameters, ...rest } =
     widgetRecommendParametersOptions;
 
-  return widgets
-    .filter(
-      (widget) =>
-        !isIndexWidget(widget) &&
-        widget.getWidgetParameters &&
-        widget.dependsOn === 'recommend'
-    )
-    .reduce<RecommendParameters>(
-      (state, widget) =>
-        widget.getWidgetParameters!(state, rest) as RecommendParameters,
-      initialRecommendParameters
-    );
+  return widgets.reduce((state, widget) => {
+    if (
+      !isIndexWidget(widget) &&
+      widget.dependsOn === 'recommend' &&
+      widget.getWidgetParameters
+    ) {
+      return widget.getWidgetParameters(state, rest);
+    }
+    return state;
+  }, initialRecommendParameters);
 }
 
 function resetPageFromWidgets(widgets: Array<Widget | IndexWidget>): void {

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -184,15 +184,17 @@ function getLocalWidgetsSearchParameters(
 ): SearchParameters {
   const { initialSearchParameters, ...rest } = widgetSearchParametersOptions;
 
-  return widgets
-    .filter((widget) => !isIndexWidget(widget))
-    .reduce<SearchParameters>((state, widget) => {
-      if (!widget.getWidgetSearchParameters) {
-        return state;
-      }
+  return widgets.reduce<SearchParameters>((state, widget) => {
+    if (!widget.getWidgetSearchParameters || isIndexWidget(widget)) {
+      return state;
+    }
 
-      return widget.getWidgetSearchParameters(state, rest);
-    }, initialSearchParameters);
+    if (widget.dependsOn === 'search' && widget.getWidgetParameters) {
+      return widget.getWidgetParameters(state, rest);
+    }
+
+    return widget.getWidgetSearchParameters(state, rest);
+  }, initialSearchParameters);
 }
 
 function getLocalWidgetsRecommendParameters(

--- a/packages/instantsearch.js/src/widgets/panel/panel.tsx
+++ b/packages/instantsearch.js/src/widgets/panel/panel.tsx
@@ -181,7 +181,10 @@ const renderer =
 type AugmentedWidget<
   TWidgetFactory extends AnyWidgetFactory,
   TOverriddenKeys extends keyof Widget = 'init' | 'render' | 'dispose'
-> = Omit<ReturnType<TWidgetFactory>, TOverriddenKeys> &
+> = Omit<
+  ReturnType<TWidgetFactory>,
+  TOverriddenKeys | 'dependsOn' | 'getWidgetParameters'
+> &
   Pick<Required<Widget>, TOverriddenKeys>;
 
 export type PanelWidget = <TWidgetFactory extends AnyWidgetFactory>(

--- a/packages/instantsearch.js/test/createWidget.ts
+++ b/packages/instantsearch.js/test/createWidget.ts
@@ -100,13 +100,11 @@ export const createDisposeOptions = (
   };
 };
 
-export const createWidget = <TWidget extends Widget>(
-  args: Partial<TWidget> = {}
-): TWidget =>
+export const createWidget = (args: Partial<Widget> = {}): Widget =>
   ({
     $$type: 'mock.widget',
     init: jest.fn(),
     render: jest.fn(),
     dispose: jest.fn(),
     ...args,
-  } as unknown as TWidget);
+  } as unknown as Widget);


### PR DESCRIPTION
**Summary**

## [FX-2766](https://algolia.atlassian.net/browse/FX-2766)

**Result**

- Added calls to `getWidgetParameters` in both `init` and `addWidgets` to get recommend params.
- Filter `widgetsToRender` based on whether `shouldRender` is implemented or not and if it returns `true`



[FX-2766]: https://algolia.atlassian.net/browse/FX-2766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ