### PR TITLE
feat(recommend): enable server-side rendering

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,19 +14,19 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "177.25 kB"
+      "maxSize": "177.5 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "50 kB"
+      "maxSize": "50.5 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "62.75 kB"
+      "maxSize": "63.25 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "67.25 kB"
+      "maxSize": "67.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",

--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -44,6 +44,7 @@ declare namespace algoliasearchHelper {
     recommendState: RecommendParameters;
     lastResults: SearchResults | null;
     lastRecommendResults: RecommendResults | null;
+    _recommendCache: RecommendResults['_rawResults'];
     derivedHelpers: DerivedHelper[];
 
     on(
@@ -1602,12 +1603,13 @@ declare namespace algoliasearchHelper {
     RecommendQueriesResponse<TObject>['results'];
 
   type RecommendResultItem<TObject = any> = RecommendResponse<TObject>[0];
+  type RecommendResultMap<T> = { [index: number]: RecommendResultItem<T> };
 
   export class RecommendResults<T = any> {
-    constructor(state: RecommendParameters, results: RecommendResponse<T>);
+    constructor(state: RecommendParameters, results: RecommendResultMap<T>);
 
     _state: RecommendParameters;
-    _rawResults: RecommendResponse<T>;
+    _rawResults: RecommendResultMap<T>;
 
     [index: number]: RecommendResultItem<T>;
   }

--- a/packages/algoliasearch-helper/index.js
+++ b/packages/algoliasearch-helper/index.js
@@ -2,6 +2,7 @@
 
 var AlgoliaSearchHelper = require('./src/algoliasearch.helper');
 var RecommendParameters = require('./src/RecommendParameters');
+var RecommendResults = require('./src/RecommendResults');
 var SearchParameters = require('./src/SearchParameters');
 var SearchResults = require('./src/SearchResults');
 
@@ -75,5 +76,12 @@ algoliasearchHelper.RecommendParameters = RecommendParameters;
  * @type {SearchResults}
  */
 algoliasearchHelper.SearchResults = SearchResults;
+
+/**
+ * Constructor for the object containing the results for Recommend.
+ * @member module:algoliasearchHelper.RecommendResults
+ * @type {RecommendResults}
+ */
+algoliasearchHelper.RecommendResults = RecommendResults;
 
 module.exports = algoliasearchHelper;

--- a/packages/algoliasearch-helper/src/RecommendResults/index.js
+++ b/packages/algoliasearch-helper/src/RecommendResults/index.js
@@ -10,7 +10,7 @@
  **/
 function RecommendResults(state, results) {
   this._state = state;
-  this._rawResults = results;
+  this._rawResults = {};
 
   // eslint-disable-next-line consistent-this
   var self = this;
@@ -18,6 +18,7 @@ function RecommendResults(state, results) {
   state.params.forEach(function (param) {
     var id = param.$$id;
     self[id] = results[id];
+    self._rawResults[id] = results[id];
   });
 }
 

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -142,7 +142,7 @@ function AlgoliaSearchHelper(client, index, options, searchResultsOptions) {
   this._currentNbQueries = 0;
   this._currentNbRecommendQueries = 0;
   this._searchResultsOptions = searchResultsOptions;
-  this.recommendCache = {};
+  this._recommendCache = {};
 }
 
 inherits(AlgoliaSearchHelper, EventEmitter);
@@ -1591,7 +1591,7 @@ AlgoliaSearchHelper.prototype._recommend = function () {
     },
   });
 
-  var cache = this.recommendCache;
+  var cache = this._recommendCache;
 
   var derivedQueries = this.derivedHelpers.map(function (derivedHelper) {
     var derivedIndex = derivedHelper.getModifiedState(searchState).index;
@@ -1744,7 +1744,7 @@ AlgoliaSearchHelper.prototype._dispatchRecommendResponse = function (
 
   if (this._currentNbRecommendQueries === 0) this.emit('recommendQueueEmpty');
 
-  var cache = this.recommendCache;
+  var cache = this._recommendCache;
 
   var idsMap = {};
   ids

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -14,6 +14,7 @@ import {
   createDocumentationMessageGenerator,
   createDocumentationLink,
   defer,
+  hydrateRecommendCache,
   hydrateSearchClient,
   noop,
   warning,
@@ -661,6 +662,7 @@ See documentation: ${createDocumentationLink({
 
     if (this._initialResults) {
       hydrateSearchClient(this.client, this._initialResults);
+      hydrateRecommendCache(this.mainHelper, this._initialResults);
 
       const originalScheduleSearch = this.scheduleSearch;
       // We don't schedule a first search when initial results are provided

--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -99,7 +99,7 @@ describe('getInitialResults', () => {
     const search = instantsearch({
       indexName: 'indexName',
       searchClient: createSearchClient(),
-    });
+    }).addWidgets([connectSearchBox(() => {})({})]);
 
     search.start();
 
@@ -118,6 +118,7 @@ describe('getInitialResults', () => {
           index: 'indexName',
           numericRefinements: {},
           tagRefinements: [],
+          query: '',
         },
         results: [
           {
@@ -140,7 +141,9 @@ describe('getInitialResults', () => {
   test('returns the current results from one non-rootindex', async () => {
     const search = instantsearch({
       searchClient: createSearchClient(),
-    }).addWidgets([index({ indexName: 'indexName' })]);
+    })
+      .addWidgets([connectSearchBox(() => {})({})])
+      .addWidgets([index({ indexName: 'indexName' })]);
 
     search.start();
 
@@ -182,7 +185,7 @@ describe('getInitialResults', () => {
     const search = instantsearch({
       indexName: 'indexName',
       searchClient: createSearchClient(),
-    });
+    }).addWidgets([connectSearchBox(() => {})({})]);
 
     search.addWidgets([index({ indexName: 'indexName2' })]);
 
@@ -203,6 +206,7 @@ describe('getInitialResults', () => {
           index: 'indexName',
           numericRefinements: {},
           tagRefinements: [],
+          query: '',
         },
         results: [
           {

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -12,7 +12,8 @@ import type {
  * in `getServerState()`.
  */
 export function waitForResults(
-  search: InstantSearch
+  search: InstantSearch,
+  skipRecommend: boolean = false
 ): Promise<SearchOptions[]> {
   const helper = search.mainHelper!;
 
@@ -21,19 +22,32 @@ export function waitForResults(
   let requestParamsList: SearchOptions[];
   const client = helper.getClient();
   helper.setClient({
+    ...client,
     search(queries) {
       requestParamsList = queries.map(({ params }) => params!);
       return client.search(queries);
     },
   });
 
-  helper.searchOnlyWithDerivedHelpers();
+  search._hasSearchWidget && helper.searchOnlyWithDerivedHelpers();
+  !skipRecommend && search._hasRecommendWidget && helper.recommend();
 
   return new Promise((resolve, reject) => {
+    let searchResultsReceived = !search._hasSearchWidget;
+    let recommendResultsReceived = !search._hasRecommendWidget || skipRecommend;
     // All derived helpers resolve in the same tick so we're safe only relying
     // on the first one.
     helper.derivedHelpers[0].on('result', () => {
-      resolve(requestParamsList);
+      searchResultsReceived = true;
+      if (recommendResultsReceived) {
+        resolve(requestParamsList!);
+      }
+    });
+    helper.derivedHelpers[0].on('recommend:result', () => {
+      recommendResultsReceived = true;
+      if (searchResultsReceived) {
+        resolve(requestParamsList!);
+      }
     });
 
     // However, we listen to errors that can happen on any derived helper because
@@ -68,13 +82,23 @@ export function getInitialResults(
   let requestParamsIndex = 0;
   walkIndex(rootIndex, (widget) => {
     const searchResults = widget.getResults();
-    if (searchResults) {
+    const recommendResults = widget.getHelper()?.lastRecommendResults;
+    if (searchResults || recommendResults) {
       const requestParams = requestParamsList?.[requestParamsIndex++];
       initialResults[widget.getIndexId()] = {
         // We convert the Helper state to a plain object to pass parsable data
         // structures from server to client.
-        state: { ...searchResults._state },
-        results: searchResults._rawResults,
+        ...(searchResults && {
+          state: { ...searchResults._state },
+          results: searchResults._rawResults,
+        }),
+        ...(recommendResults && {
+          recommendResults: {
+            // We have to stringify + parse because of some explicitly undefined values.
+            params: JSON.parse(JSON.stringify(recommendResults._state.params)),
+            results: recommendResults._rawResults,
+          },
+        }),
         ...(requestParams && { requestParams }),
       };
     }

--- a/packages/instantsearch.js/src/lib/utils/__tests__/hydrateRecommendCache-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/hydrateRecommendCache-test.ts
@@ -2,13 +2,15 @@ import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
 import algoliaSearchHelper from 'algoliasearch-helper';
 
 import { hydrateRecommendCache } from '../hydrateRecommendCache';
 
 describe('hydrateRecommendCache', () => {
-  it('should hydrate the helper with the recommend cache', () => {
-    const helper = algoliaSearchHelper(createSearchClient(), '');
+  it('should hydrate the helper with the recommend cache', async () => {
+    const searchClient = createSearchClient();
+    const helper = algoliaSearchHelper(searchClient, '');
 
     const response0 = createSingleSearchResponse();
     const response1 = createSingleSearchResponse();
@@ -32,5 +34,26 @@ describe('hydrateRecommendCache', () => {
       0: response0,
       1: response1,
     });
+
+    helper.recommend();
+
+    await wait(0);
+
+    expect(searchClient.getRecommendations).not.toHaveBeenCalled();
+  });
+
+  it('should handle empty responses', async () => {
+    const searchClient = createSearchClient();
+    const helper = algoliaSearchHelper(searchClient, '');
+
+    hydrateRecommendCache(helper, {
+      a: {},
+    });
+
+    helper.addFrequentlyBoughtTogether({ $$id: 0, objectID: 'a' }).recommend();
+
+    await wait(0);
+
+    expect(searchClient.getRecommendations).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/instantsearch.js/src/lib/utils/__tests__/hydrateRecommendCache-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/hydrateRecommendCache-test.ts
@@ -1,0 +1,36 @@
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import algoliaSearchHelper from 'algoliasearch-helper';
+
+import { hydrateRecommendCache } from '../hydrateRecommendCache';
+
+describe('hydrateRecommendCache', () => {
+  it('should hydrate the helper with the recommend cache', () => {
+    const helper = algoliaSearchHelper(createSearchClient(), '');
+
+    const response0 = createSingleSearchResponse();
+    const response1 = createSingleSearchResponse();
+
+    hydrateRecommendCache(helper, {
+      a: {
+        recommendResults: {
+          params: [{ $$id: 0, objectID: '1' }],
+          results: { 0: response0 },
+        },
+      },
+      b: {
+        recommendResults: {
+          params: [{ $$id: 1, objectID: '2' }],
+          results: { 1: response1 },
+        },
+      },
+    });
+
+    expect(helper._recommendCache).toEqual({
+      0: response0,
+      1: response1,
+    });
+  });
+});

--- a/packages/instantsearch.js/src/lib/utils/__tests__/hydrateSearchClient-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/hydrateSearchClient-test.ts
@@ -147,4 +147,24 @@ describe('hydrateSearchClient', () => {
       } as unknown as InitialResults);
     }).not.toThrow();
   });
+
+  it('should not throw if state or results are missing', () => {
+    const setCache = jest.fn();
+    client = {
+      transporter: { responsesCache: { set: setCache } },
+      addAlgoliaAgent: jest.fn(),
+    } as unknown as SearchClient;
+
+    hydrateSearchClient(client, {
+      instant_search: {},
+    } as unknown as InitialResults);
+
+    expect(setCache).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: [[]],
+        method: 'search',
+      }),
+      { results: [] }
+    );
+  });
 });

--- a/packages/instantsearch.js/src/lib/utils/addWidgetId.ts
+++ b/packages/instantsearch.js/src/lib/utils/addWidgetId.ts
@@ -9,3 +9,7 @@ export function addWidgetId(widget: Widget) {
 
   widget.$$id = id++;
 }
+
+export function resetWidgetId() {
+  id = 0;
+}

--- a/packages/instantsearch.js/src/lib/utils/hydrateRecommendCache.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateRecommendCache.ts
@@ -9,7 +9,7 @@ export function hydrateRecommendCache(
     (acc, indexName) => {
       const initialResult = initialResults[indexName];
       if (initialResult.recommendResults) {
-        return { ...acc, ...initialResult.recommendResults.results };
+        return Object.assign(acc, initialResult.recommendResults.results);
       }
       return acc;
     },

--- a/packages/instantsearch.js/src/lib/utils/hydrateRecommendCache.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateRecommendCache.ts
@@ -9,7 +9,8 @@ export function hydrateRecommendCache(
     (acc, indexName) => {
       const initialResult = initialResults[indexName];
       if (initialResult.recommendResults) {
-        return Object.assign(acc, initialResult.recommendResults.results);
+        // @MAJOR: Use `Object.assign` instead of spread operator
+        return { ...acc, ...initialResult.recommendResults.results };
       }
       return acc;
     },

--- a/packages/instantsearch.js/src/lib/utils/hydrateRecommendCache.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateRecommendCache.ts
@@ -1,0 +1,19 @@
+import type { InitialResults } from '../../types';
+import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
+
+export function hydrateRecommendCache(
+  helper: AlgoliaSearchHelper,
+  initialResults: InitialResults
+) {
+  const recommendCache = Object.keys(initialResults).reduce(
+    (acc, indexName) => {
+      const initialResult = initialResults[indexName];
+      if (initialResult.recommendResults) {
+        return { ...acc, ...initialResult.recommendResults.results };
+      }
+      return acc;
+    },
+    {}
+  );
+  helper._recommendCache = recommendCache;
+}

--- a/packages/instantsearch.js/src/lib/utils/index.ts
+++ b/packages/instantsearch.js/src/lib/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './addWidgetId';
 export * from './capitalize';
 export * from './checkIndexUiState';
 export * from './checkRendering';
@@ -27,6 +28,7 @@ export * from './getRefinements';
 export * from './getWidgetAttribute';
 export * from './hits-absolute-position';
 export * from './hits-query-id';
+export * from './hydrateRecommendCache';
 export * from './hydrateSearchClient';
 export * from './isDomElement';
 export * from './isEqual';

--- a/packages/instantsearch.js/src/types/results.ts
+++ b/packages/instantsearch.js/src/types/results.ts
@@ -1,6 +1,8 @@
 import type { SearchOptions } from './algoliasearch';
 import type {
   PlainSearchParameters,
+  RecommendParametersOptions,
+  RecommendResults,
   SearchForFacetValues,
   SearchResults,
 } from 'algoliasearch-helper';
@@ -93,8 +95,12 @@ export type NumericRefinement = {
 export type Refinement = FacetRefinement | NumericRefinement;
 
 type InitialResult = {
-  state: PlainSearchParameters;
-  results: SearchResults['_rawResults'];
+  state?: PlainSearchParameters;
+  results?: SearchResults['_rawResults'];
+  recommendResults?: {
+    params: RecommendParametersOptions['params'];
+    results: RecommendResults['_rawResults'];
+  };
   requestParams?: SearchOptions;
 };
 

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -11,6 +11,7 @@ import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
   RecommendParameters,
+  RecommendResults,
 } from 'algoliasearch-helper';
 
 import { castToJestMock } from '../../../../../../tests/utils';
@@ -3471,6 +3472,62 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       expect(derivedHelperResults).toBeInstanceOf(SearchResults);
       expect(helperResults).toEqual(expectedResults);
       expect(helperResults).toBeInstanceOf(SearchResults);
+    });
+
+    it('injects recommend results to the index helper', () => {
+      const search = instantsearch({
+        indexName: 'indexName',
+        searchClient: createSearchClient(),
+      });
+      search._initialResults = {
+        indexName: {
+          recommendResults: {
+            params: [{ $$id: 0, objectID: '1' }],
+            results: {
+              0: createSingleSearchResponse({ hits: [{ objectID: '1' }] }),
+            },
+          },
+        },
+      };
+
+      search.start();
+
+      const expectedResults = {
+        _rawResults: {
+          0: {
+            exhaustiveFacetsCount: true,
+            exhaustiveNbHits: true,
+            hits: [{ objectID: '1' }],
+            hitsPerPage: 20,
+            nbHits: 1,
+            nbPages: 1,
+            page: 0,
+            params: '',
+            processingTimeMS: 0,
+            query: '',
+          },
+        },
+        _state: {
+          params: [{ $$id: 0, objectID: '1' }],
+        },
+        0: {
+          exhaustiveFacetsCount: true,
+          exhaustiveNbHits: true,
+          hits: [{ objectID: '1' }],
+          hitsPerPage: 20,
+          nbHits: 1,
+          nbPages: 1,
+          page: 0,
+          params: '',
+          processingTimeMS: 0,
+          query: '',
+        },
+      };
+
+      const helperResults = search.mainIndex.getHelper()!.lastRecommendResults;
+
+      expect(helperResults).toEqual(expectedResults);
+      expect(helperResults).toBeInstanceOf(RecommendResults);
     });
 
     it('supports nested indices', () => {

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -645,7 +645,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       const indexInitialResults =
         instantSearchInstance._initialResults?.[this.getIndexId()];
 
-      if (indexInitialResults) {
+      if (indexInitialResults?.results) {
         // We restore the shape of the results provided to the instance to respect
         // the helper's structure.
         const results = new algoliasearchHelper.SearchResults(
@@ -655,6 +655,17 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
 
         derivedHelper.lastResults = results;
         helper.lastResults = results;
+      }
+
+      if (indexInitialResults?.recommendResults) {
+        const recommendResults = new algoliasearchHelper.RecommendResults(
+          new algoliasearchHelper.RecommendParameters({
+            params: indexInitialResults.recommendResults.params,
+          }),
+          indexInitialResults.recommendResults.results
+        );
+        derivedHelper.lastRecommendResults = recommendResults;
+        helper.lastRecommendResults = recommendResults;
       }
 
       // Subscribe to the Helper state changes for the page before widgets

--- a/packages/react-instantsearch-core/src/components/InstantSearchSSRProvider.tsx
+++ b/packages/react-instantsearch-core/src/components/InstantSearchSSRProvider.tsx
@@ -30,6 +30,8 @@ export function InstantSearchSSRProvider<
     TRouteState
   > | null>(null);
 
+  const recommendIdx = React.useRef(0);
+
   // When <DynamicWidgets> is mounted, a second provider is used above the user-land
   // <InstantSearchSSRProvider> in `getServerState()`.
   // To avoid the user's provider overriding the context value with an empty object,
@@ -39,7 +41,9 @@ export function InstantSearchSSRProvider<
   }
 
   return (
-    <InstantSearchSSRContext.Provider value={{ ...props, ssrSearchRef }}>
+    <InstantSearchSSRContext.Provider
+      value={{ ...props, ssrSearchRef, recommendIdx }}
+    >
       {children}
     </InstantSearchSSRContext.Provider>
   );

--- a/packages/react-instantsearch-core/src/components/InstantSearchSSRProvider.tsx
+++ b/packages/react-instantsearch-core/src/components/InstantSearchSSRProvider.tsx
@@ -30,6 +30,7 @@ export function InstantSearchSSRProvider<
     TRouteState
   > | null>(null);
 
+  // This is used to re-map the result index to the requesting widget
   const recommendIdx = React.useRef(0);
 
   // When <DynamicWidgets> is mounted, a second provider is used above the user-land

--- a/packages/react-instantsearch-core/src/lib/InstantSearchSSRContext.ts
+++ b/packages/react-instantsearch-core/src/lib/InstantSearchSSRContext.ts
@@ -13,6 +13,7 @@ export type InstantSearchSSRContextApi<
     TUiState,
     TRouteState
   > | null>;
+  recommendIdx: MutableRefObject<number>;
 };
 
 export const InstantSearchSSRContext = createContext<Partial<

--- a/packages/react-instantsearch-core/src/lib/getIndexSearchResults.ts
+++ b/packages/react-instantsearch-core/src/lib/getIndexSearchResults.ts
@@ -25,5 +25,6 @@ export function getIndexSearchResults(indexWidget: IndexWidget) {
   return {
     results,
     scopedResults,
+    recommendResults: helper.lastRecommendResults,
   };
 }

--- a/packages/react-instantsearch-core/src/lib/useSearchResults.ts
+++ b/packages/react-instantsearch-core/src/lib/useSearchResults.ts
@@ -16,9 +16,13 @@ export type SearchResultsApi = {
 export function useSearchResults(): SearchResultsApi {
   const search = useInstantSearchContext();
   const searchIndex = useIndexContext();
-  const [searchResults, setSearchResults] = useState(() =>
-    getIndexSearchResults(searchIndex)
-  );
+  const [searchResults, setSearchResults] = useState(() => {
+    const indexSearchResults = getIndexSearchResults(searchIndex);
+    return {
+      results: indexSearchResults.results,
+      scopedResults: indexSearchResults.scopedResults,
+    };
+  });
 
   useEffect(() => {
     function handleRender() {

--- a/packages/react-instantsearch-core/src/lib/useSearchResults.ts
+++ b/packages/react-instantsearch-core/src/lib/useSearchResults.ts
@@ -18,6 +18,7 @@ export function useSearchResults(): SearchResultsApi {
   const searchIndex = useIndexContext();
   const [searchResults, setSearchResults] = useState(() => {
     const indexSearchResults = getIndexSearchResults(searchIndex);
+    // We do this not to leak `recommendResults` in the API.
     return {
       results: indexSearchResults.results,
       scopedResults: indexSearchResults.scopedResults,

--- a/packages/react-instantsearch-core/src/server/getServerState.tsx
+++ b/packages/react-instantsearch-core/src/server/getServerState.tsx
@@ -2,7 +2,7 @@ import {
   getInitialResults,
   waitForResults,
 } from 'instantsearch.js/es/lib/server';
-import { walkIndex } from 'instantsearch.js/es/lib/utils';
+import { walkIndex, resetWidgetId } from 'instantsearch.js/es/lib/utils';
 import React from 'react';
 
 import { InstantSearchServerContext, InstantSearchSSRProvider } from '..';
@@ -32,6 +32,8 @@ export function getServerState(
   const searchRef: SearchRef = {
     current: undefined,
   };
+
+  resetWidgetId();
 
   const createNotifyServer = () => {
     let hasBeenNotified = false;
@@ -71,6 +73,8 @@ export function getServerState(
     });
 
     if (shouldRefetch) {
+      resetWidgetId();
+
       return execute({
         children: (
           <InstantSearchSSRProvider {...serverState}>
@@ -80,6 +84,7 @@ export function getServerState(
         renderToString,
         searchRef,
         notifyServer: createNotifyServer(),
+        skipRecommend: true,
       });
     }
 
@@ -92,6 +97,7 @@ type ExecuteArgs = {
   renderToString: RenderToString;
   notifyServer: InstantSearchServerContextApi<UiState, UiState>['notifyServer'];
   searchRef: SearchRef;
+  skipRecommend?: boolean;
 };
 
 function execute({
@@ -99,6 +105,7 @@ function execute({
   renderToString,
   notifyServer,
   searchRef,
+  skipRecommend,
 }: ExecuteArgs) {
   return Promise.resolve()
     .then(() => {
@@ -127,7 +134,7 @@ function execute({
         );
       }
 
-      return waitForResults(searchRef.current);
+      return waitForResults(searchRef.current, skipRecommend);
     })
     .then((requestParamsList) => {
       return {

--- a/packages/react-instantsearch-nextjs/src/TriggerSearch.ts
+++ b/packages/react-instantsearch-nextjs/src/TriggerSearch.ts
@@ -8,7 +8,9 @@ export function TriggerSearch() {
   const waitForResultsRef = useRSCContext();
 
   if (waitForResultsRef?.current?.status === 'pending') {
-    instantsearch.mainHelper?.searchOnlyWithDerivedHelpers();
+    instantsearch._hasSearchWidget &&
+      instantsearch.mainHelper?.searchOnlyWithDerivedHelpers();
+    instantsearch._hasRecommendWidget && instantsearch.mainHelper?.recommend();
   }
 
   return null;

--- a/packages/react-instantsearch-nextjs/src/__tests__/InitializePromise.test.tsx
+++ b/packages/react-instantsearch-nextjs/src/__tests__/InitializePromise.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { act, render } from '@testing-library/react';
+import * as utils from 'instantsearch.js/es/lib/utils';
+import { ServerInsertedHTMLContext } from 'next/navigation';
+import React from 'react';
+import { SearchBox, TrendingItems } from 'react-instantsearch';
+import {
+  InstantSearch,
+  InstantSearchRSCContext,
+  InstantSearchSSRProvider,
+} from 'react-instantsearch-core';
+
+import { InitializePromise } from '../InitializePromise';
+import { TriggerSearch } from '../TriggerSearch';
+
+import type { PromiseWithState } from 'react-instantsearch-core';
+
+jest.mock('instantsearch.js/es/lib/utils', () => ({
+  ...jest.requireActual('instantsearch.js/es/lib/utils'),
+  resetWidgetId: jest.fn(),
+}));
+
+const renderComponent = ({
+  children,
+  ref = { current: null },
+}: {
+  children?: React.ReactNode;
+  ref?: { current: PromiseWithState<void> | null };
+} = {}) => {
+  const client = createSearchClient({
+    getRecommendations: jest.fn().mockResolvedValue({
+      results: [createSingleSearchResponse()],
+    }),
+  });
+  render(
+    <InstantSearchRSCContext.Provider value={ref}>
+      <InstantSearchSSRProvider>
+        <InstantSearch searchClient={client} indexName="indexName">
+          <ServerInsertedHTMLContext.Provider value={() => {}}>
+            <InitializePromise />
+            {children}
+            <TriggerSearch />
+          </ServerInsertedHTMLContext.Provider>
+        </InstantSearch>
+      </InstantSearchSSRProvider>
+    </InstantSearchRSCContext.Provider>
+  );
+  return client;
+};
+
+test('it calls resetWidgetId', () => {
+  renderComponent();
+
+  expect(utils.resetWidgetId).toHaveBeenCalledTimes(1);
+});
+
+test('it waits for both search and recommend results', async () => {
+  const ref: { current: PromiseWithState<void> | null } = { current: null };
+
+  const client = renderComponent({
+    ref,
+    children: (
+      <>
+        <SearchBox />
+        <TrendingItems />
+      </>
+    ),
+  });
+
+  await act(async () => {
+    await ref.current;
+  });
+
+  expect(ref.current!.status).toBe('fulfilled');
+  expect(client.search).toHaveBeenCalledTimes(1);
+  expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+});
+
+test('it waits for search only if there are only search widgets', async () => {
+  const ref: { current: PromiseWithState<void> | null } = { current: null };
+
+  const client = renderComponent({
+    ref,
+    children: (
+      <>
+        <SearchBox />
+      </>
+    ),
+  });
+
+  await act(async () => {
+    await ref.current;
+  });
+
+  expect(ref.current!.status).toBe('fulfilled');
+  expect(client.search).toHaveBeenCalledTimes(1);
+  expect(client.getRecommendations).not.toHaveBeenCalled();
+});
+
+test('it waits for recommend only if there are only recommend widgets', async () => {
+  const ref: { current: PromiseWithState<void> | null } = { current: null };
+
+  const client = renderComponent({
+    ref,
+    children: (
+      <>
+        <TrendingItems />
+      </>
+    ),
+  });
+
+  await act(async () => {
+    await ref.current;
+  });
+
+  expect(ref.current!.status).toBe('fulfilled');
+  expect(client.search).not.toHaveBeenCalled();
+  expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+});
+
+afterAll(() => {
+  jest.resetAllMocks();
+});

--- a/tsconfig.v3.json
+++ b/tsconfig.v3.json
@@ -22,6 +22,7 @@
     "packages/instantsearch.js/src/connectors/menu/__tests__/connectMenu-test.ts",
     "packages/instantsearch.js/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts",
     // this test has specific code for v4
-    "packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx"
+    "packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx",
+    "packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx"
   ]
 }


### PR DESCRIPTION
**Summary**

## [FX-2895](https://algolia.atlassian.net/browse/FX-2895)

**Result**

- Made `_rawResults` scoped for `RecommendResults` to avoid bloating multi-index with same results
- Typed and renamed `recommendCache` to `_recommendCache` as it's private
  - It will also be hydrated to avoid requests on the client
- `waitForResults` wait for either recommend or search, or both if needed
- Changes to `hydrateSearchClient` needed as search results are now optional


[FX-2895]: https://algolia.atlassian.net/browse/FX-2895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ