### PR TITLE
test(frequentlyBoughtTogether): move to common test suite

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common-connectors.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-connectors.test.tsx
@@ -16,6 +16,7 @@ import {
   connectRefinementList,
   connectToggleRefinement,
   connectRelatedProducts,
+  connectFrequentlyBoughtTogether,
 } from '../connectors';
 import instantsearch from '../index.es';
 import { refinementList } from '../widgets';
@@ -418,6 +419,35 @@ const testSetups: TestSetupsMap<TestSuites> = {
       })
       .start();
   },
+  createFrequentlyBoughtTogetherConnectorTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
+    const customFrequentlyBoughtTogether = connectFrequentlyBoughtTogether<{
+      container: HTMLElement;
+    }>((renderOptions) => {
+      renderOptions.widgetParams.container.innerHTML = `
+        <ul>${renderOptions.recommendations
+          .map((recommendation) => `<li>${recommendation.objectID}</li>`)
+          .join('')}</ul>
+      `;
+    });
+
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        customFrequentlyBoughtTogether({
+          container: document.body.appendChild(document.createElement('div')),
+          ...widgetParams,
+        }),
+      ])
+      .on('error', () => {
+        /*
+         * prevent rethrowing InstantSearch errors, so tests can be asserted.
+         * IRL this isn't needed, as the error doesn't stop execution.
+         */
+      })
+      .start();
+  },
 };
 
 const testOptions: TestOptionsMap<TestSuites> = {
@@ -432,6 +462,7 @@ const testOptions: TestOptionsMap<TestSuites> = {
   createRatingMenuConnectorTests: undefined,
   createToggleRefinementConnectorTests: undefined,
   createRelatedProductsConnectorTests: undefined,
+  createFrequentlyBoughtTogetherConnectorTests: undefined,
 };
 
 describe('Common connector tests (InstantSearch.js)', () => {

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/__tests__/connectFrequentlyBoughtTogether-test.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/__tests__/connectFrequentlyBoughtTogether-test.ts
@@ -2,10 +2,7 @@
  * @jest-environment jsdom
  */
 
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createSearchClient } from '@instantsearch/mocks';
 import algoliasearchHelper, { RecommendParameters } from 'algoliasearch-helper';
 
 import {
@@ -13,9 +10,6 @@ import {
   createRenderOptions,
 } from '../../../../test/createWidget';
 import connectFrequentlyBoughtTogether from '../connectFrequentlyBoughtTogether';
-
-import type { RenderOptions } from '../../../types';
-import type { SearchResults } from 'algoliasearch-helper';
 
 describe('connectFrequentlyBoughtTogether', () => {
   it('throws without render function', () => {
@@ -44,30 +38,6 @@ describe('connectFrequentlyBoughtTogether', () => {
         dispose: expect.any(Function),
       })
     );
-  });
-
-  it('throws when no `objectIDs` are provided', () => {
-    const makeWidget = connectFrequentlyBoughtTogether(() => {});
-    expect(() => {
-      makeWidget({
-        // @ts-expect-error
-        objectIDs: undefined,
-      });
-    }).toThrowErrorMatchingInlineSnapshot(`
-      "The \`objectIDs\` option is required.
-
-      See documentation: https://www.algolia.com/doc/api-reference/widgets/frequently-bought-together/js/#connector"
-    `);
-
-    expect(() => {
-      makeWidget({
-        objectIDs: [],
-      });
-    }).toThrowErrorMatchingInlineSnapshot(`
-      "The \`objectIDs\` option is required.
-
-      See documentation: https://www.algolia.com/doc/api-reference/widgets/frequently-bought-together/js/#connector"
-    `);
   });
 
   it('Renders during init and render', () => {
@@ -105,154 +75,6 @@ describe('connectFrequentlyBoughtTogether', () => {
       expect.objectContaining({ widgetParams: { objectIDs: ['1'] } }),
       false
     );
-  });
-
-  it('Provides the hits and the whole results', () => {
-    const renderFn = jest.fn();
-    const makeWidget = connectFrequentlyBoughtTogether(renderFn);
-    const widget = makeWidget({ objectIDs: ['1'] });
-
-    const helper = algoliasearchHelper(createSearchClient(), '', {});
-    helper.search = jest.fn();
-
-    widget.init!(
-      createInitOptions({
-        helper,
-      })
-    );
-
-    expect(renderFn).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        recommendations: [],
-      }),
-      expect.anything()
-    );
-
-    const hits = [
-      { objectID: '1', fake: 'data' },
-      { objectID: '2', sample: 'infos' },
-    ];
-
-    const results = createSingleSearchResponse({
-      hits,
-    }) as unknown as SearchResults;
-    widget.render!(
-      createRenderOptions({
-        results,
-      })
-    );
-
-    expect(renderFn).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        recommendations: hits,
-      }),
-      expect.anything()
-    );
-  });
-
-  it('transform items if requested', () => {
-    const renderFn = jest.fn();
-    const makeWidget = connectFrequentlyBoughtTogether(renderFn);
-    const widget = makeWidget({
-      objectIDs: ['1'],
-      transformItems: (items) =>
-        items.map((item) => ({ ...item, name: 'transformed' })),
-    });
-
-    const helper = algoliasearchHelper(createSearchClient(), '', {});
-    helper.search = jest.fn();
-
-    widget.init!(createInitOptions({}));
-
-    expect(renderFn).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ recommendations: [] }),
-      expect.anything()
-    );
-
-    const hits = [
-      { objectID: '1', name: 'name 1' },
-      { objectID: '2', name: 'name 2' },
-    ];
-
-    const results = createSingleSearchResponse({
-      hits,
-    }) as unknown as SearchResults;
-    widget.render!(
-      createRenderOptions({
-        results,
-      })
-    );
-
-    const expectedHits = [
-      { objectID: '1', name: 'transformed' },
-      { objectID: '2', name: 'transformed' },
-    ];
-
-    expect(renderFn).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        recommendations: expectedHits,
-      }),
-      expect.anything()
-    );
-  });
-
-  it('provides results within transformItems', () => {
-    const transformItems = jest.fn((items) => items);
-    const makeWidget = connectFrequentlyBoughtTogether(() => {});
-    const widget = makeWidget({
-      transformItems,
-      objectIDs: ['1'],
-    });
-
-    const results = createSingleSearchResponse({
-      hits: [],
-    }) as unknown as SearchResults;
-
-    widget.init!(createInitOptions({}));
-    widget.render!(
-      createRenderOptions({
-        results,
-      })
-    );
-
-    expect(transformItems).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.objectContaining({ results })
-    );
-  });
-
-  describe('getWidgetRenderState', () => {
-    it('returns the widget render state', () => {
-      const renderFn = jest.fn();
-      const unmountFn = jest.fn();
-      const createFbt = connectFrequentlyBoughtTogether(renderFn, unmountFn);
-      const fbtWidget = createFbt({ objectIDs: ['1'] });
-
-      const renderState1 = fbtWidget.getWidgetRenderState!(
-        createInitOptions({})
-      );
-
-      expect(renderState1).toEqual({
-        recommendations: [],
-        widgetParams: { objectIDs: ['1'] },
-      });
-
-      const hits = [
-        { objectID: '1', name: 'name 1' },
-        { objectID: '2', name: 'name 2' },
-      ];
-
-      const renderState2 = fbtWidget.getWidgetRenderState!({
-        results: { hits },
-      } as unknown as RenderOptions);
-
-      expect(renderState2).toEqual({
-        recommendations: hits,
-        widgetParams: { objectIDs: ['1'] },
-      });
-    });
   });
 
   describe('getWidgetParameters', () => {

--- a/packages/react-instantsearch/src/__tests__/common-connectors.test.tsx
+++ b/packages/react-instantsearch/src/__tests__/common-connectors.test.tsx
@@ -314,6 +314,7 @@ const testSetups: TestSetupsMap<TestSuites> = {
     );
   },
   createRelatedProductsConnectorTests: () => {},
+  createFrequentlyBoughtTogetherConnectorTests: () => {},
 };
 
 const testOptions: TestOptionsMap<TestSuites> = {
@@ -334,6 +335,12 @@ const testOptions: TestOptionsMap<TestSuites> = {
   createRatingMenuConnectorTests: { act },
   createToggleRefinementConnectorTests: { act },
   createRelatedProductsConnectorTests: {
+    act,
+    skippedTests: {
+      options: true,
+    },
+  },
+  createFrequentlyBoughtTogetherConnectorTests: {
     act,
     skippedTests: {
       options: true,

--- a/packages/vue-instantsearch/src/__tests__/common-connectors.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-connectors.test.js
@@ -340,6 +340,7 @@ const testSetups = {
     await nextTick();
   },
   createRelatedProductsConnectorTests: () => {},
+  createFrequentlyBoughtTogetherConnectorTests: () => {},
 };
 
 function createCustomWidget({
@@ -415,6 +416,11 @@ const testOptions = {
   createRatingMenuConnectorTests: undefined,
   createToggleRefinementConnectorTests: undefined,
   createRelatedProductsConnectorTests: {
+    skippedTests: {
+      options: true,
+    },
+  },
+  createFrequentlyBoughtTogetherConnectorTests: {
     skippedTests: {
       options: true,
     },

--- a/tests/common/connectors/frequently-bought-together/index.ts
+++ b/tests/common/connectors/frequently-bought-together/index.ts
@@ -1,0 +1,23 @@
+import { fakeAct } from '../../common';
+
+import { createOptionsTests } from './options';
+
+import type { TestOptions, TestSetup } from '../../common';
+import type { FrequentlyBoughtTogetherConnectorParams } from 'instantsearch.js/es/connectors/frequently-bought-together/connectFrequentlyBoughtTogether';
+
+export type FrequentlyBoughtTogetherConnectorSetup = TestSetup<{
+  widgetParams: FrequentlyBoughtTogetherConnectorParams;
+}>;
+
+export function createFrequentlyBoughtTogetherConnectorTests(
+  setup: FrequentlyBoughtTogetherConnectorSetup,
+  { act = fakeAct, skippedTests = {} }: TestOptions = {}
+) {
+  beforeAll(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('FrequentlyBoughtTogether connector common tests', () => {
+    createOptionsTests(setup, { act, skippedTests });
+  });
+}

--- a/tests/common/connectors/frequently-bought-together/options.ts
+++ b/tests/common/connectors/frequently-bought-together/options.ts
@@ -1,0 +1,245 @@
+import {
+  createMultiSearchResponse,
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import { screen } from '@testing-library/dom';
+
+import { skippableDescribe } from '../../common';
+
+import type { FrequentlyBoughtTogetherConnectorSetup } from '.';
+import type { SetupOptions, TestOptions } from '../../common';
+import type { SearchClient } from 'instantsearch.js';
+
+export function createOptionsTests(
+  setup: FrequentlyBoughtTogetherConnectorSetup,
+  { act, skippedTests }: Required<TestOptions>
+) {
+  skippableDescribe('options', skippedTests, () => {
+    test('throws when not passing the `objectIDs` option', async () => {
+      const options: SetupOptions<FrequentlyBoughtTogetherConnectorSetup> = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient(),
+        },
+        widgetParams: {
+          // @ts-expect-error
+          objectIDs: undefined,
+        },
+      };
+
+      await expect(async () => {
+        await setup(options);
+      }).rejects.toThrowErrorMatchingInlineSnapshot(`
+              "The \`objectIDs\` option is required.
+
+              See documentation: https://www.algolia.com/doc/api-reference/widgets/frequently-bought-together/js/#connector"
+            `);
+    });
+
+    test('forwards parameters to the client', async () => {
+      const searchClient = createMockedSearchClient();
+      const options: SetupOptions<FrequentlyBoughtTogetherConnectorSetup> = {
+        instantSearchOptions: { indexName: 'indexName', searchClient },
+        widgetParams: {
+          objectIDs: ['1'],
+          maxRecommendations: 2,
+          threshold: 3,
+          queryParameters: { analytics: true },
+        },
+      };
+
+      await setup(options);
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            objectID: '1',
+            maxRecommendations: 2,
+            threshold: 3,
+            queryParameters: { analytics: true },
+          }),
+        ])
+      );
+    });
+
+    test('returns recommendations', async () => {
+      const options: SetupOptions<FrequentlyBoughtTogetherConnectorSetup> = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createMockedSearchClient(),
+        },
+        widgetParams: { objectIDs: ['1'] },
+      };
+
+      await setup(options);
+
+      expect(screen.getByRole('list')).toMatchInlineSnapshot('<ul />');
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(screen.getByRole('list')).toMatchInlineSnapshot(`
+        <ul>
+          <li>
+            A0E200000002BLK
+          </li>
+          <li>
+            A0E200000001WFI
+          </li>
+          <li>
+            A0E2000000024R1
+          </li>
+        </ul>
+      `);
+    });
+
+    test('transforms recommendations', async () => {
+      const options: SetupOptions<FrequentlyBoughtTogetherConnectorSetup> = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createMockedSearchClient(),
+        },
+        widgetParams: {
+          objectIDs: ['1'],
+          transformItems(items) {
+            return items.map((item) => ({
+              ...item,
+              objectID: item.objectID.toLowerCase(),
+            }));
+          },
+        },
+      };
+
+      await setup(options);
+
+      expect(screen.getByRole('list')).toMatchInlineSnapshot('<ul />');
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(screen.getByRole('list')).toMatchInlineSnapshot(
+        `
+        <ul>
+          <li>
+            a0e200000002blk
+          </li>
+          <li>
+            a0e200000001wfi
+          </li>
+          <li>
+            a0e2000000024r1
+          </li>
+        </ul>
+      `
+      );
+    });
+  });
+}
+
+function createMockedSearchClient() {
+  return createSearchClient({
+    getRecommendations: jest.fn((requests) =>
+      Promise.resolve(
+        createMultiSearchResponse(
+          // @ts-ignore
+          // `request` will be implicitly typed as `any` in type-check:v3
+          // since `getRecommendations` is not available there
+          ...requests.map((request) => {
+            return createSingleSearchResponse<any>({
+              hits:
+                request.maxRecommendations === 0
+                  ? []
+                  : [
+                      {
+                        _highlightResult: {
+                          brand: {
+                            matchLevel: 'none',
+                            matchedWords: [],
+                            value: 'Moschino Love',
+                          },
+                          name: {
+                            matchLevel: 'none',
+                            matchedWords: [],
+                            value: 'Moschino Love – Shoulder bag',
+                          },
+                        },
+                        _score: 40.87,
+                        brand: 'Moschino Love',
+                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
+                        name: 'Moschino Love – Shoulder bag',
+                        objectID: 'A0E200000002BLK',
+                        parentID: 'JC4052PP10LB100A',
+                        price: {
+                          currency: 'EUR',
+                          discount_level: -100,
+                          discounted_value: 0,
+                          on_sales: false,
+                          value: 227.5,
+                        },
+                      },
+                      {
+                        _highlightResult: {
+                          brand: {
+                            matchLevel: 'none',
+                            matchedWords: [],
+                            value: 'Gabs',
+                          },
+                          name: {
+                            matchLevel: 'none',
+                            matchedWords: [],
+                            value: 'Bag “Sabrina“ medium Gabs',
+                          },
+                        },
+                        _score: 40.91,
+                        brand: 'Gabs',
+                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
+                        name: 'Bag “Sabrina“ medium Gabs',
+                        objectID: 'A0E200000001WFI',
+                        parentID: 'SABRINA',
+                        price: {
+                          currency: 'EUR',
+                          discount_level: -100,
+                          discounted_value: 0,
+                          on_sales: false,
+                          value: 210,
+                        },
+                      },
+                      {
+                        _highlightResult: {
+                          brand: {
+                            matchLevel: 'none',
+                            matchedWords: [],
+                            value: 'La Carrie Bag',
+                          },
+                          name: {
+                            matchLevel: 'none',
+                            matchedWords: [],
+                            value: 'Bag La Carrie Bag small black',
+                          },
+                        },
+                        _score: 39.92,
+                        brand: 'La Carrie Bag',
+                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
+                        name: 'Bag La Carrie Bag small black',
+                        objectID: 'A0E2000000024R1',
+                        parentID: '151',
+                        price: {
+                          currency: 'EUR',
+                          discount_level: -100,
+                          discounted_value: 0,
+                          on_sales: false,
+                          value: 161.25,
+                        },
+                      },
+                    ],
+            });
+          })
+        )
+      )
+    ) as SearchClient['getRecommendations'],
+  });
+}

--- a/tests/common/connectors/index.ts
+++ b/tests/common/connectors/index.ts
@@ -9,3 +9,4 @@ export * from './rating-menu';
 export * from './toggle-refinement';
 export * from './current-refinements';
 export * from './related-products';
+export * from './frequently-bought-together';


### PR DESCRIPTION
**Summary**

This is a followup to #6117 and it moves the connector tests to the common test suite, as introduced with #6142.