### PR TITLE
fix(helper): don't send empty "tagRefinements" and "facets" parameters

### DIFF
--- a/packages/algoliasearch-helper/src/SearchResults/index.js
+++ b/packages/algoliasearch-helper/src/SearchResults/index.js
@@ -231,7 +231,7 @@ function findMatchingHierarchicalFacetFromAttributeName(
 }
  **/
 function SearchResults(state, results, options) {
-  var mainSubResponse = results[0];
+  var mainSubResponse = results[0] || {};
 
   this._rawResults = results;
 

--- a/packages/algoliasearch-helper/src/requestBuilder.js
+++ b/packages/algoliasearch-helper/src/requestBuilder.js
@@ -139,10 +139,15 @@ var requestBuilder = {
     var facetFilters = requestBuilder._getFacetFilters(state);
     var numericFilters = requestBuilder._getNumericFilters(state);
     var tagFilters = requestBuilder._getTagFilters(state);
-    var additionalParams = {
-      facets: facets.indexOf('*') > -1 ? ['*'] : facets,
-      tagFilters: tagFilters,
-    };
+    var additionalParams = {};
+
+    if (facets.length > 0) {
+      additionalParams.facets = facets.indexOf('*') > -1 ? ['*'] : facets;
+    }
+
+    if (tagFilters.length > 0) {
+      additionalParams.tagFilters = tagFilters;
+    }
 
     if (facetFilters.length > 0) {
       additionalParams.facetFilters = facetFilters;

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/derive/empty-index.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/derive/empty-index.js
@@ -27,10 +27,7 @@ describe('searches', function () {
     expect(client.search).toHaveBeenCalledWith([
       {
         indexName: 'indexName',
-        params: {
-          facets: [],
-          tagFilters: '',
-        },
+        params: {},
       },
     ]);
   });

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/findAnswers.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/findAnswers.js
@@ -96,7 +96,6 @@ test('runs findAnswers with facets', function () {
           facetFilters: ['facet1:facetValue'],
           facets: ['facet1'],
           query: 'hello',
-          tagFilters: '',
         },
       });
     });

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/getQuery.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/getQuery.js
@@ -24,7 +24,6 @@ test('getQuery', function () {
     minWordSizefor1Typo: 8,
     ignorePlurals: true,
     facets: ['df1', 'df2', 'df3', 'facet1', 'facet2', 'facet3'],
-    tagFilters: '',
     facetFilters: [
       'facet1:FACET1-VAL-1',
       'facet2:FACET2-VAL-1',

--- a/packages/algoliasearch-helper/test/spec/requestBuilder.js
+++ b/packages/algoliasearch-helper/test/spec/requestBuilder.js
@@ -152,7 +152,6 @@ test('orders parameters alphabetically in every query', function () {
       ],
       facets: ['test', 'test_disjunctive', 'test_numeric', 'whatever'],
       numericFilters: ['test_numeric>=10'],
-      tagFilters: '',
     })
   );
   expect(JSON.stringify(queries[1].params)).toBe(

--- a/packages/instantsearch.js/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
+++ b/packages/instantsearch.js/src/connectors/configure-related-items/__tests__/connectConfigureRelatedItems-test.ts
@@ -126,9 +126,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
         {
           indexName: 'indexName',
           params: {
-            facets: [],
             facetFilters: ['objectID:-1'],
-            tagFilters: '',
             sumOrFiltersScores: true,
             optionalFilters: [
               'brand:Amazon<score=3>',
@@ -168,9 +166,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
         {
           indexName: 'indexName',
           params: {
-            facets: [],
             facetFilters: ['objectID:-1'],
-            tagFilters: '',
             sumOrFiltersScores: true,
             optionalFilters: [
               'brand:Amazon<score=3>',
@@ -213,9 +209,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure-r
         {
           indexName: 'indexName',
           params: {
-            facets: [],
             facetFilters: ['objectID:-1'],
-            tagFilters: '',
             sumOrFiltersScores: true,
             optionalFilters: [
               'brand:Amazon<score=3>',
@@ -276,9 +270,7 @@ See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/`);
         {
           indexName: 'indexName',
           params: {
-            facets: [],
             facetFilters: ['objectID:-1'],
-            tagFilters: '',
             sumOrFiltersScores: true,
             optionalFilters: [
               'brand:Amazon<score=3>',

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -195,9 +195,7 @@ describe('network requests', () => {
           {
             "indexName": "indexName",
             "params": {
-              "facets": [],
               "query": "",
-              "tagFilters": "",
             },
           },
         ]
@@ -268,9 +266,7 @@ describe('network requests', () => {
           {
             "indexName": "indexName",
             "params": {
-              "facets": [],
               "query": "",
-              "tagFilters": "",
             },
           },
         ]
@@ -343,9 +339,7 @@ describe('network requests', () => {
             "indexName": "indexName",
             "params": {
               "clickAnalytics": true,
-              "facets": [],
               "query": "",
-              "tagFilters": "",
               "userToken": "cookie-key",
             },
           },
@@ -420,9 +414,7 @@ describe('network requests', () => {
             "indexName": "indexName",
             "params": {
               "clickAnalytics": true,
-              "facets": [],
               "query": "",
-              "tagFilters": "",
               "userToken": "cookie-key",
             },
           },
@@ -496,9 +488,7 @@ describe('network requests', () => {
             "indexName": "indexName",
             "params": {
               "clickAnalytics": true,
-              "facets": [],
               "query": "",
-              "tagFilters": "",
             },
           },
         ]
@@ -572,9 +562,7 @@ describe('network requests', () => {
             "indexName": "indexName",
             "params": {
               "clickAnalytics": true,
-              "facets": [],
               "query": "",
-              "tagFilters": "",
             },
           },
         ]
@@ -623,9 +611,7 @@ describe('network requests', () => {
           {
             "indexName": "indexName",
             "params": {
-              "facets": [],
               "query": "",
-              "tagFilters": "",
             },
           },
         ]

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -1289,9 +1289,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       {
         indexName: 'indexName',
         params: {
-          facets: [],
           query: '',
-          tagFilters: '',
         },
       },
     ]);

--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -291,26 +291,18 @@ describe('getInitialResults', () => {
     expect(requestParams).toMatchInlineSnapshot(`
       [
         {
-          "facets": [],
           "query": "apple",
-          "tagFilters": "",
         },
         {
-          "facets": [],
           "query": "samsung",
-          "tagFilters": "",
         },
         {
-          "facets": [],
           "hitsPerPage": 2,
           "query": "apple",
-          "tagFilters": "",
         },
         {
-          "facets": [],
           "hitsPerPage": 3,
           "query": "apple",
-          "tagFilters": "",
         },
       ]
     `);

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -846,9 +846,7 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
         {
           indexName: 'my-index',
           params: {
-            facets: [],
             query: '',
-            tagFilters: '',
           },
         },
       ]);
@@ -868,9 +866,8 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
           indexName: 'my-index',
           params: {
             clickAnalytics: true,
-            facets: [],
+
             query: '',
-            tagFilters: '',
           },
         },
       ]);

--- a/packages/react-instantsearch-core/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/InstantSearch.test.tsx
@@ -190,7 +190,7 @@ describe('InstantSearch', () => {
     expect(searchClient.search).toHaveBeenLastCalledWith([
       {
         indexName: 'indexName',
-        params: { facets: [], query: '', tagFilters: '' },
+        params: { query: '' },
       },
       {
         indexName: 'subIndexName',
@@ -198,7 +198,6 @@ describe('InstantSearch', () => {
           facets: ['brand'],
           maxValuesPerFacet: 10,
           query: '',
-          tagFilters: '',
         },
       },
     ]);
@@ -225,7 +224,7 @@ describe('InstantSearch', () => {
     expect(searchClient.search).toHaveBeenLastCalledWith([
       {
         indexName: 'indexName',
-        params: { facets: [], query: '', tagFilters: '' },
+        params: { query: '' },
       },
       {
         indexName: 'subIndexName',
@@ -233,7 +232,6 @@ describe('InstantSearch', () => {
           facets: ['brand'],
           maxValuesPerFacet: 10,
           query: '',
-          tagFilters: '',
         },
       },
     ]);

--- a/packages/react-instantsearch-core/src/server/__tests__/__snapshots__/getServerState.test.tsx.snap
+++ b/packages/react-instantsearch-core/src/server/__tests__/__snapshots__/getServerState.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`getServerState returns initialResults 1`] = `
       "highlightPreTag": "__ais-highlight__",
       "maxValuesPerFacet": 10,
       "query": "iphone",
-      "tagFilters": "",
     },
     "results": [
       {
@@ -28,7 +27,7 @@ exports[`getServerState returns initialResults 1`] = `
         "nbHits": 0,
         "nbPages": 0,
         "page": 0,
-        "params": "facetFilters=%5B%5B%22brand%3AApple%22%5D%5D&facets=%5B%22brand%22%5D&highlightPostTag=__%2Fais-highlight__&highlightPreTag=__ais-highlight__&maxValuesPerFacet=10&query=iphone&tagFilters=",
+        "params": "facetFilters=%5B%5B%22brand%3AApple%22%5D%5D&facets=%5B%22brand%22%5D&highlightPostTag=__%2Fais-highlight__&highlightPreTag=__ais-highlight__&maxValuesPerFacet=10&query=iphone",
         "processingTimeMS": 0,
         "query": "",
       },
@@ -91,7 +90,7 @@ exports[`getServerState returns initialResults 1`] = `
         "nbHits": 0,
         "nbPages": 0,
         "page": 0,
-        "params": "facetFilters=%5B%5B%22brand%3AApple%22%5D%5D&facets=%5B%22brand%22%5D&highlightPostTag=__%2Fais-highlight__&highlightPreTag=__ais-highlight__&maxValuesPerFacet=10&query=iphone&tagFilters=",
+        "params": "facetFilters=%5B%5B%22brand%3AApple%22%5D%5D&facets=%5B%22brand%22%5D&highlightPostTag=__%2Fais-highlight__&highlightPreTag=__ais-highlight__&maxValuesPerFacet=10&query=iphone",
         "processingTimeMS": 0,
         "query": "",
       },
@@ -146,7 +145,7 @@ exports[`getServerState returns initialResults 1`] = `
         "nbHits": 0,
         "nbPages": 0,
         "page": 0,
-        "params": "facetFilters=%5B%5B%22brand%3AApple%22%5D%5D&facets=%5B%22brand%22%5D&highlightPostTag=__%2Fais-highlight__&highlightPreTag=__ais-highlight__&maxValuesPerFacet=10&query=iphone&tagFilters=",
+        "params": "facetFilters=%5B%5B%22brand%3AApple%22%5D%5D&facets=%5B%22brand%22%5D&highlightPostTag=__%2Fais-highlight__&highlightPreTag=__ais-highlight__&maxValuesPerFacet=10&query=iphone",
         "processingTimeMS": 0,
         "query": "",
       },
@@ -193,7 +192,6 @@ exports[`getServerState returns initialResults 1`] = `
       "highlightPreTag": "__ais-highlight__",
       "maxValuesPerFacet": 10,
       "query": "iphone",
-      "tagFilters": "",
     },
     "results": [
       {
@@ -205,7 +203,7 @@ exports[`getServerState returns initialResults 1`] = `
         "nbHits": 0,
         "nbPages": 0,
         "page": 0,
-        "params": "facetFilters=%5B%5B%22brand%3AApple%22%5D%5D&facets=%5B%22brand%22%5D&highlightPostTag=__%2Fais-highlight__&highlightPreTag=__ais-highlight__&maxValuesPerFacet=10&query=iphone&tagFilters=",
+        "params": "facetFilters=%5B%5B%22brand%3AApple%22%5D%5D&facets=%5B%22brand%22%5D&highlightPostTag=__%2Fais-highlight__&highlightPreTag=__ais-highlight__&maxValuesPerFacet=10&query=iphone",
         "processingTimeMS": 0,
         "query": "",
       },

--- a/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
@@ -232,7 +232,6 @@ describe('getServerState', () => {
           highlightPreTag: '__ais-highlight__',
           maxValuesPerFacet: 10,
           query: 'iphone',
-          tagFilters: '',
         },
       },
       {
@@ -258,7 +257,6 @@ describe('getServerState', () => {
           highlightPreTag: '__ais-highlight__',
           maxValuesPerFacet: 10,
           query: 'iphone',
-          tagFilters: '',
         },
       },
       {
@@ -284,7 +282,6 @@ describe('getServerState', () => {
           highlightPreTag: '__ais-highlight__',
           maxValuesPerFacet: 10,
           query: 'iphone',
-          tagFilters: '',
         },
       },
       {
@@ -310,7 +307,6 @@ describe('getServerState', () => {
           highlightPreTag: '__ais-highlight__',
           maxValuesPerFacet: 10,
           query: 'iphone',
-          tagFilters: '',
         },
       },
       {
@@ -420,7 +416,6 @@ describe('getServerState', () => {
         highlightPreTag: '__ais-highlight__',
         maxValuesPerFacet: 20,
         query: '',
-        tagFilters: '',
       },
     });
 
@@ -434,7 +429,6 @@ describe('getServerState', () => {
         highlightPreTag: '__ais-highlight__',
         maxValuesPerFacet: 20,
         query: '',
-        tagFilters: '',
       },
     });
   });

--- a/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
+++ b/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
@@ -262,10 +262,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
           {
             "indexName": "hello",
             "params": {
-              "facets": [],
               "hitsPerPage": 100,
               "query": "",
-              "tagFilters": "",
             },
           },
         ]
@@ -318,10 +316,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 
               expect(state.hello).toEqual({
                 requestParams: {
-                  facets: [],
                   hitsPerPage: 100,
                   query: '',
-                  tagFilters: '',
                 },
                 results: [
                   {
@@ -347,10 +343,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
               // Parent's widgets state should not be merged into nested index state
               expect(state.nestedIndex).toEqual({
                 requestParams: {
-                  facets: [],
                   hitsPerPage: 100,
                   query: '',
-                  tagFilters: '',
                 },
                 results: [
                   {
@@ -879,10 +873,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
             {
               "indexName": "hello",
               "params": {
-                "facets": [],
                 "hitsPerPage": 100,
                 "query": "",
-                "tagFilters": "",
               },
             },
           ]
@@ -955,10 +947,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
             {
               "indexName": "hello",
               "params": {
-                "facets": [],
                 "hitsPerPage": 100,
                 "query": "",
-                "tagFilters": "",
               },
             },
           ]

--- a/tests/common/widgets/toggle-refinement/options.ts
+++ b/tests/common/widgets/toggle-refinement/options.ts
@@ -214,7 +214,6 @@ export function createOptionsTests(
             params: {
               facetFilters: [['free_shipping:true']],
               facets: ['free_shipping'],
-              tagFilters: '',
             },
           }),
         ])
@@ -233,7 +232,6 @@ export function createOptionsTests(
           expect.objectContaining({
             params: expect.objectContaining({
               facets: ['free_shipping'],
-              tagFilters: '',
             }),
           }),
         ])
@@ -278,7 +276,6 @@ export function createOptionsTests(
             params: {
               facetFilters: [['free_shipping:yes']],
               facets: ['free_shipping'],
-              tagFilters: '',
             },
           }),
         ])


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

In the first request, we are sending `facets: []` and `tagRefinements: ''` when there are no values for those queries, this isn't needed, and removed in this pull request.

This came from an assumption that we could skip queries that have no refinements, but that's not true if you're for example _only_ displaying hits

**Result**

Slightly more minimal request sent, consistent with the other parameters

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
