### PR TITLE
feat(ui-components): introduce `TrendingItems` component

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,11 +14,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "174.75 kB"
+      "maxSize": "175 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "47.75 kB"
+      "maxSize": "48 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -54,7 +54,7 @@
     },
     {
       "path": "./packages/instantsearch.css/themes/reset-min.css",
-      "maxSize": "1 kB"
+      "maxSize": "1.25 kB"
     },
     {
       "path": "./packages/instantsearch.css/themes/satellite.css",

--- a/packages/instantsearch-ui-components/src/components/TrendingItems.tsx
+++ b/packages/instantsearch-ui-components/src/components/TrendingItems.tsx
@@ -1,0 +1,102 @@
+/** @jsx createElement */
+
+import { cx } from '../lib';
+
+import {
+  createDefaultFallbackComponent,
+  createDefaultHeaderComponent,
+  createDefaultItemComponent,
+  createListViewComponent,
+} from './recommend-shared';
+
+import type {
+  ComponentProps,
+  RecommendComponentProps,
+  RecommendTranslations,
+  Renderer,
+} from '../types';
+
+export type TrendingItemsProps<
+  TObject,
+  TComponentProps extends Record<string, unknown> = Record<string, unknown>
+> = ComponentProps<'div'> & RecommendComponentProps<TObject, TComponentProps>;
+
+export function createTrendingItemsComponent({
+  createElement,
+  Fragment,
+}: Renderer) {
+  return function TrendingItems<TObject>(
+    userProps: TrendingItemsProps<TObject>
+  ) {
+    const {
+      classNames = {},
+      fallbackComponent: FallbackComponent = createDefaultFallbackComponent({
+        createElement,
+        Fragment,
+      }),
+      headerComponent: HeaderComponent = createDefaultHeaderComponent({
+        createElement,
+        Fragment,
+      }),
+      itemComponent: ItemComponent = createDefaultItemComponent({
+        createElement,
+        Fragment,
+      }),
+      view: View = createListViewComponent({ createElement, Fragment }),
+      items,
+      status,
+      translations: userTranslations,
+      sendEvent,
+      ...props
+    } = userProps;
+
+    const translations: Required<RecommendTranslations> = {
+      title: 'Trending items',
+      sliderLabel: 'Trending items',
+      ...userTranslations,
+    };
+
+    if (items.length === 0 && status === 'idle') {
+      return (
+        <section
+          {...props}
+          className={cx(
+            'ais-TrendingItems',
+            classNames.root,
+            'ais-TrendingItems--empty',
+            classNames.emptyRoot,
+            props.className
+          )}
+        >
+          <FallbackComponent />
+        </section>
+      );
+    }
+
+    return (
+      <section {...props} className={cx('ais-TrendingItems', classNames.root)}>
+        <HeaderComponent
+          classNames={{
+            ...classNames,
+            title: cx('ais-TrendingItems-title', classNames.title),
+          }}
+          recommendations={items}
+          translations={translations}
+        />
+
+        <View
+          classNames={{
+            ...classNames,
+            container: cx('ais-TrendingItems-container', classNames.container),
+            list: cx('ais-TrendingItems-list', classNames.list),
+            item: cx('ais-TrendingItems-item', classNames.item),
+          }}
+          translations={translations}
+          itemComponent={ItemComponent}
+          items={items}
+          sendEvent={sendEvent}
+        />
+      </section>
+    );
+  };
+}

--- a/packages/instantsearch-ui-components/src/components/__tests__/TrendingItems.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/TrendingItems.test.tsx
@@ -1,0 +1,341 @@
+/**
+ * @jest-environment jsdom
+ */
+/** @jsx createElement */
+import { render } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
+import { createElement, Fragment } from 'preact';
+
+import { createTrendingItemsComponent } from '../TrendingItems';
+
+import type { RecordWithObjectID } from '../../types';
+import type { TrendingItemsProps } from '../TrendingItems';
+
+const TrendingItems = createTrendingItemsComponent({
+  createElement,
+  Fragment,
+});
+
+const ItemComponent: TrendingItemsProps<RecordWithObjectID>['itemComponent'] =
+  ({ item }) => <div>{item.objectID}</div>;
+
+describe('TrendingItems', () => {
+  test('renders items with default view and header', () => {
+    const { container } = render(
+      <TrendingItems
+        status="idle"
+        items={[
+          {
+            objectID: '1',
+            __position: 1,
+          },
+          {
+            objectID: '2',
+            __position: 2,
+          },
+        ]}
+        itemComponent={ItemComponent}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <section
+          class="ais-TrendingItems"
+        >
+          <h3
+            class="ais-TrendingItems-title"
+          >
+            Trending items
+          </h3>
+          <div
+            class="ais-TrendingItems-container"
+          >
+            <ol
+              class="ais-TrendingItems-list"
+            >
+              <li
+                class="ais-TrendingItems-item"
+              >
+                <div>
+                  1
+                </div>
+              </li>
+              <li
+                class="ais-TrendingItems-item"
+              >
+                <div>
+                  2
+                </div>
+              </li>
+            </ol>
+          </div>
+        </section>
+      </div>
+    `);
+  });
+
+  test('renders default fallback', () => {
+    const { container } = render(
+      <TrendingItems
+        status="idle"
+        items={[]}
+        itemComponent={ItemComponent}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <section
+          class="ais-TrendingItems ais-TrendingItems--empty"
+        >
+          No results
+        </section>
+      </div>
+    `);
+  });
+
+  test('renders custom header', () => {
+    const { container } = render(
+      <TrendingItems
+        status="idle"
+        items={[{ objectID: '1', __position: 1 }]}
+        headerComponent={({ classNames }) => (
+          <div className={classNames.title}>My custom header</div>
+        )}
+        itemComponent={ItemComponent}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <section
+          class="ais-TrendingItems"
+        >
+          <div
+            class="ais-TrendingItems-title"
+          >
+            My custom header
+          </div>
+          <div
+            class="ais-TrendingItems-container"
+          >
+            <ol
+              class="ais-TrendingItems-list"
+            >
+              <li
+                class="ais-TrendingItems-item"
+              >
+                <div>
+                  1
+                </div>
+              </li>
+            </ol>
+          </div>
+        </section>
+      </div>
+    `);
+  });
+
+  test('renders custom view', () => {
+    const { container } = render(
+      <TrendingItems
+        status="idle"
+        items={[{ objectID: '1', __position: 1 }]}
+        itemComponent={ItemComponent}
+        view={(props) => (
+          <div className={props.classNames.container}>
+            <ol className={props.classNames.list}>
+              {props.items.map((item) => (
+                <li key={item.objectID} className={props.classNames.item}>
+                  <props.itemComponent
+                    item={item}
+                    onClick={jest.fn()}
+                    onAuxClick={jest.fn()}
+                  />
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <section
+          class="ais-TrendingItems"
+        >
+          <h3
+            class="ais-TrendingItems-title"
+          >
+            Trending items
+          </h3>
+          <div
+            class="ais-TrendingItems-container"
+          >
+            <ol
+              class="ais-TrendingItems-list"
+            >
+              <li
+                class="ais-TrendingItems-item"
+              >
+                <div>
+                  1
+                </div>
+              </li>
+            </ol>
+          </div>
+        </section>
+      </div>
+    `);
+  });
+
+  test('renders custom fallback', () => {
+    const { container } = render(
+      <TrendingItems
+        status="idle"
+        items={[]}
+        fallbackComponent={() => <Fragment>My custom fallback</Fragment>}
+        itemComponent={ItemComponent}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <section
+          class="ais-TrendingItems ais-TrendingItems--empty"
+        >
+          My custom fallback
+        </section>
+      </div>
+    `);
+  });
+
+  test('sends a `click` event when clicking on an item', () => {
+    const sendEvent = jest.fn();
+    const items = [{ objectID: '1', __position: 1 }];
+
+    const { container } = render(
+      <TrendingItems
+        status="idle"
+        items={items}
+        itemComponent={ItemComponent}
+        sendEvent={sendEvent}
+      />
+    );
+
+    userEvent.click(container.querySelectorAll('.ais-TrendingItems-item')[0]!);
+
+    expect(sendEvent).toHaveBeenCalledTimes(1);
+  });
+
+  test('accepts custom title translation', () => {
+    const { container } = render(
+      <TrendingItems
+        status="idle"
+        items={[{ objectID: '1', __position: 1 }]}
+        translations={{ title: 'My custom title' }}
+        itemComponent={ItemComponent}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <section
+          class="ais-TrendingItems"
+        >
+          <h3
+            class="ais-TrendingItems-title"
+          >
+            My custom title
+          </h3>
+          <div
+            class="ais-TrendingItems-container"
+          >
+            <ol
+              class="ais-TrendingItems-list"
+            >
+              <li
+                class="ais-TrendingItems-item"
+              >
+                <div>
+                  1
+                </div>
+              </li>
+            </ol>
+          </div>
+        </section>
+      </div>
+    `);
+  });
+
+  test('forwards `div` props to the root element', () => {
+    const { container } = render(
+      <TrendingItems
+        status="idle"
+        items={[{ objectID: '1', __position: 1 }]}
+        hidden={true}
+        itemComponent={ItemComponent}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(
+      container.querySelector<HTMLDivElement>('.ais-TrendingItems')!.hidden
+    ).toBe(true);
+  });
+
+  test('accepts custom class names', () => {
+    const { container } = render(
+      <TrendingItems
+        status="idle"
+        items={[{ objectID: '1', __position: 1 }]}
+        classNames={{
+          root: 'ROOT',
+          title: 'TITLE',
+          container: 'CONTAINER',
+          list: 'LIST',
+          item: 'ITEM',
+        }}
+        itemComponent={ItemComponent}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <section
+          class="ais-TrendingItems ROOT"
+        >
+          <h3
+            class="ais-TrendingItems-title TITLE"
+          >
+            Trending items
+          </h3>
+          <div
+            class="ais-TrendingItems-container CONTAINER"
+          >
+            <ol
+              class="ais-TrendingItems-list LIST"
+            >
+              <li
+                class="ais-TrendingItems-item ITEM"
+              >
+                <div>
+                  1
+                </div>
+              </li>
+            </ol>
+          </div>
+        </section>
+      </div>
+    `);
+  });
+});

--- a/packages/instantsearch-ui-components/src/components/index.ts
+++ b/packages/instantsearch-ui-components/src/components/index.ts
@@ -2,3 +2,4 @@ export * from './FrequentlyBoughtTogether';
 export * from './Highlight';
 export * from './Hits';
 export * from './RelatedProducts';
+export * from './TrendingItems';

--- a/packages/instantsearch.css/src/themes/algolia.scss
+++ b/packages/instantsearch.css/src/themes/algolia.scss
@@ -23,10 +23,9 @@ a[class^='ais-'] {
 .ais-ClearRefinements,
 .ais-CurrentRefinements,
 .ais-GeoSearch,
+.ais-FrequentlyBoughtTogether,
 .ais-HierarchicalMenu,
 .ais-Hits,
-.ais-FrequentlyBoughtTogether,
-.ais-RelatedProducts,
 .ais-Results,
 .ais-HitsPerPage,
 .ais-ResultsPerPage,
@@ -48,6 +47,7 @@ a[class^='ais-'] {
 .ais-RelevantSort,
 .ais-SortBy,
 .ais-Stats,
+.ais-TrendingItems,
 .ais-ToggleRefinement {
   color: $port-gore;
 }
@@ -291,6 +291,7 @@ a[class^='ais-'] {
 .ais-Hits-list,
 .ais-FrequentlyBoughtTogether-list,
 .ais-RelatedProducts-list,
+.ais-TrendingItems-list,
 .ais-Results-list {
   margin-top: -1rem;
   margin-left: -1rem;
@@ -307,6 +308,7 @@ a[class^='ais-'] {
 .ais-Hits-item,
 .ais-FrequentlyBoughtTogether-item,
 .ais-RelatedProducts-item,
+.ais-TrendingItems-item,
 .ais-Results-item {
   margin-top: 1rem;
   margin-left: 1rem;

--- a/packages/instantsearch.css/src/themes/reset.scss
+++ b/packages/instantsearch.css/src/themes/reset.scss
@@ -6,6 +6,7 @@
 .ais-Hits-list,
 .ais-FrequentlyBoughtTogether-list,
 .ais-RelatedProducts-list,
+.ais-TrendingItems-list,
 .ais-Results-list,
 .ais-InfiniteHits-list,
 .ais-InfiniteResults-list,

--- a/packages/instantsearch.css/src/themes/satellite.scss
+++ b/packages/instantsearch.css/src/themes/satellite.scss
@@ -605,13 +605,14 @@ $break-medium: 767px;
 }
 
 /**
- * Hits, InfiniteHits, FrequentlyBoughtTogether and RelatedProducts
+ * Hits, InfiniteHits, FrequentlyBoughtTogether, RelatedProducts and TrendingItems
  */
 
 .ais-Hits-item,
 .ais-InfiniteHits-item,
 .ais-FrequentlyBoughtTogether-item,
-.ais-RelatedProducts-item {
+.ais-RelatedProducts-item,
+.ais-TrendingItems-item {
   align-items: center;
   background: $white;
   box-shadow: 0 0 0 1px rgba($grey900, 0.05), 0 1px 3px 0 rgba($grey900, 0.15);
@@ -625,21 +626,24 @@ $break-medium: 767px;
 .ais-Hits-item:first-of-type,
 .ais-InfiniteHits-item:first-of-type,
 .ais-FrequentlyBoughtTogether-item:first-of-type,
-.ais-RelatedProducts-item:first-of-type {
+.ais-RelatedProducts-item:first-of-type,
+.ais-TrendingItems-item:first-of-type {
   border-radius: 3px 3px 0 0;
 }
 
 .ais-Hits-item:last-of-type,
 .ais-InfiniteHits-item:last-of-type,
 .ais-FrequentlyBoughtTogether-item:last-of-type,
-.ais-RelatedProducts-item:last-of-type {
+.ais-RelatedProducts-item:last-of-type,
+.ais-TrendingItems-item:last-of-type {
   border-radius: 0 0 3px 3px;
 }
 
 .ais-Hits-item:only-of-type,
 .ais-InfiniteHits-item:only-of-type,
 .ais-FrequentlyBoughtTogether-item:only-of-type,
-.ais-RelatedProducts-item:only-of-type {
+.ais-RelatedProducts-item:only-of-type,
+.ais-TrendingItems-item:only-of-type {
   border-radius: 3px;
 }
 

--- a/specs/src/pages/widgets/trending-items.md
+++ b/specs/src/pages/widgets/trending-items.md
@@ -1,0 +1,72 @@
+---
+layout: ../../layouts/WidgetLayout.astro
+title: TrendingItems
+type: widget
+html: |
+  <div class="ais-TrendingItems">
+    <h3 class="ais-TrendingItems-title">Trending items</h3>
+    <div class="ais-TrendingItems-container">
+      <ol class="ais-TrendingItems-list">
+        <li class="ais-TrendingItems-item">
+          Hit 5477500: Amazon - Fire TV Stick with Alexa Voice Remote - Black
+        </li>
+        <li class="ais-TrendingItems-item">
+          Hit 4397400: Google - Chromecast - Black
+        </li>
+        <li class="ais-TrendingItems-item">
+          Hit 4397400: Google - Chromecast - Black
+        </li>
+        <li class="ais-TrendingItems-item">
+          Hit 5477500: Amazon - Fire TV Stick with Alexa Voice Remote - Black
+        </li>
+        <li class="ais-TrendingItems-item">
+          Hit 4397400: Google - Chromecast - Black
+        </li>
+        <li class="ais-TrendingItems-item">
+          Hit 4397400: Google - Chromecast - Black
+        </li>
+        <li class="ais-TrendingItems-item">
+          Hit 5477500: Amazon - Fire TV Stick with Alexa Voice Remote - Black
+        </li>
+        <li class="ais-TrendingItems-item">
+          Hit 4397400: Google - Chromecast - Black
+        </li>
+      </ol>
+    </div>
+  </div>
+classes:
+  - name: .ais-TrendingItems
+    description: the root div of the widget
+  - name: .ais-TrendingItems-title
+    description: the title heading of the widget
+  - name: .ais-TrendingItems-container
+    description: the container for the list of results
+  - name: .ais-TrendingItems-list
+    description: the list of results
+  - name: .ais-TrendingItems-item
+    description: the hit list item
+options:
+  - name: objectIDs
+    description: objectIDs of the items to get the Trending Items from
+  - name: maxRecommendations
+    description: Number of recommendations to retrieve
+  - name: fallbackParameters
+    description: List of search parameters to send as additional filters to use as fallback when there aren't enough recommendations.
+  - name: queryParameters
+    description: List of search parameters to send
+  - name: threshold
+    description: Threshold for the recommendations confidence score (between 0 and 100)
+  - name: facetName
+    description: Facet attribute to get recommendations for.
+  - name: facetValue
+    description: Value of the targeted facet attribute.
+  - name: transformItems
+    description: Function which receives the items, which will be called before displaying them. Should return a new array with the same shape as the original array. Useful for mapping over the items to transform, remove or reorder them
+translations:
+  - name: title
+    default: "Trending items"
+    description: The text for the header element
+  - name: sliderLabel
+    default: "Trending items"
+    description: The label for the horizontal slider
+---


### PR DESCRIPTION
This moves the `TrendingItems` UI component from **@algolia/recommend** to the monorepo. It also adds the base styles in instantsearch.css and describes its expected markup in our specs.

FX-2831