### PR TITLE
fix(types): make algoliasearch detection compatible with TS 5.4.5

### DIFF
--- a/packages/algoliasearch-helper/types/algoliasearch.d.ts
+++ b/packages/algoliasearch-helper/types/algoliasearch.d.ts
@@ -28,18 +28,24 @@ type SearchClientShape = {
 // @ts-ignore
 type ClientV3_4 = ReturnType<typeof algoliasearch>;
 
-type ClientLiteV5 = AnyToUnknown<
-  // @ts-ignore
-  ReturnType<typeof AlgoliaSearchLite.liteClient>
->;
-type ClientFullV5 = AnyToUnknown<
-  // @ts-ignore
-  ReturnType<typeof AlgoliaSearch.algoliasearch>
->;
-type ClientSearchV5 = AnyToUnknown<
-  // @ts-ignore
-  ReturnType<typeof ClientSearch.searchClient>
->;
+type ClientLiteV5 = AnyToUnknown<typeof AlgoliaSearchLite> extends unknown
+  ? unknown
+  : AnyToUnknown<
+      // @ts-ignore
+      ReturnType<typeof AlgoliaSearchLite.liteClient>
+    >;
+type ClientFullV5 = AnyToUnknown<typeof AlgoliaSearch> extends unknown
+  ? unknown
+  : AnyToUnknown<
+      // @ts-ignore
+      ReturnType<typeof AlgoliaSearch.algoliasearch>
+    >;
+type ClientSearchV5 = AnyToUnknown<typeof ClientSearch> extends unknown
+  ? unknown
+  : AnyToUnknown<
+      // @ts-ignore
+      ReturnType<typeof ClientSearch.searchClient>
+    >;
 type ClientV5 = ClientLiteV5 extends SearchClientShape
   ? ClientLiteV5
   : ClientSearchV5 extends SearchClientShape


### PR DESCRIPTION
I can't manage to reproduce this locally, even if i update everything to 5.4.5, but in a fresh Next.js example (like  https://codesandbox.io/s/47fy7c) `hitsPerPage` isn't accepted to Configure (because PlainSearchParameters is any)

This is I believe linked to https://github.com/microsoft/TypeScript/pull/56004, maybe also to https://github.com/sindresorhus/type-fest/issues/846 (although the case seems different).

Essentially before this change the types like `ClientLiteV5` were evaluated to `any` instead of `unknown`, poisoning the entire type and turning everything into any.

The solution is to first check if `typeof AlgoliaSearchLite` is any, and if it is any we don't even evaluate the rest of teh type. Of course if it isn't any it works correctly for v5 still.

Again, unfortunately this isn't reproducible in this repo, even when every typescript version is updated to 5.4.5, but at least the error will be fixed

fixes #5989
