### PR TITLE
fix(RawHtml): force component to remount

### DIFF
--- a/packages/instantsearch.js/src/components/Template/Template.tsx
+++ b/packages/instantsearch.js/src/components/Template/Template.tsx
@@ -121,7 +121,7 @@ See: https://www.algolia.com/doc/guides/building-search-ui/upgrade-guides/js/#up
 
     // This is to handle Hogan templates with Fragment as rootTagName
     if (RootTagName === Fragment) {
-      return <RawHtml content={content} key={content} />;
+      return <RawHtml content={content} key={Math.random()} />;
     }
 
     return (

--- a/packages/instantsearch.js/src/components/Template/__tests__/Template-test.tsx
+++ b/packages/instantsearch.js/src/components/Template/__tests__/Template-test.tsx
@@ -93,6 +93,27 @@ describe('Template', () => {
     expect(wrapper.container).toMatchSnapshot();
   });
 
+  it('remounts RawHtml component when using Fragment with a string template', () => {
+    const props = getProps({
+      rootTagName: 'fragment',
+      templates: { test: 'test' },
+    });
+    const wrapper = render(
+      <div>
+        <Template {...props} />
+      </div>
+    );
+    wrapper.rerender(
+      <div>
+        <div>Hello</div>
+        {/* It won't rerender if props don't change in testing-library */}
+        <Template {...props} data={{ a: 'a' }} />
+      </div>
+    );
+
+    expect(wrapper.container).toMatchSnapshot();
+  });
+
   it('forward rootProps to the first node', () => {
     function onClick() {}
 

--- a/packages/instantsearch.js/src/components/Template/__tests__/__snapshots__/Template-test.tsx.snap
+++ b/packages/instantsearch.js/src/components/Template/__tests__/__snapshots__/Template-test.tsx.snap
@@ -67,3 +67,15 @@ exports[`Template forward rootProps to the first node 1`] = `
   onClick={[Function]}
 />
 `;
+
+exports[`Template remounts RawHtml component when using Fragment with a string template 1`] = `
+<div>
+  <div>
+    
+    <div>
+      Hello
+    </div>
+    test
+  </div>
+</div>
+`;


### PR DESCRIPTION
**Summary**

This fixes https://github.com/algolia/instantsearch/pull/6243#discussion_r1649444124

**Result**

We didn't see that with Hits because [all templates remount regardless, as they are not memoized](https://github.com/algolia/instantsearch/blob/762e6335692bc0f05243edbf168f1be0b8d31f0c/packages/instantsearch.js/src/widgets/hits/hits.tsx#L83-L93).
There might be a way to solve this only with `componentDidUpdate` but I think there would be more duplicate code, probably fine to keep as is until we get rid of Hogan.
