### PR TITLE
ci: update generated sandboxes in pull requests

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,10 +1,11 @@
 {
   "sandboxes": [
-    "instantsearchjs-es-template-pcw1k",
-    "github/algolia/instantsearch/tree/templates/react-instantsearch",
+    "/examples/js/getting-started",
+    "/examples/react/getting-started",
+    "/examples/vue/getting-started",
     "/examples/react/default-theme",
-    "/examples/react/next-app-router",
-    "/examples/vue/default-theme"
+    "/examples/react/next-router",
+    "/examples/react/next-app-router"
   ],
   "buildCommand": "build --no-private --ignore *-maps --ignore *-native",
   "packages": [

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,10 +2,9 @@
   "sandboxes": [
     "/examples/js/getting-started",
     "/examples/react/getting-started",
-    "/examples/vue/getting-started",
-    "/examples/react/default-theme",
+    "/examples/react/next-app-router",
     "/examples/react/next-routing",
-    "/examples/react/next-app-router"
+    "/examples/vue/getting-started"
   ],
   "buildCommand": "build --no-private --ignore *-maps --ignore *-native",
   "packages": [

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -4,7 +4,7 @@
     "/examples/react/getting-started",
     "/examples/vue/getting-started",
     "/examples/react/default-theme",
-    "/examples/react/next-router",
+    "/examples/react/next-routing",
     "/examples/react/next-app-router"
   ],
   "buildCommand": "build --no-private --ignore *-maps --ignore *-native",


### PR DESCRIPTION
**Summary**

This is a quick PR that updates the list of sandboxes that are generated by CodeSandbox CI in our pull requests. It now generates a sandbox for each flavor's getting-started example, in addition to some specific to React InstantSearch and Next.js.