### PR TITLE
feat(facets): allow hiding values through renderingContent

### DIFF
--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1315,6 +1315,10 @@ declare namespace algoliasearchHelper {
         values?: {
           [facet: string]: {
             /**
+             * Hide facet values
+             */
+            hide?: string[];
+            /**
              * Ordered facet values
              */
             order?: string[];

--- a/packages/algoliasearch-helper/src/SearchResults/index.js
+++ b/packages/algoliasearch-helper/src/SearchResults/index.js
@@ -814,8 +814,9 @@ function vanillaSortFn(order, data) {
 function sortViaFacetOrdering(facetValues, facetOrdering) {
   var orderedFacets = [];
   var remainingFacets = [];
-
+  var hide = facetOrdering.hide || [];
   var order = facetOrdering.order || [];
+
   /**
    * an object with the keys being the values in order, the values their index:
    * ['one', 'two'] -> { one: 0, two: 1 }
@@ -828,9 +829,10 @@ function sortViaFacetOrdering(facetValues, facetOrdering) {
   facetValues.forEach(function (item) {
     // hierarchical facets get sorted using their raw name
     var name = item.path || item.name;
-    if (reverseOrder[name] !== undefined) {
+    var hidden = hide.indexOf(name) > -1;
+    if (!hidden && reverseOrder[name] !== undefined) {
       orderedFacets[reverseOrder[name]] = item;
-    } else {
+    } else if (!hidden) {
       remainingFacets.push(item);
     }
   });

--- a/packages/algoliasearch-helper/test/spec/SearchResults/getFacetValues-facetOrdering.js
+++ b/packages/algoliasearch-helper/test/spec/SearchResults/getFacetValues-facetOrdering.js
@@ -294,6 +294,44 @@ describe('disjunctive facet', function () {
     expect(facetValues).toEqual(expected);
   });
 
+  test('facetOrdering: hiding facet value', function () {
+    var data = require('./getFacetValues/disjunctive.json');
+    var order = {
+      renderingContent: {
+        facetOrdering: {
+          values: {
+            brand: {
+              hide: ['Samsung'],
+              order: ['Samsung', 'Apple', 'Insignia™'],
+            },
+          },
+        },
+      },
+    };
+
+    var results = data.content.results.slice();
+    results[0] = Object.assign(order, results[0]);
+
+    var searchParams = new SearchParameters(data.state);
+    var result = new SearchResults(searchParams, results);
+
+    var facetValues = result.getFacetValues('brand', {
+      facetOrdering: true,
+    });
+
+    var expected = [
+      { count: 386, isRefined: true, name: 'Apple', escapedValue: 'Apple' },
+      {
+        count: 551,
+        isRefined: false,
+        name: 'Insignia™',
+        escapedValue: 'Insignia™',
+      },
+    ];
+
+    expect(facetValues).toEqual(expected);
+  });
+
   test('without facetOrdering, nor sortBy', function () {
     var data = require('./getFacetValues/disjunctive.json');
     var order = {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Adds support for hiding facet values if set in the configuration.
JIRA ticket: https://algolia.atlassian.net/browse/EMERCH-1438

**Result**

If you have set up facets to be "hidden", they will not display. This does not increment the maxValuesPerFacet setting, so it's possible that you receive less values than the limit if you hide many values.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
