### PR TITLE
fix(algoliasearch): correctly retrieve headers for v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@wdio/static-server-service": "5.16.5",
     "algoliasearch": "4.23.2",
     "algoliasearch-v3": "npm:algoliasearch@3.35.0",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
     "babel-eslint": "10.1.0",
     "babel-jest": "27.4.6",
     "babel-plugin-inline-replace-variables": "1.3.1",

--- a/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
@@ -1,5 +1,6 @@
 import algoliasearchV4 from 'algoliasearch';
 import algoliasearchV3 from 'algoliasearch-v3';
+import { liteClient as algoliasearchV5 } from 'algoliasearch-v5/lite';
 
 import { getAppIdAndApiKey } from '../getAppIdAndApiKey';
 
@@ -21,31 +22,8 @@ describe('getAppIdAndApiKey', () => {
     expect(apiKey).toEqual(API_KEY);
   });
 
-  it("fallsback to baseHeaders if headers doesn't exist", () => {
-    const searchClient = {
-      transporter: {
-        baseHeaders: {
-          'x-algolia-application-id': APP_ID,
-          'x-algolia-api-key': API_KEY,
-        },
-        baseQueryParameters: {},
-      },
-    };
-    const [appId, apiKey] = getAppIdAndApiKey(searchClient);
-    expect(appId).toEqual(APP_ID);
-    expect(apiKey).toEqual(API_KEY);
-  });
-
-  it("fallsback to baseQueryParameters if queryParameters doesn't exist", () => {
-    const searchClient = {
-      transporter: {
-        baseHeaders: {},
-        baseQueryParameters: {
-          'x-algolia-application-id': APP_ID,
-          'x-algolia-api-key': API_KEY,
-        },
-      },
-    };
+  it('gets appId and apiKey from searchClient@v5', () => {
+    const searchClient = algoliasearchV5(APP_ID, API_KEY);
     const [appId, apiKey] = getAppIdAndApiKey(searchClient);
     expect(appId).toEqual(APP_ID);
     expect(apiKey).toEqual(API_KEY);

--- a/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
@@ -20,4 +20,34 @@ describe('getAppIdAndApiKey', () => {
     expect(appId).toEqual(APP_ID);
     expect(apiKey).toEqual(API_KEY);
   });
+
+  it("fallsback to baseHeaders if headers doesn't exist", () => {
+    const searchClient = {
+      transporter: {
+        baseHeaders: {
+          'x-algolia-application-id': APP_ID,
+          'x-algolia-api-key': API_KEY,
+        },
+        baseQueryParameters: {},
+      },
+    };
+    const [appId, apiKey] = getAppIdAndApiKey(searchClient);
+    expect(appId).toEqual(APP_ID);
+    expect(apiKey).toEqual(API_KEY);
+  });
+
+  it("fallsback to baseQueryParameters if queryParameters doesn't exist", () => {
+    const searchClient = {
+      transporter: {
+        baseHeaders: {},
+        baseQueryParameters: {
+          'x-algolia-application-id': APP_ID,
+          'x-algolia-api-key': API_KEY,
+        },
+      },
+    };
+    const [appId, apiKey] = getAppIdAndApiKey(searchClient);
+    expect(appId).toEqual(APP_ID);
+    expect(apiKey).toEqual(API_KEY);
+  });
 });

--- a/packages/instantsearch.js/src/lib/utils/getAppIdAndApiKey.ts
+++ b/packages/instantsearch.js/src/lib/utils/getAppIdAndApiKey.ts
@@ -2,7 +2,10 @@
 export function getAppIdAndApiKey(searchClient: any): [string, string] {
   if (searchClient.transporter) {
     // searchClient v4
-    const { headers, queryParameters } = searchClient.transporter;
+    const transporter = searchClient.transporter;
+    const headers = transporter.headers || transporter.baseHeaders;
+    const queryParameters =
+      transporter.queryParameters || transporter.baseQueryParameters;
     const APP_ID = 'x-algolia-application-id';
     const API_KEY = 'x-algolia-api-key';
     const appId = headers[APP_ID] || queryParameters[APP_ID];

--- a/packages/instantsearch.js/src/lib/utils/getAppIdAndApiKey.ts
+++ b/packages/instantsearch.js/src/lib/utils/getAppIdAndApiKey.ts
@@ -1,7 +1,7 @@
 // typed as any, since it accepts the _real_ js clients, not the interface we otherwise expect
 export function getAppIdAndApiKey(searchClient: any): [string, string] {
   if (searchClient.transporter) {
-    // searchClient v4
+    // searchClient v4 or v5
     const transporter = searchClient.transporter;
     const headers = transporter.headers || transporter.baseHeaders;
     const queryParameters =

--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -58,7 +58,7 @@
     "react-instantsearch-core-v6": "npm:react-instantsearch-core@6.40.4"
   },
   "peerDependencies": {
-    "algoliasearch": ">= 3.1 < 5",
+    "algoliasearch": ">= 3.1 < 6",
     "react": ">= 16.8.0 < 19"
   }
 }

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -53,7 +53,7 @@
     "react-instantsearch-core": "7.12.0"
   },
   "peerDependencies": {
-    "algoliasearch": ">= 3.1 < 5",
+    "algoliasearch": ">= 3.1 < 6",
     "react": ">= 16.8.0 < 19",
     "react-dom": ">= 16.8.0 < 19"
   }

--- a/packages/vue-instantsearch/package.json
+++ b/packages/vue-instantsearch/package.json
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@vue/server-renderer": "^3.1.2",
-    "algoliasearch": ">= 3.32.0 < 5",
+    "algoliasearch": ">= 3.32.0 < 6",
     "vue": "^2.6.0 || >=3.0.0-rc.0",
     "vue-server-renderer": "^2.6.11"
   },

--- a/scripts/legacy/downgrade-algoliasearch-dependency.js
+++ b/scripts/legacy/downgrade-algoliasearch-dependency.js
@@ -36,4 +36,12 @@ shell.sed(
   packageJsonPaths
 );
 
+// remove v5 dependency
+shell.sed(
+  '-i',
+  /"algoliasearch-v5": "npm:algoliasearch@5.*"(,?)/,
+  '',
+  packageJsonPaths
+);
+
 shell.exec('yarn install');

--- a/tsconfig.v3.json
+++ b/tsconfig.v3.json
@@ -23,6 +23,8 @@
     "packages/instantsearch.js/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts",
     // this test has specific code for v4
     "packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx",
-    "packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx"
+    "packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx",
+    // test relies on v4, v3 and v5 at once
+    "packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,6 +51,15 @@
   dependencies:
     "@algolia/cache-common" "4.23.2"
 
+"@algolia/client-abtesting@5.0.0-beta.8":
+  version "5.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@algolia/client-abtesting/-/client-abtesting-5.0.0-beta.8.tgz#07950e042e19abe473b6659660dbbaf3d5ae5750"
+  integrity sha512-SX9/v/1CinWhn8UyPS4zoiCuqLepAoaPiwiJvMal1q8huQzHPYgaQRGu5SwXf/jzUnXnWLiWakyZZ0WkGHj6yA==
+  dependencies:
+    "@algolia/client-common" "5.0.0-beta.9"
+    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
+    "@algolia/requester-node-http" "5.0.0-beta.9"
+
 "@algolia/client-account@4.23.2":
   version "4.23.2"
   resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.23.2.tgz#b53cb14e730fd8e0a0a227cf650b287b570a08bc"
@@ -70,6 +79,15 @@
     "@algolia/requester-common" "4.23.2"
     "@algolia/transporter" "4.23.2"
 
+"@algolia/client-analytics@5.0.0-beta.8":
+  version "5.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-5.0.0-beta.8.tgz#86d110bed99ca28359bd4e70eaeff568cb6462bb"
+  integrity sha512-SzMg3FeF7do/+plUawHRw2Lr3/KebKF8rCkswdR907kUa/aMVCFzsginL3xc/k8bIxx6wU8fk5iKLeK1+Ykxnw==
+  dependencies:
+    "@algolia/client-common" "5.0.0-beta.9"
+    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
+    "@algolia/requester-node-http" "5.0.0-beta.9"
+
 "@algolia/client-common@4.23.2":
   version "4.23.2"
   resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.23.2.tgz#e5f86fc2de707eb6bf9f1109b70187dae179c72c"
@@ -77,6 +95,11 @@
   dependencies:
     "@algolia/requester-common" "4.23.2"
     "@algolia/transporter" "4.23.2"
+
+"@algolia/client-common@5.0.0-beta.9":
+  version "5.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-5.0.0-beta.9.tgz#f659c0fca45663a09f7bcf5eb36318ef5ab39b40"
+  integrity sha512-TWf6l4/pWMk8CgV+8A4zTe49XaygaCZ6ir8bwf4WnpDgAxx8Y5X/I6e7vPzl7sljQEEB9q1+qlkss1nxNeRJPw==
 
 "@algolia/client-personalization@4.23.2":
   version "4.23.2"
@@ -87,6 +110,15 @@
     "@algolia/requester-common" "4.23.2"
     "@algolia/transporter" "4.23.2"
 
+"@algolia/client-personalization@5.0.0-beta.8":
+  version "5.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-5.0.0-beta.8.tgz#18b624c9e268da3c36c5416e593e778cdaca338c"
+  integrity sha512-8mGxWE3TA3+2ekc+rM38JAwFfpwPyWyPxjjOe33afiFkmDliLrsGDAyoCasu7w34JhpuLeR1wfgo58g9s9+OLw==
+  dependencies:
+    "@algolia/client-common" "5.0.0-beta.9"
+    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
+    "@algolia/requester-node-http" "5.0.0-beta.9"
+
 "@algolia/client-search@4.23.2":
   version "4.23.2"
   resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.23.2.tgz#9b2741f0a209596459f06a44583118207ea287f7"
@@ -95,6 +127,15 @@
     "@algolia/client-common" "4.23.2"
     "@algolia/requester-common" "4.23.2"
     "@algolia/transporter" "4.23.2"
+
+"@algolia/client-search@5.0.0-beta.8":
+  version "5.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-5.0.0-beta.8.tgz#5abeb90de119ee868aa6a2d898c9d98cf8292258"
+  integrity sha512-Ub7CEFLDvCF13tq6imE7sEKnxmo177k4euXjaKGUMlznUf9qLWT5g6HuvBH4Nrxwaotima3cRnIw3zkq4JZORw==
+  dependencies:
+    "@algolia/client-common" "5.0.0-beta.9"
+    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
+    "@algolia/requester-node-http" "5.0.0-beta.9"
 
 "@algolia/events@^4.0.1":
   version "4.0.1"
@@ -130,12 +171,28 @@
     "@algolia/requester-node-http" "4.23.2"
     "@algolia/transporter" "4.23.2"
 
+"@algolia/recommend@5.0.0-beta.8":
+  version "5.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@algolia/recommend/-/recommend-5.0.0-beta.8.tgz#eff81537479a3390a33ddbffcbf82ae194160019"
+  integrity sha512-B7tuqYF2YlPmRH5jfDbbC3V1sq8X3a7oadwzAOPGGC1qwi2tO8BoBLM2iIwJRAAesw4NRVeBVDDmdsdiStHeEQ==
+  dependencies:
+    "@algolia/client-common" "5.0.0-beta.9"
+    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
+    "@algolia/requester-node-http" "5.0.0-beta.9"
+
 "@algolia/requester-browser-xhr@4.23.2":
   version "4.23.2"
   resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.23.2.tgz#2d0a6b642e2a2bbfb2e2ff3d1e82158e3e143def"
   integrity sha512-TO9wLlp8+rvW9LnIfyHsu8mNAMYrqNdQ0oLF6eTWFxXfxG3k8F/Bh7nFYGk2rFAYty4Fw4XUtrv/YjeNDtM5og==
   dependencies:
     "@algolia/requester-common" "4.23.2"
+
+"@algolia/requester-browser-xhr@5.0.0-beta.9":
+  version "5.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.0.0-beta.9.tgz#7b43b57cfabe9328e54fb4a96dd10026d27329f1"
+  integrity sha512-zw/ZmZv/CLjLqBUfukk5kR8N/xF/TbUt6xLdXF1LkaEJDj7BWU1RqMMDeSU5SEcehPMqNumfzFjpaz8D0rZ/jw==
+  dependencies:
+    "@algolia/client-common" "5.0.0-beta.9"
 
 "@algolia/requester-common@4.23.2":
   version "4.23.2"
@@ -148,6 +205,13 @@
   integrity sha512-SVzgkZM/malo+2SB0NWDXpnT7nO5IZwuDTaaH6SjLeOHcya1o56LSWXk+3F3rNLz2GVH+I/rpYKiqmHhSOjerw==
   dependencies:
     "@algolia/requester-common" "4.23.2"
+
+"@algolia/requester-node-http@5.0.0-beta.9":
+  version "5.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-5.0.0-beta.9.tgz#afc04a658c1b624e03e378ea076020a51e737637"
+  integrity sha512-/32llTTdZ0zMNwn8I8FA12Pw4wZW93AvoHU/8Si2UR8S+FyL8dAkwgmQAvRZinNXD/Bo45Mpjwgydhx9UNZNBA==
+  dependencies:
+    "@algolia/client-common" "5.0.0-beta.9"
 
 "@algolia/transporter@4.23.2":
   version "4.23.2"
@@ -8018,6 +8082,20 @@ algoliasearch-helper@3.14.0:
     reduce "^1.0.1"
     semver "^5.1.0"
     tunnel-agent "^0.6.0"
+
+"algoliasearch-v5@npm:algoliasearch@5.0.0-beta.8":
+  version "5.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-5.0.0-beta.8.tgz#df9ae7351f4d16ef20f04c7ed90203bfb8bdc9df"
+  integrity sha512-HeHubssxYRD9OEBySLXM8DdsrDthdyVSogncyQkxO3U+EYfg94Fxe7Kn9ooDm4sX88HS+lOaIV3I+JSwpvoy6A==
+  dependencies:
+    "@algolia/client-abtesting" "5.0.0-beta.8"
+    "@algolia/client-analytics" "5.0.0-beta.8"
+    "@algolia/client-common" "5.0.0-beta.9"
+    "@algolia/client-personalization" "5.0.0-beta.8"
+    "@algolia/client-search" "5.0.0-beta.8"
+    "@algolia/recommend" "5.0.0-beta.8"
+    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
+    "@algolia/requester-node-http" "5.0.0-beta.9"
 
 algoliasearch@4, algoliasearch@4.23.2:
   version "4.23.2"


### PR DESCRIPTION
**Summary**

#### [FX-2928](https://algolia.atlassian.net/browse/FX-2928)

**Result**

We fallback to `baseHeaders` and `baseQueryParameters` if `headers` or `queryParameters` do not exist.
Updated all remaining peer deps to mark compatibility with v5.


[FX-2928]: https://algolia.atlassian.net/browse/FX-2928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ