### PR TITLE
tests(recommend): use shared mock client with recommendations in tests

### DIFF
--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/__tests__/frequently-bought-together.test.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/__tests__/frequently-bought-together.test.tsx
@@ -2,11 +2,7 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import {
-  createRecommendResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils';
 import { h } from 'preact';
 
@@ -21,7 +17,7 @@ describe('frequentlyBoughtTogether', () => {
   describe('options', () => {
     test('throws without a `container`', () => {
       expect(() => {
-        const searchClient = createSearchClient();
+        const searchClient = createMockedSearchClientWithRecommendations();
 
         const search = instantsearch({
           indexName: 'indexName',
@@ -43,7 +39,7 @@ describe('frequentlyBoughtTogether', () => {
 
     test('adds custom CSS classes', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof frequentlyBoughtTogether>[0] = {
         container,
         objectIDs: ['1'],
@@ -99,7 +95,9 @@ describe('frequentlyBoughtTogether', () => {
   describe('templates', () => {
     test('renders default templates', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations({
+        minimal: true,
+      });
       const options: Parameters<typeof frequentlyBoughtTogether>[0] = {
         container,
         objectIDs: ['1'],
@@ -177,7 +175,7 @@ describe('frequentlyBoughtTogether', () => {
 
     test('renders with templates using `html`', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof frequentlyBoughtTogether>[0] = {
         container,
         objectIDs: ['1'],
@@ -266,7 +264,7 @@ describe('frequentlyBoughtTogether', () => {
 
     test('renders with templates using JSX', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof frequentlyBoughtTogether>[0] = {
         container,
         objectIDs: ['1'],
@@ -355,26 +353,4 @@ describe('frequentlyBoughtTogether', () => {
       `);
     });
   });
-
-  function createMockedSearchClient() {
-    return createSearchClient({
-      getRecommendations: jest.fn((requests) =>
-        Promise.resolve(
-          createRecommendResponse(
-            // @ts-ignore
-            // `request` will be implicitly typed as any in type-check:v3
-            // since `getRecommendations` is not available there
-            requests.map((request) => {
-              return createSingleSearchResponse({
-                hits:
-                  request.maxRecommendations === 0
-                    ? []
-                    : [{ objectID: '1' }, { objectID: '2' }],
-              });
-            })
-          )
-        )
-      ),
-    });
-  }
 });

--- a/packages/instantsearch.js/src/widgets/looking-similar/__tests__/looking-similar.test.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/__tests__/looking-similar.test.tsx
@@ -2,11 +2,7 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import {
-  createRecommendResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils';
 import { h } from 'preact';
 
@@ -21,7 +17,7 @@ describe('lookingSimilar', () => {
   describe('options', () => {
     test('throws without a `container`', () => {
       expect(() => {
-        const searchClient = createSearchClient();
+        const searchClient = createMockedSearchClientWithRecommendations();
 
         const search = instantsearch({
           indexName: 'indexName',
@@ -43,7 +39,7 @@ describe('lookingSimilar', () => {
 
     test('adds custom CSS classes', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof lookingSimilar>[0] = {
         container,
         objectIDs: ['1'],
@@ -98,7 +94,9 @@ describe('lookingSimilar', () => {
   describe('templates', () => {
     test('renders default templates', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations({
+        minimal: true,
+      });
       const options: Parameters<typeof lookingSimilar>[0] = {
         container,
         objectIDs: ['1'],
@@ -174,7 +172,7 @@ describe('lookingSimilar', () => {
 
     test('renders with templates using `html`', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof lookingSimilar>[0] = {
         container,
         objectIDs: ['1'],
@@ -263,7 +261,7 @@ describe('lookingSimilar', () => {
 
     test('renders with templates using JSX', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof lookingSimilar>[0] = {
         container,
         objectIDs: ['1'],
@@ -352,26 +350,4 @@ describe('lookingSimilar', () => {
       `);
     });
   });
-
-  function createMockedSearchClient() {
-    return createSearchClient({
-      getRecommendations: jest.fn((requests) =>
-        Promise.resolve(
-          createRecommendResponse(
-            // @ts-ignore
-            // `request` will be implicitly typed as any in type-check:v3
-            // since `getRecommendations` is not available there
-            requests.map((request) => {
-              return createSingleSearchResponse({
-                hits:
-                  request.maxRecommendations === 0
-                    ? []
-                    : [{ objectID: '1' }, { objectID: '2' }],
-              });
-            })
-          )
-        )
-      ),
-    });
-  }
 });

--- a/packages/instantsearch.js/src/widgets/related-products/__tests__/related-products.test.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/__tests__/related-products.test.tsx
@@ -2,18 +2,12 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import {
-  createSearchClient,
-  createMultiSearchResponse,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils/wait';
 import { h } from 'preact';
 
 import instantsearch from '../../../index.es';
 import relatedProducts from '../related-products';
-
-import type { SearchClient } from 'instantsearch.js';
 
 beforeEach(() => {
   document.body.innerHTML = '';
@@ -23,7 +17,7 @@ describe('relatedProducts', () => {
   describe('options', () => {
     test('throws without a `container`', () => {
       expect(() => {
-        const searchClient = createSearchClient();
+        const searchClient = createMockedSearchClientWithRecommendations();
 
         const search = instantsearch({
           indexName: 'indexName',
@@ -45,7 +39,7 @@ describe('relatedProducts', () => {
 
     test('adds custom CSS classes', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof relatedProducts>[0] = {
         container,
         objectIDs: ['1'],
@@ -102,7 +96,9 @@ describe('relatedProducts', () => {
   describe('templates', () => {
     test('renders default templates', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations({
+        minimal: true,
+      });
       const options: Parameters<typeof relatedProducts>[0] = {
         container,
         objectIDs: ['1'],
@@ -181,7 +177,7 @@ describe('relatedProducts', () => {
 
     test('renders with templates using `html`', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof relatedProducts>[0] = {
         container,
         objectIDs: ['1'],
@@ -270,7 +266,7 @@ describe('relatedProducts', () => {
 
     test('renders with templates using JSX', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof relatedProducts>[0] = {
         container,
         objectIDs: ['1'],
@@ -360,25 +356,3 @@ describe('relatedProducts', () => {
     });
   });
 });
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          ...requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [{ objectID: '1' }, { objectID: '2' }],
-            });
-          })
-        )
-      )
-    ) as SearchClient['getRecommendations'],
-  });
-}

--- a/packages/instantsearch.js/src/widgets/trending-items/__tests__/trending-items.test.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/__tests__/trending-items.test.tsx
@@ -2,11 +2,7 @@
  * @jest-environment jsdom
  */
 /** @jsx h */
-import {
-  createSearchClient,
-  createSingleSearchResponse,
-  createRecommendResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils/wait';
 import { h } from 'preact';
 
@@ -21,7 +17,7 @@ describe('trendingItems', () => {
   describe('options', () => {
     test('throws without a `container`', () => {
       expect(() => {
-        const searchClient = createSearchClient();
+        const searchClient = createMockedSearchClientWithRecommendations();
 
         const search = instantsearch({
           indexName: 'indexName',
@@ -43,7 +39,7 @@ describe('trendingItems', () => {
 
     test('adds custom CSS classes', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof trendingItems>[0] = {
         container,
         cssClasses: {
@@ -95,7 +91,9 @@ describe('trendingItems', () => {
   describe('templates', () => {
     test('renders default templates', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations({
+        minimal: true,
+      });
       const options: Parameters<typeof trendingItems>[0] = {
         container,
       };
@@ -171,7 +169,7 @@ describe('trendingItems', () => {
 
     test('renders with templates using `html`', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof trendingItems>[0] = {
         container,
         templates: {
@@ -257,7 +255,7 @@ describe('trendingItems', () => {
 
     test('renders with templates using JSX', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: Parameters<typeof trendingItems>[0] = {
         container,
         templates: {
@@ -344,25 +342,3 @@ describe('trendingItems', () => {
     });
   });
 });
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createRecommendResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [{ objectID: '1' }, { objectID: '2' }],
-            });
-          })
-        )
-      )
-    ),
-  });
-}

--- a/packages/react-instantsearch/src/widgets/__tests__/FrequentlyBoughtTogether.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/FrequentlyBoughtTogether.test.tsx
@@ -2,22 +2,18 @@
  * @jest-environment jsdom
  */
 
-import {
-  createMultiSearchResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { InstantSearchTestWrapper } from '@instantsearch/testutils';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { FrequentlyBoughtTogether } from '../FrequentlyBoughtTogether';
 
-import type { SearchClient } from 'instantsearch.js';
-
 describe('FrequentlyBoughtTogether', () => {
   test('renders with translations', async () => {
-    const client = createMockedSearchClient();
+    const client = createMockedSearchClientWithRecommendations({
+      minimal: true,
+    });
     const { container } = render(
       <InstantSearchTestWrapper searchClient={client}>
         <FrequentlyBoughtTogether
@@ -86,25 +82,3 @@ describe('FrequentlyBoughtTogether', () => {
     expect(root).toHaveAttribute('aria-hidden', 'true');
   });
 });
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          ...requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [{ objectID: '1' }, { objectID: '2' }],
-            });
-          })
-        )
-      )
-    ) as SearchClient['getRecommendations'],
-  });
-}

--- a/packages/react-instantsearch/src/widgets/__tests__/LookingSimilar.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/LookingSimilar.test.tsx
@@ -2,22 +2,18 @@
  * @jest-environment jsdom
  */
 
-import {
-  createMultiSearchResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { InstantSearchTestWrapper } from '@instantsearch/testutils';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { LookingSimilar } from '../LookingSimilar';
 
-import type { SearchClient } from 'instantsearch.js';
-
 describe('LookingSimilar', () => {
   test('renders with translations', async () => {
-    const client = createMockedSearchClient();
+    const client = createMockedSearchClientWithRecommendations({
+      minimal: true,
+    });
     const { container } = render(
       <InstantSearchTestWrapper searchClient={client}>
         <LookingSimilar objectIDs={['1']} translations={{ title: 'My FBT' }} />
@@ -83,25 +79,3 @@ describe('LookingSimilar', () => {
     expect(root).toHaveAttribute('aria-hidden', 'true');
   });
 });
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          ...requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [{ objectID: '1' }, { objectID: '2' }],
-            });
-          })
-        )
-      )
-    ) as SearchClient['getRecommendations'],
-  });
-}

--- a/packages/react-instantsearch/src/widgets/__tests__/RelatedProducts.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/RelatedProducts.test.tsx
@@ -2,22 +2,18 @@
  * @jest-environment jsdom
  */
 
-import {
-  createMultiSearchResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { InstantSearchTestWrapper } from '@instantsearch/testutils';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { RelatedProducts } from '../RelatedProducts';
 
-import type { SearchClient } from 'instantsearch.js';
-
 describe('RelatedProducts', () => {
   test('renders with translations', async () => {
-    const client = createMockedSearchClient();
+    const client = createMockedSearchClientWithRecommendations({
+      minimal: true,
+    });
     const { container } = render(
       <InstantSearchTestWrapper searchClient={client}>
         <RelatedProducts
@@ -86,25 +82,3 @@ describe('RelatedProducts', () => {
     expect(root).toHaveAttribute('aria-hidden', 'true');
   });
 });
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          ...requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [{ objectID: '1' }, { objectID: '2' }],
-            });
-          })
-        )
-      )
-    ) as SearchClient['getRecommendations'],
-  });
-}

--- a/packages/react-instantsearch/src/widgets/__tests__/TrendingItems.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/TrendingItems.test.tsx
@@ -2,22 +2,18 @@
  * @jest-environment jsdom
  */
 
-import {
-  createMultiSearchResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { InstantSearchTestWrapper } from '@instantsearch/testutils';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
 import { TrendingItems } from '../TrendingItems';
 
-import type { SearchClient } from 'instantsearch.js';
-
 describe('TrendingItems', () => {
   test('renders with translations', async () => {
-    const client = createMockedSearchClient();
+    const client = createMockedSearchClientWithRecommendations({
+      minimal: true,
+    });
     const { container } = render(
       <InstantSearchTestWrapper searchClient={client}>
         <TrendingItems translations={{ title: 'My trending items' }} />
@@ -82,25 +78,3 @@ describe('TrendingItems', () => {
     expect(root).toHaveAttribute('aria-hidden', 'true');
   });
 });
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          ...requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [{ objectID: '1' }, { objectID: '2' }],
-            });
-          })
-        )
-      )
-    ) as SearchClient['getRecommendations'],
-  });
-}

--- a/tests/common/connectors/frequently-bought-together/options.ts
+++ b/tests/common/connectors/frequently-bought-together/options.ts
@@ -1,8 +1,4 @@
-import {
-  createMultiSearchResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils';
 import { screen } from '@testing-library/dom';
 
@@ -10,7 +6,6 @@ import { skippableDescribe } from '../../common';
 
 import type { FrequentlyBoughtTogetherConnectorSetup } from '.';
 import type { SetupOptions, TestOptions } from '../../common';
-import type { SearchClient } from 'instantsearch.js';
 
 export function createOptionsTests(
   setup: FrequentlyBoughtTogetherConnectorSetup,
@@ -21,7 +16,7 @@ export function createOptionsTests(
       const options: SetupOptions<FrequentlyBoughtTogetherConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations(),
         },
         widgetParams: {
           // @ts-expect-error
@@ -39,7 +34,7 @@ export function createOptionsTests(
     });
 
     test('forwards parameters to the client', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: SetupOptions<FrequentlyBoughtTogetherConnectorSetup> = {
         instantSearchOptions: { indexName: 'indexName', searchClient },
         widgetParams: {
@@ -79,7 +74,7 @@ export function createOptionsTests(
       const options: SetupOptions<FrequentlyBoughtTogetherConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createMockedSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations(),
         },
         widgetParams: { objectIDs: ['1'] },
       };
@@ -95,13 +90,10 @@ export function createOptionsTests(
       expect(screen.getByRole('list')).toMatchInlineSnapshot(`
         <ul>
           <li>
-            A0E200000002BLK
+            1
           </li>
           <li>
-            A0E200000001WFI
-          </li>
-          <li>
-            A0E2000000024R1
+            2
           </li>
         </ul>
       `);
@@ -111,14 +103,14 @@ export function createOptionsTests(
       const options: SetupOptions<FrequentlyBoughtTogetherConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createMockedSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations(),
         },
         widgetParams: {
           objectIDs: ['1'],
           transformItems(items) {
             return items.map((item) => ({
               ...item,
-              objectID: item.objectID.toLowerCase(),
+              objectID: `(${item.objectID})`,
             }));
           },
         },
@@ -132,125 +124,16 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(screen.getByRole('list')).toMatchInlineSnapshot(
-        `
+      expect(screen.getByRole('list')).toMatchInlineSnapshot(`
         <ul>
           <li>
-            a0e200000002blk
+            (1)
           </li>
           <li>
-            a0e200000001wfi
-          </li>
-          <li>
-            a0e2000000024r1
+            (2)
           </li>
         </ul>
-      `
-      );
+      `);
     });
-  });
-}
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          ...requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Moschino Love',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Moschino Love – Shoulder bag',
-                          },
-                        },
-                        _score: 40.87,
-                        brand: 'Moschino Love',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Moschino Love – Shoulder bag',
-                        objectID: 'A0E200000002BLK',
-                        parentID: 'JC4052PP10LB100A',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 227.5,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Gabs',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag “Sabrina“ medium Gabs',
-                          },
-                        },
-                        _score: 40.91,
-                        brand: 'Gabs',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag “Sabrina“ medium Gabs',
-                        objectID: 'A0E200000001WFI',
-                        parentID: 'SABRINA',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 210,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'La Carrie Bag',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag La Carrie Bag small black',
-                          },
-                        },
-                        _score: 39.92,
-                        brand: 'La Carrie Bag',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag La Carrie Bag small black',
-                        objectID: 'A0E2000000024R1',
-                        parentID: '151',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 161.25,
-                        },
-                      },
-                    ],
-            });
-          })
-        )
-      )
-    ) as SearchClient['getRecommendations'],
   });
 }

--- a/tests/common/connectors/looking-similar/options.ts
+++ b/tests/common/connectors/looking-similar/options.ts
@@ -1,8 +1,4 @@
-import {
-  createMultiSearchResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils';
 import { screen } from '@testing-library/dom';
 
@@ -10,7 +6,6 @@ import { skippableDescribe } from '../../common';
 
 import type { LookingSimilarConnectorSetup } from '.';
 import type { SetupOptions, TestOptions } from '../../common';
-import type { SearchClient } from 'instantsearch.js';
 
 export function createOptionsTests(
   setup: LookingSimilarConnectorSetup,
@@ -21,7 +16,7 @@ export function createOptionsTests(
       const options: SetupOptions<LookingSimilarConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations(),
         },
         // @ts-expect-error missing `objectIDs`
         widgetParams: {},
@@ -37,7 +32,7 @@ export function createOptionsTests(
     });
 
     test('forwards parameters to the client', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: SetupOptions<LookingSimilarConnectorSetup> = {
         instantSearchOptions: { indexName: 'indexName', searchClient },
         widgetParams: {
@@ -80,7 +75,7 @@ export function createOptionsTests(
       const options: SetupOptions<LookingSimilarConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createMockedSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations(),
         },
         widgetParams: { objectIDs: ['1'] },
       };
@@ -96,13 +91,10 @@ export function createOptionsTests(
       expect(screen.getByRole('list')).toMatchInlineSnapshot(`
         <ul>
           <li>
-            A0E200000002BLK
+            1
           </li>
           <li>
-            A0E200000001WFI
-          </li>
-          <li>
-            A0E2000000024R1
+            2
           </li>
         </ul>
       `);
@@ -112,14 +104,16 @@ export function createOptionsTests(
       const options: SetupOptions<LookingSimilarConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createMockedSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations({
+            minimal: true,
+          }),
         },
         widgetParams: {
           objectIDs: ['1'],
           transformItems(items) {
             return items.map((item) => ({
               ...item,
-              objectID: item.objectID.toLowerCase(),
+              objectID: `(${item.objectID})`,
             }));
           },
         },
@@ -136,120 +130,13 @@ export function createOptionsTests(
       expect(screen.getByRole('list')).toMatchInlineSnapshot(`
         <ul>
           <li>
-            a0e200000002blk
+            (1)
           </li>
           <li>
-            a0e200000001wfi
-          </li>
-          <li>
-            a0e2000000024r1
+            (2)
           </li>
         </ul>
       `);
     });
-  });
-}
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          ...requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Moschino Love',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Moschino Love – Shoulder bag',
-                          },
-                        },
-                        _score: 40.87,
-                        brand: 'Moschino Love',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Moschino Love – Shoulder bag',
-                        objectID: 'A0E200000002BLK',
-                        parentID: 'JC4052PP10LB100A',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 227.5,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Gabs',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag “Sabrina“ medium Gabs',
-                          },
-                        },
-                        _score: 40.91,
-                        brand: 'Gabs',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag “Sabrina“ medium Gabs',
-                        objectID: 'A0E200000001WFI',
-                        parentID: 'SABRINA',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 210,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'La Carrie Bag',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag La Carrie Bag small black',
-                          },
-                        },
-                        _score: 39.92,
-                        brand: 'La Carrie Bag',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag La Carrie Bag small black',
-                        objectID: 'A0E2000000024R1',
-                        parentID: '151',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 161.25,
-                        },
-                      },
-                    ],
-            });
-          })
-        )
-      )
-    ) as SearchClient['getRecommendations'],
   });
 }

--- a/tests/common/connectors/related-products/options.ts
+++ b/tests/common/connectors/related-products/options.ts
@@ -1,8 +1,4 @@
-import {
-  createMultiSearchResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils';
 import { screen } from '@testing-library/dom';
 
@@ -10,7 +6,6 @@ import { skippableDescribe } from '../../common';
 
 import type { RelatedProductsConnectorSetup } from '.';
 import type { SetupOptions, TestOptions } from '../../common';
-import type { SearchClient } from 'instantsearch.js';
 
 export function createOptionsTests(
   setup: RelatedProductsConnectorSetup,
@@ -21,7 +16,7 @@ export function createOptionsTests(
       const options: SetupOptions<RelatedProductsConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations(),
         },
         // @ts-expect-error missing `objectIDs`
         widgetParams: {},
@@ -37,7 +32,7 @@ export function createOptionsTests(
     });
 
     test('forwards parameters to the client', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: SetupOptions<RelatedProductsConnectorSetup> = {
         instantSearchOptions: { indexName: 'indexName', searchClient },
         widgetParams: {
@@ -80,7 +75,7 @@ export function createOptionsTests(
       const options: SetupOptions<RelatedProductsConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createMockedSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations(),
         },
         widgetParams: { objectIDs: ['1'] },
       };
@@ -96,13 +91,10 @@ export function createOptionsTests(
       expect(screen.getByRole('list')).toMatchInlineSnapshot(`
         <ul>
           <li>
-            A0E200000002BLK
+            1
           </li>
           <li>
-            A0E200000001WFI
-          </li>
-          <li>
-            A0E2000000024R1
+            2
           </li>
         </ul>
       `);
@@ -112,14 +104,16 @@ export function createOptionsTests(
       const options: SetupOptions<RelatedProductsConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createMockedSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations({
+            minimal: true,
+          }),
         },
         widgetParams: {
           objectIDs: ['1'],
           transformItems(items) {
             return items.map((item) => ({
               ...item,
-              objectID: item.objectID.toLowerCase(),
+              objectID: `(${item.objectID})`,
             }));
           },
         },
@@ -136,120 +130,13 @@ export function createOptionsTests(
       expect(screen.getByRole('list')).toMatchInlineSnapshot(`
         <ul>
           <li>
-            a0e200000002blk
+            (1)
           </li>
           <li>
-            a0e200000001wfi
-          </li>
-          <li>
-            a0e2000000024r1
+            (2)
           </li>
         </ul>
       `);
     });
-  });
-}
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          ...requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Moschino Love',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Moschino Love – Shoulder bag',
-                          },
-                        },
-                        _score: 40.87,
-                        brand: 'Moschino Love',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Moschino Love – Shoulder bag',
-                        objectID: 'A0E200000002BLK',
-                        parentID: 'JC4052PP10LB100A',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 227.5,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Gabs',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag “Sabrina“ medium Gabs',
-                          },
-                        },
-                        _score: 40.91,
-                        brand: 'Gabs',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag “Sabrina“ medium Gabs',
-                        objectID: 'A0E200000001WFI',
-                        parentID: 'SABRINA',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 210,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'La Carrie Bag',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag La Carrie Bag small black',
-                          },
-                        },
-                        _score: 39.92,
-                        brand: 'La Carrie Bag',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag La Carrie Bag small black',
-                        objectID: 'A0E2000000024R1',
-                        parentID: '151',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 161.25,
-                        },
-                      },
-                    ],
-            });
-          })
-        )
-      )
-    ) as SearchClient['getRecommendations'],
   });
 }

--- a/tests/common/connectors/trending-items/options.ts
+++ b/tests/common/connectors/trending-items/options.ts
@@ -1,8 +1,4 @@
-import {
-  createRecommendResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils';
 import { screen } from '@testing-library/dom';
 
@@ -17,7 +13,7 @@ export function createOptionsTests(
 ) {
   skippableDescribe('options', skippedTests, () => {
     test('forwards parameters to the client', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       const options: SetupOptions<TrendingItemsConnectorSetup> = {
         instantSearchOptions: { indexName: 'indexName', searchClient },
         widgetParams: {
@@ -51,7 +47,7 @@ export function createOptionsTests(
       const options: SetupOptions<TrendingItemsConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createMockedSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations(),
         },
         widgetParams: {},
       };
@@ -67,13 +63,10 @@ export function createOptionsTests(
       expect(screen.getByRole('list')).toMatchInlineSnapshot(`
         <ul>
           <li>
-            A0E200000002BLK
+            1
           </li>
           <li>
-            A0E200000001WFI
-          </li>
-          <li>
-            A0E2000000024R1
+            2
           </li>
         </ul>
       `);
@@ -83,13 +76,15 @@ export function createOptionsTests(
       const options: SetupOptions<TrendingItemsConnectorSetup> = {
         instantSearchOptions: {
           indexName: 'indexName',
-          searchClient: createMockedSearchClient(),
+          searchClient: createMockedSearchClientWithRecommendations({
+            minimal: true,
+          }),
         },
         widgetParams: {
           transformItems(items) {
             return items.map((item) => ({
               ...item,
-              objectID: item.objectID.toLowerCase(),
+              objectID: `(${item.objectID})`,
             }));
           },
         },
@@ -106,120 +101,13 @@ export function createOptionsTests(
       expect(screen.getByRole('list')).toMatchInlineSnapshot(`
         <ul>
           <li>
-            a0e200000002blk
+            (1)
           </li>
           <li>
-            a0e200000001wfi
-          </li>
-          <li>
-            a0e2000000024r1
+            (2)
           </li>
         </ul>
       `);
     });
-  });
-}
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createRecommendResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Moschino Love',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Moschino Love – Shoulder bag',
-                          },
-                        },
-                        _score: 40.87,
-                        brand: 'Moschino Love',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Moschino Love – Shoulder bag',
-                        objectID: 'A0E200000002BLK',
-                        parentID: 'JC4052PP10LB100A',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 227.5,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Gabs',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag “Sabrina“ medium Gabs',
-                          },
-                        },
-                        _score: 40.91,
-                        brand: 'Gabs',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag “Sabrina“ medium Gabs',
-                        objectID: 'A0E200000001WFI',
-                        parentID: 'SABRINA',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 210,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'La Carrie Bag',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag La Carrie Bag small black',
-                          },
-                        },
-                        _score: 39.92,
-                        brand: 'La Carrie Bag',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag La Carrie Bag small black',
-                        objectID: 'A0E2000000024R1',
-                        parentID: '151',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 161.25,
-                        },
-                      },
-                    ],
-            });
-          })
-        )
-      )
-    ),
   });
 }

--- a/tests/common/widgets/frequently-bought-together/options.ts
+++ b/tests/common/widgets/frequently-bought-together/options.ts
@@ -1,8 +1,4 @@
-import {
-  createRecommendResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { normalizeSnapshot } from '@instantsearch/testutils';
 import { wait } from '@testing-library/user-event/dist/utils';
 import { TAG_PLACEHOLDER } from 'instantsearch.js/es/lib/utils';
@@ -16,7 +12,7 @@ export function createOptionsTests(
 ) {
   describe('options', () => {
     test('renders with default props', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
 
       await setup({
         instantSearchOptions: {
@@ -56,34 +52,14 @@ export function createOptionsTests(
               >
                 {
           "_highlightResult": {
-            "brand": {
-              "matchLevel": "none",
-              "matchedWords": [],
-              "value": "Moschino Love"
-            },
             "name": {
               "matchLevel": "none",
               "matchedWords": [],
               "value": "&lt;em&gt;Moschino Love&lt;/em&gt; – Shoulder bag"
             }
           },
-          "_score": 40.87,
-          "brand": "Moschino Love",
-          "list_categories": [
-            "Women",
-            "Bags",
-            "Shoulder bags"
-          ],
           "name": "Moschino Love – Shoulder bag",
-          "objectID": "A0E200000002BLK",
-          "parentID": "JC4052PP10LB100A",
-          "price": {
-            "currency": "EUR",
-            "discount_level": -100,
-            "discounted_value": 0,
-            "on_sales": false,
-            "value": 227.5
-          }
+          "objectID": "1"
         }
               </li>
               <li
@@ -91,69 +67,14 @@ export function createOptionsTests(
               >
                 {
           "_highlightResult": {
-            "brand": {
-              "matchLevel": "none",
-              "matchedWords": [],
-              "value": "Gabs"
-            },
             "name": {
               "matchLevel": "none",
               "matchedWords": [],
-              "value": "Bag “Sabrina“ medium Gabs"
+              "value": "&lt;em&gt;Bag&lt;/em&gt; “Sabrina“ medium Gabs"
             }
           },
-          "_score": 40.91,
-          "brand": "Gabs",
-          "list_categories": [
-            "Women",
-            "Bags",
-            "Shoulder bags"
-          ],
           "name": "Bag “Sabrina“ medium Gabs",
-          "objectID": "A0E200000001WFI",
-          "parentID": "SABRINA",
-          "price": {
-            "currency": "EUR",
-            "discount_level": -100,
-            "discounted_value": 0,
-            "on_sales": false,
-            "value": 210
-          }
-        }
-              </li>
-              <li
-                class="ais-FrequentlyBoughtTogether-item"
-              >
-                {
-          "_highlightResult": {
-            "brand": {
-              "matchLevel": "none",
-              "matchedWords": [],
-              "value": "La Carrie Bag"
-            },
-            "name": {
-              "matchLevel": "none",
-              "matchedWords": [],
-              "value": "Bag La Carrie Bag small black"
-            }
-          },
-          "_score": 39.92,
-          "brand": "La Carrie Bag",
-          "list_categories": [
-            "Women",
-            "Bags",
-            "Shoulder bags"
-          ],
-          "name": "Bag La Carrie Bag small black",
-          "objectID": "A0E2000000024R1",
-          "parentID": "151",
-          "price": {
-            "currency": "EUR",
-            "discount_level": -100,
-            "discounted_value": 0,
-            "on_sales": false,
-            "value": 161.25
-          }
+          "objectID": "2"
         }
               </li>
             </ol>
@@ -164,7 +85,9 @@ export function createOptionsTests(
     });
 
     test('renders transformed items', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations({
+        minimal: true,
+      });
 
       await setup({
         instantSearchOptions: {
@@ -175,8 +98,8 @@ export function createOptionsTests(
           objectIDs: ['objectID'],
           transformItems(items) {
             return items.map((item) => ({
-              objectID: item.objectID,
-              __position: item.__position,
+              ...item,
+              objectID: `(${item.objectID})`,
             }));
           },
         },
@@ -209,21 +132,14 @@ export function createOptionsTests(
                 class="ais-FrequentlyBoughtTogether-item"
               >
                 {
-          "objectID": "A0E200000002BLK"
+          "objectID": "(1)"
         }
               </li>
               <li
                 class="ais-FrequentlyBoughtTogether-item"
               >
                 {
-          "objectID": "A0E200000001WFI"
-        }
-              </li>
-              <li
-                class="ais-FrequentlyBoughtTogether-item"
-              >
-                {
-          "objectID": "A0E2000000024R1"
+          "objectID": "(2)"
         }
               </li>
             </ol>
@@ -234,7 +150,7 @@ export function createOptionsTests(
     });
 
     test('passes parameters correctly', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
 
       await setup({
         instantSearchOptions: {
@@ -269,7 +185,7 @@ export function createOptionsTests(
     });
 
     test('escapes html entities when `escapeHTML` is true', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       let recommendItems: Parameters<
         NonNullable<
           Parameters<FrequentlyBoughtTogetherWidgetSetup>[0]['widgetParams']['transformItems']
@@ -313,109 +229,5 @@ export function createOptionsTests(
         value: '&lt;em&gt;Moschino Love&lt;/em&gt; – Shoulder bag',
       });
     });
-  });
-}
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createRecommendResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as any in type-check:v3
-          // since `getRecommendations` is not available there
-          requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Moschino Love',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: '<em>Moschino Love</em> – Shoulder bag',
-                          },
-                        },
-                        _score: 40.87,
-                        brand: 'Moschino Love',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Moschino Love – Shoulder bag',
-                        objectID: 'A0E200000002BLK',
-                        parentID: 'JC4052PP10LB100A',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 227.5,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Gabs',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag “Sabrina“ medium Gabs',
-                          },
-                        },
-                        _score: 40.91,
-                        brand: 'Gabs',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag “Sabrina“ medium Gabs',
-                        objectID: 'A0E200000001WFI',
-                        parentID: 'SABRINA',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 210,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'La Carrie Bag',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag La Carrie Bag small black',
-                          },
-                        },
-                        _score: 39.92,
-                        brand: 'La Carrie Bag',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag La Carrie Bag small black',
-                        objectID: 'A0E2000000024R1',
-                        parentID: '151',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 161.25,
-                        },
-                      },
-                    ],
-            });
-          })
-        )
-      )
-    ),
   });
 }

--- a/tests/common/widgets/looking-similar/options.ts
+++ b/tests/common/widgets/looking-similar/options.ts
@@ -1,8 +1,4 @@
-import {
-  createRecommendResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { normalizeSnapshot } from '@instantsearch/testutils';
 import { wait } from '@testing-library/user-event/dist/utils';
 import { TAG_PLACEHOLDER } from 'instantsearch.js/es/lib/utils';
@@ -16,7 +12,7 @@ export function createOptionsTests(
 ) {
   describe('options', () => {
     test('renders with default props', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
 
       await setup({
         instantSearchOptions: {
@@ -56,34 +52,14 @@ export function createOptionsTests(
               >
                 {
           "_highlightResult": {
-            "brand": {
-              "matchLevel": "none",
-              "matchedWords": [],
-              "value": "Moschino Love"
-            },
             "name": {
               "matchLevel": "none",
               "matchedWords": [],
               "value": "&lt;em&gt;Moschino Love&lt;/em&gt; – Shoulder bag"
             }
           },
-          "_score": 40.87,
-          "brand": "Moschino Love",
-          "list_categories": [
-            "Women",
-            "Bags",
-            "Shoulder bags"
-          ],
           "name": "Moschino Love – Shoulder bag",
-          "objectID": "A0E200000002BLK",
-          "parentID": "JC4052PP10LB100A",
-          "price": {
-            "currency": "EUR",
-            "discount_level": -100,
-            "discounted_value": 0,
-            "on_sales": false,
-            "value": 227.5
-          }
+          "objectID": "1"
         }
               </li>
               <li
@@ -91,69 +67,14 @@ export function createOptionsTests(
               >
                 {
           "_highlightResult": {
-            "brand": {
-              "matchLevel": "none",
-              "matchedWords": [],
-              "value": "Gabs"
-            },
             "name": {
               "matchLevel": "none",
               "matchedWords": [],
-              "value": "Bag “Sabrina“ medium Gabs"
+              "value": "&lt;em&gt;Bag&lt;/em&gt; “Sabrina“ medium Gabs"
             }
           },
-          "_score": 40.91,
-          "brand": "Gabs",
-          "list_categories": [
-            "Women",
-            "Bags",
-            "Shoulder bags"
-          ],
           "name": "Bag “Sabrina“ medium Gabs",
-          "objectID": "A0E200000001WFI",
-          "parentID": "SABRINA",
-          "price": {
-            "currency": "EUR",
-            "discount_level": -100,
-            "discounted_value": 0,
-            "on_sales": false,
-            "value": 210
-          }
-        }
-              </li>
-              <li
-                class="ais-LookingSimilar-item"
-              >
-                {
-          "_highlightResult": {
-            "brand": {
-              "matchLevel": "none",
-              "matchedWords": [],
-              "value": "La Carrie Bag"
-            },
-            "name": {
-              "matchLevel": "none",
-              "matchedWords": [],
-              "value": "Bag La Carrie Bag small black"
-            }
-          },
-          "_score": 39.92,
-          "brand": "La Carrie Bag",
-          "list_categories": [
-            "Women",
-            "Bags",
-            "Shoulder bags"
-          ],
-          "name": "Bag La Carrie Bag small black",
-          "objectID": "A0E2000000024R1",
-          "parentID": "151",
-          "price": {
-            "currency": "EUR",
-            "discount_level": -100,
-            "discounted_value": 0,
-            "on_sales": false,
-            "value": 161.25
-          }
+          "objectID": "2"
         }
               </li>
             </ol>
@@ -164,7 +85,9 @@ export function createOptionsTests(
     });
 
     test('renders transformed items', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations({
+        minimal: true,
+      });
 
       await setup({
         instantSearchOptions: {
@@ -175,8 +98,8 @@ export function createOptionsTests(
           objectIDs: ['objectID'],
           transformItems(items) {
             return items.map((item) => ({
-              objectID: item.objectID,
-              __position: item.__position,
+              ...item,
+              objectID: `(${item.objectID})`,
             }));
           },
         },
@@ -209,21 +132,14 @@ export function createOptionsTests(
                 class="ais-LookingSimilar-item"
               >
                 {
-          "objectID": "A0E200000002BLK"
+          "objectID": "(1)"
         }
               </li>
               <li
                 class="ais-LookingSimilar-item"
               >
                 {
-          "objectID": "A0E200000001WFI"
-        }
-              </li>
-              <li
-                class="ais-LookingSimilar-item"
-              >
-                {
-          "objectID": "A0E2000000024R1"
+          "objectID": "(2)"
         }
               </li>
             </ol>
@@ -234,7 +150,7 @@ export function createOptionsTests(
     });
 
     test('passes parameters correctly', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
 
       await setup({
         instantSearchOptions: {
@@ -275,7 +191,7 @@ export function createOptionsTests(
     });
 
     test('escapes html entities when `escapeHTML` is true', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       let recommendItems: Parameters<
         NonNullable<
           Parameters<LookingSimilarWidgetSetup>[0]['widgetParams']['transformItems']
@@ -319,109 +235,5 @@ export function createOptionsTests(
         value: '&lt;em&gt;Moschino Love&lt;/em&gt; – Shoulder bag',
       });
     });
-  });
-}
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createRecommendResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as any in type-check:v3
-          // since `getRecommendations` is not available there
-          requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Moschino Love',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: '<em>Moschino Love</em> – Shoulder bag',
-                          },
-                        },
-                        _score: 40.87,
-                        brand: 'Moschino Love',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Moschino Love – Shoulder bag',
-                        objectID: 'A0E200000002BLK',
-                        parentID: 'JC4052PP10LB100A',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 227.5,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Gabs',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag “Sabrina“ medium Gabs',
-                          },
-                        },
-                        _score: 40.91,
-                        brand: 'Gabs',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag “Sabrina“ medium Gabs',
-                        objectID: 'A0E200000001WFI',
-                        parentID: 'SABRINA',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 210,
-                        },
-                      },
-                      {
-                        _highlightResult: {
-                          brand: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'La Carrie Bag',
-                          },
-                          name: {
-                            matchLevel: 'none',
-                            matchedWords: [],
-                            value: 'Bag La Carrie Bag small black',
-                          },
-                        },
-                        _score: 39.92,
-                        brand: 'La Carrie Bag',
-                        list_categories: ['Women', 'Bags', 'Shoulder bags'],
-                        name: 'Bag La Carrie Bag small black',
-                        objectID: 'A0E2000000024R1',
-                        parentID: '151',
-                        price: {
-                          currency: 'EUR',
-                          discount_level: -100,
-                          discounted_value: 0,
-                          on_sales: false,
-                          value: 161.25,
-                        },
-                      },
-                    ],
-            });
-          })
-        )
-      )
-    ),
   });
 }

--- a/tests/common/widgets/related-products/options.ts
+++ b/tests/common/widgets/related-products/options.ts
@@ -1,14 +1,9 @@
-import {
-  createMultiSearchResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils';
 import { TAG_PLACEHOLDER } from 'instantsearch.js/es/lib/utils';
 
 import type { RelatedProductsWidgetSetup } from '.';
 import type { TestOptions } from '../../common';
-import type { SearchClient } from 'instantsearch.js';
 
 export function createOptionsTests(
   setup: RelatedProductsWidgetSetup,
@@ -16,7 +11,7 @@ export function createOptionsTests(
 ) {
   describe('options', () => {
     test('renders with default props', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
 
       await setup({
         instantSearchOptions: {
@@ -54,9 +49,12 @@ export function createOptionsTests(
                 {
           "_highlightResult": {
             "name": {
+              "matchLevel": "none",
+              "matchedWords": [],
               "value": "&lt;em&gt;Moschino Love&lt;/em&gt; – Shoulder bag"
             }
           },
+          "name": "Moschino Love – Shoulder bag",
           "objectID": "1"
         }
               </li>
@@ -64,6 +62,14 @@ export function createOptionsTests(
                 class="ais-RelatedProducts-item"
               >
                 {
+          "_highlightResult": {
+            "name": {
+              "matchLevel": "none",
+              "matchedWords": [],
+              "value": "&lt;em&gt;Bag&lt;/em&gt; “Sabrina“ medium Gabs"
+            }
+          },
+          "name": "Bag “Sabrina“ medium Gabs",
           "objectID": "2"
         }
               </li>
@@ -74,7 +80,9 @@ export function createOptionsTests(
     });
 
     test('renders transformed items', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations({
+        minimal: true,
+      });
 
       await setup({
         instantSearchOptions: {
@@ -116,11 +124,6 @@ export function createOptionsTests(
                 class="ais-RelatedProducts-item"
               >
                 {
-          "_highlightResult": {
-            "name": {
-              "value": "&lt;em&gt;Moschino Love&lt;/em&gt; – Shoulder bag"
-            }
-          },
           "objectID": "(1)"
         }
               </li>
@@ -138,7 +141,7 @@ export function createOptionsTests(
     });
 
     test('renders with no results', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
 
       await setup({
         instantSearchOptions: {
@@ -167,7 +170,7 @@ export function createOptionsTests(
     });
 
     test('passes parameters correctly', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
 
       await setup({
         instantSearchOptions: {
@@ -208,7 +211,7 @@ export function createOptionsTests(
     });
 
     test('escapes html entities when `escapeHTML` is true', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       let recommendItems: Parameters<
         NonNullable<
           Parameters<RelatedProductsWidgetSetup>[0]['widgetParams']['transformItems']
@@ -247,40 +250,10 @@ export function createOptionsTests(
       ]);
 
       expect(recommendItems[0]._highlightResult!.name).toEqual({
+        matchLevel: 'none',
+        matchedWords: [],
         value: '&lt;em&gt;Moschino Love&lt;/em&gt; – Shoulder bag',
       });
     });
-  });
-}
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          ...requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [
-                      {
-                        _highlightResult: {
-                          name: {
-                            value: '<em>Moschino Love</em> – Shoulder bag',
-                          },
-                        },
-                        objectID: '1',
-                      },
-                      { objectID: '2' },
-                    ],
-            });
-          })
-        )
-      )
-    ) as SearchClient['getRecommendations'],
   });
 }

--- a/tests/common/widgets/trending-items/options.ts
+++ b/tests/common/widgets/trending-items/options.ts
@@ -1,8 +1,4 @@
-import {
-  createRecommendResponse,
-  createSearchClient,
-  createSingleSearchResponse,
-} from '@instantsearch/mocks';
+import { createMockedSearchClientWithRecommendations } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils';
 import { TAG_PLACEHOLDER } from 'instantsearch.js/es/lib/utils';
 
@@ -15,7 +11,7 @@ export function createOptionsTests(
 ) {
   describe('options', () => {
     test('renders with default props', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
 
       await setup({
         instantSearchOptions: {
@@ -51,9 +47,12 @@ export function createOptionsTests(
                 {
           "_highlightResult": {
             "name": {
+              "matchLevel": "none",
+              "matchedWords": [],
               "value": "&lt;em&gt;Moschino Love&lt;/em&gt; – Shoulder bag"
             }
           },
+          "name": "Moschino Love – Shoulder bag",
           "objectID": "1"
         }
               </li>
@@ -61,6 +60,14 @@ export function createOptionsTests(
                 class="ais-TrendingItems-item"
               >
                 {
+          "_highlightResult": {
+            "name": {
+              "matchLevel": "none",
+              "matchedWords": [],
+              "value": "&lt;em&gt;Bag&lt;/em&gt; “Sabrina“ medium Gabs"
+            }
+          },
+          "name": "Bag “Sabrina“ medium Gabs",
           "objectID": "2"
         }
               </li>
@@ -71,7 +78,9 @@ export function createOptionsTests(
     });
 
     test('renders transformed items', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations({
+        minimal: true,
+      });
 
       await setup({
         instantSearchOptions: {
@@ -112,11 +121,6 @@ export function createOptionsTests(
                 class="ais-TrendingItems-item"
               >
                 {
-          "_highlightResult": {
-            "name": {
-              "value": "&lt;em&gt;Moschino Love&lt;/em&gt; – Shoulder bag"
-            }
-          },
           "objectID": "(1)"
         }
               </li>
@@ -134,7 +138,7 @@ export function createOptionsTests(
     });
 
     test('renders with no results', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
 
       await setup({
         instantSearchOptions: {
@@ -162,7 +166,7 @@ export function createOptionsTests(
     });
 
     test('passes parameters correctly', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
 
       await setup({
         instantSearchOptions: {
@@ -203,7 +207,7 @@ export function createOptionsTests(
     });
 
     test('escapes html entities when `escapeHTML` is true', async () => {
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClientWithRecommendations();
       let recommendItems: Parameters<
         NonNullable<
           Parameters<TrendingItemsWidgetSetup>[0]['widgetParams']['transformItems']
@@ -241,40 +245,10 @@ export function createOptionsTests(
       ]);
 
       expect(recommendItems[0]._highlightResult!.name).toEqual({
+        matchLevel: 'none',
+        matchedWords: [],
         value: '&lt;em&gt;Moschino Love&lt;/em&gt; – Shoulder bag',
       });
     });
-  });
-}
-
-function createMockedSearchClient() {
-  return createSearchClient({
-    getRecommendations: jest.fn((requests) =>
-      Promise.resolve(
-        createRecommendResponse(
-          // @ts-ignore
-          // `request` will be implicitly typed as `any` in type-check:v3
-          // since `getRecommendations` is not available there
-          requests.map((request) => {
-            return createSingleSearchResponse<any>({
-              hits:
-                request.maxRecommendations === 0
-                  ? []
-                  : [
-                      {
-                        _highlightResult: {
-                          name: {
-                            value: '<em>Moschino Love</em> – Shoulder bag',
-                          },
-                        },
-                        objectID: '1',
-                      },
-                      { objectID: '2' },
-                    ],
-            });
-          })
-        )
-      )
-    ),
   });
 }

--- a/tests/mocks/fixtures/index.ts
+++ b/tests/mocks/fixtures/index.ts
@@ -1,0 +1,1 @@
+export * from './recommendations';

--- a/tests/mocks/fixtures/recommendations.ts
+++ b/tests/mocks/fixtures/recommendations.ts
@@ -1,0 +1,68 @@
+import {
+  createRecommendResponse,
+  createSingleSearchResponse,
+} from '../createAPIResponse';
+import { createSearchClient } from '../createSearchClient';
+
+type Options = {
+  /**
+   * Returns only the `objectID` attribute of the hits when `true`.
+   *
+   * @default false
+   */
+  minimal?: boolean;
+};
+
+const fixture = [
+  {
+    _highlightResult: {
+      name: {
+        matchLevel: 'none' as const,
+        matchedWords: [],
+        value: '<em>Moschino Love</em> – Shoulder bag',
+      },
+    },
+    name: 'Moschino Love – Shoulder bag',
+    objectID: '1',
+  },
+  {
+    _highlightResult: {
+      name: {
+        matchLevel: 'none' as const,
+        matchedWords: [],
+        value: '<em>Bag</em> “Sabrina“ medium Gabs',
+      },
+    },
+    name: 'Bag “Sabrina“ medium Gabs',
+    objectID: '2',
+  },
+];
+
+export function createMockedSearchClientWithRecommendations(
+  options: Options = {}
+) {
+  const { minimal = false } = options;
+  return createSearchClient({
+    getRecommendations: jest.fn((requests) =>
+      Promise.resolve(
+        createRecommendResponse(
+          // @ts-ignore
+          // `request` will be implicitly typed as any in type-check:v3
+          // since `getRecommendations` is not available there
+          requests.map((request) => {
+            return createSingleSearchResponse({
+              hits: fixture
+                .slice(
+                  0,
+                  typeof request.maxRecommendations === 'number'
+                    ? Math.min(request.maxRecommendations, fixture.length)
+                    : fixture.length
+                )
+                .map((hit) => (minimal ? { objectID: hit.objectID } : hit)),
+            });
+          })
+        )
+      )
+    ),
+  });
+}


### PR DESCRIPTION
**Summary**

This PR moves the `createMockedSearchClient()` defined on all recommend tests into a shared location and makes it customizable.

**Result**

Mocked search client with recommendations fixture is now defined only once and can be used in all tests for recommend widgets.