### PR TITLE
chore(examples): set instantsearchjs monorepo version in vue examples

### DIFF
--- a/examples/vue/default-theme/package.json
+++ b/examples/vue/default-theme/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "algoliasearch": "4.23.2",
     "core-js": "2",
-    "instantsearch.js": "4.72.1",
+    "instantsearch.js": "4.72.2",
     "vue": "2.7.14",
     "vue-instantsearch": "4.17.5"
   },

--- a/examples/vue/e-commerce/package.json
+++ b/examples/vue/e-commerce/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "algoliasearch": "4.23.2",
     "core-js": "2",
-    "instantsearch.js": "4.72.1",
+    "instantsearch.js": "4.72.2",
     "vue": "2.7.14",
     "vue-instantsearch": "4.17.5",
     "vue-slider-component": "3.0.32"

--- a/examples/vue/getting-started/package.json
+++ b/examples/vue/getting-started/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "algoliasearch": "4.23.2",
     "core-js": "2",
-    "instantsearch.js": "4.72.1",
+    "instantsearch.js": "4.72.2",
     "vue": "2.7.14",
     "vue-instantsearch": "4.17.5"
   },

--- a/examples/vue/media/package.json
+++ b/examples/vue/media/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "algoliasearch": "4.23.2",
     "core-js": "2",
-    "instantsearch.js": "4.72.1",
+    "instantsearch.js": "4.72.2",
     "vue": "2.7.14",
     "vue-instantsearch": "4.17.5"
   },

--- a/packages/vue-instantsearch/package.json
+++ b/packages/vue-instantsearch/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "instantsearch-ui-components": "0.7.0",
-    "instantsearch.js": "4.72.1",
+    "instantsearch.js": "4.72.2",
     "mitt": "^2.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
**Summary**

It seems during last release the vue examples were not provided the right version for instantsearch.js, making the package an actual dependency instead of being linked from the monorepo.