### PR TITLE
feat(recommend): enable multiple objectIDs in connectors

### DIFF
--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -1751,15 +1751,18 @@ AlgoliaSearchHelper.prototype._dispatchRecommendResponse = function (
   var results = {};
   Object.keys(idsMap).forEach(function (id) {
     var indices = idsMap[id];
+    var firstResult = content.results[indices[0]];
     if (indices.length === 1) {
-      results[id] = content.results[indices[0]];
+      results[id] = firstResult;
       return;
     }
-    results[id] = sortAndMergeRecommendations(
-      indices.map(function (idx) {
-        return content.results[idx].hits;
-      })
-    );
+    results[id] = Object.assign({}, firstResult, {
+      hits: sortAndMergeRecommendations(
+        indices.map(function (idx) {
+          return content.results[idx].hits;
+        })
+      ),
+    });
   });
 
   states.forEach(function (s) {

--- a/packages/algoliasearch-helper/test/spec/recommend.js
+++ b/packages/algoliasearch-helper/test/spec/recommend.js
@@ -34,7 +34,7 @@ describe('recommend()', () => {
 
       // This one should be sorted
       var hits = testData.response.results[0].hits;
-      expect(results[1]).toEqual([hits[1], hits[0], hits[2]]);
+      expect(results[1].hits).toEqual([hits[1], hits[0], hits[2]]);
       expect(results[2]).toBe(testData.response.results[2]);
 
       var state = event.recommend.state;

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/__tests__/connectFrequentlyBoughtTogether-test.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/__tests__/connectFrequentlyBoughtTogether-test.ts
@@ -82,7 +82,7 @@ describe('connectFrequentlyBoughtTogether', () => {
       const render = () => {};
       const makeWidget = connectFrequentlyBoughtTogether(render);
       const widget = makeWidget({
-        objectIDs: ['1'],
+        objectIDs: ['1', '2'],
         maxRecommendations: 10,
         threshold: 95,
         queryParameters: { userToken: 'token' },
@@ -94,14 +94,23 @@ describe('connectFrequentlyBoughtTogether', () => {
       });
 
       expect(actual).toEqual(
-        new RecommendParameters().addFrequentlyBoughtTogether({
-          // @ts-expect-error
-          $$id: widget.$$id,
-          objectID: '1',
-          maxRecommendations: 10,
-          threshold: 95,
-          queryParameters: { userToken: 'token' },
-        })
+        new RecommendParameters()
+          .addFrequentlyBoughtTogether({
+            // @ts-expect-error
+            $$id: widget.$$id,
+            objectID: '1',
+            maxRecommendations: 10,
+            threshold: 95,
+            queryParameters: { userToken: 'token' },
+          })
+          .addFrequentlyBoughtTogether({
+            // @ts-expect-error
+            $$id: widget.$$id,
+            objectID: '2',
+            maxRecommendations: 10,
+            threshold: 95,
+            queryParameters: { userToken: 'token' },
+          })
       );
     });
   });

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
@@ -137,16 +137,17 @@ const connectFrequentlyBoughtTogether: FrequentlyBoughtTogetherConnector =
         },
 
         getWidgetParameters(state) {
-          // We only use the first objectID to get the recommendations for
-          // until we implement support for multiple objectIDs in the helper.
-          const objectID = objectIDs[0];
-          return state.addFrequentlyBoughtTogether({
-            objectID,
-            threshold,
-            maxRecommendations,
-            queryParameters,
-            $$id: this.$$id!,
-          });
+          return objectIDs.reduce(
+            (acc, objectID) =>
+              acc.addFrequentlyBoughtTogether({
+                objectID,
+                threshold,
+                maxRecommendations,
+                queryParameters,
+                $$id: this.$$id!,
+              }),
+            state
+          );
         },
       };
     };

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -136,18 +136,18 @@ const connectRelatedProducts: RelatedProductsConnector =
         },
 
         getWidgetParameters(state) {
-          // We only use the first `objectID` to get the recommendations for
-          // until we implement support for multiple `objectIDs` in the helper.
-          const objectID = objectIDs[0];
-
-          return state.addRelatedProducts({
-            objectID,
-            maxRecommendations,
-            threshold,
-            fallbackParameters,
-            queryParameters,
-            $$id: this.$$id!,
-          });
+          return objectIDs.reduce(
+            (acc, objectID) =>
+              acc.addRelatedProducts({
+                objectID,
+                maxRecommendations,
+                threshold,
+                fallbackParameters,
+                queryParameters,
+                $$id: this.$$id!,
+              }),
+            state
+          );
         },
       };
     };

--- a/tests/common/connectors/frequently-bought-together/options.ts
+++ b/tests/common/connectors/frequently-bought-together/options.ts
@@ -43,7 +43,7 @@ export function createOptionsTests(
       const options: SetupOptions<FrequentlyBoughtTogetherConnectorSetup> = {
         instantSearchOptions: { indexName: 'indexName', searchClient },
         widgetParams: {
-          objectIDs: ['1'],
+          objectIDs: ['1', '2'],
           maxRecommendations: 2,
           threshold: 3,
           queryParameters: { analytics: true },
@@ -56,6 +56,12 @@ export function createOptionsTests(
         expect.arrayContaining([
           expect.objectContaining({
             objectID: '1',
+            maxRecommendations: 2,
+            threshold: 3,
+            queryParameters: { analytics: true },
+          }),
+          expect.objectContaining({
+            objectID: '2',
             maxRecommendations: 2,
             threshold: 3,
             queryParameters: { analytics: true },

--- a/tests/common/connectors/related-products/options.ts
+++ b/tests/common/connectors/related-products/options.ts
@@ -41,7 +41,7 @@ export function createOptionsTests(
       const options: SetupOptions<RelatedProductsConnectorSetup> = {
         instantSearchOptions: { indexName: 'indexName', searchClient },
         widgetParams: {
-          objectIDs: ['1'],
+          objectIDs: ['1', '2'],
           maxRecommendations: 2,
           threshold: 3,
           fallbackParameters: { facetFilters: ['test1'] },
@@ -55,6 +55,13 @@ export function createOptionsTests(
         expect.arrayContaining([
           expect.objectContaining({
             objectID: '1',
+            maxRecommendations: 2,
+            threshold: 3,
+            fallbackParameters: { facetFilters: ['test1'] },
+            queryParameters: { analytics: true },
+          }),
+          expect.objectContaining({
+            objectID: '2',
             maxRecommendations: 2,
             threshold: 3,
             fallbackParameters: { facetFilters: ['test1'] },


### PR DESCRIPTION
**Summary**

### [FX-2822](https://algolia.atlassian.net/browse/FX-2822)

**Result**

Following the previous PR, this enables the connectors to pass multiple object IDs


[FX-2822]: https://algolia.atlassian.net/browse/FX-2822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ