### PR TITLE
feat(hits): add banner to hit ui component

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "77.5 kB"
+      "maxSize": "77.75 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "170.75 kB"
+      "maxSize": "171 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
@@ -26,11 +26,11 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "66.25 kB"
+      "maxSize": "66.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "66.75 kB"
+      "maxSize": "67 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",

--- a/packages/instantsearch-ui-components/src/components/Hits.tsx
+++ b/packages/instantsearch-ui-components/src/components/Hits.tsx
@@ -8,6 +8,57 @@ type Hit = Record<string, unknown> & {
   objectID: string;
 };
 type SendEventForHits = (...props: unknown[]) => void;
+type Banner = {
+  image: {
+    urls: Array<{
+      url: string;
+    }>;
+    title?: string;
+  };
+  link?: {
+    url?: string;
+    target?: '_blank' | '_self';
+  };
+};
+
+type BannerProps = ComponentProps<'aside'> & {
+  banner: Banner;
+  classNames: Pick<
+    Partial<HitsClassNames>,
+    'bannerRoot' | 'bannerLink' | 'bannerImage'
+  >;
+};
+
+function createDefaultBannerComponent({ createElement }: Renderer) {
+  return function DefaultBanner({ classNames, banner }: BannerProps) {
+    if (!banner.image.urls[0].url) {
+      return null;
+    }
+    return (
+      <aside className={cx('ais-Hits-banner', classNames.bannerRoot)}>
+        {banner.link?.url ? (
+          <a
+            className={cx('ais-Hits-banner-link', classNames.bannerLink)}
+            href={banner.link.url}
+            target={banner.link.target}
+          >
+            <img
+              className={cx('ais-Hits-banner-image', classNames.bannerImage)}
+              src={banner.image.urls[0].url}
+              alt={banner.image.title}
+            />
+          </a>
+        ) : (
+          <img
+            className={cx('ais-Hits-banner-image', classNames.bannerImage)}
+            src={banner.image.urls[0].url}
+            alt={banner.image.title}
+          />
+        )}
+      </aside>
+    );
+  };
+}
 
 export type HitsProps<THit> = ComponentProps<'div'> & {
   hits: THit[];
@@ -20,7 +71,12 @@ export type HitsProps<THit> = ComponentProps<'div'> & {
   }) => JSX.Element;
   sendEvent: SendEventForHits;
   classNames?: Partial<HitsClassNames>;
-  emptyComponent?: (props: { className: string }) => JSX.Element;
+  emptyComponent?: (props: { className?: string }) => JSX.Element;
+  banner?: Banner;
+  bannerComponent?: (props: {
+    className: string;
+    banner: Banner;
+  }) => JSX.Element;
 };
 
 export type HitsClassNames = {
@@ -40,9 +96,26 @@ export type HitsClassNames = {
    * Class names to apply to each item element
    */
   item: string | string[];
+  /**
+   * Class names to apply to the banner element
+   */
+  bannerRoot: string | string[];
+  /**
+   * Class names to apply to the banner image element
+   */
+  bannerImage: string | string[];
+  /**
+   * Class names to apply to the banner link element
+   */
+  bannerLink: string | string[];
 };
 
-export function createHitsComponent({ createElement }: Renderer) {
+export function createHitsComponent({ createElement, Fragment }: Renderer) {
+  const DefaultBannerComponent = createDefaultBannerComponent({
+    createElement,
+    Fragment,
+  });
+
   return function Hits<THit extends Hit>(userProps: HitsProps<THit>) {
     const {
       classNames = {},
@@ -50,21 +123,11 @@ export function createHitsComponent({ createElement }: Renderer) {
       itemComponent: ItemComponent,
       sendEvent,
       emptyComponent: EmptyComponent,
+      banner,
+      bannerComponent: BannerComponent,
       ...props
     } = userProps;
 
-    if (hits.length === 0 && EmptyComponent) {
-      return (
-        <EmptyComponent
-          className={cx(
-            'ais-Hits',
-            classNames.root,
-            cx('ais-Hits--empty', classNames.emptyRoot),
-            props.className
-          )}
-        />
-      );
-    }
     return (
       <div
         {...props}
@@ -75,22 +138,35 @@ export function createHitsComponent({ createElement }: Renderer) {
           props.className
         )}
       >
-        <ol className={cx('ais-Hits-list', classNames.list)}>
-          {hits.map((hit, index) => (
-            <ItemComponent
-              key={hit.objectID}
-              hit={hit}
-              index={index}
-              className={cx('ais-Hits-item', classNames.item)}
-              onClick={() => {
-                sendEvent('click:internal', hit, 'Hit Clicked');
-              }}
-              onAuxClick={() => {
-                sendEvent('click:internal', hit, 'Hit Clicked');
-              }}
+        {banner &&
+          (BannerComponent ? (
+            <BannerComponent
+              className={cx('ais-Hits-banner', classNames.bannerRoot)}
+              banner={banner}
             />
+          ) : (
+            <DefaultBannerComponent classNames={classNames} banner={banner} />
           ))}
-        </ol>
+        {hits.length === 0 && EmptyComponent ? (
+          <EmptyComponent />
+        ) : (
+          <ol className={cx('ais-Hits-list', classNames.list)}>
+            {hits.map((hit, index) => (
+              <ItemComponent
+                key={hit.objectID}
+                hit={hit}
+                index={index}
+                className={cx('ais-Hits-item', classNames.item)}
+                onClick={() => {
+                  sendEvent('click:internal', hit, 'Hit Clicked');
+                }}
+                onAuxClick={() => {
+                  sendEvent('click:internal', hit, 'Hit Clicked');
+                }}
+              />
+            ))}
+          </ol>
+        )}
       </div>
     );
   };

--- a/packages/instantsearch-ui-components/src/components/__tests__/Hits.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Hits.test.tsx
@@ -194,9 +194,7 @@ describe('Hits', () => {
     test('renders when defined and there are no hits', () => {
       const props = createProps({
         hits: [],
-        emptyComponent: ({ ...rootProps }) => (
-          <div {...rootProps}>No results</div>
-        ),
+        emptyComponent: () => <span>No results</span>,
       });
       const { container } = render(<Hits {...props} />);
       expect(container).toMatchInlineSnapshot(`
@@ -204,7 +202,9 @@ describe('Hits', () => {
           <div
             class="ais-Hits ais-Hits--empty"
           >
-            No results
+            <span>
+              No results
+            </span>
           </div>
         </div>
       `);

--- a/packages/instantsearch-ui-components/src/components/__tests__/Hits.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Hits.test.tsx
@@ -60,6 +60,96 @@ describe('Hits', () => {
     `);
   });
 
+  test('renders with a banner (navigable)', () => {
+    const props = createProps({
+      banner: {
+        image: {
+          urls: [{ url: 'https://example.com/image.jpg' }],
+        },
+        link: {
+          url: 'https://example.com',
+        },
+      },
+    });
+    const { container } = render(<Hits {...props} />);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Hits"
+        >
+          <aside
+            class="ais-Hits-banner"
+          >
+            <a
+              class="ais-Hits-banner-link"
+              href="https://example.com"
+            >
+              <img
+                class="ais-Hits-banner-image"
+                src="https://example.com/image.jpg"
+              />
+            </a>
+          </aside>
+          <ol
+            class="ais-Hits-list"
+          >
+            <li
+              class="ais-Hits-item"
+            >
+              abc
+            </li>
+            <li
+              class="ais-Hits-item"
+            >
+              def
+            </li>
+          </ol>
+        </div>
+      </div>
+    `);
+  });
+
+  test('renders with a banner (non-navigable)', () => {
+    const props = createProps({
+      banner: {
+        image: {
+          urls: [{ url: 'https://example.com/image.jpg' }],
+        },
+      },
+    });
+    const { container } = render(<Hits {...props} />);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-Hits"
+        >
+          <aside
+            class="ais-Hits-banner"
+          >
+            <img
+              class="ais-Hits-banner-image"
+              src="https://example.com/image.jpg"
+            />
+          </aside>
+          <ol
+            class="ais-Hits-list"
+          >
+            <li
+              class="ais-Hits-item"
+            >
+              abc
+            </li>
+            <li
+              class="ais-Hits-item"
+            >
+              def
+            </li>
+          </ol>
+        </div>
+      </div>
+    `);
+  });
+
   test('forwards `div` props to the root element', () => {
     const props = createProps({
       hidden: true,
@@ -205,6 +295,89 @@ describe('Hits', () => {
             <span>
               No results
             </span>
+          </div>
+        </div>
+      `);
+    });
+  });
+
+  describe('bannerComponent', () => {
+    test('renders when defined', () => {
+      const props = createProps({
+        banner: {
+          image: {
+            urls: [{ url: 'https://example.com/image.jpg' }],
+          },
+          link: {
+            url: 'https://example.com',
+          },
+        },
+        bannerComponent: ({ banner }) => (
+          <a href={banner?.link?.url}>
+            <img src={banner.image.urls[0].url} />
+          </a>
+        ),
+      });
+      const { container } = render(<Hits {...props} />);
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <div
+            class="ais-Hits"
+          >
+            <a
+              href="https://example.com"
+            >
+              <img
+                src="https://example.com/image.jpg"
+              />
+            </a>
+            <ol
+              class="ais-Hits-list"
+            >
+              <li
+                class="ais-Hits-item"
+              >
+                abc
+              </li>
+              <li
+                class="ais-Hits-item"
+              >
+                def
+              </li>
+            </ol>
+          </div>
+        </div>
+      `);
+    });
+
+    test('does not render when no banner data', () => {
+      const props = createProps({
+        bannerComponent: ({ banner }) => (
+          <a href={banner?.link?.url}>
+            <img src={banner.image.urls[0].url} />
+          </a>
+        ),
+      });
+      const { container } = render(<Hits {...props} />);
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <div
+            class="ais-Hits"
+          >
+            <ol
+              class="ais-Hits-list"
+            >
+              <li
+                class="ais-Hits-item"
+              >
+                abc
+              </li>
+              <li
+                class="ais-Hits-item"
+              >
+                def
+              </li>
+            </ol>
           </div>
         </div>
       `);

--- a/packages/instantsearch.js/src/components/Template/Template.tsx
+++ b/packages/instantsearch.js/src/components/Template/Template.tsx
@@ -12,19 +12,30 @@ import type { JSX } from 'preact';
 
 class RawHtml extends Component<{ content: string }> {
   ref = createRef();
-  nodes: Element[] = [];
+  nodes: ChildNode[] = [];
 
   componentDidMount() {
     const fragment = new DocumentFragment();
     const root = document.createElement('div');
     root.innerHTML = this.props.content;
-    this.nodes = [...root.children];
+    this.nodes = [...root.childNodes];
     this.nodes.forEach((node) => fragment.appendChild(node));
     this.ref.current.replaceWith(fragment);
   }
 
   componentWillUnmount() {
-    this.nodes.forEach((node) => (node.outerHTML = ''));
+    this.nodes.forEach((node) => {
+      if (node instanceof Element) {
+        node.outerHTML = '';
+        return;
+      }
+      node.nodeValue = '';
+    });
+    // if there is one TextNode first and one TextNode last, the
+    // last one's nodeValue will be assigned to the first.
+    if (this.nodes[0].nodeValue) {
+      this.nodes[0].nodeValue = '';
+    }
   }
 
   render() {

--- a/packages/instantsearch.js/src/components/Template/__tests__/Template-test.tsx
+++ b/packages/instantsearch.js/src/components/Template/__tests__/Template-test.tsx
@@ -59,9 +59,16 @@ describe('Template', () => {
   it('can have Fragment as rootTagName with string template', () => {
     const props = getProps({
       rootTagName: 'fragment',
-      templates: { test: '<span>test</span>' },
+      templates: { test: 'Hello <span>{{name}}</span> !' },
+      data: { name: 'world' },
     });
     const wrapper = render(<Template {...props} />);
+
+    expect(wrapper.container).toMatchSnapshot();
+
+    props.data = { name: 'world2' };
+
+    wrapper.rerender(<Template {...props} />);
 
     expect(wrapper.container).toMatchSnapshot();
   });
@@ -70,6 +77,16 @@ describe('Template', () => {
     const props = getProps({
       rootTagName: 'fragment',
       templates: { test: () => <span>test</span> },
+    });
+    const wrapper = render(<Template {...props} />);
+
+    expect(wrapper.container).toMatchSnapshot();
+  });
+
+  it('can have Fragment as rootTagName with simple string', () => {
+    const props = getProps({
+      rootTagName: 'fragment',
+      templates: { test: 'test' },
     });
     const wrapper = render(<Template {...props} />);
 

--- a/packages/instantsearch.js/src/components/Template/__tests__/__snapshots__/Template-test.tsx.snap
+++ b/packages/instantsearch.js/src/components/Template/__tests__/__snapshots__/Template-test.tsx.snap
@@ -28,11 +28,31 @@ exports[`Template can have Fragment as rootTagName with Preact template 1`] = `
 </div>
 `;
 
+exports[`Template can have Fragment as rootTagName with simple string 1`] = `
+<div>
+  test
+</div>
+`;
+
 exports[`Template can have Fragment as rootTagName with string template 1`] = `
 <div>
+  Hello 
   <span>
-    test
+    world
   </span>
+   !
+</div>
+`;
+
+exports[`Template can have Fragment as rootTagName with string template 2`] = `
+<div>
+  
+  
+  Hello 
+  <span>
+    world2
+  </span>
+   !
 </div>
 `;
 

--- a/packages/instantsearch.js/src/widgets/hits/hits.tsx
+++ b/packages/instantsearch.js/src/widgets/hits/hits.tsx
@@ -86,6 +86,7 @@ const renderer =
         rootProps={rootProps}
         templateKey="empty"
         data={results}
+        rootTagName="fragment"
       />
     );
 

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
@@ -9,14 +9,14 @@ export { Vue, Vue2, isVue2, isVue3, version };
 
 const augmentCreateElement =
   (createElement) =>
-  (tag, propsWithClassName = {}, children) => {
+  (tag, propsWithClassName = {}, ...children) => {
     const { className, ...props } = propsWithClassName;
 
     if (typeof tag === 'function') {
       return tag(
         Object.assign(props, {
           class: className || props.class,
-          children,
+          children: children.length > 0 ? children : undefined,
         })
       );
     }
@@ -24,7 +24,7 @@ const augmentCreateElement =
     return createElement(
       tag,
       Object.assign(props, { class: className || props.class }),
-      [children]
+      children
     );
   };
 

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
@@ -8,7 +8,8 @@ export { createApp, createSSRApp, h, version, nextTick } from 'vue';
 export { Vue, Vue2, isVue2, isVue3 };
 
 export function renderCompat(fn) {
-  function h(tag, props, children) {
+  function h(tag, props, ...childrenArray) {
+    const children = childrenArray.length > 0 ? childrenArray : undefined;
     if (
       typeof props === 'object' &&
       (props.attrs || props.props || props.scopedSlots || props.on)


### PR DESCRIPTION
**Summary**

This is the second pull request to add support for no-code banners to the Hits widget ([RFC](https://algolia.atlassian.net/wiki/spaces/MERCH/pages/4948099490/RFC+-+Rule+Visual+Editor+Banner+Consequence)). It updates the `Hits` `instantsearch-ui-component` to conditionally render a banner (either the default layout or a custom layout if the `bannerComponent` is included) in the DOM with the appropriate class names.

[EMERCH-1420](https://algolia.atlassian.net/browse/EMERCH-1420)

**Result**

  No UI changes

- Update Hits UI component to support conditionally rendering a banner above the hits `ol`
- Update and add new snapshot tests for `banner` and `bannerComponent` props
- Update `Template` component to support Hits widget `emptyComponent` (root changed to `fragment`)
- Update Vue utilities to handle multiple children arguments for `createElement()`
- Increment `bundlesize.config.json`


[EMERCH-1420]: https://algolia.atlassian.net/browse/EMERCH-1420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ