### PR TITLE
feat(hits): add banner to react instantsearch hits

### DIFF
--- a/packages/react-instantsearch/src/widgets/Hits.tsx
+++ b/packages/react-instantsearch/src/widgets/Hits.tsx
@@ -84,10 +84,9 @@ export function Hits<THit extends BaseHit = BaseHit>({
 
   const banner = BannerComponent === false ? undefined : bannerData;
 
-  const bannerComponent =
-    BannerComponent === false
-      ? undefined
-      : (BannerComponent as HitsUiComponentProps<Hit<THit>>['bannerComponent']);
+  const bannerComponent = (
+    BannerComponent === false ? () => null : BannerComponent
+  ) as HitsUiComponentProps<Hit<THit>>['bannerComponent'];
 
   const uiProps: UiProps<THit> = {
     hits,

--- a/packages/react-instantsearch/src/widgets/Hits.tsx
+++ b/packages/react-instantsearch/src/widgets/Hits.tsx
@@ -12,7 +12,12 @@ import type { UseHitsProps } from 'react-instantsearch-core';
 
 type UiProps<THit extends BaseHit> = Pick<
   HitsUiComponentProps<Hit<THit>>,
-  'hits' | 'sendEvent' | 'itemComponent' | 'emptyComponent'
+  | 'hits'
+  | 'sendEvent'
+  | 'itemComponent'
+  | 'emptyComponent'
+  | 'banner'
+  | 'bannerComponent'
 >;
 
 export type HitsProps<THit extends BaseHit> = Omit<
@@ -23,6 +28,13 @@ export type HitsProps<THit extends BaseHit> = Omit<
     hit: Hit<THit>;
     sendEvent: SendEventForHits;
   }>;
+} & {
+  bannerComponent?:
+    | React.JSXElementConstructor<{
+        banner: Required<HitsUiComponentProps<Hit<THit>>>['banner'];
+        className: string;
+      }>
+    | false;
 } & UseHitsProps<THit>;
 
 // @MAJOR: Move default hit component back to the UI library
@@ -48,9 +60,14 @@ export function Hits<THit extends BaseHit = BaseHit>({
   escapeHTML,
   transformItems,
   hitComponent: HitComponent = DefaultHitComponent,
+  bannerComponent: BannerComponent,
   ...props
 }: HitsProps<THit>) {
-  const { hits, sendEvent } = useHits<THit>(
+  const {
+    hits,
+    banner: bannerData,
+    sendEvent,
+  } = useHits<THit>(
     { escapeHTML, transformItems },
     { $$widgetType: 'ais.hits' }
   );
@@ -65,10 +82,19 @@ export function Hits<THit extends BaseHit = BaseHit>({
     </li>
   );
 
+  const banner = BannerComponent === false ? undefined : bannerData;
+
+  const bannerComponent =
+    BannerComponent === false
+      ? undefined
+      : (BannerComponent as HitsUiComponentProps<Hit<THit>>['bannerComponent']);
+
   const uiProps: UiProps<THit> = {
     hits,
     sendEvent,
     itemComponent,
+    banner,
+    bannerComponent,
   };
 
   return <HitsUiComponent {...props} {...uiProps} />;

--- a/packages/react-instantsearch/src/widgets/Hits.tsx
+++ b/packages/react-instantsearch/src/widgets/Hits.tsx
@@ -63,11 +63,7 @@ export function Hits<THit extends BaseHit = BaseHit>({
   bannerComponent: BannerComponent,
   ...props
 }: HitsProps<THit>) {
-  const {
-    hits,
-    banner: bannerData,
-    sendEvent,
-  } = useHits<THit>(
+  const { hits, banner, sendEvent } = useHits<THit>(
     { escapeHTML, transformItems },
     { $$widgetType: 'ais.hits' }
   );
@@ -81,8 +77,6 @@ export function Hits<THit extends BaseHit = BaseHit>({
       <HitComponent hit={hit} sendEvent={sendEvent} />
     </li>
   );
-
-  const banner = BannerComponent === false ? undefined : bannerData;
 
   const bannerComponent = (
     BannerComponent === false ? () => null : BannerComponent

--- a/packages/react-instantsearch/src/widgets/__tests__/Hits.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Hits.test.tsx
@@ -16,31 +16,57 @@ import { Hits } from '../Hits';
 import type { MockSearchClient } from '@instantsearch/mocks';
 import type { AlgoliaHit } from 'instantsearch.js';
 
-describe('Hits', () => {
-  test('renders with a custom hit component', async () => {
-    type CustomRecord = {
-      somethingSpecial: string;
-    };
+type CustomRecord = {
+  somethingSpecial: string;
+};
 
-    const searchClient = createSearchClient({
-      search: jest.fn((requests) =>
-        Promise.resolve(
-          createMultiSearchResponse(
-            ...requests.map(
-              (request: Parameters<MockSearchClient['search']>[0][number]) =>
-                createSingleSearchResponse<AlgoliaHit<CustomRecord>>({
-                  hits: [
-                    { objectID: '1', somethingSpecial: 'a' },
-                    { objectID: '2', somethingSpecial: 'b' },
-                    { objectID: '3', somethingSpecial: 'c' },
-                  ],
-                  index: request.indexName,
-                })
-            )
+const hits = [
+  { objectID: '1', somethingSpecial: 'a' },
+  { objectID: '2', somethingSpecial: 'b' },
+  { objectID: '3', somethingSpecial: 'c' },
+];
+
+const bannerWidgetRenderingContent = {
+  widgets: {
+    banners: [
+      {
+        image: {
+          urls: [{ url: 'https://via.placeholder.com/550x250' }],
+        },
+        link: {
+          url: 'https://www.algolia.com',
+        },
+      },
+    ],
+  },
+};
+
+function getSearchClient(withBannerWidget = false) {
+  return createSearchClient({
+    search: jest.fn((requests) =>
+      Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map(
+            (request: Parameters<MockSearchClient['search']>[0][number]) =>
+              createSingleSearchResponse<AlgoliaHit<CustomRecord>>({
+                hits,
+                index: request.indexName,
+                // @TODO: remove once algoliasearch js client has been updated
+                // @ts-expect-error
+                renderingContent: withBannerWidget
+                  ? bannerWidgetRenderingContent
+                  : undefined,
+              })
           )
         )
-      ) as MockSearchClient['search'],
-    });
+      )
+    ) as MockSearchClient['search'],
+  });
+}
+
+describe('Hits', () => {
+  test('renders with a custom hit component', async () => {
+    const searchClient = getSearchClient();
 
     const { container } = render(
       <InstantSearchTestWrapper searchClient={searchClient}>
@@ -102,5 +128,159 @@ describe('Hits', () => {
     const root = container.firstChild;
     expect(root).toHaveClass('MyHits', 'ROOT');
     expect(root).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  describe('banner', () => {
+    test('renders a banner', async () => {
+      const searchClient = getSearchClient(true);
+
+      const { container } = render(
+        <InstantSearchTestWrapper searchClient={searchClient}>
+          <Hits<CustomRecord> />
+        </InstantSearchTestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('img')).toHaveLength(1);
+        expect(container.querySelectorAll('a')).toHaveLength(1);
+        expect(container.querySelector('.ais-Hits')).toMatchInlineSnapshot(`
+          <div
+            class="ais-Hits"
+          >
+            <aside
+              class="ais-Hits-banner"
+            >
+              <a
+                class="ais-Hits-banner-link"
+                href="https://www.algolia.com"
+              >
+                <img
+                  class="ais-Hits-banner-image"
+                  src="https://via.placeholder.com/550x250"
+                />
+              </a>
+            </aside>
+            <ol
+              class="ais-Hits-list"
+            >
+              <li
+                class="ais-Hits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"1","somethingSpecial":"a","__position":1}
+                  …
+                </div>
+              </li>
+              <li
+                class="ais-Hits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"2","somethingSpecial":"b","__position":2}
+                  …
+                </div>
+              </li>
+              <li
+                class="ais-Hits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"3","somethingSpecial":"c","__position":3}
+                  …
+                </div>
+              </li>
+            </ol>
+          </div>
+        `);
+      });
+    });
+
+    test('does not render a banner when "bannerComponent" is set to `false`', async () => {
+      const searchClient = getSearchClient(true);
+
+      const { container } = render(
+        <InstantSearchTestWrapper searchClient={searchClient}>
+          <Hits<CustomRecord> bannerComponent={false} />
+        </InstantSearchTestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('img')).toHaveLength(0);
+        expect(container.querySelector('.ais-Hits')).toMatchInlineSnapshot(`
+          <div
+            class="ais-Hits ais-Hits--empty"
+          >
+            <ol
+              class="ais-Hits-list"
+            />
+          </div>
+        `);
+      });
+    });
+
+    test('renders custom banner component', async () => {
+      const searchClient = getSearchClient(true);
+
+      const { container } = render(
+        <InstantSearchTestWrapper searchClient={searchClient}>
+          <Hits<CustomRecord>
+            bannerComponent={({ banner }) => (
+              <img src={banner.image.urls[0].url} />
+            )}
+          />
+        </InstantSearchTestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('img')).toHaveLength(1);
+        expect(container.querySelector('.ais-Hits')).toMatchInlineSnapshot(`
+          <div
+            class="ais-Hits"
+          >
+            <img
+              src="https://via.placeholder.com/550x250"
+            />
+            <ol
+              class="ais-Hits-list"
+            >
+              <li
+                class="ais-Hits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"1","somethingSpecial":"a","__position":1}
+                  …
+                </div>
+              </li>
+              <li
+                class="ais-Hits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"2","somethingSpecial":"b","__position":2}
+                  …
+                </div>
+              </li>
+              <li
+                class="ais-Hits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"3","somethingSpecial":"c","__position":3}
+                  …
+                </div>
+              </li>
+            </ol>
+          </div>
+        `);
+      });
+    });
   });
 });


### PR DESCRIPTION
**Summary**

This is the fourth pull request to add support for no-code banners to the Hits widget ([RFC](https://algolia.atlassian.net/wiki/spaces/MERCH/pages/4948099490/RFC+-+Rule+Visual+Editor+Banner+Consequence)). Building on the recent changes to the `Hits` `instantsearch-ui-component` it updates the `Hits` React InstantSearch widget to support a new `bannerComponent`.

[EMERCH-1421](https://algolia.atlassian.net/browse/EMERCH-1421)

There will be a follow-on PR to update React InstantSearch.

**Result**

The hits widget tests have been updated to ensure that the new optional banner component is supported. No styling was applied in the examples or to `instantsearch.css` - that will most likely come in a follow-up PR.

Additionally, the code was tested in the `getting-started` example codebase (connected to appId: `F4T6CUV2AH`, index: `products` in the `beta` environment - where the test rules with a banner consequence exists).

Getting Started App (no `bannerComponent`; query: `nikon`; `nikon camera promotion` alt text and links to `https://www.nikonusa.com/`):
![image](https://github.com/algolia/instantsearch/assets/10552296/c8380e63-f4eb-452e-847a-27aa38397833)

Getting Started App (custom `bannerComponent`; query `nikon`):
![image](https://github.com/algolia/instantsearch/assets/10552296/2346c85e-9a83-4bb1-9b77-67e6ee4d4430)

Getting Started App (`bannerComponent={false}`; query `nikon`):
![image](https://github.com/algolia/instantsearch/assets/10552296/80090c81-361f-42d6-976f-ff05390b1bb6)


[EMERCH-1421]: https://algolia.atlassian.net/browse/EMERCH-1421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
