### PR TITLE
fix(next-app-router): set nonce in injected script when provided

### DIFF
--- a/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
@@ -12,7 +12,16 @@ import { htmlEscapeJsonString } from './htmlEscape';
 
 import type { SearchOptions } from 'instantsearch.js';
 
-export function InitializePromise() {
+type InitializePromiseProps = {
+  /**
+   * The nonce to use for the injected script tag.
+   *
+   * @see https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy#nonces
+   */
+  nonce?: string;
+};
+
+export function InitializePromise({ nonce }: InitializePromiseProps) {
   const search = useInstantSearchContext();
   const waitForResultsRef = useRSCContext();
   const insertHTML =
@@ -62,6 +71,7 @@ export function InitializePromise() {
       inserted = true;
       return (
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `window[Symbol.for("InstantSearchInitialResults")] = ${htmlEscapeJsonString(
               JSON.stringify(results)

--- a/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
+++ b/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
@@ -1,4 +1,5 @@
 import { safelyRunOnBrowser } from 'instantsearch.js/es/lib/utils';
+import { headers } from 'next/headers';
 import React, { useEffect, useRef } from 'react';
 import {
   InstantSearch,
@@ -72,7 +73,9 @@ This message will only be displayed in development mode.`
     <InstantSearchRSCContext.Provider value={promiseRef}>
       <InstantSearchSSRProvider initialResults={initialResults}>
         <InstantSearch {...instantSearchProps} routing={routing}>
-          {!initialResults && <InitializePromise />}
+          {!initialResults && (
+            <InitializePromise nonce={headers().get('x-nonce') || undefined} />
+          )}
           {children}
           {!initialResults && <TriggerSearch />}
         </InstantSearch>

--- a/yarn.lock
+++ b/yarn.lock
@@ -18038,7 +18038,7 @@ is-color-stop@^1.0.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-core-module@^2.1.0, is-core-module@^2.11.0, is-core-module@^2.13.0, is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-module@^2.6.0, is-core-module@^2.8.0, is-core-module@^2.8.1:
+is-core-module@^2.1.0, is-core-module@^2.13.0, is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-module@^2.6.0, is-core-module@^2.8.0, is-core-module@^2.8.1:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.1.tgz#ad0d7532c6fea9da1ebdc82742d74525c6273384"
   integrity sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==


### PR DESCRIPTION
**Summary**

Customers who follow [Next.js' guide for implementing CSP rules](https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy) to their application can define a nonce that flags inline scripts as allowed. This is properly handled with Next.js' own inline scripts, but not yet with **react-instantsearch-nextjs**.

This PR retrieves the nonce value and applies it to the injected script tag added by `<InitializePromise>`.

**Result**

InstantSearch does not trigger an error in Next.js applications where a middleware define CSP rules and apply nonces.

CR-6159