### PR TITLE
fix(pagination): any page outside the range is also first or last

### DIFF
--- a/packages/instantsearch.js/src/connectors/pagination/Paginator.ts
+++ b/packages/instantsearch.js/src/connectors/pagination/Paginator.ts
@@ -65,7 +65,7 @@ class Paginator {
   }
 
   public isFirstPage() {
-    return this.currentPage === 0;
+    return this.currentPage <= 0;
   }
 }
 

--- a/packages/instantsearch.js/src/connectors/pagination/Paginator.ts
+++ b/packages/instantsearch.js/src/connectors/pagination/Paginator.ts
@@ -61,7 +61,7 @@ class Paginator {
   }
 
   public isLastPage() {
-    return this.currentPage === this.total - 1 || this.total === 0;
+    return this.currentPage >= this.total - 1;
   }
 
   public isFirstPage() {

--- a/packages/instantsearch.js/src/connectors/pagination/__tests__/Paginator-test.ts
+++ b/packages/instantsearch.js/src/connectors/pagination/__tests__/Paginator-test.ts
@@ -106,6 +106,28 @@ describe('paginator: simple cases', () => {
       expect(pager.isFirstPage()).toBe(false);
     });
 
+    it('should be the last page', () => {
+      expect(pager.isLastPage()).toBe(true);
+    });
+  });
+
+  describe('past last page', () => {
+    const pager = new Paginator({
+      currentPage: 10,
+      total: 10,
+      padding: 2,
+    });
+
+    it('should return the pages', () => {
+      const pages = pager.pages();
+      expect(pages).toHaveLength(5);
+      expect(pages).toEqual([5, 6, 7, 8, 9]);
+    });
+
+    it('should not be the first page', () => {
+      expect(pager.isFirstPage()).toBe(false);
+    });
+
     it('should not be the last page', () => {
       expect(pager.isLastPage()).toBe(true);
     });

--- a/packages/instantsearch.js/src/connectors/pagination/__tests__/Paginator-test.ts
+++ b/packages/instantsearch.js/src/connectors/pagination/__tests__/Paginator-test.ts
@@ -128,8 +128,30 @@ describe('paginator: simple cases', () => {
       expect(pager.isFirstPage()).toBe(false);
     });
 
-    it('should not be the last page', () => {
+    it('should be the last page', () => {
       expect(pager.isLastPage()).toBe(true);
+    });
+  });
+
+  describe('before first page', () => {
+    const pager = new Paginator({
+      currentPage: -1,
+      total: 10,
+      padding: 2,
+    });
+
+    it('should return the pages', () => {
+      const pages = pager.pages();
+      expect(pages).toHaveLength(5);
+      expect(pages).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it('should be the first page', () => {
+      expect(pager.isFirstPage()).toBe(true);
+    });
+
+    it('should not be the last page', () => {
+      expect(pager.isLastPage()).toBe(false);
     });
   });
 });

--- a/tests/common/widgets/pagination/options.ts
+++ b/tests/common/widgets/pagination/options.ts
@@ -922,7 +922,7 @@ export function createOptionsTests(
       );
     });
 
-    test("does not display a next page when that doesn't exist", async () => {
+    test('does not display a next page when outside of range', async () => {
       const searchClient = createMockedSearchClient({ nbHits: 120 });
 
       await setup({
@@ -948,6 +948,35 @@ export function createOptionsTests(
       ).toHaveClass('ais-Pagination-item--disabled');
       expect(
         document.querySelector('.ais-Pagination-item--lastPage')
+      ).toHaveClass('ais-Pagination-item--disabled');
+    });
+
+    test('does not display a next previous page when outside of range', async () => {
+      const searchClient = createMockedSearchClient({ nbHits: 120 });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+          initialUiState: {
+            indexName: { page: -4 },
+          },
+        },
+        widgetParams: { padding: 4 },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(
+        document.querySelectorAll('.ais-Pagination-item--page')
+      ).toHaveLength(6);
+      expect(
+        document.querySelector('.ais-Pagination-item--previousPage')
+      ).toHaveClass('ais-Pagination-item--disabled');
+      expect(
+        document.querySelector('.ais-Pagination-item--firstPage')
       ).toHaveClass('ais-Pagination-item--disabled');
     });
 

--- a/tests/common/widgets/pagination/options.ts
+++ b/tests/common/widgets/pagination/options.ts
@@ -922,6 +922,35 @@ export function createOptionsTests(
       );
     });
 
+    test("does not display a next page when that doesn't exist", async () => {
+      const searchClient = createMockedSearchClient({ nbHits: 120 });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+          initialUiState: {
+            indexName: { page: 200 },
+          },
+        },
+        widgetParams: { padding: 4 },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(
+        document.querySelectorAll('.ais-Pagination-item--page')
+      ).toHaveLength(6);
+      expect(
+        document.querySelector('.ais-Pagination-item--nextPage')
+      ).toHaveClass('ais-Pagination-item--disabled');
+      expect(
+        document.querySelector('.ais-Pagination-item--lastPage')
+      ).toHaveClass('ais-Pagination-item--disabled');
+    });
+
     test('limits the total pages to display', async () => {
       const searchClient = createMockedSearchClient();
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

If the page is outside the range, it should behave like the 0th or last page. This disables the relevant buttons and links, which makes more sense UX-wise, and avoids creating pages that don't exist when you start from an invalid URL.

[CR-6249]


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

- Page >= limit page is considered last page
- negative page or page 0 is considered first page

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->


[CR-6249]: https://algolia.atlassian.net/browse/CR-6249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ