### PR TITLE
chore(hits): update banner link type

### DIFF
--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1359,7 +1359,7 @@ declare namespace algoliasearchHelper {
             /**
              * URL to navigate to when the banner is clicked
              */
-            url?: string;
+            url: string;
             /**
              * Target of the navigation
              * - `_blank` opens the URL in a new tab

--- a/packages/instantsearch-ui-components/src/components/Hits.tsx
+++ b/packages/instantsearch-ui-components/src/components/Hits.tsx
@@ -16,7 +16,7 @@ type Banner = {
     title?: string;
   };
   link?: {
-    url?: string;
+    url: string;
     target?: '_blank' | '_self';
   };
 };
@@ -36,7 +36,7 @@ function createDefaultBannerComponent({ createElement }: Renderer) {
     }
     return (
       <aside className={cx('ais-Hits-banner', classNames.bannerRoot)}>
-        {banner.link?.url ? (
+        {banner.link ? (
           <a
             className={cx('ais-Hits-banner-link', classNames.bannerLink)}
             href={banner.link.url}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This minor PR updates makes the `url` property of the new banner type (part of `SearchResults.renderingContent.widgets.banners`) required. `link` is still optional, but if `link` _is_ present then we want to ensure that the `url` is also present.

Part of [EMERCH-1370](https://algolia.atlassian.net/browse/EMERCH-1370)

**Result**

Green CI (all tests still pass)


[EMERCH-1370]: https://algolia.atlassian.net/browse/EMERCH-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ