### PR TITLE
chore(examples): explicitly set typescript dev dependency to prevent issues on CSB

### DIFF
--- a/examples/js/e-commerce-umd/package.json
+++ b/examples/js/e-commerce-umd/package.json
@@ -17,6 +17,7 @@
     "@parcel/core": "2.10.0",
     "@parcel/packager-raw-url": "2.10.0",
     "@parcel/transformer-webmanifest": "2.10.0",
-    "parcel": "2.10.0"
+    "parcel": "2.10.0",
+    "typescript": "5.5.2"
   }
 }

--- a/examples/js/e-commerce/package.json
+++ b/examples/js/e-commerce/package.json
@@ -17,6 +17,7 @@
     "@parcel/core": "2.10.0",
     "@parcel/packager-raw-url": "2.10.0",
     "@parcel/transformer-webmanifest": "2.10.0",
-    "parcel": "2.10.0"
+    "parcel": "2.10.0",
+    "typescript": "5.5.2"
   }
 }

--- a/examples/js/media/package.json
+++ b/examples/js/media/package.json
@@ -17,6 +17,7 @@
     "@parcel/core": "2.10.0",
     "@parcel/packager-raw-url": "2.10.0",
     "@parcel/transformer-webmanifest": "2.10.0",
-    "parcel": "2.10.0"
+    "parcel": "2.10.0",
+    "typescript": "5.5.2"
   }
 }


### PR DESCRIPTION
**Summary**

Small PR that marks **typescript** as an explicit dev dependency to help Codesandbox interpret TypeScript appropriately in our example sandboxes.

**Result**

No more problem with `type` being an unknown keyword and other similar errors.