### PR TITLE
feat(hits): return banner from connectHits

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "47.25 kB"
+      "maxSize": "47.5 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",

--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1365,7 +1365,7 @@ declare namespace algoliasearchHelper {
              * - `_blank` opens the URL in a new tab
              * - `_self` opens the URL in the same tab
              */
-            target?: '__blank' | '__self';
+            target?: '_blank' | '_self';
           };
         }>;
       };

--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1337,7 +1337,7 @@ declare namespace algoliasearchHelper {
           /**
            * Configuration for the banner image
            */
-          image: Array<{
+          image: {
             /**
              * Set of possible URLs of the banner image
              */
@@ -1351,7 +1351,7 @@ declare namespace algoliasearchHelper {
              * Alt text of the banner image
              */
             title?: string;
-          }>;
+          };
           /**
            * Configuration for the banner click navigation
            */

--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1326,6 +1326,49 @@ declare namespace algoliasearchHelper {
           };
         };
       };
+      /**
+       * Defining UI widget configuration
+       */
+      widgets?: {
+        /**
+         * Configuration for banners
+         */
+        banners?: Array<{
+          /**
+           * Configuration for the banner image
+           */
+          image?: Array<{
+            /**
+             * Set of possible URLs of the banner image
+             */
+            urls?: Array<{
+              /**
+               * URL of the banner image
+               */
+              url?: string;
+            }>;
+            /**
+             * Alt text of the banner image
+             */
+            title?: string;
+          }>;
+          /**
+           * Configuration for the banner click navigation
+           */
+          link?: {
+            /**
+             * URL to navigate to when the banner is clicked
+             */
+            url?: string;
+            /**
+             * Target of the navigation
+             * - `_blank` opens the URL in a new tab
+             * - `_self` opens the URL in the same tab
+             */
+            target?: '__blank' | '__self';
+          };
+        }>;
+      };
     };
 
     /**

--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1337,15 +1337,15 @@ declare namespace algoliasearchHelper {
           /**
            * Configuration for the banner image
            */
-          image?: Array<{
+          image: Array<{
             /**
              * Set of possible URLs of the banner image
              */
-            urls?: Array<{
+            urls: Array<{
               /**
                * URL of the banner image
                */
-              url?: string;
+              url: string;
             }>;
             /**
              * Alt text of the banner image

--- a/packages/instantsearch.js/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/packages/instantsearch.js/src/connectors/hits/__tests__/connectHits-test.ts
@@ -528,6 +528,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
         createSingleSearchResponse({
           hits,
           queryID: 'theQueryID',
+          // @TODO: remove once algoliasearch js client has been updated
+          // @ts-expect-error
           renderingContent,
         }),
       ]);

--- a/packages/instantsearch.js/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/packages/instantsearch.js/src/connectors/hits/__tests__/connectHits-test.ts
@@ -498,6 +498,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
         index: 'indexName',
       });
+      const banner = { image: { urls: [{ url: 'https://example.com' }] } };
+      const renderingContent = {
+        widgets: {
+          banners: [banner],
+        },
+      };
 
       const renderState1 = hitsWidget.getRenderState(
         {},
@@ -506,6 +512,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
       expect(renderState1.hits).toEqual({
         hits: [],
+        banner: undefined,
         sendEvent: expect.any(Function),
         bindEvent: expect.any(Function),
         results: undefined,
@@ -518,7 +525,11 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       ];
 
       const results = new SearchResults(helper.state, [
-        createSingleSearchResponse({ hits, queryID: 'theQueryID' }),
+        createSingleSearchResponse({
+          hits,
+          queryID: 'theQueryID',
+          renderingContent,
+        }),
       ]);
 
       const renderState2 = hitsWidget.getRenderState(
@@ -537,6 +548,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
       expect(renderState2.hits).toEqual({
         hits: expectedHits,
+        banner,
         sendEvent: renderState1.hits.sendEvent,
         bindEvent: renderState1.hits.bindEvent,
         results,

--- a/packages/instantsearch.js/src/connectors/hits/connectHits.ts
+++ b/packages/instantsearch.js/src/connectors/hits/connectHits.ts
@@ -146,6 +146,7 @@ const connectHits: HitsConnector = function connectHits(
           return {
             hits: [],
             results: undefined,
+            banner: undefined,
             sendEvent,
             bindEvent,
             widgetParams,
@@ -172,9 +173,12 @@ const connectHits: HitsConnector = function connectHits(
           { results }
         );
 
+        const banner = results.renderingContent?.widgets?.banners?.[0];
+
         return {
           hits: transformedHits,
           results,
+          banner,
           sendEvent,
           bindEvent,
           widgetParams,

--- a/tsconfig.v3.json
+++ b/tsconfig.v3.json
@@ -16,6 +16,7 @@
     // v3 has a wrong definition for optionalWords (only accepts string[])
     "packages/instantsearch.js/src/connectors/voice-search/__tests__/connectVoiceSearch-test.ts",
     // v3 does not have renderingContent (only errors in the test)
+    "packages/instantSearch.js/src/connectors/hits/__tests__/connectHits-test.ts",
     "packages/instantsearch.js/src/connectors/dynamic-widgets/__tests__/connectDynamicWidgets-test.ts",
     "packages/instantsearch.js/src/connectors/hierarchical-menu/__tests__/connectHierarchicalMenu-test.ts",
     "packages/instantsearch.js/src/connectors/menu/__tests__/connectMenu-test.ts",


### PR DESCRIPTION
**Summary**

This is the first pull request to add support for no-code banners to the Hits widget ([RFC](https://algolia.atlassian.net/wiki/spaces/MERCH/pages/4948099490/RFC+-+Rule+Visual+Editor+Banner+Consequence)). It updates the `SearchResults` type to include `renderingContent.widgets.banners` and return a new `banner` property from `connectHits` connector.

[EMERCH-1369](https://algolia.atlassian.net/browse/EMERCH-1369)

**Result**

- No UI changes
- `connectHits-test.ts` has been updated and passes (using a `// @ts-ignore-error` in the test until the algoliasearch js client types are updated)

[EMERCH-1369]: https://algolia.atlassian.net/browse/EMERCH-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ