### PR TITLE
refactor(codemods): move addWidgets to instantsearch-codemods package

### DIFF
--- a/packages/instantsearch-codemods/README.md
+++ b/packages/instantsearch-codemods/README.md
@@ -33,6 +33,14 @@ This will:
 npx @codeshift/cli --packages 'instantsearch-codemods#ris-v6-to-v7' <path>
 ```
 
+### `addWidget-to-addWidgets`
+
+This will replace all `addWidget` calls to `addWidgets` and `removeWidget` calls to `removeWidgets`.
+
+```
+npx @codeshift/cli --packages 'instantsearch-codemods#addWidget-to-addWidgets' <path>
+```
+
 ### Notes
 
 If you are using Prettier or ESLint, make sure to run its autofixing after this transformation, since code can be formatted differently after it has been transformed. For example, in our repository, the Prettier command would be:

--- a/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/global.input.js
+++ b/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/global.input.js
@@ -1,0 +1,6 @@
+/* global instantsearch */
+
+const search = instantsearch();
+
+search.addWidget(instantsearch.widgets.hits({}));
+search.addWidget(instantsearch.widgets.hits({}));

--- a/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/global.output.js
+++ b/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/global.output.js
@@ -1,0 +1,6 @@
+/* global instantsearch */
+
+const search = instantsearch();
+
+search.addWidgets([instantsearch.widgets.hits({})]);
+search.addWidgets([instantsearch.widgets.hits({})]);

--- a/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/imported.input.js
+++ b/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/imported.input.js
@@ -1,0 +1,6 @@
+import instantsearch from 'instantsearch.js';
+
+const search = instantsearch();
+
+search.addWidget(instantsearch.widgets.hits({}));
+search.addWidget(instantsearch.widgets.hits({}));

--- a/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/imported.output.js
+++ b/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/imported.output.js
@@ -1,0 +1,6 @@
+import instantsearch from 'instantsearch.js';
+
+const search = instantsearch();
+
+search.addWidgets([instantsearch.widgets.hits({})]);
+search.addWidgets([instantsearch.widgets.hits({})]);

--- a/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/mixed.input.js
+++ b/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/mixed.input.js
@@ -1,0 +1,19 @@
+/* global instantsearch */
+
+const search = instantsearch();
+
+function someRandomFunction() {}
+const unrelated = {
+  function() {},
+};
+
+search.addWidget(instantsearch.widgets.hits({}));
+
+someRandomFunction();
+unrelated.function();
+
+search.addWidget(instantsearch.widgets.hits({}));
+
+search.addWidgets([instantsearch.widgets.hits({})]);
+
+search.addWidget(instantsearch.widgets.hits({}));

--- a/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/mixed.output.js
+++ b/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/mixed.output.js
@@ -1,0 +1,19 @@
+/* global instantsearch */
+
+const search = instantsearch();
+
+function someRandomFunction() {}
+const unrelated = {
+  function() {},
+};
+
+search.addWidgets([instantsearch.widgets.hits({})]);
+
+someRandomFunction();
+unrelated.function();
+
+search.addWidgets([instantsearch.widgets.hits({})]);
+
+search.addWidgets([instantsearch.widgets.hits({})]);
+
+search.addWidgets([instantsearch.widgets.hits({})]);

--- a/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/remove.input.js
+++ b/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/remove.input.js
@@ -1,0 +1,11 @@
+/* global instantsearch */
+
+const search = instantsearch();
+
+const hits = instantsearch.widgets.hits({});
+
+search.addWidget(hits);
+
+search.removeWidget(hits);
+
+search.addWidget(hits);

--- a/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/remove.output.js
+++ b/packages/instantsearch-codemods/__testfixtures__/addWidget-to-addWidgets/remove.output.js
@@ -1,0 +1,11 @@
+/* global instantsearch */
+
+const search = instantsearch();
+
+const hits = instantsearch.widgets.hits({});
+
+search.addWidgets([hits]);
+
+search.removeWidgets([hits]);
+
+search.addWidgets([hits]);

--- a/packages/instantsearch-codemods/__tests__/addWidget-to-addWidgets.test.js
+++ b/packages/instantsearch-codemods/__tests__/addWidget-to-addWidgets.test.js
@@ -1,0 +1,30 @@
+/* eslint-disable import/no-commonjs */
+const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+
+defineTest(
+  __dirname,
+  'src/addWidget-to-addWidgets',
+  null,
+  'addWidget-to-addWidgets/global'
+);
+
+defineTest(
+  __dirname,
+  'src/addWidget-to-addWidgets',
+  null,
+  'addWidget-to-addWidgets/imported'
+);
+
+defineTest(
+  __dirname,
+  'src/addWidget-to-addWidgets',
+  null,
+  'addWidget-to-addWidgets/mixed'
+);
+
+defineTest(
+  __dirname,
+  'src/addWidget-to-addWidgets',
+  null,
+  'addWidget-to-addWidgets/remove'
+);

--- a/packages/instantsearch-codemods/src/addWidget-to-addWidgets.ts
+++ b/packages/instantsearch-codemods/src/addWidget-to-addWidgets.ts
@@ -1,0 +1,44 @@
+/* eslint-disable no-shadow */
+
+import type { FileInfo, API, Options, Collection } from 'jscodeshift';
+
+export default function transform(
+  file: FileInfo,
+  { jscodeshift: j }: API,
+  options: Options
+) {
+  const printOptions = options.printOptions || { quote: 'single' };
+  const root = j(file.source);
+
+  // replace xxx[from](arguments) to xxx[to]([arguments])
+  const replaceSingularToPlural =
+    (from: string, to: string) => (root: Collection) =>
+      root
+        .find(j.CallExpression, {
+          callee: { property: { name: from } },
+        })
+        .replaceWith((path) => {
+          if (path.value.callee.type !== 'MemberExpression') {
+            return path.value;
+          }
+          return j.callExpression(
+            j.memberExpression(
+              path.value.callee.object,
+              j.identifier(to),
+              false
+            ),
+            [j.arrayExpression(path.value.arguments)]
+          );
+        });
+
+  const replaceAddWidget = replaceSingularToPlural('addWidget', 'addWidgets');
+  const replaceRemoveWidget = replaceSingularToPlural(
+    'removeWidget',
+    'removeWidgets'
+  );
+
+  replaceAddWidget(root);
+  replaceRemoveWidget(root);
+
+  return root.toSource(printOptions);
+}

--- a/packages/instantsearch-codemods/src/codeshift.config.js
+++ b/packages/instantsearch-codemods/src/codeshift.config.js
@@ -4,5 +4,6 @@ module.exports = {
   presets: {
     'ris-v6-to-v7': require('./ris-v6-to-v7'),
     'rish-to-ris': require('./rish-to-ris'),
+    'addWidget-to-addWidgets': require('./addWidget-to-addWidgets'),
   },
 };

--- a/packages/instantsearch.js/scripts/transforms/README.md
+++ b/packages/instantsearch.js/scripts/transforms/README.md
@@ -7,7 +7,7 @@ These codemods (code transformers) can be ran with [jscodeshift]((https://github
 This will replace calls of `addWidget(widget)` to `addWidgets([widget])`, as well as `removeWidget(widget) to `removeWidgets([widget])`.
 
 ```
-npx jscodeshift --transform scripts/transforms/addWidget-addWidgets.js --extensions='ts,js,tsx' <path>
+npx @codeshift/cli --packages 'instantsearch-codemods#addWidget-to-addWidgets' <path>
 ```
 
 ### Notes

--- a/packages/instantsearch.js/scripts/transforms/addWidget-to-addWidgets.js
+++ b/packages/instantsearch.js/scripts/transforms/addWidget-to-addWidgets.js
@@ -1,29 +1,9 @@
-/* eslint-disable no-shadow */
+/* eslint-disable no-console, import/no-commonjs */
 
-export default function transform(file, api, options) {
-  const j = api.jscodeshift;
-  const printOptions = options.printOptions || { quote: 'single' };
-  const root = j(file.source);
+// @MAJOR: remove this file and only keep only the `instantsearch-codemods` one
+// also ensure this is removed from package.json
+console.warn(
+  "This file is deprecated. Please use `npx @codeshift/cli --packages 'instantsearch-codemods#addWidget-to-addWidgets' <path>` instead."
+);
 
-  // replace xxx[from](arguments) to xxx[to]([arguments])
-  const replaceSingularToPlural = (from, to) => (root) =>
-    root
-      .find(j.CallExpression, { callee: { property: { name: from } } })
-      .replaceWith((path) =>
-        j.callExpression(
-          j.memberExpression(path.value.callee.object, j.identifier(to), false),
-          [j.arrayExpression(path.value.arguments)]
-        )
-      );
-
-  const replaceAddWidget = replaceSingularToPlural('addWidget', 'addWidgets');
-  const replaceRemoveWidget = replaceSingularToPlural(
-    'removeWidget',
-    'removeWidgets'
-  );
-
-  replaceAddWidget(root);
-  replaceRemoveWidget(root);
-
-  return root.toSource(printOptions);
-}
+module.exports = require('instantsearch-codemods/src/addWidget-to-addWidgets');


### PR DESCRIPTION
Move the "addWidgets" codemod to the dedicated instantsearch-codemods package

This is done so we can update the documentation etc. to only use instantsearch-codemods and we can remove this folder in a next major version

Left an alias and the original tests in place