### PR TITLE
feat(recommend): cache results per $$id

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "packages/algoliasearch-helper/dist/algoliasearch.helper.js",
-      "maxSize": "41 kB"
+      "maxSize": "41.25 kB"
     },
     {
       "path": "packages/algoliasearch-helper/dist/algoliasearch.helper.min.js",

--- a/packages/algoliasearch-helper/src/RecommendParameters/index.js
+++ b/packages/algoliasearch-helper/src/RecommendParameters/index.js
@@ -67,13 +67,17 @@ RecommendParameters.prototype = {
     );
   },
 
-  _buildQueries: function (indexName) {
-    return this.params.map(function (params) {
-      var query = Object.assign({}, params, { indexName: indexName });
-      delete query.$$id;
+  _buildQueries: function (indexName, cache) {
+    return this.params
+      .filter(function (params) {
+        return cache[params.$$id] === undefined;
+      })
+      .map(function (params) {
+        var query = Object.assign({}, params, { indexName: indexName });
+        delete query.$$id;
 
-      return query;
-    });
+        return query;
+      });
   },
 };
 

--- a/packages/algoliasearch-helper/test/spec/RecommendParameters/methods.js
+++ b/packages/algoliasearch-helper/test/spec/RecommendParameters/methods.js
@@ -76,7 +76,7 @@ describe('_buildQueries', () => {
       params: [params1, params2],
     });
 
-    var queries = recommendParameters._buildQueries('indexName');
+    var queries = recommendParameters._buildQueries('indexName', {});
     expect(queries).toHaveLength(2);
     expect(
       queries.map(function (query) {
@@ -90,7 +90,7 @@ describe('_buildQueries', () => {
       params: [params1, params2],
     });
 
-    var queries = recommendParameters._buildQueries('indexName');
+    var queries = recommendParameters._buildQueries('indexName', {});
     expect(queries).toHaveLength(2);
     expect(queries).toMatchInlineSnapshot(`
       Array [


### PR DESCRIPTION
**Summary**

#### [FX-2851](https://algolia.atlassian.net/browse/FX-2851)

**Result**

This is to make sure we don't needlessly request again when a new widget has been added.



[FX-2851]: https://algolia.atlassian.net/browse/FX-2851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ