### PR TITLE
chore(hits): update css templates to style hits banner

### DIFF
--- a/packages/instantsearch.css/src/themes/algolia.scss
+++ b/packages/instantsearch.css/src/themes/algolia.scss
@@ -334,6 +334,15 @@ a[class^='ais-'] {
   margin-bottom: 1rem;
 }
 
+.ais-Hits-banner {
+  display: flex;
+  justify-content: center;
+}
+
+.ais-Hits-banner-image {
+  max-width: 100%;
+}
+
 .ais-MenuSelect-select,
 .ais-NumericSelector-select,
 .ais-HitsPerPage-select,

--- a/packages/instantsearch.css/src/themes/satellite.scss
+++ b/packages/instantsearch.css/src/themes/satellite.scss
@@ -658,6 +658,15 @@ $break-medium: 767px;
   margin: 1rem auto;
 }
 
+.ais-Hits-banner {
+  display: flex;
+  justify-content: center;
+}
+
+.ais-Hits-banner-image {
+  max-width: 100%;
+}
+
 /**
  * GeoSearch
  */


### PR DESCRIPTION
**Summary**

This PR updates the theme CSS for the new banner portion of the `Hits` widget. Both `satellite.scss` and `algolia.scss` were updated to include the following rulesets:
```css
.ais-Hits-banner {
  display: flex;
  justify-content: center;
}

.ais-Hits-banner-image {
  max-width: 100%;
}
```
[EMERCH-1479](https://algolia.atlassian.net/browse/EMERCH-1479)

**Result**

When the banner is wider than the Hits container, `max-width: 100%` restricts the width.
![image](https://github.com/algolia/instantsearch/assets/10552296/8e8385af-7d83-40f1-a27a-3ea19a809eb1)

When the banner is narrower than the Hits container, it is centered horizontally.
![image](https://github.com/algolia/instantsearch/assets/10552296/61e749cc-46e8-4296-aed5-09e4e8e6ed57)



[EMERCH-1479]: https://algolia.atlassian.net/browse/EMERCH-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ