### PR TITLE
fix: provide scopedResults when main index has no index name set

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "171 kB"
+      "maxSize": "171.25 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
@@ -22,11 +22,11 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "59.25 kB"
+      "maxSize": "59.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "66.5 kB"
+      "maxSize": "66.75 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -303,9 +303,19 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
 
     getScopedResults() {
       const widgetParent = this.getParent();
+      let widgetSiblings;
 
-      // If the widget is the root, we consider itself as the only sibling.
-      const widgetSiblings = widgetParent ? widgetParent.getWidgets() : [this];
+      if (widgetParent) {
+        widgetSiblings = widgetParent.getWidgets();
+      } else if (indexName.length === 0) {
+        // The widget is the root but has no index name:
+        // we resolve results from its children index widgets
+        widgetSiblings = this.getWidgets();
+      } else {
+        // The widget is the root and has an index name:
+        // we consider itself as the only sibling
+        widgetSiblings = [this];
+      }
 
       return resolveScopedResultsFromWidgets(widgetSiblings);
     },

--- a/packages/react-instantsearch-core/src/lib/__tests__/useSearchResults.test.tsx
+++ b/packages/react-instantsearch-core/src/lib/__tests__/useSearchResults.test.tsx
@@ -6,7 +6,7 @@ import { createInstantSearchTestWrapper } from '@instantsearch/testutils';
 import { renderHook } from '@testing-library/react-hooks';
 import { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
 import React from 'react';
-import { SearchBox } from 'react-instantsearch';
+import { Index, SearchBox } from 'react-instantsearch';
 
 import { useSearchResults } from '../useSearchResults';
 
@@ -52,6 +52,59 @@ describe('useSearchResults', () => {
       ],
     });
     expect(result.current.results.__isArtificial).toBeUndefined();
+  });
+
+  test('returns scoped results', async () => {
+    const wrapper = createInstantSearchTestWrapper();
+    const { result, waitForNextUpdate } = renderHook(() => useSearchResults(), {
+      wrapper: ({ children }: { children: React.ReactNode }) =>
+        wrapper({
+          children: (
+            <>
+              <SearchBox />
+              <Index indexName="indexName1"></Index>
+              <Index indexName="indexName2"></Index>
+              {children}
+            </>
+          ),
+        }),
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current.scopedResults).toHaveLength(3);
+    expect(result.current.scopedResults.map(({ indexId }) => indexId)).toEqual([
+      'indexName',
+      'indexName1',
+      'indexName2',
+    ]);
+  });
+
+  test('returns scoped results when the main index has no indexName set', async () => {
+    const wrapper = createInstantSearchTestWrapper({
+      indexName: undefined,
+    });
+    const { result, waitForNextUpdate } = renderHook(() => useSearchResults(), {
+      wrapper: ({ children }: { children: React.ReactNode }) =>
+        wrapper({
+          children: (
+            <>
+              <SearchBox />
+              <Index indexName="indexName1"></Index>
+              <Index indexName="indexName2"></Index>
+              {children}
+            </>
+          ),
+        }),
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current.scopedResults).toHaveLength(2);
+    expect(result.current.scopedResults.map(({ indexId }) => indexId)).toEqual([
+      'indexName1',
+      'indexName2',
+    ]);
   });
 
   test('does not return `null` results when the first search is stalled', async () => {

--- a/packages/react-instantsearch-core/src/lib/useSearchResults.ts
+++ b/packages/react-instantsearch-core/src/lib/useSearchResults.ts
@@ -1,3 +1,4 @@
+import { isIndexWidget } from 'instantsearch.js/es/lib/utils';
 import { useEffect, useState } from 'react';
 
 import { getIndexSearchResults } from './getIndexSearchResults';
@@ -31,6 +32,15 @@ export function useSearchResults(): SearchResultsApi {
           results,
           scopedResults: searchIndex.getScopedResults(),
         });
+      } else if (search.mainIndex.getIndexName().length === 0) {
+        // If the main index has no name, we get the scoped results from
+        // the first child index instead.
+        const childIndex = search.mainIndex.getWidgets().find(isIndexWidget);
+        childIndex &&
+          setSearchResults({
+            results: getIndexSearchResults(searchIndex).results,
+            scopedResults: childIndex.getScopedResults(),
+          });
       }
     }
 


### PR DESCRIPTION
**Summary**

This PR fixes an issue which returns an empty `scopedResults` through `useInstantSearch()` when the main index has no index name set.

**Result**

Scoped results are now properly returned even when the main index has no name set.

Fixes #6132