### PR TITLE
fix(recommend): rename maxRecommendations to limit

### DIFF
--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/__tests__/connectFrequentlyBoughtTogether-test.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/__tests__/connectFrequentlyBoughtTogether-test.ts
@@ -83,7 +83,7 @@ describe('connectFrequentlyBoughtTogether', () => {
       const makeWidget = connectFrequentlyBoughtTogether(render);
       const widget = makeWidget({
         objectIDs: ['1', '2'],
-        maxRecommendations: 10,
+        limit: 10,
         threshold: 95,
         queryParameters: { userToken: 'token' },
       });

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
@@ -40,7 +40,7 @@ export type FrequentlyBoughtTogetherConnectorParams<
   /**
    * The maximum number of recommendations to return.
    */
-  maxRecommendations?: number;
+  limit?: number;
 
   /**
    * Parameters to pass to the request.
@@ -79,7 +79,7 @@ const connectFrequentlyBoughtTogether: FrequentlyBoughtTogetherConnector =
           FrequentlyBoughtTogetherConnectorParams['transformItems']
         >,
         objectIDs,
-        maxRecommendations,
+        limit,
         threshold,
         queryParameters,
       } = widgetParams || {};
@@ -142,7 +142,7 @@ const connectFrequentlyBoughtTogether: FrequentlyBoughtTogetherConnector =
               acc.addFrequentlyBoughtTogether({
                 objectID,
                 threshold,
-                maxRecommendations,
+                maxRecommendations: limit,
                 queryParameters,
                 $$id: this.$$id!,
               }),

--- a/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
@@ -30,7 +30,7 @@ export type LookingSimilarConnectorParams<THit extends BaseHit = BaseHit> = {
   /**
    * The number of recommendations to retrieve.
    */
-  maxRecommendations?: number;
+  limit?: number;
   /**
    * The threshold for the recommendations confidence score (between 0 and 100).
    */
@@ -72,7 +72,7 @@ const connectLookingSimilar: LookingSimilarConnector =
     return function LookingSimilar(widgetParams) {
       const {
         objectIDs,
-        maxRecommendations,
+        limit,
         threshold,
         fallbackParameters,
         queryParameters,
@@ -139,7 +139,7 @@ const connectLookingSimilar: LookingSimilarConnector =
             (acc, objectID) =>
               acc.addLookingSimilar({
                 objectID,
-                maxRecommendations,
+                maxRecommendations: limit,
                 threshold,
                 fallbackParameters,
                 queryParameters,

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -30,7 +30,7 @@ export type RelatedProductsConnectorParams<THit extends BaseHit = BaseHit> = {
   /**
    * The number of recommendations to retrieve.
    */
-  maxRecommendations?: number;
+  limit?: number;
   /**
    * The threshold for the recommendations confidence score (between 0 and 100).
    */
@@ -73,7 +73,7 @@ const connectRelatedProducts: RelatedProductsConnector =
     return function relatedProducts(widgetParams) {
       const {
         objectIDs,
-        maxRecommendations,
+        limit,
         threshold,
         fallbackParameters,
         queryParameters,
@@ -140,7 +140,7 @@ const connectRelatedProducts: RelatedProductsConnector =
             (acc, objectID) =>
               acc.addRelatedProducts({
                 objectID,
-                maxRecommendations,
+                maxRecommendations: limit,
                 threshold,
                 fallbackParameters,
                 queryParameters,

--- a/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
@@ -38,7 +38,7 @@ export type TrendingItemsConnectorParams<THit extends BaseHit = BaseHit> = (
   /**
    * The number of recommendations to retrieve.
    */
-  maxRecommendations?: number;
+  limit?: number;
   /**
    * The threshold for the recommendations confidence score (between 0 and 100).
    */
@@ -81,7 +81,7 @@ const connectTrendingItems: TrendingItemsConnector =
       const {
         facetName,
         facetValue,
-        maxRecommendations,
+        limit,
         threshold,
         fallbackParameters,
         queryParameters,
@@ -143,7 +143,7 @@ const connectTrendingItems: TrendingItemsConnector =
           return state.addTrendingItems({
             facetName,
             facetValue,
-            maxRecommendations,
+            maxRecommendations: limit,
             threshold,
             fallbackParameters,
             queryParameters,

--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/__tests__/frequently-bought-together.test.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/__tests__/frequently-bought-together.test.tsx
@@ -84,9 +84,7 @@ describe('frequentlyBoughtTogether', () => {
 
       search
         .removeWidgets([widget])
-        .addWidgets([
-          frequentlyBoughtTogether({ ...options, maxRecommendations: 0 }),
-        ]);
+        .addWidgets([frequentlyBoughtTogether({ ...options, limit: 0 })]);
 
       await wait(0);
 
@@ -158,9 +156,7 @@ describe('frequentlyBoughtTogether', () => {
 
       search
         .removeWidgets([widget])
-        .addWidgets([
-          frequentlyBoughtTogether({ ...options, maxRecommendations: 0 }),
-        ]);
+        .addWidgets([frequentlyBoughtTogether({ ...options, limit: 0 })]);
 
       await wait(0);
 
@@ -245,7 +241,7 @@ describe('frequentlyBoughtTogether', () => {
       search.removeWidgets([widget]).addWidgets([
         frequentlyBoughtTogether({
           ...options,
-          maxRecommendations: 0,
+          limit: 0,
         }),
       ]);
 
@@ -336,7 +332,7 @@ describe('frequentlyBoughtTogether', () => {
       search.removeWidgets([widget]).addWidgets([
         frequentlyBoughtTogether({
           ...options,
-          maxRecommendations: 0,
+          limit: 0,
         }),
       ]);
 

--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
@@ -181,7 +181,7 @@ const frequentlyBoughtTogether: FrequentlyBoughtTogetherWidget =
     const {
       container,
       objectIDs,
-      maxRecommendations,
+      limit,
       queryParameters,
       threshold,
       transformItems,
@@ -209,7 +209,7 @@ const frequentlyBoughtTogether: FrequentlyBoughtTogetherWidget =
     return {
       ...makeWidget({
         objectIDs,
-        maxRecommendations,
+        limit,
         queryParameters,
         threshold,
         transformItems,

--- a/packages/instantsearch.js/src/widgets/looking-similar/__tests__/looking-similar.test.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/__tests__/looking-similar.test.tsx
@@ -84,7 +84,7 @@ describe('lookingSimilar', () => {
 
       search
         .removeWidgets([widget])
-        .addWidgets([lookingSimilar({ ...options, maxRecommendations: 0 })]);
+        .addWidgets([lookingSimilar({ ...options, limit: 0 })]);
 
       await wait(0);
 
@@ -157,7 +157,7 @@ describe('lookingSimilar', () => {
 
       search
         .removeWidgets([widget])
-        .addWidgets([lookingSimilar({ ...options, maxRecommendations: 0 })]);
+        .addWidgets([lookingSimilar({ ...options, limit: 0 })]);
 
       await wait(0);
 
@@ -242,7 +242,7 @@ describe('lookingSimilar', () => {
       search.removeWidgets([widget]).addWidgets([
         lookingSimilar({
           ...options,
-          maxRecommendations: 0,
+          limit: 0,
         }),
       ]);
 
@@ -333,7 +333,7 @@ describe('lookingSimilar', () => {
       search.removeWidgets([widget]).addWidgets([
         lookingSimilar({
           ...options,
-          maxRecommendations: 0,
+          limit: 0,
         }),
       ]);
 

--- a/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
@@ -178,7 +178,7 @@ const lookingSimilar: LookingSimilarWidget = function lookingSimilar(
   const {
     container,
     objectIDs,
-    maxRecommendations,
+    limit,
     queryParameters,
     fallbackParameters,
     threshold,
@@ -206,7 +206,7 @@ const lookingSimilar: LookingSimilarWidget = function lookingSimilar(
   return {
     ...makeWidget({
       objectIDs,
-      maxRecommendations,
+      limit,
       queryParameters,
       fallbackParameters,
       threshold,

--- a/packages/instantsearch.js/src/widgets/related-products/__tests__/related-products.test.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/__tests__/related-products.test.tsx
@@ -86,9 +86,7 @@ describe('relatedProducts', () => {
 
       search.removeWidgets([relatedProductsWidget]);
 
-      search.addWidgets([
-        relatedProducts({ ...options, maxRecommendations: 0 }),
-      ]);
+      search.addWidgets([relatedProducts({ ...options, limit: 0 })]);
 
       await wait(0);
 
@@ -162,9 +160,7 @@ describe('relatedProducts', () => {
 
       search.removeWidgets([relatedProductsWidget]);
 
-      search.addWidgets([
-        relatedProducts({ ...options, maxRecommendations: 0 }),
-      ]);
+      search.addWidgets([relatedProducts({ ...options, limit: 0 })]);
 
       await wait(0);
 
@@ -249,9 +245,7 @@ describe('relatedProducts', () => {
 
       search.removeWidgets([relatedProductsWidget]);
 
-      search.addWidgets([
-        relatedProducts({ ...options, maxRecommendations: 0 }),
-      ]);
+      search.addWidgets([relatedProducts({ ...options, limit: 0 })]);
 
       await wait(0);
 
@@ -340,9 +334,7 @@ describe('relatedProducts', () => {
 
       search.removeWidgets([relatedProductsWidget]);
 
-      search.addWidgets([
-        relatedProducts({ ...options, maxRecommendations: 0 }),
-      ]);
+      search.addWidgets([relatedProducts({ ...options, limit: 0 })]);
 
       await wait(0);
 

--- a/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
@@ -182,7 +182,7 @@ const relatedProducts: RelatedProductsWidget = function relatedProducts(
   const {
     container,
     objectIDs,
-    maxRecommendations,
+    limit,
     queryParameters,
     fallbackParameters,
     threshold,
@@ -211,7 +211,7 @@ const relatedProducts: RelatedProductsWidget = function relatedProducts(
   return {
     ...makeWidget({
       objectIDs,
-      maxRecommendations,
+      limit,
       queryParameters,
       fallbackParameters,
       threshold,

--- a/packages/instantsearch.js/src/widgets/trending-items/__tests__/trending-items.test.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/__tests__/trending-items.test.tsx
@@ -81,7 +81,7 @@ describe('trendingItems', () => {
 
       search.removeWidgets([trendingItemsWidget]);
 
-      search.addWidgets([trendingItems({ ...options, maxRecommendations: 0 })]);
+      search.addWidgets([trendingItems({ ...options, limit: 0 })]);
 
       await wait(0);
 
@@ -154,7 +154,7 @@ describe('trendingItems', () => {
 
       search.removeWidgets([trendingItemsWidget]);
 
-      search.addWidgets([trendingItems({ ...options, maxRecommendations: 0 })]);
+      search.addWidgets([trendingItems({ ...options, limit: 0 })]);
 
       await wait(0);
 
@@ -238,7 +238,7 @@ describe('trendingItems', () => {
 
       search.removeWidgets([trendingItemsWidget]);
 
-      search.addWidgets([trendingItems({ ...options, maxRecommendations: 0 })]);
+      search.addWidgets([trendingItems({ ...options, limit: 0 })]);
 
       await wait(0);
 
@@ -326,7 +326,7 @@ describe('trendingItems', () => {
 
       search.removeWidgets([trendingItemsWidget]);
 
-      search.addWidgets([trendingItems({ ...options, maxRecommendations: 0 })]);
+      search.addWidgets([trendingItems({ ...options, limit: 0 })]);
 
       await wait(0);
 

--- a/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
@@ -181,7 +181,7 @@ const trendingItems: TrendingItemsWidget = function trendingItems(
     container,
     facetName,
     facetValue,
-    maxRecommendations,
+    limit,
     queryParameters,
     fallbackParameters,
     threshold,
@@ -213,7 +213,7 @@ const trendingItems: TrendingItemsWidget = function trendingItems(
   return {
     ...makeWidget({
       ...facetParameters,
-      maxRecommendations,
+      limit,
       queryParameters,
       fallbackParameters,
       threshold,

--- a/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
+++ b/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
@@ -40,7 +40,7 @@ const FrequentlyBoughtTogetherUiComponent =
 
 export function FrequentlyBoughtTogether<THit extends BaseHit = BaseHit>({
   objectIDs,
-  maxRecommendations,
+  limit,
   threshold,
   queryParameters,
   transformItems,
@@ -53,7 +53,7 @@ export function FrequentlyBoughtTogether<THit extends BaseHit = BaseHit>({
   const { recommendations } = useFrequentlyBoughtTogether<THit>(
     {
       objectIDs,
-      maxRecommendations,
+      limit,
       threshold,
       queryParameters,
       transformItems,

--- a/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
+++ b/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
@@ -36,7 +36,7 @@ const LookingSimilarUiComponent = createLookingSimilarComponent({
 
 export function LookingSimilar<THit extends BaseHit = BaseHit>({
   objectIDs,
-  maxRecommendations,
+  limit,
   threshold,
   queryParameters,
   fallbackParameters,
@@ -50,7 +50,7 @@ export function LookingSimilar<THit extends BaseHit = BaseHit>({
   const { recommendations } = useLookingSimilar<THit>(
     {
       objectIDs,
-      maxRecommendations,
+      limit,
       threshold,
       queryParameters,
       fallbackParameters,

--- a/packages/react-instantsearch/src/widgets/RelatedProducts.tsx
+++ b/packages/react-instantsearch/src/widgets/RelatedProducts.tsx
@@ -36,7 +36,7 @@ const RelatedProductsUiComponent = createRelatedProductsComponent({
 
 export function RelatedProducts<TItem extends BaseHit = BaseHit>({
   objectIDs,
-  maxRecommendations,
+  limit,
   threshold,
   fallbackParameters,
   queryParameters,
@@ -50,7 +50,7 @@ export function RelatedProducts<TItem extends BaseHit = BaseHit>({
   const { recommendations } = useRelatedProducts(
     {
       objectIDs,
-      maxRecommendations,
+      limit,
       threshold,
       fallbackParameters,
       queryParameters,

--- a/packages/react-instantsearch/src/widgets/TrendingItems.tsx
+++ b/packages/react-instantsearch/src/widgets/TrendingItems.tsx
@@ -37,7 +37,7 @@ const TrendingItemsUiComponent = createTrendingItemsComponent({
 export function TrendingItems<TItem extends BaseHit = BaseHit>({
   facetName,
   facetValue,
-  maxRecommendations,
+  limit,
   threshold,
   fallbackParameters,
   queryParameters,
@@ -54,7 +54,7 @@ export function TrendingItems<TItem extends BaseHit = BaseHit>({
   const { recommendations } = useTrendingItems(
     {
       ...facetParameters,
-      maxRecommendations,
+      limit,
       threshold,
       fallbackParameters,
       queryParameters,

--- a/tests/common/connectors/frequently-bought-together/options.ts
+++ b/tests/common/connectors/frequently-bought-together/options.ts
@@ -44,7 +44,7 @@ export function createOptionsTests(
         instantSearchOptions: { indexName: 'indexName', searchClient },
         widgetParams: {
           objectIDs: ['1', '2'],
-          maxRecommendations: 2,
+          limit: 2,
           threshold: 3,
           queryParameters: { analytics: true },
         },

--- a/tests/common/connectors/looking-similar/options.ts
+++ b/tests/common/connectors/looking-similar/options.ts
@@ -42,7 +42,7 @@ export function createOptionsTests(
         instantSearchOptions: { indexName: 'indexName', searchClient },
         widgetParams: {
           objectIDs: ['1', '2'],
-          maxRecommendations: 2,
+          limit: 2,
           threshold: 3,
           fallbackParameters: { facetFilters: ['test1'] },
           queryParameters: { analytics: true },

--- a/tests/common/connectors/related-products/options.ts
+++ b/tests/common/connectors/related-products/options.ts
@@ -42,7 +42,7 @@ export function createOptionsTests(
         instantSearchOptions: { indexName: 'indexName', searchClient },
         widgetParams: {
           objectIDs: ['1', '2'],
-          maxRecommendations: 2,
+          limit: 2,
           threshold: 3,
           fallbackParameters: { facetFilters: ['test1'] },
           queryParameters: { analytics: true },

--- a/tests/common/connectors/trending-items/options.ts
+++ b/tests/common/connectors/trending-items/options.ts
@@ -23,7 +23,7 @@ export function createOptionsTests(
         widgetParams: {
           facetName: 'facetName',
           facetValue: 'facetValue',
-          maxRecommendations: 2,
+          limit: 2,
           threshold: 3,
           fallbackParameters: { facetFilters: ['test1'] },
           queryParameters: { analytics: true },

--- a/tests/common/widgets/frequently-bought-together/options.ts
+++ b/tests/common/widgets/frequently-bought-together/options.ts
@@ -246,7 +246,7 @@ export function createOptionsTests(
             query: 'regular query',
           },
           threshold: 80,
-          maxRecommendations: 3,
+          limit: 3,
         },
       });
 

--- a/tests/common/widgets/looking-similar/options.ts
+++ b/tests/common/widgets/looking-similar/options.ts
@@ -249,7 +249,7 @@ export function createOptionsTests(
             query: 'fallback query',
           },
           threshold: 80,
-          maxRecommendations: 3,
+          limit: 3,
         },
       });
 

--- a/tests/common/widgets/related-products/options.ts
+++ b/tests/common/widgets/related-products/options.ts
@@ -137,7 +137,7 @@ export function createOptionsTests(
         widgetParams: {
           objectIDs: ['1'],
           // This simulates receiving no recommendations
-          maxRecommendations: 0,
+          limit: 0,
         },
       });
 
@@ -172,7 +172,7 @@ export function createOptionsTests(
             query: 'fallback query',
           },
           threshold: 80,
-          maxRecommendations: 3,
+          limit: 3,
         },
       });
 

--- a/tests/common/widgets/trending-items/options.ts
+++ b/tests/common/widgets/trending-items/options.ts
@@ -132,7 +132,7 @@ export function createOptionsTests(
         },
         widgetParams: {
           // This simulates receiving no recommendations
-          maxRecommendations: 0,
+          limit: 0,
         },
       });
 
@@ -166,7 +166,7 @@ export function createOptionsTests(
             query: 'fallback query',
           },
           threshold: 80,
-          maxRecommendations: 3,
+          limit: 3,
         },
       });
 


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

rename `maxRecommendations` to `limit`

**Result**

Any user-facing interface is called `limit`, but the underlying parameter (also for the helper) is still called `maxRecommendations`

This is consistent with other widgets that don't have pagination like refinementList

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
