### PR TITLE
fix(requests): don't fire a request when there are no widgets

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -742,7 +742,7 @@ See documentation: ${createDocumentationLink({
   }
 
   public scheduleSearch = defer(() => {
-    if (this.started) {
+    if (this.started && this.mainIndex.getWidgets().length > 0) {
       this.mainHelper!.search();
     }
   });


### PR DESCRIPTION
Still to investigate further. I believe this won't have any negative repercussions, but at least some test cases will need to be written, as these don't seem to exist yet.

Comes out of an attempt to fix https://github.com/algolia/instantsearch/discussions/6174 before realising that behaviour was happening

Likely optimisation possible once this is done is to remove extra checks in:
- https://github.com/algolia/instantsearch/blob/1405aebb52cd84b02a4f645ee5395763f4878b79/packages/instantsearch.js/src/widgets/index/index.ts#L477-L479
- https://github.com/algolia/instantsearch/blob/1b683c5ebbcae4a77a43ff2034da406c9eb0dbc4/packages/instantsearch.js/src/lib/InstantSearch.ts#L671-L681
