### PR TITLE
fix(recommend): ensure unicity of recommend queries

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common-connectors.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-connectors.test.tsx
@@ -23,6 +23,7 @@ import {
 import instantsearch from '../index.es';
 import { refinementList } from '../widgets';
 
+import type { InstantSearch, Widget } from '../index.es';
 import type { TestOptionsMap, TestSetupsMap } from '@instantsearch/tests';
 
 type TestSuites = typeof suites;
@@ -406,7 +407,12 @@ const testSetups: TestSetupsMap<TestSuites> = {
           .join('')}</ul>`;
     });
 
-    instantsearch(instantSearchOptions)
+    const widget = customRelatedProducts({
+      container: document.body.appendChild(document.createElement('div')),
+      ...widgetParams,
+    });
+
+    const search = instantsearch(instantSearchOptions)
       .addWidgets([
         customRelatedProducts({
           container: document.body.appendChild(document.createElement('div')),
@@ -418,8 +424,11 @@ const testSetups: TestSetupsMap<TestSuites> = {
          * prevent rethrowing InstantSearch errors, so tests can be asserted.
          * IRL this isn't needed, as the error doesn't stop execution.
          */
-      })
-      .start();
+      });
+
+    addWidgetToggleUi(search, widget);
+
+    search.start();
   },
   createFrequentlyBoughtTogetherConnectorTests({
     instantSearchOptions,
@@ -435,7 +444,12 @@ const testSetups: TestSetupsMap<TestSuites> = {
       `;
     });
 
-    instantsearch(instantSearchOptions)
+    const widget = customFrequentlyBoughtTogether({
+      container: document.body.appendChild(document.createElement('div')),
+      ...widgetParams,
+    });
+
+    const search = instantsearch(instantSearchOptions)
       .addWidgets([
         customFrequentlyBoughtTogether({
           container: document.body.appendChild(document.createElement('div')),
@@ -447,8 +461,11 @@ const testSetups: TestSetupsMap<TestSuites> = {
          * prevent rethrowing InstantSearch errors, so tests can be asserted.
          * IRL this isn't needed, as the error doesn't stop execution.
          */
-      })
-      .start();
+      });
+
+    addWidgetToggleUi(search, widget);
+
+    search.start();
   },
   createTrendingItemsConnectorTests({ instantSearchOptions, widgetParams }) {
     const customTrendingItems = connectTrendingItems<{
@@ -461,7 +478,12 @@ const testSetups: TestSetupsMap<TestSuites> = {
       `;
     });
 
-    instantsearch(instantSearchOptions)
+    const widget = customTrendingItems({
+      container: document.body.appendChild(document.createElement('div')),
+      ...widgetParams,
+    });
+
+    const search = instantsearch(instantSearchOptions)
       .addWidgets([
         customTrendingItems({
           container: document.body.appendChild(document.createElement('div')),
@@ -473,8 +495,11 @@ const testSetups: TestSetupsMap<TestSuites> = {
          * prevent rethrowing InstantSearch errors, so tests can be asserted.
          * IRL this isn't needed, as the error doesn't stop execution.
          */
-      })
-      .start();
+      });
+
+    addWidgetToggleUi(search, widget);
+
+    search.start();
   },
   createLookingSimilarConnectorTests({ instantSearchOptions, widgetParams }) {
     const customLookingSimilar = connectLookingSimilar<{
@@ -487,22 +512,39 @@ const testSetups: TestSetupsMap<TestSuites> = {
       `;
     });
 
-    instantsearch(instantSearchOptions)
-      .addWidgets([
-        customLookingSimilar({
-          container: document.body.appendChild(document.createElement('div')),
-          ...widgetParams,
-        }),
-      ])
+    const widget = customLookingSimilar({
+      container: document.body.appendChild(document.createElement('div')),
+      ...widgetParams,
+    });
+
+    const search = instantsearch(instantSearchOptions)
+      .addWidgets([widget])
       .on('error', () => {
         /*
          * prevent rethrowing InstantSearch errors, so tests can be asserted.
          * IRL this isn't needed, as the error doesn't stop execution.
          */
-      })
-      .start();
+      });
+
+    addWidgetToggleUi(search, widget);
+
+    search.start();
   },
 };
+
+function addWidgetToggleUi(search: InstantSearch, widget: Widget) {
+  const button = document.createElement('button');
+  button.addEventListener('click', () => {
+    const hasWidget = search.mainIndex.getWidgets().includes(widget);
+    if (hasWidget) {
+      search.removeWidgets([widget]);
+    } else {
+      search.addWidgets([widget]);
+    }
+  });
+
+  document.body.appendChild(button);
+}
 
 const testOptions: TestOptionsMap<TestSuites> = {
   createHierarchicalMenuConnectorTests: undefined,

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
@@ -163,7 +163,7 @@ const connectFrequentlyBoughtTogether: FrequentlyBoughtTogetherConnector =
                 },
                 $$id: this.$$id!,
               }),
-            state
+            state.removeParams(this.$$id!)
           );
         },
       };

--- a/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
@@ -164,7 +164,7 @@ const connectLookingSimilar: LookingSimilarConnector =
                 },
                 $$id: this.$$id!,
               }),
-            state
+            state.removeParams(this.$$id!)
           );
         },
       };

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -165,7 +165,7 @@ const connectRelatedProducts: RelatedProductsConnector =
                 },
                 $$id: this.$$id!,
               }),
-            state
+            state.removeParams(this.$$id!)
           );
         },
       };

--- a/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
@@ -153,7 +153,7 @@ const connectTrendingItems: TrendingItemsConnector =
         },
 
         getWidgetParameters(state) {
-          return state.addTrendingItems({
+          return state.removeParams(this.$$id!).addTrendingItems({
             facetName,
             facetValue,
             maxRecommendations,

--- a/packages/react-instantsearch/src/__tests__/common-connectors.test.tsx
+++ b/packages/react-instantsearch/src/__tests__/common-connectors.test.tsx
@@ -5,7 +5,7 @@ import { runTestSuites } from '@instantsearch/tests';
 import * as suites from '@instantsearch/tests/connectors';
 import { act, render } from '@testing-library/react';
 import { connectRatingMenu } from 'instantsearch.js/es/connectors';
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   InstantSearch,
@@ -337,11 +337,17 @@ const testSetups: TestSetupsMap<TestSuites> = {
       );
     }
 
-    render(
-      <InstantSearch {...instantSearchOptions}>
-        <CustomRelatedProducts {...widgetParams} />
-      </InstantSearch>
-    );
+    function App() {
+      const [visible, setVisible] = useState(true);
+      return (
+        <InstantSearch {...instantSearchOptions}>
+          {visible && <CustomRelatedProducts {...widgetParams} />}
+          <button onClick={() => setVisible(!visible)}>toggle</button>
+        </InstantSearch>
+      );
+    }
+
+    render(<App />);
   },
   createFrequentlyBoughtTogetherConnectorTests: ({
     instantSearchOptions,
@@ -361,11 +367,17 @@ const testSetups: TestSetupsMap<TestSuites> = {
       );
     }
 
-    render(
-      <InstantSearch {...instantSearchOptions}>
-        <CustomFrequentlyBoughtTogether {...widgetParams} />
-      </InstantSearch>
-    );
+    function App() {
+      const [visible, setVisible] = useState(true);
+      return (
+        <InstantSearch {...instantSearchOptions}>
+          {visible && <CustomFrequentlyBoughtTogether {...widgetParams} />}
+          <button onClick={() => setVisible(!visible)}>toggle</button>
+        </InstantSearch>
+      );
+    }
+
+    render(<App />);
   },
   createTrendingItemsConnectorTests: ({
     instantSearchOptions,
@@ -383,11 +395,17 @@ const testSetups: TestSetupsMap<TestSuites> = {
       );
     }
 
-    render(
-      <InstantSearch {...instantSearchOptions}>
-        <CustomTrendingItems {...widgetParams} />
-      </InstantSearch>
-    );
+    function App() {
+      const [visible, setVisible] = useState(true);
+      return (
+        <InstantSearch {...instantSearchOptions}>
+          {visible && <CustomTrendingItems {...widgetParams} />}
+          <button onClick={() => setVisible(!visible)}>toggle</button>
+        </InstantSearch>
+      );
+    }
+
+    render(<App />);
   },
   createLookingSimilarConnectorTests: ({
     instantSearchOptions,
@@ -405,11 +423,17 @@ const testSetups: TestSetupsMap<TestSuites> = {
       );
     }
 
-    render(
-      <InstantSearch {...instantSearchOptions}>
-        <CustomLookingSimilar {...widgetParams} />
-      </InstantSearch>
-    );
+    function App() {
+      const [visible, setVisible] = useState(true);
+      return (
+        <InstantSearch {...instantSearchOptions}>
+          {visible && <CustomLookingSimilar {...widgetParams} />}
+          <button onClick={() => setVisible(!visible)}>toggle</button>
+        </InstantSearch>
+      );
+    }
+
+    render(<App />);
   },
 };
 

--- a/packages/vue-instantsearch/src/__tests__/common-connectors.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-connectors.test.js
@@ -420,21 +420,25 @@ const testOptions = {
   createRelatedProductsConnectorTests: {
     skippedTests: {
       options: true,
+      state: true,
     },
   },
   createFrequentlyBoughtTogetherConnectorTests: {
     skippedTests: {
       options: true,
+      state: true,
     },
   },
   createTrendingItemsConnectorTests: {
     skippedTests: {
       options: true,
+      state: true,
     },
   },
   createLookingSimilarConnectorTests: {
     skippedTests: {
       options: true,
+      state: true,
     },
   },
 };

--- a/tests/common/connectors/frequently-bought-together/index.ts
+++ b/tests/common/connectors/frequently-bought-together/index.ts
@@ -1,6 +1,7 @@
 import { fakeAct } from '../../common';
 
 import { createOptionsTests } from './options';
+import { createStateTests } from './state';
 
 import type { TestOptions, TestSetup } from '../../common';
 import type { FrequentlyBoughtTogetherConnectorParams } from 'instantsearch.js/es/connectors/frequently-bought-together/connectFrequentlyBoughtTogether';
@@ -19,5 +20,6 @@ export function createFrequentlyBoughtTogetherConnectorTests(
 
   describe('FrequentlyBoughtTogether connector common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createStateTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/connectors/frequently-bought-together/state.ts
+++ b/tests/common/connectors/frequently-bought-together/state.ts
@@ -1,0 +1,60 @@
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
+import { wait } from '@instantsearch/testutils';
+import { screen } from '@testing-library/dom';
+
+import { skippableDescribe } from '../../common';
+
+import type { FrequentlyBoughtTogetherConnectorSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createStateTests(
+  setup: FrequentlyBoughtTogetherConnectorSetup,
+  { act, skippedTests }: Required<TestOptions>
+) {
+  skippableDescribe('state', skippedTests, () => {
+    test('sets the proper number of queries', async () => {
+      const searchClient = createRecommendSearchClient();
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          objectIDs: ['1', '2'],
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(1);
+
+      // removing the widget
+      await act(async () => {
+        screen.getByRole('button').click();
+        await wait(0);
+      });
+
+      // adding the same widget again
+      await act(async () => {
+        screen.getByRole('button').click();
+        await wait(0);
+      });
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(2);
+      expect(searchClient.getRecommendations).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          objectID: '1',
+          model: 'bought-together',
+          indexName: 'indexName',
+        }),
+        expect.objectContaining({
+          objectID: '2',
+          model: 'bought-together',
+          indexName: 'indexName',
+        }),
+      ]);
+    });
+  });
+}

--- a/tests/common/connectors/looking-similar/index.ts
+++ b/tests/common/connectors/looking-similar/index.ts
@@ -1,6 +1,7 @@
 import { fakeAct } from '../../common';
 
 import { createOptionsTests } from './options';
+import { createStateTests } from './state';
 
 import type { TestOptions, TestSetup } from '../../common';
 import type { LookingSimilarConnectorParams } from 'instantsearch.js/src/connectors/looking-similar/connectLookingSimilar';
@@ -19,5 +20,6 @@ export function createLookingSimilarConnectorTests(
 
   describe('LookingSimilar connector common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createStateTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/connectors/looking-similar/state.ts
+++ b/tests/common/connectors/looking-similar/state.ts
@@ -1,0 +1,60 @@
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
+import { wait } from '@instantsearch/testutils';
+import { screen } from '@testing-library/dom';
+
+import { skippableDescribe } from '../../common';
+
+import type { LookingSimilarConnectorSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createStateTests(
+  setup: LookingSimilarConnectorSetup,
+  { act, skippedTests }: Required<TestOptions>
+) {
+  skippableDescribe('state', skippedTests, () => {
+    test('sets the proper number of queries', async () => {
+      const searchClient = createRecommendSearchClient();
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          objectIDs: ['1', '2'],
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(1);
+
+      // removing the widget
+      await act(async () => {
+        screen.getByRole('button').click();
+        await wait(0);
+      });
+
+      // adding the same widget again
+      await act(async () => {
+        screen.getByRole('button').click();
+        await wait(0);
+      });
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(2);
+      expect(searchClient.getRecommendations).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          objectID: '1',
+          model: 'looking-similar',
+          indexName: 'indexName',
+        }),
+        expect.objectContaining({
+          objectID: '2',
+          model: 'looking-similar',
+          indexName: 'indexName',
+        }),
+      ]);
+    });
+  });
+}

--- a/tests/common/connectors/related-products/index.ts
+++ b/tests/common/connectors/related-products/index.ts
@@ -1,6 +1,7 @@
 import { fakeAct } from '../../common';
 
 import { createOptionsTests } from './options';
+import { createStateTests } from './state';
 
 import type { TestOptions, TestSetup } from '../../common';
 import type { RelatedProductsConnectorParams } from 'instantsearch.js/src/connectors/related-products/connectRelatedProducts';
@@ -19,5 +20,6 @@ export function createRelatedProductsConnectorTests(
 
   describe('RelatedProducts connector common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createStateTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/connectors/related-products/state.ts
+++ b/tests/common/connectors/related-products/state.ts
@@ -1,0 +1,60 @@
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
+import { wait } from '@instantsearch/testutils';
+import { screen } from '@testing-library/dom';
+
+import { skippableDescribe } from '../../common';
+
+import type { RelatedProductsConnectorSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createStateTests(
+  setup: RelatedProductsConnectorSetup,
+  { act, skippedTests }: Required<TestOptions>
+) {
+  skippableDescribe('state', skippedTests, () => {
+    test('sets the proper number of queries', async () => {
+      const searchClient = createRecommendSearchClient();
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          objectIDs: ['1', '2'],
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(1);
+
+      // removing the widget
+      await act(async () => {
+        screen.getByRole('button').click();
+        await wait(0);
+      });
+
+      // adding the same widget again
+      await act(async () => {
+        screen.getByRole('button').click();
+        await wait(0);
+      });
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(2);
+      expect(searchClient.getRecommendations).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          objectID: '1',
+          model: 'related-products',
+          indexName: 'indexName',
+        }),
+        expect.objectContaining({
+          objectID: '2',
+          model: 'related-products',
+          indexName: 'indexName',
+        }),
+      ]);
+    });
+  });
+}

--- a/tests/common/connectors/trending-items/index.ts
+++ b/tests/common/connectors/trending-items/index.ts
@@ -1,6 +1,7 @@
 import { fakeAct } from '../../common';
 
 import { createOptionsTests } from './options';
+import { createStateTests } from './state';
 
 import type { TestOptions, TestSetup } from '../../common';
 import type { TrendingItemsConnectorParams } from 'instantsearch.js/src/connectors/trending-items/connectTrendingItems';
@@ -19,5 +20,6 @@ export function createTrendingItemsConnectorTests(
 
   describe('TrendingItems connector common tests', () => {
     createOptionsTests(setup, { act, skippedTests });
+    createStateTests(setup, { act, skippedTests });
   });
 }

--- a/tests/common/connectors/trending-items/state.ts
+++ b/tests/common/connectors/trending-items/state.ts
@@ -1,0 +1,52 @@
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
+import { wait } from '@instantsearch/testutils';
+import { screen } from '@testing-library/dom';
+
+import { skippableDescribe } from '../../common';
+
+import type { TrendingItemsConnectorSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createStateTests(
+  setup: TrendingItemsConnectorSetup,
+  { act, skippedTests }: Required<TestOptions>
+) {
+  skippableDescribe('state', skippedTests, () => {
+    test('sets the proper number of queries', async () => {
+      const searchClient = createRecommendSearchClient();
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {},
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(1);
+
+      // removing the widget
+      await act(async () => {
+        screen.getByRole('button').click();
+        await wait(0);
+      });
+
+      // adding the same widget again
+      await act(async () => {
+        screen.getByRole('button').click();
+        await wait(0);
+      });
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(2);
+      expect(searchClient.getRecommendations).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          model: 'trending-items',
+          indexName: 'indexName',
+        }),
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
**Summary**

This PR cleans up hypothethical stale queries from recommend widgets in unmount/remount scenarios.

FX-2890