### PR TITLE
feat(infinite-hits): add top banner to InfiniteHits widget

### DIFF
--- a/packages/instantsearch.css/src/themes/algolia.scss
+++ b/packages/instantsearch.css/src/themes/algolia.scss
@@ -334,12 +334,14 @@ a[class^='ais-'] {
   margin-bottom: 1rem;
 }
 
-.ais-Hits-banner {
+.ais-Hits-banner,
+.ais-InfiniteHits-banner {
   display: flex;
   justify-content: center;
 }
 
-.ais-Hits-banner-image {
+.ais-Hits-banner-image
+.ais-InfiniteHits-banner-image {
   max-width: 100%;
 }
 

--- a/packages/instantsearch.css/src/themes/satellite.scss
+++ b/packages/instantsearch.css/src/themes/satellite.scss
@@ -658,12 +658,14 @@ $break-medium: 767px;
   margin: 1rem auto;
 }
 
-.ais-Hits-banner {
+.ais-Hits-banner,
+.ais-InfiniteHits-banner {
   display: flex;
   justify-content: center;
 }
 
-.ais-Hits-banner-image {
+.ais-Hits-banner-image,
+.ais-InfiniteHits-banner-image {
   max-width: 100%;
 }
 

--- a/packages/instantsearch.js/src/components/InfiniteHits/InfiniteHits.tsx
+++ b/packages/instantsearch.js/src/components/InfiniteHits/InfiniteHits.tsx
@@ -38,6 +38,45 @@ export type InfiniteHitsProps = {
   banner?: Banner;
 };
 
+const DefaultBanner = ({
+  banner,
+  classNames,
+}: {
+  banner: Banner;
+  classNames: Pick<
+    InfiniteHitsCSSClasses,
+    'bannerRoot' | 'bannerLink' | 'bannerImage'
+  >;
+}) => {
+  if (!banner.image.urls[0].url) {
+    return null;
+  }
+
+  return (
+    <aside className={cx(classNames.bannerRoot)}>
+      {banner.link ? (
+        <a
+          className={cx(classNames.bannerLink)}
+          href={banner.link.url}
+          target={banner.link.target}
+        >
+          <img
+            className={cx(classNames.bannerImage)}
+            src={banner.image.urls[0].url}
+            alt={banner.image.title}
+          />
+        </a>
+      ) : (
+        <img
+          className={cx(classNames.bannerImage)}
+          src={banner.image.urls[0].url}
+          alt={banner.image.title}
+        />
+      )}
+    </aside>
+  );
+};
+
 const InfiniteHits = ({
   results,
   hits,
@@ -60,27 +99,28 @@ const InfiniteHits = ({
 
   if (results.hits.length === 0) {
     return (
-      <div className={cssClasses.root}>
-        {banner && templateProps.templates.banner ? (
-          <Template
-            {...templateProps}
-            templateKey="banner"
-            rootTagName="aside"
-            rootProps={{
-              className: cssClasses.bannerRoot,
-            }}
-            data={banner}
-          />
-        ) : (
-          <aside>default component goes here</aside>
-        )}
+      <div
+        className={cx(cssClasses.root, cssClasses.emptyRoot)}
+        onClick={handleInsightsClick}
+      >
+        {banner &&
+          (templateProps.templates.banner ? (
+            <Template
+              {...templateProps}
+              templateKey="banner"
+              rootTagName="fragment"
+              rootProps={{
+                className: cssClasses.bannerRoot,
+              }}
+              data={banner}
+            />
+          ) : (
+            <DefaultBanner banner={banner} classNames={cssClasses} />
+          ))}
         <Template
           {...templateProps}
           templateKey="empty"
-          rootProps={{
-            className: cssClasses.emptyRoot,
-            onClick: handleInsightsClick,
-          }}
+          rootTagName="fragment"
           data={results}
         />
       </div>
@@ -105,19 +145,20 @@ const InfiniteHits = ({
         />
       )}
 
-      {banner && templateProps.templates.banner ? (
-        <Template
-          {...templateProps}
-          templateKey="banner"
-          rootTagName="aside"
-          rootProps={{
-            className: cssClasses.bannerRoot,
-          }}
-          data={banner}
-        />
-      ) : (
-        <aside>default component goes here</aside>
-      )}
+      {banner &&
+        (templateProps.templates.banner ? (
+          <Template
+            {...templateProps}
+            templateKey="banner"
+            rootTagName="fragment"
+            rootProps={{
+              className: cssClasses.bannerRoot,
+            }}
+            data={banner}
+          />
+        ) : (
+          <DefaultBanner banner={banner} classNames={cssClasses} />
+        ))}
 
       <ol className={cssClasses.list}>
         {hits.map((hit, index) => (

--- a/packages/instantsearch.js/src/components/InfiniteHits/InfiniteHits.tsx
+++ b/packages/instantsearch.js/src/components/InfiniteHits/InfiniteHits.tsx
@@ -13,11 +13,11 @@ import type {
   InfiniteHitsCSSClasses,
   InfiniteHitsTemplates,
 } from '../../widgets/infinite-hits/infinite-hits';
-import type { SearchResults } from 'algoliasearch-helper';
+import type { Banner, SearchResults } from 'algoliasearch-helper';
 
 export type InfiniteHitsComponentCSSClasses =
   ComponentCSSClasses<InfiniteHitsCSSClasses>;
-export type InfiniteHitsComponentTemplates = Required<InfiniteHitsTemplates>;
+export type InfiniteHitsComponentTemplates = InfiniteHitsTemplates;
 
 export type InfiniteHitsProps = {
   cssClasses: InfiniteHitsComponentCSSClasses;
@@ -35,6 +35,7 @@ export type InfiniteHitsProps = {
   insights?: InsightsClient;
   sendEvent: SendEventForHits;
   bindEvent: BindEventForHits;
+  banner?: Banner;
 };
 
 const InfiniteHits = ({
@@ -50,6 +51,7 @@ const InfiniteHits = ({
   isLastPage,
   cssClasses,
   templateProps,
+  banner,
 }: InfiniteHitsProps) => {
   const handleInsightsClick = createInsightsEventHandler({
     insights,
@@ -58,15 +60,30 @@ const InfiniteHits = ({
 
   if (results.hits.length === 0) {
     return (
-      <Template
-        {...templateProps}
-        templateKey="empty"
-        rootProps={{
-          className: cx(cssClasses.root, cssClasses.emptyRoot),
-          onClick: handleInsightsClick,
-        }}
-        data={results}
-      />
+      <div className={cssClasses.root}>
+        {banner && templateProps.templates.banner ? (
+          <Template
+            {...templateProps}
+            templateKey="banner"
+            rootTagName="aside"
+            rootProps={{
+              className: cssClasses.bannerRoot,
+            }}
+            data={banner}
+          />
+        ) : (
+          <aside>default component goes here</aside>
+        )}
+        <Template
+          {...templateProps}
+          templateKey="empty"
+          rootProps={{
+            className: cssClasses.emptyRoot,
+            onClick: handleInsightsClick,
+          }}
+          data={results}
+        />
+      </div>
     );
   }
 
@@ -86,6 +103,20 @@ const InfiniteHits = ({
             onClick: showPrevious,
           }}
         />
+      )}
+
+      {banner && templateProps.templates.banner ? (
+        <Template
+          {...templateProps}
+          templateKey="banner"
+          rootTagName="aside"
+          rootProps={{
+            className: cssClasses.bannerRoot,
+          }}
+          data={banner}
+        />
+      ) : (
+        <aside>default component goes here</aside>
       )}
 
       <ol className={cssClasses.list}>

--- a/packages/instantsearch.js/src/components/InfiniteHits/InfiniteHits.tsx
+++ b/packages/instantsearch.js/src/components/InfiniteHits/InfiniteHits.tsx
@@ -109,10 +109,10 @@ const InfiniteHits = ({
               {...templateProps}
               templateKey="banner"
               rootTagName="fragment"
-              rootProps={{
+              data={{
+                banner,
                 className: cssClasses.bannerRoot,
               }}
-              data={banner}
             />
           ) : (
             <DefaultBanner banner={banner} classNames={cssClasses} />
@@ -151,10 +151,10 @@ const InfiniteHits = ({
             {...templateProps}
             templateKey="banner"
             rootTagName="fragment"
-            rootProps={{
+            data={{
+              banner,
               className: cssClasses.bannerRoot,
             }}
-            data={banner}
           />
         ) : (
           <DefaultBanner banner={banner} classNames={cssClasses} />

--- a/packages/instantsearch.js/src/components/InfiniteHits/__tests__/InfiniteHits-test.tsx
+++ b/packages/instantsearch.js/src/components/InfiniteHits/__tests__/InfiniteHits-test.tsx
@@ -28,6 +28,9 @@ describe('InfiniteHits', () => {
     disabledLoadPrevious: 'disabledLoadPrevious',
     loadMore: 'loadMore',
     disabledLoadMore: 'disabledLoadMore',
+    bannerRoot: 'bannerRoot',
+    bannerImage: 'bannerImage',
+    bannerLink: 'bannerLink',
   };
 
   const sendEvent = () => {};

--- a/packages/instantsearch.js/src/components/InfiniteHits/__tests__/InfiniteHits.test.tsx
+++ b/packages/instantsearch.js/src/components/InfiniteHits/__tests__/InfiniteHits.test.tsx
@@ -63,6 +63,9 @@ describe('InfiniteHits', () => {
         disabledLoadPrevious: '',
         loadMore: '',
         disabledLoadMore: '',
+        bannerRoot: '',
+        bannerImage: '',
+        bannerLink: '',
       },
       templateProps: prepareTemplateProps({
         defaultTemplates: {

--- a/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits.test.tsx
+++ b/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits.test.tsx
@@ -343,8 +343,10 @@ describe('infiniteHits', () => {
             empty({ query }, { html }) {
               return html`<p>No results for <q>${query}</q></p>`;
             },
-            banner(_, { html }) {
-              return html`<p>Banner</p>`;
+            banner({ banner, className }, { html }) {
+              return html`<div class="${className}">
+                <img src="${banner?.image.urls[0].url}" />
+              </div>`;
             },
           },
         }),
@@ -367,9 +369,13 @@ describe('infiniteHits', () => {
                 Show previous
               </span>
             </button>
-            <p>
-              Banner
-            </p>
+            <div
+              class="ais-InfiniteHits-banner"
+            >
+              <img
+                src="https://via.placeholder.com/550x250"
+              />
+            </div>
             <ol
               class="ais-InfiniteHits-list"
             >
@@ -553,9 +559,13 @@ describe('infiniteHits', () => {
           <div
             class="ais-InfiniteHits ais-InfiniteHits--empty"
           >
-            <p>
-              Banner
-            </p>
+            <div
+              class="ais-InfiniteHits-banner"
+            >
+              <img
+                src="https://via.placeholder.com/550x250"
+              />
+            </div>
             <p>
               No results for 
               <q>

--- a/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits.test.tsx
+++ b/packages/instantsearch.js/src/widgets/infinite-hits/__tests__/infinite-hits.test.tsx
@@ -20,6 +20,21 @@ import infiniteHits from '../infinite-hits';
 import type { SearchResponse } from '../../../../src/types';
 import type { MockSearchClient } from '@instantsearch/mocks';
 
+const bannerWidgetRenderingContent = {
+  widgets: {
+    banners: [
+      {
+        image: {
+          urls: [{ url: 'https://via.placeholder.com/550x250' }],
+        },
+        link: {
+          url: 'https://www.algolia.com',
+        },
+      },
+    ],
+  },
+};
+
 beforeEach(() => {
   document.body.innerHTML = '';
 });
@@ -50,7 +65,11 @@ describe('infiniteHits', () => {
 
     test('adds custom CSS classes', async () => {
       const container = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClient({
+        // @TODO: remove once algoliasearch js client has been updated
+        // @ts-expect-error
+        renderingContent: bannerWidgetRenderingContent,
+      });
 
       const search = instantsearch({
         indexName: 'indexName',
@@ -78,6 +97,9 @@ describe('infiniteHits', () => {
             loadMore: 'LOAD_MORE',
             disabledLoadPrevious: 'DISABLED_LOAD_PREVIOUS',
             disabledLoadMore: 'DISABLED_LOAD_MORE',
+            bannerRoot: 'BANNER_ROOT',
+            bannerImage: 'BANNER_IMAGE',
+            bannerLink: 'BANNER_LINK',
           },
         }),
       ]);
@@ -99,6 +121,15 @@ describe('infiniteHits', () => {
       expect(container.querySelector('.ais-InfiniteHits-loadMore')).toHaveClass(
         'LOAD_MORE DISABLED_LOAD_MORE'
       );
+      expect(container.querySelector('.ais-InfiniteHits-banner')).toHaveClass(
+        'BANNER_ROOT'
+      );
+      expect(
+        container.querySelector('.ais-InfiniteHits-banner-image')
+      ).toHaveClass('BANNER_IMAGE');
+      expect(
+        container.querySelector('.ais-InfiniteHits-banner-link')
+      ).toHaveClass('BANNER_LINK');
     });
 
     type CustomRecord = { somethingSpecial: string };
@@ -274,7 +305,11 @@ describe('infiniteHits', () => {
     test('renders with templates using `html`', async () => {
       const container = document.createElement('div');
       const searchBoxContainer = document.createElement('div');
-      const searchClient = createMockedSearchClient();
+      const searchClient = createMockedSearchClient({
+        // @TODO: remove once algoliasearch js client has been updated
+        // @ts-expect-error
+        renderingContent: bannerWidgetRenderingContent,
+      });
 
       const search = instantsearch({ indexName: 'indexName', searchClient });
 
@@ -308,6 +343,9 @@ describe('infiniteHits', () => {
             empty({ query }, { html }) {
               return html`<p>No results for <q>${query}</q></p>`;
             },
+            banner(_, { html }) {
+              return html`<p>Banner</p>`;
+            },
           },
         }),
       ]);
@@ -329,6 +367,9 @@ describe('infiniteHits', () => {
                 Show previous
               </span>
             </button>
+            <p>
+              Banner
+            </p>
             <ol
               class="ais-InfiniteHits-list"
             >
@@ -512,6 +553,9 @@ describe('infiniteHits', () => {
           <div
             class="ais-InfiniteHits ais-InfiniteHits--empty"
           >
+            <p>
+              Banner
+            </p>
             <p>
               No results for 
               <q>

--- a/packages/instantsearch.js/src/widgets/infinite-hits/infinite-hits.tsx
+++ b/packages/instantsearch.js/src/widgets/infinite-hits/infinite-hits.tsx
@@ -82,6 +82,21 @@ export type InfiniteHitsCSSClasses = Partial<{
    * The disabled “Show more” button.
    */
   disabledLoadMore: string | string[];
+
+  /**
+   * Class names to apply to the banner element
+   */
+  bannerRoot: string | string[];
+
+  /**
+   * Class names to apply to the banner image element
+   */
+  bannerImage: string | string[];
+
+  /**
+   * Class names to apply to the banner link element
+   */
+  bannerLink: string | string[];
 }>;
 
 export type InfiniteHitsTemplates<THit extends NonNullable<object> = BaseHit> =
@@ -110,6 +125,14 @@ export type InfiniteHitsTemplates<THit extends NonNullable<object> = BaseHit> =
         __hitIndex: number;
       }
     >;
+
+    /**
+     * Template to use for the banner.
+     */
+    banner: Template<{
+      banner: Required<InfiniteHitsRenderState['banner']>;
+      className: string;
+    }>;
   }>;
 
 export type InfiniteHitsWidgetParams<
@@ -172,6 +195,7 @@ const renderer =
       insights,
       bindEvent,
       sendEvent,
+      banner,
     },
     isFirstRendering
   ) => {
@@ -199,6 +223,7 @@ const renderer =
         insights={insights as InsightsClient}
         sendEvent={sendEvent}
         bindEvent={bindEvent}
+        banner={banner}
       />,
       containerNode
     );
@@ -242,6 +267,18 @@ export default (function infiniteHits<
     disabledLoadMore: cx(
       suit({ descendantName: 'loadMore', modifierName: 'disabled' }),
       userCssClasses.disabledLoadMore
+    ),
+    bannerRoot: cx(
+      suit({ descendantName: 'banner' }),
+      userCssClasses.bannerRoot
+    ),
+    bannerImage: cx(
+      suit({ descendantName: 'banner-image' }),
+      userCssClasses.bannerImage
+    ),
+    bannerLink: cx(
+      suit({ descendantName: 'banner-link' }),
+      userCssClasses.bannerLink
     ),
   };
 

--- a/packages/react-instantsearch/src/ui/InfiniteHits.tsx
+++ b/packages/react-instantsearch/src/ui/InfiniteHits.tsx
@@ -1,15 +1,21 @@
 import { cx } from 'instantsearch-ui-components';
 import React from 'react';
 
+import type { Banner } from 'algoliasearch-helper';
 import type { Hit } from 'instantsearch.js';
 import type { SendEventForHits } from 'instantsearch.js/es/lib/utils';
 
 export type InfiniteHitsProps<THit> = React.ComponentProps<'div'> & {
   hits: THit[];
+  banner?: Banner;
   sendEvent: SendEventForHits;
   hitComponent?: React.JSXElementConstructor<{
     hit: THit;
     sendEvent: SendEventForHits;
+  }>;
+  bannerComponent?: React.JSXElementConstructor<{
+    className: string;
+    banner: Banner;
   }>;
   isFirstPage: boolean;
   isLastPage: boolean;
@@ -52,6 +58,20 @@ export type InfiniteHitsClassNames = {
    * Class names to apply to each item element
    */
   item: string;
+  /**
+   * Class names to apply to the banner element
+   */
+  bannerRoot: string | string[];
+
+  /**
+   * Class names to apply to the banner image element
+   */
+  bannerImage: string | string[];
+
+  /**
+   * Class names to apply to the banner link element
+   */
+  bannerLink: string | string[];
 };
 
 export type InfiniteHitsTranslations = {
@@ -67,9 +87,54 @@ function DefaultHitComponent({ hit }: { hit: Hit }) {
   );
 }
 
+type BannerProps = {
+  banner: Banner;
+  classNames: Pick<
+    Partial<InfiniteHitsClassNames>,
+    'bannerRoot' | 'bannerLink' | 'bannerImage'
+  >;
+};
+
+function DefaultBanner({ classNames, banner }: BannerProps) {
+  if (!banner.image.urls[0].url) {
+    return null;
+  }
+  return (
+    <aside className={cx('ais-InfiniteHits-banner', classNames.bannerRoot)}>
+      {banner.link ? (
+        <a
+          className={cx('ais-InfiniteHits-banner-link', classNames.bannerLink)}
+          href={banner.link.url}
+          target={banner.link.target}
+        >
+          <img
+            className={cx(
+              'ais-InfiniteHits-banner-image',
+              classNames.bannerImage
+            )}
+            src={banner.image.urls[0].url}
+            alt={banner.image.title}
+          />
+        </a>
+      ) : (
+        <img
+          className={cx(
+            'ais-InfiniteHits-banner-image',
+            classNames.bannerImage
+          )}
+          src={banner.image.urls[0].url}
+          alt={banner.image.title}
+        />
+      )}
+    </aside>
+  );
+}
+
 export function InfiniteHits<THit extends Hit>({
   hitComponent: HitComponent = DefaultHitComponent,
   hits,
+  bannerComponent: BannerComponent,
+  banner,
   sendEvent,
   isFirstPage,
   isLastPage,
@@ -107,6 +172,15 @@ export function InfiniteHits<THit extends Hit>({
           {translations.showPreviousButtonText}
         </button>
       )}
+      {banner &&
+        (BannerComponent ? (
+          <BannerComponent
+            className={cx('ais-InfiniteHits-banner', classNames.bannerRoot)}
+            banner={banner}
+          />
+        ) : (
+          <DefaultBanner classNames={classNames} banner={banner} />
+        ))}
       <ol className={cx('ais-InfiniteHits-list', classNames.list)}>
         {hits.map((hit) => (
           <li

--- a/packages/react-instantsearch/src/ui/__tests__/InfiniteHits.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/InfiniteHits.test.tsx
@@ -83,6 +83,140 @@ describe('InfiniteHits', () => {
     `);
   });
 
+  test('renders with a banner (navigable)', () => {
+    const props = createProps({
+      banner: {
+        image: {
+          urls: [{ url: 'https://example.com/image.jpg' }],
+        },
+        link: {
+          url: 'https://example.com',
+        },
+      },
+    });
+
+    const { container } = render(<InfiniteHits {...props} />);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-InfiniteHits"
+        >
+          <button
+            class="ais-InfiniteHits-loadPrevious ais-InfiniteHits-loadPrevious--disabled"
+            disabled=""
+          >
+            Show previous results
+          </button>
+          <aside
+            class="ais-InfiniteHits-banner"
+          >
+            <a
+              class="ais-InfiniteHits-banner-link"
+              href="https://example.com"
+            >
+              <img
+                class="ais-InfiniteHits-banner-image"
+                src="https://example.com/image.jpg"
+              />
+            </a>
+          </aside>
+          <ol
+            class="ais-InfiniteHits-list"
+          >
+            <li
+              class="ais-InfiniteHits-item"
+            >
+              <div
+                style="word-break: break-all;"
+              >
+                {"objectID":"abc","__position":1}
+                …
+              </div>
+            </li>
+            <li
+              class="ais-InfiniteHits-item"
+            >
+              <div
+                style="word-break: break-all;"
+              >
+                {"objectID":"def","__position":2}
+                …
+              </div>
+            </li>
+          </ol>
+          <button
+            class="ais-InfiniteHits-loadMore"
+          >
+            Show more results
+          </button>
+        </div>
+      </div>
+    `);
+  });
+
+  test('renders with a banner (non-navigable)', () => {
+    const props = createProps({
+      banner: {
+        image: {
+          urls: [{ url: 'https://example.com/image.jpg' }],
+        },
+      },
+    });
+
+    const { container } = render(<InfiniteHits {...props} />);
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <div
+          class="ais-InfiniteHits"
+        >
+          <button
+            class="ais-InfiniteHits-loadPrevious ais-InfiniteHits-loadPrevious--disabled"
+            disabled=""
+          >
+            Show previous results
+          </button>
+          <aside
+            class="ais-InfiniteHits-banner"
+          >
+            <img
+              class="ais-InfiniteHits-banner-image"
+              src="https://example.com/image.jpg"
+            />
+          </aside>
+          <ol
+            class="ais-InfiniteHits-list"
+          >
+            <li
+              class="ais-InfiniteHits-item"
+            >
+              <div
+                style="word-break: break-all;"
+              >
+                {"objectID":"abc","__position":1}
+                …
+              </div>
+            </li>
+            <li
+              class="ais-InfiniteHits-item"
+            >
+              <div
+                style="word-break: break-all;"
+              >
+                {"objectID":"def","__position":2}
+                …
+              </div>
+            </li>
+          </ol>
+          <button
+            class="ais-InfiniteHits-loadMore"
+          >
+            Show more results
+          </button>
+        </div>
+      </div>
+    `);
+  });
+
   test('renders with translations', () => {
     const props = createProps({
       translations: {
@@ -203,6 +337,128 @@ describe('InfiniteHits', () => {
 
     expect(props.sendEvent).toHaveBeenCalledTimes(2);
     expect((props.sendEvent as jest.Mock).mock.calls[0][0]).toBe(props.hits[0]);
+  });
+
+  describe('bannerComponent', () => {
+    test('renders when defined', () => {
+      const props = createProps({
+        banner: {
+          image: {
+            urls: [{ url: 'https://example.com/image.jpg' }],
+          },
+        },
+      });
+
+      const { container } = render(<InfiniteHits {...props} />);
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <div
+            class="ais-InfiniteHits"
+          >
+            <button
+              class="ais-InfiniteHits-loadPrevious ais-InfiniteHits-loadPrevious--disabled"
+              disabled=""
+            >
+              Show previous results
+            </button>
+            <aside
+              class="ais-InfiniteHits-banner"
+            >
+              <img
+                class="ais-InfiniteHits-banner-image"
+                src="https://example.com/image.jpg"
+              />
+            </aside>
+            <ol
+              class="ais-InfiniteHits-list"
+            >
+              <li
+                class="ais-InfiniteHits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"abc","__position":1}
+                  …
+                </div>
+              </li>
+              <li
+                class="ais-InfiniteHits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"def","__position":2}
+                  …
+                </div>
+              </li>
+            </ol>
+            <button
+              class="ais-InfiniteHits-loadMore"
+            >
+              Show more results
+            </button>
+          </div>
+        </div>
+      `);
+    });
+
+    test('does not render when no banner data', () => {
+      const props = createProps({
+        bannerComponent: ({ banner }) => (
+          <a href={banner?.link?.url}>
+            <img src={banner.image.urls[0].url} />
+          </a>
+        ),
+      });
+
+      const { container } = render(<InfiniteHits {...props} />);
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <div
+            class="ais-InfiniteHits"
+          >
+            <button
+              class="ais-InfiniteHits-loadPrevious ais-InfiniteHits-loadPrevious--disabled"
+              disabled=""
+            >
+              Show previous results
+            </button>
+            <ol
+              class="ais-InfiniteHits-list"
+            >
+              <li
+                class="ais-InfiniteHits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"abc","__position":1}
+                  …
+                </div>
+              </li>
+              <li
+                class="ais-InfiniteHits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"def","__position":2}
+                  …
+                </div>
+              </li>
+            </ol>
+            <button
+              class="ais-InfiniteHits-loadMore"
+            >
+              Show more results
+            </button>
+          </div>
+        </div>
+      `);
+    });
   });
 
   describe('showPrevious', () => {

--- a/packages/react-instantsearch/src/widgets/InfiniteHits.tsx
+++ b/packages/react-instantsearch/src/widgets/InfiniteHits.tsx
@@ -10,6 +10,8 @@ import type { UseInfiniteHitsProps } from 'react-instantsearch-core';
 type UiProps<THit extends BaseHit = BaseHit> = Pick<
   InfiniteHitsUiComponentProps<Hit<THit>>,
   | 'hits'
+  | 'banner'
+  | 'bannerComponent'
   | 'sendEvent'
   | 'onShowPrevious'
   | 'onShowMore'
@@ -21,8 +23,14 @@ type UiProps<THit extends BaseHit = BaseHit> = Pick<
 export type InfiniteHitsProps<THit extends BaseHit = BaseHit> = Omit<
   InfiniteHitsUiComponentProps<Hit<THit>>,
   keyof UiProps<THit>
-> &
-  UseInfiniteHitsProps<THit> & {
+> & {
+  bannerComponent?:
+    | React.JSXElementConstructor<{
+        banner: Required<InfiniteHitsUiComponentProps<Hit<THit>>>['banner'];
+        className: string;
+      }>
+    | false;
+} & UseInfiniteHitsProps<THit> & {
     /**
      * Displays the "Show Previous" button when the UI is loaded from a page
      * beyond the first one.
@@ -39,16 +47,30 @@ export function InfiniteHits<THit extends BaseHit = BaseHit>({
   showPrevious: userShowPrevious,
   transformItems,
   translations,
+  bannerComponent: BannerComponent,
   ...props
 }: InfiniteHitsProps<THit>) {
-  const { hits, sendEvent, showPrevious, showMore, isFirstPage, isLastPage } =
-    useInfiniteHits<THit>(
-      { cache, escapeHTML, showPrevious: userShowPrevious, transformItems },
-      { $$widgetType: 'ais.infiniteHits' }
-    );
+  const {
+    hits,
+    banner,
+    sendEvent,
+    showPrevious,
+    showMore,
+    isFirstPage,
+    isLastPage,
+  } = useInfiniteHits<THit>(
+    { cache, escapeHTML, showPrevious: userShowPrevious, transformItems },
+    { $$widgetType: 'ais.infiniteHits' }
+  );
+
+  const bannerComponent = (
+    BannerComponent === false ? () => null : BannerComponent
+  ) as InfiniteHitsUiComponentProps<THit>['bannerComponent'];
 
   const uiProps: UiProps<THit> = {
     hits,
+    banner,
+    bannerComponent,
     sendEvent,
     onShowPrevious: shouldShowPrevious ? showPrevious : undefined,
     onShowMore: showMore,

--- a/packages/react-instantsearch/src/widgets/__tests__/InfiniteHits.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/InfiniteHits.test.tsx
@@ -14,10 +14,66 @@ import React from 'react';
 import { InfiniteHits } from '../InfiniteHits';
 
 import type { MockSearchClient } from '@instantsearch/mocks';
+import type { AlgoliaHit } from 'instantsearch.js';
+
+type CustomHit = { somethingSpecial: string };
+
+const bannerWidgetRenderingContent = {
+  widgets: {
+    banners: [
+      {
+        image: {
+          urls: [{ url: 'https://via.placeholder.com/550x250' }],
+        },
+        link: {
+          url: 'https://www.algolia.com',
+        },
+      },
+    ],
+  },
+};
+
+function getSearchClient(withBannerWidget = false) {
+  return createSearchClient({
+    search: jest.fn((requests) =>
+      Promise.resolve(
+        createMultiSearchResponse(
+          ...requests.map(
+            (request: Parameters<MockSearchClient['search']>[0][number]) => {
+              const { hitsPerPage = 3, page = 0 } = request.params!;
+              const hits = Array.from({ length: hitsPerPage }, (_, i) => {
+                const offset = hitsPerPage * page;
+                return {
+                  objectID: (i + offset).toString(),
+                  somethingSpecial: String.fromCharCode(
+                    'a'.charCodeAt(0) + i + offset
+                  ),
+                };
+              });
+
+              return createSingleSearchResponse<AlgoliaHit<CustomHit>>({
+                hits,
+                page,
+                nbPages: 10,
+                hitsPerPage,
+                index: request.indexName,
+                // @TODO: remove once algoliasearch js client has been updated
+                // @ts-expect-error
+                renderingContent: withBannerWidget
+                  ? bannerWidgetRenderingContent
+                  : undefined,
+              });
+            }
+          )
+        )
+      )
+    ) as MockSearchClient['search'],
+  });
+}
 
 describe('InfiniteHits', () => {
   test('renders the "Show Previous" button by default', async () => {
-    const searchClient = createMockedSearchClient();
+    const searchClient = getSearchClient();
     const { container } = render(
       <InstantSearchTestWrapper
         searchClient={searchClient}
@@ -39,7 +95,7 @@ describe('InfiniteHits', () => {
   });
 
   test('renders with a custom hit component', async () => {
-    const searchClient = createMockedSearchClient();
+    const searchClient = getSearchClient();
     const { container } = render(
       <InstantSearchTestWrapper searchClient={searchClient}>
         <InfiniteHits<CustomHit>
@@ -99,7 +155,7 @@ describe('InfiniteHits', () => {
   });
 
   test('forwards custom class names and `div` props to the root element', () => {
-    const searchClient = createMockedSearchClient();
+    const searchClient = getSearchClient();
     const { container } = render(
       <InstantSearchTestWrapper searchClient={searchClient}>
         <InfiniteHits
@@ -116,7 +172,7 @@ describe('InfiniteHits', () => {
   });
 
   test('renders with translations', async () => {
-    const searchClient = createMockedSearchClient();
+    const searchClient = getSearchClient();
     const { getByRole } = render(
       <InstantSearchTestWrapper
         searchClient={searchClient}
@@ -138,39 +194,125 @@ describe('InfiniteHits', () => {
       getByRole('button', { name: 'Display previous' })
     ).toBeInTheDocument();
   });
-});
 
-type CustomHit = { somethingSpecial: string };
+  describe('banner', () => {
+    test('renders a banner', async () => {
+      const searchClient = getSearchClient(true);
+      const { container } = render(
+        <InstantSearchTestWrapper searchClient={searchClient}>
+          <InfiniteHits />
+        </InstantSearchTestWrapper>
+      );
 
-function createMockedSearchClient() {
-  return createSearchClient({
-    search: jest.fn((requests) =>
-      Promise.resolve(
-        createMultiSearchResponse(
-          ...requests.map(
-            (request: Parameters<MockSearchClient['search']>[0][number]) => {
-              const { hitsPerPage = 3, page = 0 } = request.params!;
-              const hits = Array.from({ length: hitsPerPage }, (_, i) => {
-                const offset = hitsPerPage * page;
-                return {
-                  objectID: (i + offset).toString(),
-                  somethingSpecial: String.fromCharCode(
-                    'a'.charCodeAt(0) + i + offset
-                  ),
-                };
-              });
+      await waitFor(() => {
+        expect(container.querySelectorAll('img')).toHaveLength(1);
+        expect(container.querySelectorAll('a')).toHaveLength(1);
+        expect(container.querySelector('.ais-Hits')).toMatchInlineSnapshot(
+          `null`
+        );
+      });
+    });
 
-              return createSingleSearchResponse<CustomHit>({
-                hits,
-                page,
-                nbPages: 10,
-                hitsPerPage,
-                index: request.indexName,
-              });
-            }
-          )
-        )
-      )
-    ) as MockSearchClient['search'],
+    test('does not render a banner when "bannerComponent" is set to false', async () => {
+      const searchClient = getSearchClient(true);
+      const { container } = render(
+        <InstantSearchTestWrapper searchClient={searchClient}>
+          <InfiniteHits bannerComponent={false} />
+        </InstantSearchTestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('img')).toHaveLength(0);
+        expect(container.querySelectorAll('a')).toHaveLength(0);
+        expect(container.querySelector('.ais-InfiniteHits'))
+          .toMatchInlineSnapshot(`
+          <div
+            class="ais-InfiniteHits ais-InfiniteHits--empty"
+          >
+            <ol
+              class="ais-InfiniteHits-list"
+            />
+            <button
+              class="ais-InfiniteHits-loadMore ais-InfiniteHits-loadMore--disabled"
+              disabled=""
+            >
+              Show more results
+            </button>
+          </div>
+        `);
+      });
+    });
+
+    test('renders custom banner component', async () => {
+      const searchClient = getSearchClient(true);
+      const { container } = render(
+        <InstantSearchTestWrapper searchClient={searchClient}>
+          <InfiniteHits
+            bannerComponent={({ banner }) => (
+              <img src={banner.image.urls[0].url} />
+            )}
+          />
+        </InstantSearchTestWrapper>
+      );
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('img')).toHaveLength(1);
+        expect(container.querySelector('.ais-InfiniteHits'))
+          .toMatchInlineSnapshot(`
+          <div
+            class="ais-InfiniteHits"
+          >
+            <button
+              class="ais-InfiniteHits-loadPrevious ais-InfiniteHits-loadPrevious--disabled"
+              disabled=""
+            >
+              Show previous results
+            </button>
+            <img
+              src="https://via.placeholder.com/550x250"
+            />
+            <ol
+              class="ais-InfiniteHits-list"
+            >
+              <li
+                class="ais-InfiniteHits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"0","somethingSpecial":"a","__position":1}
+                  …
+                </div>
+              </li>
+              <li
+                class="ais-InfiniteHits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"1","somethingSpecial":"b","__position":2}
+                  …
+                </div>
+              </li>
+              <li
+                class="ais-InfiniteHits-item"
+              >
+                <div
+                  style="word-break: break-all;"
+                >
+                  {"objectID":"2","somethingSpecial":"c","__position":3}
+                  …
+                </div>
+              </li>
+            </ol>
+            <button
+              class="ais-InfiniteHits-loadMore"
+            >
+              Show more results
+            </button>
+          </div>
+        `);
+      });
+    });
   });
-}
+});

--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -589,8 +589,12 @@ const testOptions = {
   createBreadcrumbWidgetTests: undefined,
   createMenuWidgetTests: undefined,
   createPaginationWidgetTests: undefined,
-  createInfiniteHitsWidgetTests: undefined,
-  createHitsWidgetTests: undefined,
+  createInfiniteHitsWidgetTests: {
+    skippedTests: { 'banner option': true },
+  },
+  createHitsWidgetTests: {
+    skippedTests: { 'banner option': true },
+  },
   createRangeInputWidgetTests: undefined,
   createRatingMenuWidgetTests: undefined,
   createInstantSearchWidgetTests: undefined,

--- a/tests/common/widgets/hits/options.ts
+++ b/tests/common/widgets/hits/options.ts
@@ -171,6 +171,80 @@ export function createOptionsTests(
         );
       });
     });
+
+    skippableDescribe('banner option', skippedTests, () => {
+      test('renders default banner element with banner widget renderingContent', async () => {
+        const searchClient = createMockedSearchClient({
+          renderingContent: {
+            // @TODO: remove once algoliasearch js client has been updated
+            // @ts-expect-error
+            widgets: {
+              banners: [
+                {
+                  image: {
+                    urls: [{ url: 'https://via.placeholder.com/550x250' }],
+                  },
+                  link: {
+                    url: 'https://www.algolia.com',
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+        await setup({
+          instantSearchOptions: {
+            indexName: 'indexName',
+            searchClient,
+          },
+          widgetParams: {},
+        });
+
+        await act(async () => {
+          await wait(0);
+        });
+
+        expect(
+          document.querySelector('#hits-with-defaults .ais-Hits')
+        ).toMatchNormalizedInlineSnapshot(
+          normalizeSnapshot,
+          `
+          <div
+            class="ais-Hits"
+          >
+            <aside
+              class="ais-Hits-banner"
+            >
+              <a
+                class="ais-Hits-banner-link"
+                href="https://www.algolia.com"
+              >
+                <img
+                  class="ais-Hits-banner-image"
+                  src="https://via.placeholder.com/550x250"
+                />
+              </a>
+            </aside>
+            <ol
+              class="ais-Hits-list"
+            >
+              <li
+                class="ais-Hits-item"
+              >
+                {"objectID":"1"}
+              </li>
+              <li
+                class="ais-Hits-item"
+              >
+                {"objectID":"2"}
+              </li>
+            </ol>
+          </div>
+          `
+        );
+      });
+    });
   });
 }
 

--- a/tests/common/widgets/infinite-hits/options.ts
+++ b/tests/common/widgets/infinite-hits/options.ts
@@ -9,6 +9,8 @@ import {
 } from '@instantsearch/testutils';
 import userEvent from '@testing-library/user-event';
 
+import { skippableDescribe } from '../../common';
+
 import type { InfiniteHitsWidgetSetup } from '.';
 import type { TestOptions } from '../../common';
 import type { MockSearchClient } from '@instantsearch/mocks';
@@ -51,7 +53,7 @@ function normalizeSnapshot(html: string) {
 
 export function createOptionsTests(
   setup: InfiniteHitsWidgetSetup,
-  { act }: Required<TestOptions>
+  { act, skippedTests }: Required<TestOptions>
 ) {
   describe('options', () => {
     test('renders with default props', async () => {
@@ -104,6 +106,90 @@ export function createOptionsTests(
         </div>
       `
       );
+    });
+
+    skippableDescribe('banner option', skippedTests, () => {
+      test('renders default banner element with banner widget renderingContent', async () => {
+        const searchClient = createMockedSearchClient({
+          renderingContent: {
+            // @TODO: remove once algoliasearch js client has been updated
+            // @ts-expect-error
+            widgets: {
+              banners: [
+                {
+                  image: {
+                    urls: [{ url: 'https://via.placeholder.com/550x250' }],
+                  },
+                  link: {
+                    url: 'https://www.algolia.com',
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+        await setup({
+          instantSearchOptions: {
+            indexName: 'indexName',
+            searchClient,
+          },
+          widgetParams: {},
+        });
+
+        await act(async () => {
+          await wait(0);
+        });
+
+        expect(
+          document.querySelector('#hits-with-defaults .ais-InfiniteHits')
+        ).toMatchNormalizedInlineSnapshot(
+          normalizeSnapshot,
+          `
+          <div
+            class="ais-InfiniteHits"
+          >
+            <aside
+              class="ais-InfiniteHits-banner"
+            >
+              <a
+                class="ais-InfiniteHits-banner-link"
+                href="https://www.algolia.com"
+              >
+                <img
+                  class="ais-InfiniteHits-banner-image"
+                  src="https://via.placeholder.com/550x250"
+                />
+              </a>
+            </aside>
+            <ol
+              class="ais-InfiniteHits-list"
+            >
+              <li
+                class="ais-InfiniteHits-item"
+              >
+                {"objectID":"0"}
+              </li>
+              <li
+                class="ais-InfiniteHits-item"
+              >
+                {"objectID":"1"}
+              </li>
+              <li
+                class="ais-InfiniteHits-item"
+              >
+                {"objectID":"2"}
+              </li>
+            </ol>
+            <button
+              class="ais-InfiniteHits-loadMore"
+            >
+              Show more results
+            </button>
+          </div>
+          `
+        );
+      });
     });
 
     test('renders transformed items', async () => {


### PR DESCRIPTION
**Summary**

A series of PRs recently added a top banner to the `Hits` widget (visibility is controlled by rules that update `renderingContent` for a given query). This PR implements the same feature, but for the `InfiniteHits` widget.

This was done by:

1. updating `connectInfiniteHits` (previous PR)
2. updating `InfiniteHits` JS component
3. updating `infinite-hits` JS widget
4. updating `InfiniteHits` React component
5. updating `InfiniteHits` React widget
6. updating `satellite.scss` and `algolia.scss`

Related tickets:

- https://algolia.atlassian.net/browse/EMERCH-1501
- https://algolia.atlassian.net/browse/EMERCH-1502
- https://algolia.atlassian.net/browse/EMERCH-1503
- https://algolia.atlassian.net/browse/EMERCH-1505

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

JS Hits, default banner:
![image](https://github.com/algolia/instantsearch/assets/10552296/7785e096-e995-4533-a3f7-1710675616de)

JS InfiniteHits, default banner:
![image](https://github.com/algolia/instantsearch/assets/10552296/5ebf5c4b-225b-4a9f-8ac9-c578b0942574)

JS InfiniteHits, default banner, no results:
![image](https://github.com/algolia/instantsearch/assets/10552296/441fcfed-3591-4911-8057-b8ad98395315)

React Hits, default banner:
![image](https://github.com/algolia/instantsearch/assets/10552296/9205c185-7b14-4bcf-93b7-fb5dcd58e40d)

React InfiniteHits, default banner:
![image](https://github.com/algolia/instantsearch/assets/10552296/1c73db68-bfd8-4712-96b5-41a217386753)

React InfiniteHits, default banner, no results:
![image](https://github.com/algolia/instantsearch/assets/10552296/6dd612cb-b257-4f1d-b49b-e1f0bf750691)
