### PR TITLE
fix(Configure): prevent aroundRadius="all" throwing

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "47.5 kB"
+      "maxSize": "48.5 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",

--- a/packages/react-instantsearch-core/src/components/Configure.tsx
+++ b/packages/react-instantsearch-core/src/components/Configure.tsx
@@ -5,7 +5,7 @@ import type { UseConfigureProps } from '../connectors/useConfigure';
 export type ConfigureProps = UseConfigureProps;
 
 export function Configure(props: ConfigureProps) {
-  useConfigure(props, { $$widgetType: 'ais.configure' });
+  useConfigure({ ...props }, { $$widgetType: 'ais.configure' });
 
   return null;
 }

--- a/packages/react-instantsearch-core/src/components/__tests__/Configure.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/Configure.test.tsx
@@ -45,4 +45,45 @@ describe('Configure', () => {
       ]);
     });
   });
+
+  test('does not break for aroundRadius="all"', async () => {
+    const searchClient = createSearchClient({});
+
+    /**
+     * Inside the helper, aroundRadius is one of the "numeric" parameters. This means
+     * that it goes through the flow of _parseNumbers when a SearchParameters object is
+     * created.
+     *
+     * The _parseNumbers function is responsible for converting the value of aroundRadius
+     * to a number. However if it is set to "all", it should not be converted to a number.
+     *
+     * Due to this logic, the props get copied to the search parameters object as is. This
+     * could be problematic if we use the React `props` object directly in the helper, as
+     * its keys are not writable.
+     *
+     * This test exists to ensure that the helper does not break when aroundRadius is set
+     * to "all".
+     *
+     * For the bug report, see: https://github.com/algolia/instantsearch/issues/6136, and
+     * a relevant part of the code being edited: https://github.com/algolia/instantsearch/pull/6011
+     */
+
+    render(
+      <InstantSearch indexName="indexName" searchClient={searchClient}>
+        <Configure aroundRadius="all" />
+      </InstantSearch>
+    );
+
+    await waitFor(() => {
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+      expect(searchClient.search).toHaveBeenCalledWith([
+        {
+          indexName: 'indexName',
+          params: expect.objectContaining({
+            aroundRadius: 'all',
+          }),
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Because React props are not writable, behaviour inside _parseNumbers > merge in the helper requires the configure props to be writable.

fixes #6136


See https://github.com/algolia/instantsearch/pull/6011 for the ultimate cause of this issue; _parseNumbers mutates the arguments as it's much more performant than making a copy on every interaction (this is a very hot function).

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

This bug is reproducible by simply rendering `<Configure aroundRadius="all" />` or any other numeric (https://github.com/algolia/instantsearch/blob/d1aa720c8e4e1aad2d7b64e385a29b258240c7df/packages/algoliasearch-helper/src/SearchParameters/index.js#L239-L251) key as a non-number string. After this PR, the bug no longer happens.

Note that of course this has a performance penalty (or regression) for the Configure widget. There's no way around this as far as I can tell, unless we'd manually make the props writable, but that seems like a bad idea.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
