### PR TITLE
refactor(ui-components): compute classNames only once

### DIFF
--- a/packages/instantsearch-ui-components/src/components/FrequentlyBoughtTogether.tsx
+++ b/packages/instantsearch-ui-components/src/components/FrequentlyBoughtTogether.tsx
@@ -14,6 +14,7 @@ import type {
   Renderer,
   ComponentProps,
   RecommendComponentProps,
+  RecommendClassNames,
 } from '../types';
 
 export type FrequentlyBoughtTogetherProps<
@@ -56,47 +57,42 @@ export function createFrequentlyBoughtTogetherComponent({
       ...userTranslations,
     };
 
+    const cssClasses: RecommendClassNames = {
+      root: cx('ais-FrequentlyBoughtTogether', classNames.root),
+      emptyRoot: cx(
+        'ais-FrequentlyBoughtTogether',
+        classNames.root,
+        'ais-FrequentlyBoughtTogether--empty',
+        classNames.emptyRoot,
+        props.className
+      ),
+      title: cx('ais-FrequentlyBoughtTogether-title', classNames.title),
+      container: cx(
+        'ais-FrequentlyBoughtTogether-container',
+        classNames.container
+      ),
+      list: cx('ais-FrequentlyBoughtTogether-list', classNames.list),
+      item: cx('ais-FrequentlyBoughtTogether-item', classNames.item),
+    };
+
     if (items.length === 0 && status === 'idle') {
       return (
-        <section
-          {...props}
-          className={cx(
-            'ais-FrequentlyBoughtTogether',
-            classNames.root,
-            'ais-FrequentlyBoughtTogether--empty',
-            classNames.emptyRoot,
-            props.className
-          )}
-        >
+        <section {...props} className={cssClasses.emptyRoot}>
           <EmptyComponent />
         </section>
       );
     }
 
     return (
-      <section
-        {...props}
-        className={cx('ais-FrequentlyBoughtTogether', classNames.root)}
-      >
+      <section {...props} className={cssClasses.root}>
         <HeaderComponent
-          classNames={{
-            ...classNames,
-            title: cx('ais-FrequentlyBoughtTogether-title', classNames.title),
-          }}
+          classNames={cssClasses}
           items={items}
           translations={translations}
         />
 
         <View
-          classNames={{
-            ...classNames,
-            container: cx(
-              'ais-FrequentlyBoughtTogether-container',
-              classNames.container
-            ),
-            list: cx('ais-FrequentlyBoughtTogether-list', classNames.list),
-            item: cx('ais-FrequentlyBoughtTogether-item', classNames.item),
-          }}
+          classNames={cssClasses}
           translations={translations}
           itemComponent={ItemComponent}
           items={items}

--- a/packages/instantsearch-ui-components/src/components/LookingSimilar.tsx
+++ b/packages/instantsearch-ui-components/src/components/LookingSimilar.tsx
@@ -11,6 +11,7 @@ import {
 
 import type {
   ComponentProps,
+  RecommendClassNames,
   RecommendComponentProps,
   RecommendTranslations,
   Renderer,
@@ -56,41 +57,39 @@ export function createLookingSimilarComponent({
       ...userTranslations,
     };
 
+    const cssClasses: RecommendClassNames = {
+      root: cx('ais-LookingSimilar', classNames.root),
+      emptyRoot: cx(
+        'ais-LookingSimilar',
+        classNames.root,
+        'ais-LookingSimilar--empty',
+        classNames.emptyRoot,
+        props.className
+      ),
+      title: cx('ais-LookingSimilar-title', classNames.title),
+      container: cx('ais-LookingSimilar-container', classNames.container),
+      list: cx('ais-LookingSimilar-list', classNames.list),
+      item: cx('ais-LookingSimilar-item', classNames.item),
+    };
+
     if (items.length === 0 && status === 'idle') {
       return (
-        <section
-          {...props}
-          className={cx(
-            'ais-LookingSimilar',
-            classNames.root,
-            'ais-LookingSimilar--empty',
-            classNames.emptyRoot,
-            props.className
-          )}
-        >
+        <section {...props} className={cssClasses.emptyRoot}>
           <EmptyComponent />
         </section>
       );
     }
 
     return (
-      <section {...props} className={cx('ais-LookingSimilar', classNames.root)}>
+      <section {...props} className={cssClasses.root}>
         <HeaderComponent
-          classNames={{
-            ...classNames,
-            title: cx('ais-LookingSimilar-title', classNames.title),
-          }}
+          classNames={cssClasses}
           items={items}
           translations={translations}
         />
 
         <View
-          classNames={{
-            ...classNames,
-            container: cx('ais-LookingSimilar-container', classNames.container),
-            list: cx('ais-LookingSimilar-list', classNames.list),
-            item: cx('ais-LookingSimilar-item', classNames.item),
-          }}
+          classNames={cssClasses}
           translations={translations}
           itemComponent={ItemComponent}
           items={items}

--- a/packages/instantsearch-ui-components/src/components/RelatedProducts.tsx
+++ b/packages/instantsearch-ui-components/src/components/RelatedProducts.tsx
@@ -11,6 +11,7 @@ import {
 
 import type {
   ComponentProps,
+  RecommendClassNames,
   RecommendComponentProps,
   RecommendTranslations,
   Renderer,
@@ -56,47 +57,39 @@ export function createRelatedProductsComponent({
       ...userTranslations,
     };
 
+    const cssClasses: RecommendClassNames = {
+      root: cx('ais-RelatedProducts', classNames.root),
+      emptyRoot: cx(
+        'ais-RelatedProducts',
+        classNames.root,
+        'ais-RelatedProducts--empty',
+        classNames.emptyRoot,
+        props.className
+      ),
+      title: cx('ais-RelatedProducts-title', classNames.title),
+      container: cx('ais-RelatedProducts-container', classNames.container),
+      list: cx('ais-RelatedProducts-list', classNames.list),
+      item: cx('ais-RelatedProducts-item', classNames.item),
+    };
+
     if (items.length === 0 && status === 'idle') {
       return (
-        <section
-          {...props}
-          className={cx(
-            'ais-RelatedProducts',
-            classNames.root,
-            'ais-RelatedProducts--empty',
-            classNames.emptyRoot,
-            props.className
-          )}
-        >
+        <section {...props} className={cssClasses.emptyRoot}>
           <EmptyComponent />
         </section>
       );
     }
 
     return (
-      <section
-        {...props}
-        className={cx('ais-RelatedProducts', classNames.root)}
-      >
+      <section {...props} className={cssClasses.root}>
         <HeaderComponent
-          classNames={{
-            ...classNames,
-            title: cx('ais-RelatedProducts-title', classNames.title),
-          }}
+          classNames={cssClasses}
           items={items}
           translations={translations}
         />
 
         <View
-          classNames={{
-            ...classNames,
-            container: cx(
-              'ais-RelatedProducts-container',
-              classNames.container
-            ),
-            list: cx('ais-RelatedProducts-list', classNames.list),
-            item: cx('ais-RelatedProducts-item', classNames.item),
-          }}
+          classNames={cssClasses}
           translations={translations}
           itemComponent={ItemComponent}
           items={items}

--- a/packages/instantsearch-ui-components/src/components/TrendingItems.tsx
+++ b/packages/instantsearch-ui-components/src/components/TrendingItems.tsx
@@ -11,6 +11,7 @@ import {
 
 import type {
   ComponentProps,
+  RecommendClassNames,
   RecommendComponentProps,
   RecommendTranslations,
   Renderer,
@@ -56,41 +57,39 @@ export function createTrendingItemsComponent({
       ...userTranslations,
     };
 
+    const cssClasses: RecommendClassNames = {
+      root: cx('ais-RelatedProducts', classNames.root),
+      emptyRoot: cx(
+        'ais-RelatedProducts',
+        classNames.root,
+        'ais-RelatedProducts--empty',
+        classNames.emptyRoot,
+        props.className
+      ),
+      title: cx('ais-RelatedProducts-title', classNames.title),
+      container: cx('ais-RelatedProducts-container', classNames.container),
+      list: cx('ais-RelatedProducts-list', classNames.list),
+      item: cx('ais-RelatedProducts-item', classNames.item),
+    };
+
     if (items.length === 0 && status === 'idle') {
       return (
-        <section
-          {...props}
-          className={cx(
-            'ais-TrendingItems',
-            classNames.root,
-            'ais-TrendingItems--empty',
-            classNames.emptyRoot,
-            props.className
-          )}
-        >
+        <section {...props} className={cssClasses.emptyRoot}>
           <EmptyComponent />
         </section>
       );
     }
 
     return (
-      <section {...props} className={cx('ais-TrendingItems', classNames.root)}>
+      <section {...props} className={cssClasses.root}>
         <HeaderComponent
-          classNames={{
-            ...classNames,
-            title: cx('ais-TrendingItems-title', classNames.title),
-          }}
+          classNames={cssClasses}
           items={items}
           translations={translations}
         />
 
         <View
-          classNames={{
-            ...classNames,
-            container: cx('ais-TrendingItems-container', classNames.container),
-            list: cx('ais-TrendingItems-list', classNames.list),
-            item: cx('ais-TrendingItems-item', classNames.item),
-          }}
+          classNames={cssClasses}
           translations={translations}
           itemComponent={ItemComponent}
           items={items}


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

FX-2860

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

Compute the classNames/cssClasses only once in the ui component, and ensure the components have access to all classes

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
