### PR TITLE
test(dynamic-widgets): common test suite

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
@@ -31,6 +31,7 @@ import {
   lookingSimilar,
   poweredBy,
   menuSelect,
+  dynamicWidgets,
 } from '../widgets';
 
 import type { TestOptionsMap, TestSetupsMap } from '@instantsearch/tests';
@@ -594,6 +595,20 @@ const testSetups: TestSetupsMap<TestSuites> = {
       ])
       .start();
   },
+  createDynamicWidgetsWidgetTests({ instantSearchOptions, widgetParams }) {
+    instantsearch(instantSearchOptions)
+      .addWidgets([
+        dynamicWidgets({
+          container: document.body.appendChild(document.createElement('div')),
+          widgets: [
+            (container) => refinementList({ attribute: 'brand', container }),
+            (container) => menu({ attribute: 'category', container }),
+          ],
+          ...widgetParams,
+        }),
+      ])
+      .start();
+  },
 };
 
 const testOptions: TestOptionsMap<TestSuites> = {
@@ -625,6 +640,7 @@ const testOptions: TestOptionsMap<TestSuites> = {
   createLookingSimilarWidgetTests: undefined,
   createPoweredByWidgetTests: undefined,
   createMenuSelectWidgetTests: undefined,
+  createDynamicWidgetsWidgetTests: undefined,
 };
 
 describe('Common widget tests (InstantSearch.js)', () => {

--- a/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
@@ -603,6 +603,14 @@ const testSetups: TestSetupsMap<TestSuites> = {
           widgets: [
             (container) => refinementList({ attribute: 'brand', container }),
             (container) => menu({ attribute: 'category', container }),
+            (container) =>
+              hierarchicalMenu({
+                attributes: [
+                  'hierarchicalCategories.lvl0',
+                  'hierarchicalCategories.lvl1',
+                ],
+                container,
+              }),
           ],
           ...widgetParams,
         }),

--- a/packages/react-instantsearch/src/__tests__/common-widgets.test.tsx
+++ b/packages/react-instantsearch/src/__tests__/common-widgets.test.tsx
@@ -380,6 +380,12 @@ const testSetups: TestSetupsMap<TestSuites> = {
           <DynamicWidgets {...widgetParams}>
             <RefinementList attribute="brand" />
             <Menu attribute="category" />
+            <HierarchicalMenu
+              attributes={[
+                'hierarchicalCategories.lvl0',
+                'hierarchicalCategories.lvl1',
+              ]}
+            />
           </DynamicWidgets>
         </div>
         <GlobalErrorSwallower />

--- a/packages/react-instantsearch/src/__tests__/common-widgets.test.tsx
+++ b/packages/react-instantsearch/src/__tests__/common-widgets.test.tsx
@@ -30,6 +30,7 @@ import {
   TrendingItems,
   LookingSimilar,
   PoweredBy,
+  DynamicWidgets,
 } from '..';
 
 import type { TestOptionsMap, TestSetupsMap } from '@instantsearch/tests';
@@ -372,6 +373,19 @@ const testSetups: TestSetupsMap<TestSuites> = {
   createMenuSelectWidgetTests() {
     throw new Error('MenuSelect is not supported in React InstantSearch');
   },
+  createDynamicWidgetsWidgetTests({ instantSearchOptions, widgetParams }) {
+    render(
+      <InstantSearch {...instantSearchOptions}>
+        <div className="ais-DynamicWidgets">
+          <DynamicWidgets {...widgetParams}>
+            <RefinementList attribute="brand" />
+            <Menu attribute="category" />
+          </DynamicWidgets>
+        </div>
+        <GlobalErrorSwallower />
+      </InstantSearch>
+    );
+  },
 };
 
 const testOptions: TestOptionsMap<TestSuites> = {
@@ -414,6 +428,7 @@ const testOptions: TestOptionsMap<TestSuites> = {
       'MenuSelect widget common tests': true,
     },
   },
+  createDynamicWidgetsWidgetTests: { act },
 };
 
 /**

--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -564,7 +564,15 @@ const testSetups = {
               AisDynamicWidgets,
               { props: widgetParams },
               h(AisRefinementList, { props: { attribute: 'brand' } }),
-              h(AisMenu, { props: { attribute: 'category' } })
+              h(AisMenu, { props: { attribute: 'category' } }),
+              h(AisHierarchicalMenu, {
+                props: {
+                  attributes: [
+                    'hierarchicalCategories.lvl0',
+                    'hierarchicalCategories.lvl1',
+                  ],
+                },
+              })
             ),
             h(GlobalErrorSwallower),
           ])

--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -28,6 +28,7 @@ import {
   AisNumericMenu,
   AisPoweredBy,
   AisMenuSelect,
+  AisDynamicWidgets,
 } from '../instantsearch';
 import { renderCompat } from '../util/vue-compat';
 
@@ -554,6 +555,24 @@ const testSetups = {
 
     await nextTick();
   },
+  createDynamicWidgetsWidgetTests({ instantSearchOptions, widgetParams }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(
+              AisDynamicWidgets,
+              { props: widgetParams },
+              h(AisRefinementList, { props: { attribute: 'brand' } }),
+              h(AisMenu, { props: { attribute: 'category' } })
+            ),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
+  },
 };
 
 const testOptions = {
@@ -591,6 +610,7 @@ const testOptions = {
     skippedTests: { 'LookingSimilar widget common tests': true },
   },
   createPoweredByWidgetTests: undefined,
+  createDynamicWidgetsWidgetTests: undefined,
 };
 
 describe('Common widget tests (Vue InstantSearch)', () => {

--- a/tests/common/widgets/dynamic-widgets/index.ts
+++ b/tests/common/widgets/dynamic-widgets/index.ts
@@ -1,0 +1,24 @@
+import { fakeAct } from '../../common';
+
+import { createOptionsTests } from './options';
+
+import type { TestOptions, TestSetup } from '../../common';
+import type { DynamicWidgetsWidget } from 'instantsearch.js/es/widgets/dynamic-widgets/dynamic-widgets';
+
+type WidgetParams = Parameters<DynamicWidgetsWidget>[0];
+export type DynamicWidgetsWidgetSetup = TestSetup<{
+  widgetParams: Omit<WidgetParams, 'container' | 'widgets' | 'fallbackWidget'>;
+}>;
+
+export function createDynamicWidgetsWidgetTests(
+  setup: DynamicWidgetsWidgetSetup,
+  { act = fakeAct, skippedTests = {} }: TestOptions = {}
+) {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('DynamicWidgets widget common tests', () => {
+    createOptionsTests(setup, { act, skippedTests });
+  });
+}

--- a/tests/common/widgets/dynamic-widgets/options.ts
+++ b/tests/common/widgets/dynamic-widgets/options.ts
@@ -14,41 +14,9 @@ export function createOptionsTests(
   { act }: Required<TestOptions>
 ) {
   describe('options', () => {
-    const searchClient = createAlgoliaSearchClient({
-      search: jest.fn((requests) => {
-        return Promise.resolve(
-          createMultiSearchResponse(
-            ...requests.map(() => {
-              return createSingleSearchResponse({
-                facets: {
-                  brand: {
-                    Samsung: 633,
-                    Metra: 591,
-                  },
-                  category: {
-                    TV: 633,
-                    Radio: 591,
-                  },
-                },
-                renderingContent: {
-                  facetOrdering: {
-                    facets: {
-                      order: ['category', 'brand'],
-                    },
-                  },
-                },
-              });
-            })
-          )
-        );
-      }),
-    });
-
-    beforeEach(() => {
-      searchClient.search.mockClear();
-    });
-
     it('renders with default options', async () => {
+      const searchClient = createMockedSearchClient();
+
       await setup({
         instantSearchOptions: {
           searchClient,
@@ -69,7 +37,7 @@ export function createOptionsTests(
         // Vue 3 outputs comment nodes
       ).filter((node) => node.nodeType === Node.ELEMENT_NODE);
 
-      expect(dynamicWidgets).toHaveLength(2);
+      expect(dynamicWidgets).toHaveLength(3);
 
       expect(
         within(dynamicWidgets[0] as HTMLElement).getByRole('link', {
@@ -82,9 +50,17 @@ export function createOptionsTests(
           name: /samsung/i,
         })
       ).toBeInTheDocument();
+
+      expect(
+        within(dynamicWidgets[2] as HTMLElement).getByRole('link', {
+          name: /books/i,
+        })
+      ).toBeInTheDocument();
     });
 
     it('forwards the `maxValuesPerFacet` option', async () => {
+      const searchClient = createMockedSearchClient();
+
       await setup({
         instantSearchOptions: {
           searchClient,
@@ -112,6 +88,8 @@ export function createOptionsTests(
     });
 
     it('forwards the `facets` option', async () => {
+      const searchClient = createMockedSearchClient();
+
       await setup({
         instantSearchOptions: {
           searchClient,
@@ -139,6 +117,8 @@ export function createOptionsTests(
     });
 
     it('transforms items by calling the `transformItem` option', async () => {
+      const searchClient = createMockedSearchClient();
+
       await setup({
         instantSearchOptions: {
           searchClient,
@@ -164,5 +144,41 @@ export function createOptionsTests(
         screen.queryByRole('link', { name: /tv/i })
       ).not.toBeInTheDocument();
     });
+  });
+}
+
+function createMockedSearchClient() {
+  return createAlgoliaSearchClient({
+    search: jest.fn((requests) => {
+      return Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map(() => {
+            return createSingleSearchResponse({
+              facets: {
+                brand: {
+                  Samsung: 633,
+                  Metra: 591,
+                },
+                category: {
+                  TV: 633,
+                  Radio: 591,
+                },
+                'hierarchicalCategories.lvl0': {
+                  Electronics: 633,
+                  Books: 591,
+                },
+              },
+              renderingContent: {
+                facetOrdering: {
+                  facets: {
+                    order: ['category', 'brand', 'hierarchicalCategories.lvl0'],
+                  },
+                },
+              },
+            });
+          })
+        )
+      );
+    }),
   });
 }

--- a/tests/common/widgets/dynamic-widgets/options.ts
+++ b/tests/common/widgets/dynamic-widgets/options.ts
@@ -1,0 +1,168 @@
+import {
+  createAlgoliaSearchClient,
+  createMultiSearchResponse,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import { within, screen } from '@testing-library/dom';
+
+import type { DynamicWidgetsWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+export function createOptionsTests(
+  setup: DynamicWidgetsWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('options', () => {
+    const searchClient = createAlgoliaSearchClient({
+      search: jest.fn((requests) => {
+        return Promise.resolve(
+          createMultiSearchResponse(
+            ...requests.map(() => {
+              return createSingleSearchResponse({
+                facets: {
+                  brand: {
+                    Samsung: 633,
+                    Metra: 591,
+                  },
+                  category: {
+                    TV: 633,
+                    Radio: 591,
+                  },
+                },
+                renderingContent: {
+                  facetOrdering: {
+                    facets: {
+                      order: ['category', 'brand'],
+                    },
+                  },
+                },
+              });
+            })
+          )
+        );
+      }),
+    });
+
+    beforeEach(() => {
+      searchClient.search.mockClear();
+    });
+
+    it('renders with default options', async () => {
+      await setup({
+        instantSearchOptions: {
+          searchClient,
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {},
+          },
+        },
+        widgetParams: {},
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const dynamicWidgets = Array.from(
+        document.querySelector('.ais-DynamicWidgets')!.childNodes
+        // Vue 3 outputs comment nodes
+      ).filter((node) => node.nodeType === Node.ELEMENT_NODE);
+
+      expect(dynamicWidgets).toHaveLength(2);
+
+      expect(
+        within(dynamicWidgets[0] as HTMLElement).getByRole('link', {
+          name: /tv/i,
+        })
+      ).toBeInTheDocument();
+
+      expect(
+        within(dynamicWidgets[1] as HTMLElement).getByRole('checkbox', {
+          name: /samsung/i,
+        })
+      ).toBeInTheDocument();
+    });
+
+    it('forwards the `maxValuesPerFacet` option', async () => {
+      await setup({
+        instantSearchOptions: {
+          searchClient,
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {},
+          },
+        },
+        widgetParams: { maxValuesPerFacet: 25 },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.search).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            params: expect.objectContaining({
+              maxValuesPerFacet: 25,
+            }),
+          }),
+        ])
+      );
+    });
+
+    it('forwards the `facets` option', async () => {
+      await setup({
+        instantSearchOptions: {
+          searchClient,
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {},
+          },
+        },
+        widgetParams: { facets: ['other'] },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.search).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            params: expect.objectContaining({
+              facets: expect.arrayContaining(['other']),
+            }),
+          }),
+        ])
+      );
+    });
+
+    it('transforms items by calling the `transformItem` option', async () => {
+      await setup({
+        instantSearchOptions: {
+          searchClient,
+          indexName: 'indexName',
+          initialUiState: {
+            indexName: {},
+          },
+        },
+        widgetParams: {
+          transformItems: () => ['brand'],
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(
+        screen.queryByRole('checkbox', { name: /samsung/i })
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('link', { name: /tv/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+}

--- a/tests/common/widgets/index.ts
+++ b/tests/common/widgets/index.ts
@@ -1,6 +1,7 @@
 export * from './breadcrumb';
 export * from './clear-refinements';
 export * from './current-refinements';
+export * from './dynamic-widgets';
 export * from './hierarchical-menu';
 export * from './hits';
 export * from './infinite-hits';


### PR DESCRIPTION
**Summary**

#### [FX-2510](https://algolia.atlassian.net/browse/FX-2510)

**Result**

Tried to test as much as possible, but we're limited due to the implems being very different, notably the lack of `fallback` mechanism in Vue.

Still these test the order to render widgets, whether a widget should render or not, and makes sure that certain params are correctly forwarded to the search request.

I didn't remove any pre-existing tests for now.


[FX-2510]: https://algolia.atlassian.net/browse/FX-2510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ