### PR TITLE
fix(recommend): rename return type consistently to "items"

### DIFF
--- a/packages/instantsearch-ui-components/src/components/FrequentlyBoughtTogether.tsx
+++ b/packages/instantsearch-ui-components/src/components/FrequentlyBoughtTogether.tsx
@@ -83,7 +83,7 @@ export function createFrequentlyBoughtTogetherComponent({
             ...classNames,
             title: cx('ais-FrequentlyBoughtTogether-title', classNames.title),
           }}
-          recommendations={items}
+          items={items}
           translations={translations}
         />
 

--- a/packages/instantsearch-ui-components/src/components/LookingSimilar.tsx
+++ b/packages/instantsearch-ui-components/src/components/LookingSimilar.tsx
@@ -80,7 +80,7 @@ export function createLookingSimilarComponent({
             ...classNames,
             title: cx('ais-LookingSimilar-title', classNames.title),
           }}
-          recommendations={items}
+          items={items}
           translations={translations}
         />
 

--- a/packages/instantsearch-ui-components/src/components/RelatedProducts.tsx
+++ b/packages/instantsearch-ui-components/src/components/RelatedProducts.tsx
@@ -83,7 +83,7 @@ export function createRelatedProductsComponent({
             ...classNames,
             title: cx('ais-RelatedProducts-title', classNames.title),
           }}
-          recommendations={items}
+          items={items}
           translations={translations}
         />
 

--- a/packages/instantsearch-ui-components/src/components/TrendingItems.tsx
+++ b/packages/instantsearch-ui-components/src/components/TrendingItems.tsx
@@ -80,7 +80,7 @@ export function createTrendingItemsComponent({
             ...classNames,
             title: cx('ais-TrendingItems-title', classNames.title),
           }}
-          recommendations={items}
+          items={items}
           translations={translations}
         />
 

--- a/packages/instantsearch-ui-components/src/components/recommend-shared/DefaultHeader.tsx
+++ b/packages/instantsearch-ui-components/src/components/recommend-shared/DefaultHeader.tsx
@@ -6,9 +6,9 @@ export function createDefaultHeaderComponent({ createElement }: Renderer) {
   return function DefaultHeader<TObject>(
     userProps: RecommendInnerComponentProps<TObject>
   ) {
-    const { classNames = {}, recommendations, translations } = userProps;
+    const { classNames = {}, items, translations } = userProps;
 
-    if (!recommendations || recommendations.length < 1) {
+    if (!items || items.length < 1) {
       return null;
     }
 

--- a/packages/instantsearch-ui-components/src/types/Recommend.ts
+++ b/packages/instantsearch-ui-components/src/types/Recommend.ts
@@ -84,7 +84,7 @@ export type RecommendComponentProps<
 
 export type RecommendInnerComponentProps<TObject> = {
   classNames: Partial<RecommendClassNames>;
-  recommendations: TObject[];
+  items: TObject[];
   translations: Partial<RecommendTranslations>;
 };
 

--- a/packages/instantsearch.js/src/__tests__/common-connectors.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-connectors.test.tsx
@@ -401,8 +401,8 @@ const testSetups: TestSetupsMap<TestSuites> = {
       container: HTMLElement;
     }>((renderOptions) => {
       renderOptions.widgetParams.container.innerHTML = `
-        <ul>${renderOptions.recommendations
-          .map((recommendation) => `<li>${recommendation.objectID}</li>`)
+        <ul>${renderOptions.items
+          .map((item) => `<li>${item.objectID}</li>`)
           .join('')}</ul>`;
     });
 
@@ -429,8 +429,8 @@ const testSetups: TestSetupsMap<TestSuites> = {
       container: HTMLElement;
     }>((renderOptions) => {
       renderOptions.widgetParams.container.innerHTML = `
-        <ul>${renderOptions.recommendations
-          .map((recommendation) => `<li>${recommendation.objectID}</li>`)
+        <ul>${renderOptions.items
+          .map((item) => `<li>${item.objectID}</li>`)
           .join('')}</ul>
       `;
     });
@@ -455,8 +455,8 @@ const testSetups: TestSetupsMap<TestSuites> = {
       container: HTMLElement;
     }>((renderOptions) => {
       renderOptions.widgetParams.container.innerHTML = `
-        <ul>${renderOptions.recommendations
-          .map((recommendation) => `<li>${recommendation.objectID}</li>`)
+        <ul>${renderOptions.items
+          .map((item) => `<li>${item.objectID}</li>`)
           .join('')}</ul>
       `;
     });
@@ -481,8 +481,8 @@ const testSetups: TestSetupsMap<TestSuites> = {
       container: HTMLElement;
     }>((renderOptions) => {
       renderOptions.widgetParams.container.innerHTML = `
-        <ul>${renderOptions.recommendations
-          .map((recommendation) => `<li>${recommendation.objectID}</li>`)
+        <ul>${renderOptions.items
+          .map((item) => `<li>${item.objectID}</li>`)
           .join('')}</ul>
       `;
     });

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
@@ -21,7 +21,7 @@ export type FrequentlyBoughtTogetherRenderState<
   /**
    * The matched recommendations from Algolia API.
    */
-  recommendations: Array<Hit<THit>>;
+  items: Array<Hit<THit>>;
 };
 
 export type FrequentlyBoughtTogetherConnectorParams<
@@ -120,14 +120,14 @@ const connectFrequentlyBoughtTogether: FrequentlyBoughtTogetherConnector =
 
         getWidgetRenderState({ results }) {
           if (results === null || results === undefined) {
-            return { recommendations: [], widgetParams };
+            return { items: [], widgetParams };
           }
 
           const transformedItems = transformItems(results.hits, {
             results: results as RecommendResultItem,
           });
 
-          return { recommendations: transformedItems, widgetParams };
+          return { items: transformedItems, widgetParams };
         },
 
         dispose({ state }) {

--- a/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
@@ -19,7 +19,7 @@ export type LookingSimilarRenderState<THit extends BaseHit = BaseHit> = {
   /**
    * The matched recommendations from the Algolia API.
    */
-  recommendations: Array<Hit<THit>>;
+  items: Array<Hit<THit>>;
 };
 
 export type LookingSimilarConnectorParams<THit extends BaseHit = BaseHit> = {
@@ -117,11 +117,11 @@ const connectLookingSimilar: LookingSimilarConnector =
 
         getWidgetRenderState({ results }) {
           if (results === null || results === undefined) {
-            return { recommendations: [], widgetParams };
+            return { items: [], widgetParams };
           }
 
           return {
-            recommendations: transformItems(results.hits, {
+            items: transformItems(results.hits, {
               results: results as RecommendResultItem,
             }),
             widgetParams,

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -19,7 +19,7 @@ export type RelatedProductsRenderState<THit extends BaseHit = BaseHit> = {
   /**
    * The matched recommendations from the Algolia API.
    */
-  recommendations: Array<Hit<THit>>;
+  items: Array<Hit<THit>>;
 };
 
 export type RelatedProductsConnectorParams<THit extends BaseHit = BaseHit> = {
@@ -118,11 +118,11 @@ const connectRelatedProducts: RelatedProductsConnector =
 
         getWidgetRenderState({ results }) {
           if (results === null || results === undefined) {
-            return { recommendations: [], widgetParams };
+            return { items: [], widgetParams };
           }
 
           return {
-            recommendations: transformItems(results.hits, {
+            items: transformItems(results.hits, {
               results: results as RecommendResultItem,
             }),
             widgetParams,

--- a/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
@@ -19,7 +19,7 @@ export type TrendingItemsRenderState<THit extends BaseHit = BaseHit> = {
   /**
    * The matched recommendations from the Algolia API.
    */
-  recommendations: Array<Hit<THit>>;
+  items: Array<Hit<THit>>;
 };
 
 export type TrendingItemsConnectorParams<THit extends BaseHit = BaseHit> = (
@@ -122,11 +122,11 @@ const connectTrendingItems: TrendingItemsConnector =
 
         getWidgetRenderState({ results }) {
           if (results === null || results === undefined) {
-            return { recommendations: [], widgetParams };
+            return { items: [], widgetParams };
           }
 
           return {
-            recommendations: transformItems(results.hits, {
+            items: transformItems(results.hits, {
               results: results as RecommendResultItem,
             }),
             widgetParams,

--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/__tests__/frequently-bought-together.test.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/__tests__/frequently-bought-together.test.tsx
@@ -182,9 +182,9 @@ describe('frequentlyBoughtTogether', () => {
         container,
         objectIDs: ['1'],
         templates: {
-          header({ recommendations, cssClasses }, { html }) {
+          header({ items, cssClasses }, { html }) {
             return html`<h4 class="${cssClasses.title}">
-              Frequently bought together (${recommendations.length})
+              Frequently bought together (${items.length})
             </h4>`;
           },
           item(hit, { html }) {
@@ -271,10 +271,10 @@ describe('frequentlyBoughtTogether', () => {
         container,
         objectIDs: ['1'],
         templates: {
-          header({ recommendations, cssClasses }) {
+          header({ items, cssClasses }) {
             return (
               <h4 className={cssClasses.title}>
-                Frequently bought together ({recommendations.length})
+                Frequently bought together ({items.length})
               </h4>
             );
           },

--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
@@ -52,14 +52,7 @@ const renderer =
     FrequentlyBoughtTogetherRenderState,
     Partial<FrequentlyBoughtTogetherWidgetParams>
   > =>
-  (
-    {
-      recommendations: receivedRecommendations,
-      results,
-      instantSearchInstance,
-    },
-    isFirstRendering
-  ) => {
+  ({ items, results, instantSearchInstance }, isFirstRendering) => {
     if (isFirstRendering) {
       renderState.templateProps = prepareTemplateProps({
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -72,12 +65,12 @@ const renderer =
 
     const headerComponent = (
       templates.header
-        ? ({ classNames, recommendations }) => (
+        ? (data) => (
             <TemplateComponent
               {...renderState.templateProps}
               templateKey="header"
               rootTagName="fragment"
-              data={{ cssClasses: classNames, recommendations }}
+              data={{ cssClasses: data.classNames, items: data.items }}
             />
           )
         : undefined
@@ -113,7 +106,7 @@ const renderer =
 
     render(
       <FrequentlyBoughtTogether
-        items={receivedRecommendations}
+        items={items}
         headerComponent={headerComponent}
         itemComponent={itemComponent}
         sendEvent={() => {}}
@@ -141,7 +134,7 @@ export type FrequentlyBoughtTogetherTemplates = Partial<{
       Parameters<
         NonNullable<FrequentlyBoughtTogetherUiProps<Hit>['headerComponent']>
       >[0],
-      'recommendations'
+      'items'
     > & { cssClasses: RecommendClassNames }
   >;
 

--- a/packages/instantsearch.js/src/widgets/looking-similar/__tests__/looking-similar.test.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/__tests__/looking-similar.test.tsx
@@ -179,9 +179,9 @@ describe('lookingSimilar', () => {
         container,
         objectIDs: ['1'],
         templates: {
-          header({ recommendations, cssClasses }, { html }) {
+          header({ items, cssClasses }, { html }) {
             return html`<h4 class="${cssClasses.title}">
-              Looking similar (${recommendations.length})
+              Looking similar (${items.length})
             </h4>`;
           },
           item(hit, { html }) {
@@ -268,10 +268,10 @@ describe('lookingSimilar', () => {
         container,
         objectIDs: ['1'],
         templates: {
-          header({ recommendations, cssClasses }) {
+          header({ items, cssClasses }) {
             return (
               <h4 className={cssClasses.title}>
-                Looking similar ({recommendations.length})
+                Looking similar ({items.length})
               </h4>
             );
           },

--- a/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
@@ -50,14 +50,7 @@ const renderer =
     LookingSimilarRenderState,
     Partial<LookingSimilarWidgetParams>
   > =>
-  (
-    {
-      recommendations: receivedRecommendations,
-      results,
-      instantSearchInstance,
-    },
-    isFirstRendering
-  ) => {
+  ({ items, results, instantSearchInstance }, isFirstRendering) => {
     if (isFirstRendering) {
       renderState.templateProps = prepareTemplateProps({
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -70,12 +63,12 @@ const renderer =
 
     const headerComponent = (
       templates.header
-        ? ({ classNames, recommendations }) => (
+        ? (data) => (
             <TemplateComponent
               {...renderState.templateProps}
               templateKey="header"
               rootTagName="fragment"
-              data={{ cssClasses: classNames, recommendations }}
+              data={{ cssClasses: data.classNames, items: data.items }}
             />
           )
         : undefined
@@ -111,7 +104,7 @@ const renderer =
 
     render(
       <LookingSimilar
-        items={receivedRecommendations}
+        items={items}
         headerComponent={headerComponent}
         itemComponent={itemComponent}
         sendEvent={() => {}}
@@ -137,7 +130,7 @@ export type LookingSimilarTemplates = Partial<{
   header: Template<
     Pick<
       Parameters<NonNullable<LookingSimilarUiProps<Hit>['headerComponent']>>[0],
-      'recommendations'
+      'items'
     > & { cssClasses: RecommendClassNames }
   >;
 

--- a/packages/instantsearch.js/src/widgets/related-products/__tests__/related-products.test.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/__tests__/related-products.test.tsx
@@ -186,9 +186,9 @@ describe('relatedProducts', () => {
         container,
         objectIDs: ['1'],
         templates: {
-          header({ recommendations, cssClasses }, { html }) {
+          header({ items, cssClasses }, { html }) {
             return html`<h4 class="${cssClasses.title}">
-              Related products (${recommendations.length})
+              Related products (${items.length})
             </h4>`;
           },
           item(item, { html }) {
@@ -275,10 +275,10 @@ describe('relatedProducts', () => {
         container,
         objectIDs: ['1'],
         templates: {
-          header({ recommendations, cssClasses }) {
+          header({ items, cssClasses }) {
             return (
               <h4 className={cssClasses.title}>
-                Related products ({recommendations.length})
+                Related products ({items.length})
               </h4>
             );
           },

--- a/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
@@ -52,7 +52,7 @@ function createRenderer({
   Partial<RelatedProductsWidgetParams>
 > {
   return function renderer(
-    { recommendations, results, instantSearchInstance },
+    { items, results, instantSearchInstance },
     isFirstRendering
   ) {
     if (isFirstRendering) {
@@ -75,7 +75,7 @@ function createRenderer({
               rootTagName="fragment"
               data={{
                 cssClasses: data.classNames,
-                recommendations: data.recommendations,
+                items: data.items,
               }}
             />
           )
@@ -112,7 +112,7 @@ function createRenderer({
 
     render(
       <RelatedProducts
-        items={recommendations}
+        items={items}
         sendEvent={() => {}}
         classNames={cssClasses}
         headerComponent={headerComponent}
@@ -141,7 +141,7 @@ export type RelatedProductsTemplates = Partial<{
       Parameters<
         NonNullable<RelatedProductsUiProps<Hit>['headerComponent']>
       >[0],
-      'recommendations'
+      'items'
     > & { cssClasses: RecommendClassNames }
   >;
 

--- a/packages/instantsearch.js/src/widgets/trending-items/__tests__/trending-items.test.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/__tests__/trending-items.test.tsx
@@ -175,9 +175,9 @@ describe('trendingItems', () => {
       const options: Parameters<typeof trendingItems>[0] = {
         container,
         templates: {
-          header({ recommendations, cssClasses }, { html }) {
+          header({ items, cssClasses }, { html }) {
             return html`<h4 class="${cssClasses.title}">
-              Trending items (${recommendations.length})
+              Trending items (${items.length})
             </h4>`;
           },
           item(item, { html }) {
@@ -261,10 +261,10 @@ describe('trendingItems', () => {
       const options: Parameters<typeof trendingItems>[0] = {
         container,
         templates: {
-          header({ recommendations, cssClasses }) {
+          header({ items, cssClasses }) {
             return (
               <h4 className={cssClasses.title}>
-                Trending items ({recommendations.length})
+                Trending items ({items.length})
               </h4>
             );
           },

--- a/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
@@ -52,7 +52,7 @@ function createRenderer({
   Partial<TrendingItemsWidgetParams>
 > {
   return function renderer(
-    { recommendations, results, instantSearchInstance },
+    { items, results, instantSearchInstance },
     isFirstRendering
   ) {
     if (isFirstRendering) {
@@ -75,7 +75,7 @@ function createRenderer({
               rootTagName="fragment"
               data={{
                 cssClasses: data.classNames,
-                recommendations: data.recommendations,
+                items: data.items,
               }}
             />
           )
@@ -112,7 +112,7 @@ function createRenderer({
 
     render(
       <TrendingItems
-        items={recommendations}
+        items={items}
         sendEvent={() => {}}
         classNames={cssClasses}
         headerComponent={headerComponent}
@@ -139,7 +139,7 @@ export type TrendingItemsTemplates = Partial<{
   header: Template<
     Pick<
       Parameters<NonNullable<TrendingItemsUiProps<Hit>['headerComponent']>>[0],
-      'recommendations'
+      'items'
     > & { cssClasses: RecommendClassNames }
   >;
 

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useRelatedProducts.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useRelatedProducts.test.tsx
@@ -14,11 +14,11 @@ describe('useRelatedProducts', () => {
     );
 
     // Initial render state from manual `getWidgetRenderState`
-    expect(result.current).toEqual({ recommendations: expect.any(Array) });
+    expect(result.current).toEqual({ items: expect.any(Array) });
 
     await waitForNextUpdate();
 
     // InstantSearch.js state from the `render` lifecycle step
-    expect(result.current).toEqual({ recommendations: expect.any(Array) });
+    expect(result.current).toEqual({ items: expect.any(Array) });
   });
 });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useTrendingItems.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useTrendingItems.test.tsx
@@ -14,11 +14,11 @@ describe('useTrendingItems', () => {
     );
 
     // Initial render state from manual `getWidgetRenderState`
-    expect(result.current).toEqual({ recommendations: expect.any(Array) });
+    expect(result.current).toEqual({ items: expect.any(Array) });
 
     await waitForNextUpdate();
 
     // InstantSearch.js state from the `render` lifecycle step
-    expect(result.current).toEqual({ recommendations: expect.any(Array) });
+    expect(result.current).toEqual({ items: expect.any(Array) });
   });
 });

--- a/packages/react-instantsearch/src/__tests__/common-connectors.test.tsx
+++ b/packages/react-instantsearch/src/__tests__/common-connectors.test.tsx
@@ -326,12 +326,12 @@ const testSetups: TestSetupsMap<TestSuites> = {
     widgetParams,
   }) => {
     function CustomRelatedProducts(props: UseRelatedProductsProps) {
-      const { recommendations } = useRelatedProducts(props);
+      const { items } = useRelatedProducts(props);
 
       return (
         <ul>
-          {recommendations.map((recommendation) => (
-            <li key={recommendation.objectID}>{recommendation.objectID}</li>
+          {items.map((item) => (
+            <li key={item.objectID}>{item.objectID}</li>
           ))}
         </ul>
       );
@@ -350,12 +350,12 @@ const testSetups: TestSetupsMap<TestSuites> = {
     function CustomFrequentlyBoughtTogether(
       props: UseFrequentlyBoughtTogetherProps
     ) {
-      const { recommendations } = useFrequentlyBoughtTogether(props);
+      const { items } = useFrequentlyBoughtTogether(props);
 
       return (
         <ul>
-          {recommendations.map((recommendation) => (
-            <li key={recommendation.objectID}>{recommendation.objectID}</li>
+          {items.map((item) => (
+            <li key={item.objectID}>{item.objectID}</li>
           ))}
         </ul>
       );
@@ -372,12 +372,12 @@ const testSetups: TestSetupsMap<TestSuites> = {
     widgetParams,
   }) => {
     function CustomTrendingItems(props: UseTrendingItemsProps) {
-      const { recommendations } = useTrendingItems(props);
+      const { items } = useTrendingItems(props);
 
       return (
         <ul>
-          {recommendations.map((recommendation) => (
-            <li key={recommendation.objectID}>{recommendation.objectID}</li>
+          {items.map((item) => (
+            <li key={item.objectID}>{item.objectID}</li>
           ))}
         </ul>
       );
@@ -394,12 +394,12 @@ const testSetups: TestSetupsMap<TestSuites> = {
     widgetParams,
   }) => {
     function CustomLookingSimilar(props: UseLookingSimilarProps) {
-      const { recommendations } = useLookingSimilar(props);
+      const { items } = useLookingSimilar(props);
 
       return (
         <ul>
-          {recommendations.map((recommendation) => (
-            <li key={recommendation.objectID}>{recommendation.objectID}</li>
+          {items.map((item) => (
+            <li key={item.objectID}>{item.objectID}</li>
           ))}
         </ul>
       );

--- a/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
+++ b/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
@@ -50,7 +50,7 @@ export function FrequentlyBoughtTogether<THit extends BaseHit = BaseHit>({
   ...props
 }: FrequentlyBoughtTogetherProps<THit>) {
   const { status } = useInstantSearch();
-  const { recommendations } = useFrequentlyBoughtTogether<THit>(
+  const { items } = useFrequentlyBoughtTogether<THit>(
     {
       objectIDs,
       maxRecommendations,
@@ -62,7 +62,7 @@ export function FrequentlyBoughtTogether<THit extends BaseHit = BaseHit>({
   );
 
   const uiProps: UiProps<THit> = {
-    items: recommendations,
+    items,
     itemComponent,
     headerComponent,
     emptyComponent,

--- a/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
+++ b/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
@@ -47,7 +47,7 @@ export function LookingSimilar<THit extends BaseHit = BaseHit>({
   ...props
 }: LookingSimilarProps<THit>) {
   const { status } = useInstantSearch();
-  const { recommendations } = useLookingSimilar<THit>(
+  const { items } = useLookingSimilar<THit>(
     {
       objectIDs,
       maxRecommendations,
@@ -60,7 +60,7 @@ export function LookingSimilar<THit extends BaseHit = BaseHit>({
   );
 
   const uiProps: UiProps<THit> = {
-    items: recommendations,
+    items,
     itemComponent,
     headerComponent,
     emptyComponent,

--- a/packages/react-instantsearch/src/widgets/RelatedProducts.tsx
+++ b/packages/react-instantsearch/src/widgets/RelatedProducts.tsx
@@ -47,7 +47,7 @@ export function RelatedProducts<TItem extends BaseHit = BaseHit>({
   ...props
 }: RelatedProductsProps<TItem>) {
   const { status } = useInstantSearch();
-  const { recommendations } = useRelatedProducts(
+  const { items } = useRelatedProducts(
     {
       objectIDs,
       maxRecommendations,
@@ -60,7 +60,7 @@ export function RelatedProducts<TItem extends BaseHit = BaseHit>({
   );
 
   const uiProps: UiProps<TItem> = {
-    items: recommendations as Array<Hit<TItem>>,
+    items: items as Array<Hit<TItem>>,
     itemComponent,
     headerComponent,
     emptyComponent,

--- a/packages/react-instantsearch/src/widgets/TrendingItems.tsx
+++ b/packages/react-instantsearch/src/widgets/TrendingItems.tsx
@@ -51,7 +51,7 @@ export function TrendingItems<TItem extends BaseHit = BaseHit>({
     facetName && facetValue ? { facetName, facetValue } : {};
 
   const { status } = useInstantSearch();
-  const { recommendations } = useTrendingItems(
+  const { items } = useTrendingItems(
     {
       ...facetParameters,
       maxRecommendations,
@@ -64,7 +64,7 @@ export function TrendingItems<TItem extends BaseHit = BaseHit>({
   );
 
   const uiProps: UiProps<TItem> = {
-    items: recommendations as Array<Hit<TItem>>,
+    items: items as Array<Hit<TItem>>,
     itemComponent,
     headerComponent,
     emptyComponent,


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

FX-2857

**Result**

the exposed items are consistently called "items", in tandem with `transformItems` and other widgets (except hits, which still uses hits for now but probably should change in a next major too)

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
