### PR TITLE
feat(recommend): rename `fallbackComponent` into `emptyComponent`

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "61.75 kB"
+      "maxSize": "62 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/packages/instantsearch-ui-components/src/components/FrequentlyBoughtTogether.tsx
+++ b/packages/instantsearch-ui-components/src/components/FrequentlyBoughtTogether.tsx
@@ -3,7 +3,7 @@
 import { cx } from '../lib';
 
 import {
-  createDefaultFallbackComponent,
+  createDefaultEmptyComponent,
   createDefaultHeaderComponent,
   createDefaultItemComponent,
   createListViewComponent,
@@ -30,7 +30,7 @@ export function createFrequentlyBoughtTogetherComponent({
   ) {
     const {
       classNames = {},
-      fallbackComponent: FallbackComponent = createDefaultFallbackComponent({
+      emptyComponent: EmptyComponent = createDefaultEmptyComponent({
         createElement,
         Fragment,
       }),
@@ -68,7 +68,7 @@ export function createFrequentlyBoughtTogetherComponent({
             props.className
           )}
         >
-          <FallbackComponent />
+          <EmptyComponent />
         </section>
       );
     }

--- a/packages/instantsearch-ui-components/src/components/LookingSimilar.tsx
+++ b/packages/instantsearch-ui-components/src/components/LookingSimilar.tsx
@@ -3,7 +3,7 @@
 import { cx } from '../lib';
 
 import {
-  createDefaultFallbackComponent,
+  createDefaultEmptyComponent,
   createDefaultHeaderComponent,
   createDefaultItemComponent,
   createListViewComponent,
@@ -30,7 +30,7 @@ export function createLookingSimilarComponent({
   ) {
     const {
       classNames = {},
-      fallbackComponent: FallbackComponent = createDefaultFallbackComponent({
+      emptyComponent: EmptyComponent = createDefaultEmptyComponent({
         createElement,
         Fragment,
       }),
@@ -68,7 +68,7 @@ export function createLookingSimilarComponent({
             props.className
           )}
         >
-          <FallbackComponent />
+          <EmptyComponent />
         </section>
       );
     }

--- a/packages/instantsearch-ui-components/src/components/RelatedProducts.tsx
+++ b/packages/instantsearch-ui-components/src/components/RelatedProducts.tsx
@@ -3,7 +3,7 @@
 import { cx } from '../lib';
 
 import {
-  createDefaultFallbackComponent,
+  createDefaultEmptyComponent,
   createDefaultHeaderComponent,
   createDefaultItemComponent,
   createListViewComponent,
@@ -30,7 +30,7 @@ export function createRelatedProductsComponent({
   ) {
     const {
       classNames = {},
-      fallbackComponent: FallbackComponent = createDefaultFallbackComponent({
+      emptyComponent: EmptyComponent = createDefaultEmptyComponent({
         createElement,
         Fragment,
       }),
@@ -68,7 +68,7 @@ export function createRelatedProductsComponent({
             props.className
           )}
         >
-          <FallbackComponent />
+          <EmptyComponent />
         </section>
       );
     }

--- a/packages/instantsearch-ui-components/src/components/TrendingItems.tsx
+++ b/packages/instantsearch-ui-components/src/components/TrendingItems.tsx
@@ -3,7 +3,7 @@
 import { cx } from '../lib';
 
 import {
-  createDefaultFallbackComponent,
+  createDefaultEmptyComponent,
   createDefaultHeaderComponent,
   createDefaultItemComponent,
   createListViewComponent,
@@ -30,7 +30,7 @@ export function createTrendingItemsComponent({
   ) {
     const {
       classNames = {},
-      fallbackComponent: FallbackComponent = createDefaultFallbackComponent({
+      emptyComponent: EmptyComponent = createDefaultEmptyComponent({
         createElement,
         Fragment,
       }),
@@ -68,7 +68,7 @@ export function createTrendingItemsComponent({
             props.className
           )}
         >
-          <FallbackComponent />
+          <EmptyComponent />
         </section>
       );
     }

--- a/packages/instantsearch-ui-components/src/components/__tests__/FrequentlyBoughtTogether.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/FrequentlyBoughtTogether.test.tsx
@@ -76,7 +76,7 @@ describe('FrequentlyBoughtTogether', () => {
     `);
   });
 
-  test('renders default fallback', () => {
+  test('renders default empty component', () => {
     const { container } = render(
       <FrequentlyBoughtTogether
         status="idle"
@@ -195,12 +195,12 @@ describe('FrequentlyBoughtTogether', () => {
     `);
   });
 
-  test('renders custom fallback', () => {
+  test('renders custom empty component', () => {
     const { container } = render(
       <FrequentlyBoughtTogether
         status="idle"
         items={[]}
-        fallbackComponent={() => <div>My custom fallback</div>}
+        emptyComponent={() => <div>My custom empty component</div>}
         itemComponent={ItemComponent}
         sendEvent={jest.fn()}
       />
@@ -212,7 +212,7 @@ describe('FrequentlyBoughtTogether', () => {
           class="ais-FrequentlyBoughtTogether ais-FrequentlyBoughtTogether--empty"
         >
           <div>
-            My custom fallback
+            My custom empty component
           </div>
         </section>
       </div>

--- a/packages/instantsearch-ui-components/src/components/__tests__/LookingSimilar.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/LookingSimilar.test.tsx
@@ -76,7 +76,7 @@ describe('LookingSimilar', () => {
     `);
   });
 
-  test('renders default fallback', () => {
+  test('renders default empty component', () => {
     const { container } = render(
       <LookingSimilar
         status="idle"
@@ -195,12 +195,12 @@ describe('LookingSimilar', () => {
     `);
   });
 
-  test('renders custom fallback', () => {
+  test('renders custom empty component', () => {
     const { container } = render(
       <LookingSimilar
         status="idle"
         items={[]}
-        fallbackComponent={() => <Fragment>My custom fallback</Fragment>}
+        emptyComponent={() => <Fragment>My custom empty component</Fragment>}
         itemComponent={ItemComponent}
         sendEvent={jest.fn()}
       />
@@ -211,7 +211,7 @@ describe('LookingSimilar', () => {
         <section
           class="ais-LookingSimilar ais-LookingSimilar--empty"
         >
-          My custom fallback
+          My custom empty component
         </section>
       </div>
     `);

--- a/packages/instantsearch-ui-components/src/components/__tests__/RelatedProducts.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/RelatedProducts.test.tsx
@@ -76,7 +76,7 @@ describe('RelatedProducts', () => {
     `);
   });
 
-  test('renders default fallback', () => {
+  test('renders default empty component', () => {
     const { container } = render(
       <RelatedProducts
         status="idle"
@@ -195,12 +195,12 @@ describe('RelatedProducts', () => {
     `);
   });
 
-  test('renders custom fallback', () => {
+  test('renders custom empty component', () => {
     const { container } = render(
       <RelatedProducts
         status="idle"
         items={[]}
-        fallbackComponent={() => <Fragment>My custom fallback</Fragment>}
+        emptyComponent={() => <Fragment>My custom empty component</Fragment>}
         itemComponent={ItemComponent}
         sendEvent={jest.fn()}
       />
@@ -211,7 +211,7 @@ describe('RelatedProducts', () => {
         <section
           class="ais-RelatedProducts ais-RelatedProducts--empty"
         >
-          My custom fallback
+          My custom empty component
         </section>
       </div>
     `);

--- a/packages/instantsearch-ui-components/src/components/__tests__/TrendingItems.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/TrendingItems.test.tsx
@@ -76,7 +76,7 @@ describe('TrendingItems', () => {
     `);
   });
 
-  test('renders default fallback', () => {
+  test('renders default empty component', () => {
     const { container } = render(
       <TrendingItems
         status="idle"
@@ -195,12 +195,12 @@ describe('TrendingItems', () => {
     `);
   });
 
-  test('renders custom fallback', () => {
+  test('renders custom empty component', () => {
     const { container } = render(
       <TrendingItems
         status="idle"
         items={[]}
-        fallbackComponent={() => <Fragment>My custom fallback</Fragment>}
+        emptyComponent={() => <Fragment>My custom empty component</Fragment>}
         itemComponent={ItemComponent}
         sendEvent={jest.fn()}
       />
@@ -211,7 +211,7 @@ describe('TrendingItems', () => {
         <section
           class="ais-TrendingItems ais-TrendingItems--empty"
         >
-          My custom fallback
+          My custom empty component
         </section>
       </div>
     `);

--- a/packages/instantsearch-ui-components/src/components/recommend-shared/DefaultEmpty.tsx
+++ b/packages/instantsearch-ui-components/src/components/recommend-shared/DefaultEmpty.tsx
@@ -2,11 +2,11 @@
 
 import type { Renderer } from '../../types';
 
-export function createDefaultFallbackComponent({
+export function createDefaultEmptyComponent({
   createElement,
   Fragment,
 }: Renderer) {
-  return function DefaultFallback() {
+  return function DefaultEmpty() {
     return <Fragment>No results</Fragment>;
   };
 }

--- a/packages/instantsearch-ui-components/src/components/recommend-shared/index.ts
+++ b/packages/instantsearch-ui-components/src/components/recommend-shared/index.ts
@@ -1,4 +1,4 @@
-export * from './DefaultFallback';
+export * from './DefaultEmpty';
 export * from './DefaultHeader';
 export * from './DefaultItem';
 export * from './ListView';

--- a/packages/instantsearch-ui-components/src/types/Recommend.ts
+++ b/packages/instantsearch-ui-components/src/types/Recommend.ts
@@ -65,7 +65,7 @@ export type RecommendComponentProps<
   ) => JSX.Element;
   items: Array<RecordWithObjectID<TObject>>;
   classNames?: Partial<RecommendClassNames>;
-  fallbackComponent?: (props: TComponentProps) => JSX.Element;
+  emptyComponent?: (props: TComponentProps) => JSX.Element;
   headerComponent?: (
     props: RecommendInnerComponentProps<TObject> & TComponentProps
   ) => JSX.Element;

--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
@@ -98,7 +98,7 @@ const renderer =
         : undefined
     ) as FrequentlyBoughtTogetherUiProps<Hit>['itemComponent'];
 
-    const fallbackComponent = (
+    const emptyComponent = (
       templates.empty
         ? () => (
             <TemplateComponent
@@ -109,7 +109,7 @@ const renderer =
             />
           )
         : undefined
-    ) as FrequentlyBoughtTogetherUiProps<Hit>['fallbackComponent'];
+    ) as FrequentlyBoughtTogetherUiProps<Hit>['emptyComponent'];
 
     render(
       <FrequentlyBoughtTogether
@@ -118,7 +118,7 @@ const renderer =
         itemComponent={itemComponent}
         sendEvent={() => {}}
         classNames={cssClasses}
-        fallbackComponent={fallbackComponent}
+        emptyComponent={emptyComponent}
         status={instantSearchInstance.status}
       />,
       containerNode

--- a/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
@@ -96,7 +96,7 @@ const renderer =
         : undefined
     ) as LookingSimilarUiProps<Hit>['itemComponent'];
 
-    const fallbackComponent = (
+    const emptyComponent = (
       templates.empty
         ? () => (
             <TemplateComponent
@@ -107,7 +107,7 @@ const renderer =
             />
           )
         : undefined
-    ) as LookingSimilarUiProps<Hit>['fallbackComponent'];
+    ) as LookingSimilarUiProps<Hit>['emptyComponent'];
 
     render(
       <LookingSimilar
@@ -116,7 +116,7 @@ const renderer =
         itemComponent={itemComponent}
         sendEvent={() => {}}
         classNames={cssClasses}
-        fallbackComponent={fallbackComponent}
+        emptyComponent={emptyComponent}
         status={instantSearchInstance.status}
       />,
       containerNode

--- a/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
@@ -97,7 +97,7 @@ function createRenderer({
         : undefined
     ) as RelatedProductsUiProps<Hit>['itemComponent'];
 
-    const fallbackComponent = (
+    const emptyComponent = (
       templates.empty
         ? () => (
             <TemplateComponent
@@ -108,7 +108,7 @@ function createRenderer({
             />
           )
         : undefined
-    ) as RelatedProductsUiProps<Hit>['fallbackComponent'];
+    ) as RelatedProductsUiProps<Hit>['emptyComponent'];
 
     render(
       <RelatedProducts
@@ -117,7 +117,7 @@ function createRenderer({
         classNames={cssClasses}
         headerComponent={headerComponent}
         itemComponent={itemComponent}
-        fallbackComponent={fallbackComponent}
+        emptyComponent={emptyComponent}
         status={instantSearchInstance.status}
       />,
       containerNode

--- a/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
@@ -97,7 +97,7 @@ function createRenderer({
         : undefined
     ) as TrendingItemsUiProps<Hit>['itemComponent'];
 
-    const fallbackComponent = (
+    const emptyComponent = (
       templates.empty
         ? () => (
             <TemplateComponent
@@ -108,7 +108,7 @@ function createRenderer({
             />
           )
         : undefined
-    ) as TrendingItemsUiProps<Hit>['fallbackComponent'];
+    ) as TrendingItemsUiProps<Hit>['emptyComponent'];
 
     render(
       <TrendingItems
@@ -117,7 +117,7 @@ function createRenderer({
         classNames={cssClasses}
         headerComponent={headerComponent}
         itemComponent={itemComponent}
-        fallbackComponent={fallbackComponent}
+        emptyComponent={emptyComponent}
         status={instantSearchInstance.status}
       />,
       containerNode

--- a/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
+++ b/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
@@ -17,7 +17,7 @@ type UiProps<THit extends BaseHit> = Pick<
   | 'items'
   | 'itemComponent'
   | 'headerComponent'
-  | 'fallbackComponent'
+  | 'emptyComponent'
   | 'status'
   | 'sendEvent'
 >;
@@ -29,7 +29,7 @@ export type FrequentlyBoughtTogetherProps<THit extends BaseHit> = Omit<
   UseFrequentlyBoughtTogetherProps<THit> & {
     itemComponent?: FrequentlyBoughtTogetherPropsUiComponentProps<THit>['itemComponent'];
     headerComponent?: FrequentlyBoughtTogetherPropsUiComponentProps<THit>['headerComponent'];
-    fallbackComponent?: FrequentlyBoughtTogetherPropsUiComponentProps<THit>['fallbackComponent'];
+    emptyComponent?: FrequentlyBoughtTogetherPropsUiComponentProps<THit>['emptyComponent'];
   };
 
 const FrequentlyBoughtTogetherUiComponent =
@@ -46,7 +46,7 @@ export function FrequentlyBoughtTogether<THit extends BaseHit = BaseHit>({
   transformItems,
   itemComponent,
   headerComponent,
-  fallbackComponent,
+  emptyComponent,
   ...props
 }: FrequentlyBoughtTogetherProps<THit>) {
   const { status } = useInstantSearch();
@@ -65,7 +65,7 @@ export function FrequentlyBoughtTogether<THit extends BaseHit = BaseHit>({
     items: recommendations,
     itemComponent,
     headerComponent,
-    fallbackComponent,
+    emptyComponent,
     status,
     sendEvent: () => {},
   };

--- a/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
+++ b/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
@@ -14,7 +14,7 @@ type UiProps<THit extends BaseHit> = Pick<
   | 'items'
   | 'itemComponent'
   | 'headerComponent'
-  | 'fallbackComponent'
+  | 'emptyComponent'
   | 'status'
   | 'sendEvent'
 >;
@@ -26,7 +26,7 @@ export type LookingSimilarProps<THit extends BaseHit> = Omit<
   UseLookingSimilarProps<THit> & {
     itemComponent?: LookingSimilarPropsUiComponentProps<THit>['itemComponent'];
     headerComponent?: LookingSimilarPropsUiComponentProps<THit>['headerComponent'];
-    fallbackComponent?: LookingSimilarPropsUiComponentProps<THit>['fallbackComponent'];
+    emptyComponent?: LookingSimilarPropsUiComponentProps<THit>['emptyComponent'];
   };
 
 const LookingSimilarUiComponent = createLookingSimilarComponent({
@@ -43,7 +43,7 @@ export function LookingSimilar<THit extends BaseHit = BaseHit>({
   transformItems,
   itemComponent,
   headerComponent,
-  fallbackComponent,
+  emptyComponent,
   ...props
 }: LookingSimilarProps<THit>) {
   const { status } = useInstantSearch();
@@ -63,7 +63,7 @@ export function LookingSimilar<THit extends BaseHit = BaseHit>({
     items: recommendations,
     itemComponent,
     headerComponent,
-    fallbackComponent,
+    emptyComponent,
     status,
     sendEvent: () => {},
   };

--- a/packages/react-instantsearch/src/widgets/RelatedProducts.tsx
+++ b/packages/react-instantsearch/src/widgets/RelatedProducts.tsx
@@ -14,7 +14,7 @@ type UiProps<TItem extends BaseHit> = Pick<
   | 'items'
   | 'itemComponent'
   | 'headerComponent'
-  | 'fallbackComponent'
+  | 'emptyComponent'
   | 'status'
   | 'sendEvent'
 >;
@@ -26,7 +26,7 @@ export type RelatedProductsProps<TItem extends BaseHit> = Omit<
   UseRelatedProductsProps & {
     itemComponent?: RelatedProductsUiComponentProps<TItem>['itemComponent'];
     headerComponent?: RelatedProductsUiComponentProps<TItem>['headerComponent'];
-    fallbackComponent?: RelatedProductsUiComponentProps<TItem>['fallbackComponent'];
+    emptyComponent?: RelatedProductsUiComponentProps<TItem>['emptyComponent'];
   };
 
 const RelatedProductsUiComponent = createRelatedProductsComponent({
@@ -43,7 +43,7 @@ export function RelatedProducts<TItem extends BaseHit = BaseHit>({
   transformItems,
   itemComponent,
   headerComponent,
-  fallbackComponent,
+  emptyComponent,
   ...props
 }: RelatedProductsProps<TItem>) {
   const { status } = useInstantSearch();
@@ -63,7 +63,7 @@ export function RelatedProducts<TItem extends BaseHit = BaseHit>({
     items: recommendations as Array<Hit<TItem>>,
     itemComponent,
     headerComponent,
-    fallbackComponent,
+    emptyComponent,
     status,
     sendEvent: () => {},
   };

--- a/packages/react-instantsearch/src/widgets/TrendingItems.tsx
+++ b/packages/react-instantsearch/src/widgets/TrendingItems.tsx
@@ -14,7 +14,7 @@ type UiProps<TItem extends BaseHit> = Pick<
   | 'items'
   | 'itemComponent'
   | 'headerComponent'
-  | 'fallbackComponent'
+  | 'emptyComponent'
   | 'status'
   | 'sendEvent'
 >;
@@ -26,7 +26,7 @@ export type TrendingItemsProps<TItem extends BaseHit> = Omit<
   UseTrendingItemsProps & {
     itemComponent?: TrendingItemsUiComponentProps<TItem>['itemComponent'];
     headerComponent?: TrendingItemsUiComponentProps<TItem>['headerComponent'];
-    fallbackComponent?: TrendingItemsUiComponentProps<TItem>['fallbackComponent'];
+    emptyComponent?: TrendingItemsUiComponentProps<TItem>['emptyComponent'];
   };
 
 const TrendingItemsUiComponent = createTrendingItemsComponent({
@@ -44,7 +44,7 @@ export function TrendingItems<TItem extends BaseHit = BaseHit>({
   transformItems,
   itemComponent,
   headerComponent,
-  fallbackComponent,
+  emptyComponent,
   ...props
 }: TrendingItemsProps<TItem>) {
   const facetParameters =
@@ -67,7 +67,7 @@ export function TrendingItems<TItem extends BaseHit = BaseHit>({
     items: recommendations as Array<Hit<TItem>>,
     itemComponent,
     headerComponent,
-    fallbackComponent,
+    emptyComponent,
     status,
     sendEvent: () => {},
   };


### PR DESCRIPTION
This renames `fallbackComponent` into `emptyComponent` in Recommend widgets.

https://algolia.atlassian.net/browse/FX-2856