### PR TITLE
fix(recommend): clean recommend state when removing widgets

### DIFF
--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -310,11 +310,11 @@ declare namespace algoliasearchHelper {
      */
     removeExclude(facet: string, value: string): this;
     removeTag(value: string): this;
-    removeFrequentlyBoughtTogether(id: string): this;
-    removeRelatedProducts(id: string): this;
-    removeTrendingItems(id: string): this;
-    removeTrendingFacets(id: string): this;
-    removeLookingSimilar(id: string): this;
+    removeFrequentlyBoughtTogether(id: number): this;
+    removeRelatedProducts(id: number): this;
+    removeTrendingItems(id: number): this;
+    removeTrendingFacets(id: number): this;
+    removeLookingSimilar(id: number): this;
     toggleFacetExclusion(facet: string, value: string): this;
     /**
      * @deprecated since version 2.4.0, see {@link AlgoliaSearchHelper#toggleFacetExclusion}
@@ -1537,7 +1537,7 @@ declare namespace algoliasearchHelper {
     params: RecommendParametersWithId[];
     constructor(opts?: RecommendParametersOptions);
     addParams(params: RecommendParametersWithId): RecommendParameters;
-    removeParams(id: string): RecommendParameters;
+    removeParams(id: number): RecommendParameters;
     addFrequentlyBoughtTogether(
       params: RecommendParametersWithId<FrequentlyBoughtTogetherQuery>
     ): RecommendParameters;

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -931,7 +931,7 @@ AlgoliaSearchHelper.prototype.removeTag = function (tag) {
 /**
  * Removes a "frequently bought together" recommendation query.
  *
- * @param {string} id identifier of the recommendation widget
+ * @param {number} id identifier of the recommendation widget
  * @returns {AlgoliaSearchHelper} Method is chainable, it returns itself
  * @fires change
  * @chainable
@@ -947,7 +947,7 @@ AlgoliaSearchHelper.prototype.removeFrequentlyBoughtTogether = function (id) {
 /**
  * Removes a "related products" recommendation query.
  *
- * @param {string} id identifier of the recommendation widget
+ * @param {number} id identifier of the recommendation widget
  * @returns {AlgoliaSearchHelper} Method is chainable, it returns itself
  * @fires change
  * @chainable
@@ -963,7 +963,7 @@ AlgoliaSearchHelper.prototype.removeRelatedProducts = function (id) {
 /**
  * Removes a "trending items" recommendation query.
  *
- * @param {string} id identifier of the recommendation widget
+ * @param {number} id identifier of the recommendation widget
  * @returns {AlgoliaSearchHelper} Method is chainable, it returns itself
  * @fires change
  * @chainable
@@ -979,7 +979,7 @@ AlgoliaSearchHelper.prototype.removeTrendingItems = function (id) {
 /**
  * Removes a "trending facets" recommendation query.
  *
- * @param {string} id identifier of the recommendation widget
+ * @param {number} id identifier of the recommendation widget
  * @returns {AlgoliaSearchHelper} Method is chainable, it returns itself
  * @fires change
  * @chainable
@@ -995,7 +995,7 @@ AlgoliaSearchHelper.prototype.removeTrendingFacets = function (id) {
 /**
  * Removes a "looking similar" recommendation query.
  *
- * @param {string} id identifier of the recommendation widget
+ * @param {number} id identifier of the recommendation widget
  * @returns {AlgoliaSearchHelper} Method is chainable, it returns itself
  * @fires change
  * @chainable

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
@@ -130,9 +130,9 @@ const connectFrequentlyBoughtTogether: FrequentlyBoughtTogetherConnector =
           return { recommendations: transformedItems, widgetParams };
         },
 
-        dispose({ state }) {
+        dispose({ recommendState }) {
           unmountFn();
-          return state.removeParams(this.$$id!);
+          return recommendState?.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
@@ -132,8 +132,7 @@ const connectFrequentlyBoughtTogether: FrequentlyBoughtTogetherConnector =
 
         dispose({ state }) {
           unmountFn();
-
-          return state;
+          return state.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
@@ -132,7 +132,7 @@ const connectFrequentlyBoughtTogether: FrequentlyBoughtTogetherConnector =
 
         dispose({ recommendState }) {
           unmountFn();
-          return recommendState?.removeParams(this.$$id!);
+          return recommendState.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
@@ -128,10 +128,9 @@ const connectLookingSimilar: LookingSimilarConnector =
           };
         },
 
-        dispose({ state }) {
+        dispose({ recommendState }) {
           unmountFn();
-
-          return state.removeParams(this.$$id!);
+          return recommendState?.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
@@ -131,7 +131,7 @@ const connectLookingSimilar: LookingSimilarConnector =
         dispose({ state }) {
           unmountFn();
 
-          return state;
+          return state.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
@@ -130,7 +130,7 @@ const connectLookingSimilar: LookingSimilarConnector =
 
         dispose({ recommendState }) {
           unmountFn();
-          return recommendState?.removeParams(this.$$id!);
+          return recommendState.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/pagination/__tests__/connectPagination-test.ts
+++ b/packages/instantsearch.js/src/connectors/pagination/__tests__/connectPagination-test.ts
@@ -350,7 +350,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/pagination/
         throw new Error('expect state to be returned');
       }
 
-      expect(nextState.page).toBeUndefined();
+      expect((nextState as SearchParameters).page).toBeUndefined();
     });
   });
 

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -129,10 +129,9 @@ const connectRelatedProducts: RelatedProductsConnector =
           };
         },
 
-        dispose({ state }) {
+        dispose({ recommendState }) {
           unmountFn();
-
-          return state.removeParams(this.$$id!);
+          return recommendState?.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -131,7 +131,7 @@ const connectRelatedProducts: RelatedProductsConnector =
 
         dispose({ recommendState }) {
           unmountFn();
-          return recommendState?.removeParams(this.$$id!);
+          return recommendState.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -132,7 +132,7 @@ const connectRelatedProducts: RelatedProductsConnector =
         dispose({ state }) {
           unmountFn();
 
-          return state;
+          return state.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
@@ -135,7 +135,7 @@ const connectTrendingItems: TrendingItemsConnector =
 
         dispose({ recommendState }) {
           unmountFn();
-          return recommendState?.removeParams(this.$$id!);
+          return recommendState.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
@@ -133,10 +133,9 @@ const connectTrendingItems: TrendingItemsConnector =
           };
         },
 
-        dispose({ state }) {
+        dispose({ recommendState }) {
           unmountFn();
-
-          return state.removeParams(this.$$id!);
+          return recommendState?.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
@@ -136,7 +136,7 @@ const connectTrendingItems: TrendingItemsConnector =
         dispose({ state }) {
           unmountFn();
 
-          return state;
+          return state.removeParams(this.$$id!);
         },
 
         getWidgetParameters(state) {

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -51,7 +51,7 @@ export type RenderOptions = SharedRenderOptions & {
 export type DisposeOptions = {
   helper: Helper;
   state: SearchParameters;
-  recommendState?: RecommendParameters;
+  recommendState: RecommendParameters;
   parent: IndexWidget;
 };
 

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -48,11 +48,10 @@ export type RenderOptions = SharedRenderOptions & {
   results: SearchResults;
 };
 
-export type DisposeOptions<
-  TParameters = SearchParameters | RecommendParameters
-> = {
+export type DisposeOptions = {
   helper: Helper;
-  state: TParameters;
+  state: SearchParameters;
+  recommendState?: RecommendParameters;
   parent: IndexWidget;
 };
 
@@ -159,13 +158,6 @@ type SearchWidget<TWidgetDescription extends WidgetDescription> = {
       >;
     }
   ) => SearchParameters;
-  /**
-   * Called when this widget is unmounted. Used to remove refinements set by
-   * during this widget's initialization and life time.
-   */
-  dispose?: (
-    options: DisposeOptions<SearchParameters>
-  ) => SearchParameters | void;
 };
 
 type RecommendRenderOptions = SharedRenderOptions & {
@@ -199,13 +191,6 @@ type RecommendWidget<
       TWidgetDescription['widgetParams']
     >
   >;
-  /**
-   * Called when this widget is unmounted. Used to remove refinements set by
-   * during this widget's initialization and life time.
-   */
-  dispose?: (
-    options: DisposeOptions<RecommendParameters>
-  ) => RecommendParameters | void;
 };
 
 type RequiredWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
@@ -226,6 +211,13 @@ type RequiredWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
    * Called after each search response has been received.
    */
   render?: (options: RenderOptions) => void;
+  /**
+   * Called when this widget is unmounted. Used to remove refinements set by
+   * during this widget's initialization and life time.
+   */
+  dispose?: (
+    options: DisposeOptions
+  ) => SearchParameters | RecommendParameters | void;
 };
 
 type RequiredWidgetType<TWidgetDescription extends WidgetDescription> = {

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -48,9 +48,11 @@ export type RenderOptions = SharedRenderOptions & {
   results: SearchResults;
 };
 
-export type DisposeOptions = {
+export type DisposeOptions<
+  TParameters = SearchParameters | RecommendParameters
+> = {
   helper: Helper;
-  state: SearchParameters;
+  state: TParameters;
   parent: IndexWidget;
 };
 
@@ -157,6 +159,13 @@ type SearchWidget<TWidgetDescription extends WidgetDescription> = {
       >;
     }
   ) => SearchParameters;
+  /**
+   * Called when this widget is unmounted. Used to remove refinements set by
+   * during this widget's initialization and life time.
+   */
+  dispose?: (
+    options: DisposeOptions<SearchParameters>
+  ) => SearchParameters | void;
 };
 
 type RecommendRenderOptions = SharedRenderOptions & {
@@ -190,6 +199,13 @@ type RecommendWidget<
       TWidgetDescription['widgetParams']
     >
   >;
+  /**
+   * Called when this widget is unmounted. Used to remove refinements set by
+   * during this widget's initialization and life time.
+   */
+  dispose?: (
+    options: DisposeOptions<RecommendParameters>
+  ) => RecommendParameters | void;
 };
 
 type RequiredWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
@@ -210,11 +226,6 @@ type RequiredWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
    * Called after each search response has been received.
    */
   render?: (options: RenderOptions) => void;
-  /**
-   * Called when this widget is unmounted. Used to remove refinements set by
-   * during this widget's initialization and life time.
-   */
-  dispose?: (options: DisposeOptions) => SearchParameters | void;
 };
 
 type RequiredWidgetType<TWidgetDescription extends WidgetDescription> = {

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -122,7 +122,7 @@ describe('index', () => {
         });
       },
       dispose({ recommendState }) {
-        return recommendState?.removeParams(this.$$id!);
+        return recommendState.removeParams(this.$$id!);
       },
       ...args,
     } as Widget) as unknown as Widget & { $$id: number };

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -10,6 +10,7 @@ import { wait } from '@instantsearch/testutils';
 import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
+  RecommendParameters,
 } from 'algoliasearch-helper';
 
 import { castToJestMock } from '../../../../../../tests/utils';
@@ -119,6 +120,9 @@ describe('index', () => {
           $$id: this.$$id!,
           objectID: 'abc',
         });
+      },
+      dispose({ recommendState }) {
+        return recommendState?.removeParams(this.$$id!);
       },
       ...args,
     } as Widget) as unknown as Widget & { $$id: number };
@@ -552,6 +556,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           },
         });
 
+        const fbt = createFrequentlyBoughtTogether();
+
         instance.addWidgets([
           createSearchBox({
             getWidgetSearchParameters(state) {
@@ -559,6 +565,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
             },
           }),
           pagination,
+          fbt,
         ]);
 
         instance.init(createIndexInitOptions({ parent: null }));
@@ -571,13 +578,24 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           })
         );
 
-        instance.removeWidgets([pagination]);
+        expect(instance.getHelper()!.recommendState).toEqual(
+          new RecommendParameters().addFrequentlyBoughtTogether({
+            objectID: 'abc',
+            $$id: fbt.$$id,
+          })
+        );
+
+        instance.removeWidgets([pagination, fbt]);
 
         expect(instance.getHelper()!.state).toEqual(
           new SearchParameters({
             index: 'indexName',
             query: 'Apple',
           })
+        );
+
+        expect(instance.getHelper()!.recommendState).toEqual(
+          new RecommendParameters()
         );
       });
 
@@ -813,6 +831,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           expect(widget.dispose).toHaveBeenCalledWith({
             helper: instance.getHelper(),
             state: instance.getHelper()!.state,
+            recommendState: instance.getHelper()!.recommendState,
             parent: instance,
           });
         });
@@ -3060,6 +3079,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         expect(widget.dispose).toHaveBeenCalledTimes(1);
         expect(widget.dispose).toHaveBeenCalledWith({
           state: helper!.state,
+          recommendState: helper!.recommendState,
           helper,
           parent: instance,
         });

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -468,15 +468,13 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
               parent: this,
             });
 
-            return {
-              ...states,
-              ...(next instanceof algoliasearchHelper.SearchParameters
-                ? { cleanedSearchState: next }
-                : {}),
-              ...(next instanceof algoliasearchHelper.RecommendParameters
-                ? { cleanedRecommendState: next }
-                : {}),
-            };
+            if (next instanceof algoliasearchHelper.RecommendParameters) {
+              states.cleanedRecommendState = next;
+            } else if (next) {
+              states.cleanedSearchState = next;
+            }
+
+            return states;
           },
           {
             cleanedSearchState: helper!.state,

--- a/packages/instantsearch.js/test/createWidget.ts
+++ b/packages/instantsearch.js/test/createWidget.ts
@@ -95,6 +95,7 @@ export const createDisposeOptions = (
   return {
     helper,
     state: helper.state,
+    recommendState: helper.recommendState,
     parent: instantSearchInstance.mainIndex,
     ...args,
   };


### PR DESCRIPTION
**Summary**

This PR removes recommend parameters from the recommend state when their relevant widgets are disposed.

FX-2854
