### PR TITLE
fix(queries): prevent network request

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "80.5 kB"
+      "maxSize": "81.5 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
@@ -18,11 +18,11 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "48.5 kB"
+      "maxSize": "49.5 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "62 kB"
+      "maxSize": "62.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -222,6 +222,8 @@ class InstantSearch<
   public _createURL: CreateURL<TUiState>;
   public _searchFunction?: InstantSearchOptions['searchFunction'];
   public _mainHelperSearch?: AlgoliaSearchHelper['search'];
+  public _hasSearchWidget: boolean = false;
+  public _hasRecommendWidget: boolean = false;
   public _insights: InstantSearchOptions['insights'];
   public middleware: Array<{
     creator: Middleware<TUiState>;
@@ -580,9 +582,15 @@ See documentation: ${createDocumentationLink({
       // under the hood, we have a different implementation. It should be
       // completely transparent for the rest of the codebase. Only this module
       // is impacted.
-      return (
-        mainHelper.searchOnlyWithDerivedHelpers() && mainHelper.recommend()
-      );
+      if (this._hasSearchWidget) {
+        mainHelper.searchOnlyWithDerivedHelpers();
+      }
+
+      if (this._hasRecommendWidget) {
+        mainHelper.recommend();
+      }
+
+      return mainHelper;
     };
 
     if (this._searchFunction) {

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -174,7 +174,7 @@ describe('network requests', () => {
         castToJestMock(searchClient.search).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
       expect(
-        castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0]
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
     });
 
@@ -203,7 +203,7 @@ describe('network requests', () => {
         ]
       `);
       expect(
-        castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0]
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
     });
 
@@ -226,8 +226,9 @@ describe('network requests', () => {
       expect(
         castToJestMock(searchClient.search).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
-      expect(castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0])
-        .toMatchInlineSnapshot(`
+      expect(
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
+      ).toMatchInlineSnapshot(`
         [
           {
             "indexName": "indexName",
@@ -274,8 +275,9 @@ describe('network requests', () => {
           },
         ]
       `);
-      expect(castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0])
-        .toMatchInlineSnapshot(`
+      expect(
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
+      ).toMatchInlineSnapshot(`
         [
           {
             "indexName": "indexName",
@@ -318,7 +320,7 @@ describe('network requests', () => {
         castToJestMock(searchClient.search).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
       expect(
-        castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0]
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
     });
 
@@ -350,7 +352,7 @@ describe('network requests', () => {
         ]
       `);
       expect(
-        castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0]
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
     });
 
@@ -374,8 +376,9 @@ describe('network requests', () => {
       expect(
         castToJestMock(searchClient.search).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
-      expect(castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0])
-        .toMatchInlineSnapshot(`
+      expect(
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
+      ).toMatchInlineSnapshot(`
         [
           {
             "indexName": "indexName",
@@ -425,8 +428,9 @@ describe('network requests', () => {
           },
         ]
       `);
-      expect(castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0])
-        .toMatchInlineSnapshot(`
+      expect(
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
+      ).toMatchInlineSnapshot(`
         [
           {
             "indexName": "indexName",
@@ -469,7 +473,7 @@ describe('network requests', () => {
         castToJestMock(searchClient.search).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
       expect(
-        castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0]
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
     });
 
@@ -500,7 +504,7 @@ describe('network requests', () => {
         ]
       `);
       expect(
-        castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0]
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
     });
 
@@ -524,8 +528,9 @@ describe('network requests', () => {
       expect(
         castToJestMock(searchClient.search).mock.calls[0]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
-      expect(castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0])
-        .toMatchInlineSnapshot(`
+      expect(
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
+      ).toMatchInlineSnapshot(`
         [
           {
             "indexName": "indexName",
@@ -574,8 +579,9 @@ describe('network requests', () => {
           },
         ]
       `);
-      expect(castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0])
-        .toMatchInlineSnapshot(`
+      expect(
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
+      ).toMatchInlineSnapshot(`
         [
           {
             "indexName": "indexName",
@@ -624,8 +630,9 @@ describe('network requests', () => {
           },
         ]
       `);
-      expect(castToJestMock(searchClient.getRecommendations).mock.calls[0]?.[0])
-        .toMatchInlineSnapshot(`
+      expect(
+        castToJestMock(searchClient.getRecommendations!).mock.calls[0]?.[0]
+      ).toMatchInlineSnapshot(`
         [
           {
             "indexName": "indexName",
@@ -649,7 +656,7 @@ describe('network requests', () => {
         castToJestMock(searchClient.search).mock.calls[1]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
       expect(
-        castToJestMock(searchClient.getRecommendations).mock.calls[1]?.[0]
+        castToJestMock(searchClient.getRecommendations!).mock.calls[1]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
 
       // Ensure that calling search() after removing all widgets doesn't trigger a new search
@@ -659,7 +666,7 @@ describe('network requests', () => {
         castToJestMock(searchClient.search).mock.calls[2]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
       expect(
-        castToJestMock(searchClient.getRecommendations).mock.calls[2]?.[0]
+        castToJestMock(searchClient.getRecommendations!).mock.calls[2]?.[0]
       ).toMatchInlineSnapshot(`undefined`);
     });
   });

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -3,6 +3,7 @@
  */
 
 import { createSearchClient } from '@instantsearch/mocks';
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
 import { castToJestMock } from '@instantsearch/testutils';
 import { wait } from '@instantsearch/testutils/wait';
 import { getByText, fireEvent } from '@testing-library/dom';
@@ -161,7 +162,7 @@ describe('errors', () => {
 describe('network requests', () => {
   describe('no insights', () => {
     it('sends no search or recommend query when there are no widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -178,7 +179,7 @@ describe('network requests', () => {
     });
 
     it('sends only one search query when there are search widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -207,7 +208,7 @@ describe('network requests', () => {
     });
 
     it('sends only one recommend query when there are recommend widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -244,7 +245,7 @@ describe('network requests', () => {
     });
 
     it('sends only one search and recommend query when there are search and recommend widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -304,7 +305,7 @@ describe('network requests', () => {
     });
 
     it('sends no search or recommend query when there are no widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -322,7 +323,7 @@ describe('network requests', () => {
     });
 
     it('sends only one search query when there are search widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -354,7 +355,7 @@ describe('network requests', () => {
     });
 
     it('sends only one recommend query when there are recommend widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -392,7 +393,7 @@ describe('network requests', () => {
     });
 
     it('sends only one search and recommend query when there are search and recommend widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -455,7 +456,7 @@ describe('network requests', () => {
     });
 
     it('sends no search or recommend query when there are no widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -473,7 +474,7 @@ describe('network requests', () => {
     });
 
     it('sends only one search query when there are search widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -504,7 +505,7 @@ describe('network requests', () => {
     });
 
     it('sends only one recommend query when there are recommend widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -542,7 +543,7 @@ describe('network requests', () => {
     });
 
     it('sends only one search and recommend query when there are search and recommend widgets', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       instantsearch({
         indexName: 'indexName',
         searchClient,
@@ -594,7 +595,7 @@ describe('network requests', () => {
 
   describe('interactive life cycle', () => {
     it('sends no queries when widgets are removed', async () => {
-      const searchClient = createSearchClient();
+      const searchClient = createRecommendSearchClient();
       const searchBoxWidget = searchBox({
         container: document.createElement('div'),
       });

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -468,6 +468,22 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         (widget) => widgets.indexOf(widget) === -1
       );
 
+      localWidgets.forEach((widget) => {
+        if (isIndexWidget(widget)) {
+          return;
+        }
+
+        if (localInstantSearchInstance && widget.dependsOn === 'recommend') {
+          localInstantSearchInstance._hasRecommendWidget = true;
+        } else if (localInstantSearchInstance) {
+          localInstantSearchInstance._hasSearchWidget = true;
+        } else if (widget.dependsOn === 'recommend') {
+          hasRecommendWidget = true;
+        } else {
+          hasSearchWidget = true;
+        }
+      });
+
       if (localInstantSearchInstance && Boolean(widgets.length)) {
         const { cleanedSearchState, cleanedRecommendState } = widgets.reduce(
           (states, widget) => {
@@ -767,9 +783,10 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
 
       // We only render index widgets if there are no results.
       // This makes sure `render` is never called with `results` being `null`.
-      let widgetsToRender = this.getResults()
-        ? localWidgets
-        : localWidgets.filter(isIndexWidget);
+      let widgetsToRender =
+        this.getResults() || derivedHelper?.lastRecommendResults
+          ? localWidgets
+          : localWidgets.filter(isIndexWidget);
 
       widgetsToRender = widgetsToRender.filter((widget) => {
         if (!widget.shouldRender) {

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -273,6 +273,8 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
   let helper: Helper | null = null;
   let derivedHelper: DerivedHelper | null = null;
   let lastValidSearchParameters: SearchParameters | null = null;
+  let hasRecommendWidget: boolean = false;
+  let hasSearchWidget: boolean = false;
 
   return {
     $$type: 'ais.index',
@@ -382,11 +384,20 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
           return;
         }
 
+        if (localInstantSearchInstance && widget.dependsOn === 'recommend') {
+          localInstantSearchInstance._hasRecommendWidget = true;
+        } else if (localInstantSearchInstance) {
+          localInstantSearchInstance._hasSearchWidget = true;
+        } else if (widget.dependsOn === 'recommend') {
+          hasRecommendWidget = true;
+        } else {
+          hasSearchWidget = true;
+        }
+
         addWidgetId(widget);
       });
 
       localWidgets = localWidgets.concat(widgets);
-
       if (localInstantSearchInstance && Boolean(widgets.length)) {
         privateHelperSetState(helper!, {
           state: getLocalWidgetsSearchParameters(localWidgets, {
@@ -733,6 +744,13 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         // because we don't trigger an initial search. We therefore need to directly
         // schedule a render that will render the results injected on the helper.
         instantSearchInstance.scheduleRender();
+      }
+
+      if (hasRecommendWidget) {
+        instantSearchInstance._hasRecommendWidget = true;
+      }
+      if (hasSearchWidget) {
+        instantSearchInstance._hasSearchWidget = true;
       }
     },
 

--- a/packages/instantsearch.js/test/createInstantSearch.ts
+++ b/packages/instantsearch.js/test/createInstantSearch.ts
@@ -44,6 +44,8 @@ export const createInstantSearch = (
     _initialResults: null,
     _createURL: jest.fn(() => '#'),
     _insights: undefined,
+    _hasRecommendWidget: false,
+    _hasSearchWidget: false,
     onStateChange: null,
     setUiState: jest.fn(),
     getUiState: jest.fn(() => ({})),

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useRelatedProducts.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useRelatedProducts.test.tsx
@@ -1,3 +1,4 @@
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
 import { createInstantSearchTestWrapper } from '@instantsearch/testutils';
 import { renderHook } from '@testing-library/react-hooks';
 
@@ -5,7 +6,9 @@ import { useRelatedProducts } from '../useRelatedProducts';
 
 describe('useRelatedProducts', () => {
   test('returns the connector render state', async () => {
-    const wrapper = createInstantSearchTestWrapper();
+    const wrapper = createInstantSearchTestWrapper({
+      searchClient: createRecommendSearchClient({ minimal: true }),
+    });
     const { result, waitForNextUpdate } = renderHook(
       () => useRelatedProducts({ objectIDs: ['1'] }),
       {
@@ -14,11 +17,13 @@ describe('useRelatedProducts', () => {
     );
 
     // Initial render state from manual `getWidgetRenderState`
-    expect(result.current).toEqual({ items: expect.any(Array) });
+    expect(result.current).toEqual({ items: [] });
 
     await waitForNextUpdate();
 
     // InstantSearch.js state from the `render` lifecycle step
-    expect(result.current).toEqual({ items: expect.any(Array) });
+    expect(result.current).toEqual({
+      items: expect.arrayContaining([{ objectID: '1' }, { objectID: '2' }]),
+    });
   });
 });

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useTrendingItems.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useTrendingItems.test.tsx
@@ -1,3 +1,4 @@
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
 import { createInstantSearchTestWrapper } from '@instantsearch/testutils';
 import { renderHook } from '@testing-library/react-hooks';
 
@@ -5,7 +6,9 @@ import { useTrendingItems } from '../useTrendingItems';
 
 describe('useTrendingItems', () => {
   test('returns the connector render state', async () => {
-    const wrapper = createInstantSearchTestWrapper();
+    const wrapper = createInstantSearchTestWrapper({
+      searchClient: createRecommendSearchClient({ minimal: true }),
+    });
     const { result, waitForNextUpdate } = renderHook(
       () => useTrendingItems({}),
       {
@@ -14,11 +17,13 @@ describe('useTrendingItems', () => {
     );
 
     // Initial render state from manual `getWidgetRenderState`
-    expect(result.current).toEqual({ items: expect.any(Array) });
+    expect(result.current).toEqual({ items: [] });
 
     await waitForNextUpdate();
 
     // InstantSearch.js state from the `render` lifecycle step
-    expect(result.current).toEqual({ items: expect.any(Array) });
+    expect(result.current).toEqual({
+      items: expect.arrayContaining([{ objectID: '1' }, { objectID: '2' }]),
+    });
   });
 });

--- a/packages/react-instantsearch/src/widgets/__tests__/FrequentlyBoughtTogether.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/FrequentlyBoughtTogether.test.tsx
@@ -24,7 +24,7 @@ describe('FrequentlyBoughtTogether', () => {
     );
 
     await waitFor(() => {
-      expect(client.search).toHaveBeenCalledTimes(1);
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
     });
 
     await waitFor(() => {

--- a/packages/react-instantsearch/src/widgets/__tests__/LookingSimilar.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/LookingSimilar.test.tsx
@@ -21,7 +21,7 @@ describe('LookingSimilar', () => {
     );
 
     await waitFor(() => {
-      expect(client.search).toHaveBeenCalledTimes(1);
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
     });
 
     await waitFor(() => {

--- a/packages/react-instantsearch/src/widgets/__tests__/RelatedProducts.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/RelatedProducts.test.tsx
@@ -24,7 +24,7 @@ describe('RelatedProducts', () => {
     );
 
     await waitFor(() => {
-      expect(client.search).toHaveBeenCalledTimes(1);
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
     });
 
     await waitFor(() => {

--- a/packages/react-instantsearch/src/widgets/__tests__/TrendingItems.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/TrendingItems.test.tsx
@@ -21,7 +21,7 @@ describe('TrendingItems', () => {
     );
 
     await waitFor(() => {
-      expect(client.search).toHaveBeenCalledTimes(1);
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
     });
 
     await waitFor(() => {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

In index and instantsearch, keep track of which type of widgets are used, and only send a request of the right type.

**Result**

If only recommend or search widgets are present, only that request is done.

This has slight further impact to ensure that a render still happens when only recommend returns results.

FX-2892

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
