### PR TITLE
fix(index): allow dispose to be called before init

### DIFF
--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -3155,6 +3155,16 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
 
       expect(mainHelper.derivedHelpers).toHaveLength(0);
     });
+
+    it('does not crash when calling `dispose` before `init`', () => {
+      const instance = index({ indexName: 'indexName' });
+
+      instance.addWidgets([virtualSearchBox({})]);
+
+      expect(() => {
+        instance.dispose(createDisposeOptions());
+      }).not.toThrow();
+    });
   });
 
   describe('getWidgetState', () => {

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -758,7 +758,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
 
     dispose() {
       localWidgets.forEach((widget) => {
-        if (widget.dispose) {
+        if (widget.dispose && helper) {
           // The dispose function is always called once the instance is started
           // (it's an effect of `removeWidgets`). The index is initialized and
           // the Helper is available. We don't care about the return value of
@@ -766,8 +766,8 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
           // because we want to keep the widgets on the instance, to allow idempotent
           // operations on `add` & `remove`.
           widget.dispose({
-            helper: helper!,
-            state: helper!.state,
+            helper,
+            state: helper.state,
             parent: this,
           });
         }


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

If init isn't called (this happens in React InstantSearch Next, as well as some other cases), then dispose on the actual widgets doesn't make sense to be called, because the `helper` is still null.

This does mean that some state could be considered stray (not cleaned up), but that likely doesn't matter as the index widget is removed anyway.

**Result**

fixes #6073

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
