### PR TITLE
fix(next-app-router): do not retrieve headers in csr

### DIFF
--- a/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
+++ b/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
@@ -55,6 +55,10 @@ export function InstantSearchNext<
     };
   }, []);
 
+  const nonce = safelyRunOnBrowser(() => undefined, {
+    fallback: () => headers().get('x-nonce') || undefined,
+  });
+
   const routing = useInstantSearchRouting(passedRouting, isMounting);
 
   const promiseRef = useRef<PromiseWithState<void> | null>(null);
@@ -73,9 +77,7 @@ This message will only be displayed in development mode.`
     <InstantSearchRSCContext.Provider value={promiseRef}>
       <InstantSearchSSRProvider initialResults={initialResults}>
         <InstantSearch {...instantSearchProps} routing={routing}>
-          {!initialResults && (
-            <InitializePromise nonce={headers().get('x-nonce') || undefined} />
-          )}
+          {!initialResults && <InitializePromise nonce={nonce} />}
           {children}
           {!initialResults && <TriggerSearch />}
         </InstantSearch>


### PR DESCRIPTION
**Summary**

This PR fixes a side-effect introduced in #6223 , which tries to retrieve a `nonce` value from headers to apply it to the injected script tag. It unconditionally called Next's `headers()` in SSR and CSR, which caused the implementation to throw an error at the first CSR search interaction, because `headers()` are obviously not retrievable from a client environment.

The `header()` function is now only called in SSR.