### PR TITLE
fix(algoliasearch): v5 does not default threshold to 0

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "67.75 kB"
+      "maxSize": "68 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",

--- a/packages/algoliasearch-helper/src/RecommendParameters/index.js
+++ b/packages/algoliasearch-helper/src/RecommendParameters/index.js
@@ -73,7 +73,11 @@ RecommendParameters.prototype = {
         return cache[params.$$id] === undefined;
       })
       .map(function (params) {
-        var query = Object.assign({}, params, { indexName: indexName });
+        var query = Object.assign({}, params, {
+          indexName: indexName,
+          // @TODO: remove this if it ever gets handled by the API
+          threshold: params.threshold || 0,
+        });
         delete query.$$id;
 
         return query;

--- a/packages/algoliasearch-helper/test/spec/RecommendParameters/methods.js
+++ b/packages/algoliasearch-helper/test/spec/RecommendParameters/methods.js
@@ -98,11 +98,13 @@ describe('_buildQueries', () => {
           "indexName": "indexName",
           "model": "bought-together",
           "objectID": "objectID1",
+          "threshold": 0,
         },
         Object {
           "facetName": "brand",
           "indexName": "indexName",
           "model": "trending-facets",
+          "threshold": 0,
         },
       ]
     `);

--- a/packages/algoliasearch-helper/test/spec/RecommendParameters/methods.js
+++ b/packages/algoliasearch-helper/test/spec/RecommendParameters/methods.js
@@ -109,4 +109,23 @@ describe('_buildQueries', () => {
       ]
     `);
   });
+
+  test('does not override threshold', () => {
+    var recommendParameters = new RecommendParameters({
+      params: [{ ...params1, threshold: 10 }],
+    });
+
+    var queries = recommendParameters._buildQueries('indexName', {});
+    expect(queries).toHaveLength(1);
+    expect(queries).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "indexName": "indexName",
+          "model": "bought-together",
+          "objectID": "objectID1",
+          "threshold": 10,
+        },
+      ]
+    `);
+  });
 });

--- a/packages/algoliasearch-helper/test/spec/recommend.js
+++ b/packages/algoliasearch-helper/test/spec/recommend.js
@@ -50,13 +50,20 @@ describe('recommend()', () => {
         indexName: 'indexName',
         model: 'bought-together',
         objectID: 'A0E20000000279B',
+        threshold: 0,
       },
       {
         indexName: 'indexName',
         model: 'bought-together',
         objectID: 'A0E20000000279C',
+        threshold: 0,
       },
-      { indexName: 'indexName', model: 'trending-facets', facetName: 'brand' },
+      {
+        indexName: 'indexName',
+        model: 'trending-facets',
+        facetName: 'brand',
+        threshold: 0,
+      },
     ]);
   });
 
@@ -158,6 +165,7 @@ describe('recommend()', () => {
         indexName: 'indexName',
         model: 'bought-together',
         objectID: 'A0E20000000279B',
+        threshold: 0,
       },
     ]);
 
@@ -175,6 +183,7 @@ describe('recommend()', () => {
           indexName: 'indexName',
           model: 'bought-together',
           objectID: 'A0E20000000279C',
+          threshold: 0,
         },
       ]);
     });

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -237,7 +237,7 @@ describe('network requests', () => {
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
             },
-            "threshold": undefined,
+            "threshold": 0,
           },
         ]
       `);
@@ -284,7 +284,7 @@ describe('network requests', () => {
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
             },
-            "threshold": undefined,
+            "threshold": 0,
           },
         ]
       `);
@@ -383,7 +383,7 @@ describe('network requests', () => {
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
             },
-            "threshold": undefined,
+            "threshold": 0,
           },
         ]
       `);
@@ -433,7 +433,7 @@ describe('network requests', () => {
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
             },
-            "threshold": undefined,
+            "threshold": 0,
           },
         ]
       `);
@@ -531,7 +531,7 @@ describe('network requests', () => {
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
             },
-            "threshold": undefined,
+            "threshold": 0,
           },
         ]
       `);
@@ -580,7 +580,7 @@ describe('network requests', () => {
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
             },
-            "threshold": undefined,
+            "threshold": 0,
           },
         ]
       `);
@@ -629,7 +629,7 @@ describe('network requests', () => {
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
             },
-            "threshold": undefined,
+            "threshold": 0,
           },
         ]
       `);


### PR DESCRIPTION
**Summary**

#### [FX-2926](https://algolia.atlassian.net/browse/FX-2926)

**Result**

The v5 of the API client does not do extra logic like it did before for ease of maintenance, so for now we have to do this on our end.


[FX-2926]: https://algolia.atlassian.net/browse/FX-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ