### PR TITLE
fix(client): support v5 fully

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,10 @@ workflows:
       - unit tests:
           requires:
             - build
-      - legacy algoliasearch:
+      - legacy algoliasearch v3:
+          requires:
+            - build
+      - legacy algoliasearch v4:
           requires:
             - build
       - vue v3:
@@ -97,7 +100,8 @@ workflows:
             - lint
             - unit tests
             - examples
-            - legacy algoliasearch
+            - legacy algoliasearch v3
+            - legacy algoliasearch v4
             - helper docs
             - e2e tests
           filters:
@@ -202,7 +206,7 @@ jobs:
           name: Type Checking
           command: yarn run type-check
 
-  legacy algoliasearch:
+  legacy algoliasearch v3:
     <<: *defaults
     steps:
       - checkout
@@ -220,6 +224,28 @@ jobs:
       - run:
           name: Type Checking
           command: yarn run type-check:v3
+
+  legacy algoliasearch v4:
+    <<: *defaults
+    resource_class: large
+    steps:
+      - checkout
+      - *attach_workspace
+      - *install_yarn_version
+      - *restore_yarn_cache
+      - *run_yarn_install
+      - run:
+          name: Update dependencies
+          command: |
+            ./scripts/legacy/downgrade-algoliasearch-v4.js
+      - run:
+          name: Unit & Integration tests
+          command: yarn run test:ci
+      - store_test_results:
+          path: junit/jest/
+      - run:
+          name: Type Checking
+          command: yarn run type-check
 
   vue v3:
     <<: *defaults

--- a/examples/js/calendar-widget/app.js
+++ b/examples/js/calendar-widget/app.js
@@ -1,5 +1,5 @@
 /* global moment Calendar $ */
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
 import { connectRange } from 'instantsearch.js/es/connectors';
 import { searchBox, hits } from 'instantsearch.js/es/widgets';

--- a/examples/js/calendar-widget/package.json
+++ b/examples/js/calendar-widget/package.json
@@ -8,7 +8,7 @@
     "website:examples": "BABEL_ENV=parcel parcel build index.html --public-url . --dist-dir=../../../website/examples/js/calendar-widget"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.js": "4.73.4"
   },
   "devDependencies": {

--- a/examples/js/e-commerce-umd/package.json
+++ b/examples/js/e-commerce-umd/package.json
@@ -9,7 +9,7 @@
   },
   "browserslist": "firefox 68, chrome 78, IE 11",
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.js": "4.73.4"
   },
   "devDependencies": {

--- a/examples/js/e-commerce-umd/src/search.ts
+++ b/examples/js/e-commerce-umd/src/search.ts
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 
 import getRouting from './routing';
 import {

--- a/examples/js/e-commerce/package.json
+++ b/examples/js/e-commerce/package.json
@@ -9,7 +9,7 @@
   },
   "browserslist": "firefox 68, chrome 78, IE 11",
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.js": "4.73.4"
   },
   "devDependencies": {

--- a/examples/js/e-commerce/src/search.ts
+++ b/examples/js/e-commerce/src/search.ts
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
 
 import getRouting from './routing';

--- a/examples/js/getting-started/package.json
+++ b/examples/js/getting-started/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "npm run lint -- --fix"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.css": "8.4.0",
     "instantsearch.js": "4.73.4"
   },

--- a/examples/js/getting-started/products.html
+++ b/examples/js/getting-started/products.html
@@ -35,6 +35,6 @@
       <div id="related-products"></div>
     </div>
 
-    <script type="module" src="./src/products.js"></script>
+    <script type="module" src="./src/products.ts"></script>
   </body>
 </html>

--- a/examples/js/getting-started/src/app.js
+++ b/examples/js/getting-started/src/app.js
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
 import { carousel } from 'instantsearch.js/es/templates';
 import {

--- a/examples/js/getting-started/src/products.js
+++ b/examples/js/getting-started/src/products.js
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
 import { carousel } from 'instantsearch.js/es/templates';
 import { configure, hits, relatedProducts } from 'instantsearch.js/es/widgets';

--- a/examples/js/getting-started/src/products.ts
+++ b/examples/js/getting-started/src/products.ts
@@ -9,6 +9,10 @@ const searchParams = new URLSearchParams(document.location.search);
 
 const pid = searchParams.get('pid');
 
+if (!pid) {
+  throw new Error('No product ID provided');
+}
+
 const searchClient = algoliasearch(
   'latency',
   '6be0576ff61c053d5f9a3225e2a90f76'

--- a/examples/js/media/package.json
+++ b/examples/js/media/package.json
@@ -8,7 +8,7 @@
     "website:examples": "BABEL_ENV=parcel parcel build index.html --public-url . --dist-dir=../../../website/examples/js/media"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "date-fns": "2.25.0",
     "instantsearch.js": "4.73.4"
   },

--- a/examples/js/media/src/search.ts
+++ b/examples/js/media/src/search.ts
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
 import { singleIndex } from 'instantsearch.js/es/lib/stateMappings';
 

--- a/examples/js/tourism/package.json
+++ b/examples/js/tourism/package.json
@@ -8,7 +8,7 @@
     "website:examples": "BABEL_ENV=parcel parcel build index.html --public-url . --dist-dir=../../../website/examples/js/tourism"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.js": "4.73.4"
   },
   "devDependencies": {

--- a/examples/js/tourism/search.js
+++ b/examples/js/tourism/search.js
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
 import {
   configure,

--- a/examples/react/default-theme/package.json
+++ b/examples/react/default-theme/package.json
@@ -7,7 +7,7 @@
     "start": "BABEL_ENV=parcel parcel index.html"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.js": "4.73.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/examples/react/default-theme/src/App.tsx
+++ b/examples/react/default-theme/src/App.tsx
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { Hit as AlgoliaHit } from 'instantsearch.js';
 import React from 'react';
 import {

--- a/examples/react/e-commerce/App.tsx
+++ b/examples/react/e-commerce/App.tsx
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import React, { useRef } from 'react';
 import {
   Configure,

--- a/examples/react/e-commerce/package.json
+++ b/examples/react/e-commerce/package.json
@@ -9,7 +9,7 @@
   },
   "browserslist": "firefox 68, chrome 78, IE 11",
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.js": "4.73.4",
     "react": "18.2.0",
     "react-compound-slider": "3.4.0",

--- a/examples/react/getting-started/package.json
+++ b/examples/react/getting-started/package.json
@@ -7,7 +7,7 @@
     "start": "BABEL_ENV=parcel parcel index.html products.html --port 3000"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.js": "4.73.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/examples/react/getting-started/src/App.tsx
+++ b/examples/react/getting-started/src/App.tsx
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { Hit } from 'instantsearch.js';
 import React from 'react';
 import {

--- a/examples/react/getting-started/src/Product.tsx
+++ b/examples/react/getting-started/src/Product.tsx
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { type Hit } from 'instantsearch.js';
 import React from 'react';
 import {

--- a/examples/react/next-app-router/app/Search.tsx
+++ b/examples/react/next-app-router/app/Search.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { Hit as AlgoliaHit } from 'instantsearch.js';
 import React from 'react';
 import {

--- a/examples/react/next-app-router/package.json
+++ b/examples/react/next-app-router/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.css": "8.4.0",
     "next": "13.5.1",
     "react": "18.2.0",

--- a/examples/react/next-routing/package.json
+++ b/examples/react/next-routing/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.css": "8.4.0",
     "next": "13.5.1",
     "react": "18.2.0",

--- a/examples/react/next-routing/pages/index.tsx
+++ b/examples/react/next-routing/pages/index.tsx
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { Hit as AlgoliaHit } from 'instantsearch.js';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';

--- a/examples/react/next-routing/pages/test.tsx
+++ b/examples/react/next-routing/pages/test.tsx
@@ -1,5 +1,5 @@
 // This is only to test `onStateChange` does not get called twice
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';

--- a/examples/react/next/package.json
+++ b/examples/react/next/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "instantsearch.css": "8.4.0",
     "next": "13.5.1",
     "react": "18.2.0",

--- a/examples/react/next/pages/index.tsx
+++ b/examples/react/next/pages/index.tsx
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { Hit as AlgoliaHit } from 'instantsearch.js';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';

--- a/examples/react/react-native/App.tsx
+++ b/examples/react/react-native/App.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import { FlatList, SafeAreaView, StyleSheet, Text, View } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { InstantSearch } from 'react-instantsearch-core';
 
 import { InfiniteHits } from './src/InfiniteHits';

--- a/examples/react/react-native/package.json
+++ b/examples/react/react-native/package.json
@@ -11,7 +11,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "expo": "~44.0.0",
     "expo-status-bar": "~1.2.0",
     "instantsearch.js": "4.73.4",

--- a/examples/react/react-native/src/Highlight.tsx
+++ b/examples/react/react-native/src/Highlight.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { StyleSheet, Text } from 'react-native';
-import { Hit as AlgoliaHit } from '@algolia/client-search';
+import { Hit as AlgoliaHit } from 'instantsearch.js';
 import {
   getHighlightedParts,
   getPropertyByPath,
@@ -26,7 +26,7 @@ type HighlightProps<THit> = {
   separator?: string;
 };
 
-export function Highlight<THit extends AlgoliaHit<Record<string, unknown>>>({
+export function Highlight<THit extends AlgoliaHit>({
   hit,
   attribute,
   separator = ', ',

--- a/examples/react/react-native/src/InfiniteHits.tsx
+++ b/examples/react/react-native/src/InfiniteHits.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import { StyleSheet, View, FlatList } from 'react-native';
-import { Hit as AlgoliaHit } from '@algolia/client-search';
+import { Hit as AlgoliaHit } from 'instantsearch.js';
 import {
   useInfiniteHits,
   UseInfiniteHitsProps,

--- a/examples/react/react-native/types/ProductHit.ts
+++ b/examples/react/react-native/types/ProductHit.ts
@@ -1,4 +1,4 @@
-import { Hit as AlgoliaHit } from '@algolia/client-search';
+import { Hit as AlgoliaHit } from 'instantsearch.js';
 
 export type ProductHit = AlgoliaHit<{
   brand: string;

--- a/examples/react/ssr/package.json
+++ b/examples/react/ssr/package.json
@@ -22,7 +22,7 @@
     "webpack-node-externals": "1.7.2"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "express": "4.17.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/examples/react/ssr/src/searchClient.js
+++ b/examples/react/ssr/src/searchClient.js
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 
 export const searchClient = algoliasearch(
   'latency',

--- a/examples/react/ssr/webpack.config.js
+++ b/examples/react/ssr/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = [
       rules: [
         {
           test: /\.js$/,
-          exclude: /node_modules/,
+          exclude: /node_modules\/(?!(algoliasearch)\/).*/,
           use: [
             {
               loader: 'babel-loader',
@@ -48,7 +48,7 @@ module.exports = [
       rules: [
         {
           test: /\.js$/,
-          exclude: /node_modules/,
+          exclude: /node_modules\/(?!(algoliasearch)\/).*/,
           use: [
             {
               loader: 'babel-loader',

--- a/examples/vue/default-theme/babel.config.js
+++ b/examples/vue/default-theme/babel.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   presets: ['@vue/app'],
+  plugins: ['@babel/plugin-proposal-optional-chaining'],
   sourceType: 'unambiguous',
 };

--- a/examples/vue/default-theme/package.json
+++ b/examples/vue/default-theme/package.json
@@ -8,7 +8,7 @@
     "website:examples": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build --dest ../../../website/examples/vue/default-theme"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "core-js": "2",
     "instantsearch.js": "4.73.4",
     "vue": "2.7.14",

--- a/examples/vue/default-theme/src/App.vue
+++ b/examples/vue/default-theme/src/App.vue
@@ -123,7 +123,7 @@
 </template>
 
 <script>
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { history as historyRouter } from 'instantsearch.js/es/lib/routers';
 import { simple as simpleMapping } from 'instantsearch.js/es/lib/stateMappings';
 

--- a/examples/vue/default-theme/vue.config.js
+++ b/examples/vue/default-theme/vue.config.js
@@ -3,4 +3,5 @@ module.exports = {
   devServer: {
     disableHostCheck: true,
   },
+  transpileDependencies: ['algoliasearch'],
 };

--- a/examples/vue/e-commerce/babel.config.js
+++ b/examples/vue/e-commerce/babel.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   presets: ['@vue/app'],
+  plugins: ['@babel/plugin-proposal-optional-chaining'],
   sourceType: 'unambiguous',
 };

--- a/examples/vue/e-commerce/package.json
+++ b/examples/vue/e-commerce/package.json
@@ -8,7 +8,7 @@
     "website:examples": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build --dest ../../../website/examples/vue/e-commerce"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "core-js": "2",
     "instantsearch.js": "4.73.4",
     "vue": "2.7.14",

--- a/examples/vue/e-commerce/src/App.vue
+++ b/examples/vue/e-commerce/src/App.vue
@@ -489,7 +489,7 @@
 </template>
 
 <script>
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import VueSlider from 'vue-slider-component';
 
 import getRouting from './routing';

--- a/examples/vue/e-commerce/vue.config.js
+++ b/examples/vue/e-commerce/vue.config.js
@@ -3,4 +3,5 @@ module.exports = {
   devServer: {
     disableHostCheck: true,
   },
+  transpileDependencies: ['algoliasearch'],
 };

--- a/examples/vue/getting-started/babel.config.js
+++ b/examples/vue/getting-started/babel.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   presets: ['@vue/app'],
+  plugins: ['@babel/plugin-syntax-dynamic-import'],
   sourceType: 'unambiguous',
 };

--- a/examples/vue/getting-started/package.json
+++ b/examples/vue/getting-started/package.json
@@ -7,7 +7,7 @@
     "build": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "core-js": "2",
     "instantsearch.js": "4.73.4",
     "vue": "2.7.14",

--- a/examples/vue/getting-started/src/App.vue
+++ b/examples/vue/getting-started/src/App.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script>
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 
 export default {
   data() {

--- a/examples/vue/getting-started/vue.config.js
+++ b/examples/vue/getting-started/vue.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  devServer: {
-    disableHostCheck: true,
-  },
-};

--- a/examples/vue/getting-started/vue.config.js
+++ b/examples/vue/getting-started/vue.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  devServer: {
+    disableHostCheck: true,
+  },
+  transpileDependencies: ['algoliasearch'],
+};

--- a/examples/vue/media/babel.config.js
+++ b/examples/vue/media/babel.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   presets: ['@vue/app'],
+  plugins: ['@babel/plugin-proposal-optional-chaining'],
   sourceType: 'unambiguous',
 };

--- a/examples/vue/media/package.json
+++ b/examples/vue/media/package.json
@@ -8,7 +8,7 @@
     "website:examples": "NODE_OPTIONS=--openssl-legacy-provider vue-cli-service build --dest ../../../website/examples/vue/media"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "core-js": "2",
     "instantsearch.js": "4.73.4",
     "vue": "2.7.14",

--- a/examples/vue/media/src/App.vue
+++ b/examples/vue/media/src/App.vue
@@ -112,7 +112,7 @@
 </template>
 
 <script>
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { history as historyRouter } from 'instantsearch.js/es/lib/routers';
 import { simple as simpleMapping } from 'instantsearch.js/es/lib/stateMappings';
 

--- a/examples/vue/media/vue.config.js
+++ b/examples/vue/media/vue.config.js
@@ -3,4 +3,5 @@ module.exports = {
   devServer: {
     disableHostCheck: true,
   },
+  transpileDependencies: ['algoliasearch'],
 };

--- a/examples/vue/nuxt/package.json
+++ b/examples/vue/nuxt/package.json
@@ -11,7 +11,7 @@
     "generate": "nuxt generate"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "cross-env": "^5.2.0",
     "css-loader": "^4.3.0",
     "nuxt": "^2.4.5",

--- a/examples/vue/nuxt/pages/search.vue
+++ b/examples/vue/nuxt/pages/search.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script>
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import {
   AisInstantSearchSsr,
   AisIndex,

--- a/examples/vue/ssr/package.json
+++ b/examples/vue/ssr/package.json
@@ -8,7 +8,7 @@
     "start": "NODE_ENV=production NODE_OPTIONS=--openssl-legacy-provider vue-cli-service ssr:serve --mode production"
   },
   "dependencies": {
-    "algoliasearch": "4.23.2",
+    "algoliasearch": "5.0.0",
     "core-js": "2",
     "instantsearch.css": "8.4.0",
     "qs": "6.9.7",

--- a/examples/vue/ssr/src/main.js
+++ b/examples/vue/ssr/src/main.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-nested-ternary */
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import qs from 'qs';
 import Vue from 'vue';
 import { createServerRootMixin } from 'vue-instantsearch';

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "devDependencies": {
     "@algolia/cache-common": "4.23.2",
     "@algolia/cache-in-memory": "4.23.2",
-    "@algolia/client-search": "4.23.2",
+    "@algolia/client-search": "5.0.0",
+    "@algolia/client-common": "5.0.0",
     "@algolia/logger-common": "4.23.2",
     "@algolia/requester-node-http": "4.23.2",
     "@algolia/transporter": "4.23.2",
@@ -87,9 +88,10 @@
     "@wdio/selenium-standalone-service": "5.16.5",
     "@wdio/spec-reporter": "5.16.5",
     "@wdio/static-server-service": "5.16.5",
-    "algoliasearch": "4.23.2",
     "algoliasearch-v3": "npm:algoliasearch@3.35.0",
+    "algoliasearch-v4": "npm:algoliasearch@4.23.2",
     "algoliasearch-v5": "npm:algoliasearch@5.0.0",
+    "algoliasearch": "5.0.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "27.4.6",
     "babel-plugin-inline-replace-variables": "1.3.1",
@@ -145,6 +147,7 @@
     "typescript": "5.5.2"
   },
   "resolutions": {
+    "places.js/algoliasearch": "5.0.0",
     "brotli-size": "4.0.0",
     "webpack": "4.47.0",
     "babel-loader": "8.2.2"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@wdio/static-server-service": "5.16.5",
     "algoliasearch": "4.23.2",
     "algoliasearch-v3": "npm:algoliasearch@3.35.0",
-    "algoliasearch-v5": "npm:algoliasearch@5.0.0-beta.8",
+    "algoliasearch-v5": "npm:algoliasearch@5.0.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "27.4.6",
     "babel-plugin-inline-replace-variables": "1.3.1",

--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1,23 +1,23 @@
 import EventEmitter from '@algolia/events';
 
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import type {
   FindAnswersResponse,
+  FrequentlyBoughtTogetherQuery,
   HighlightResult,
+  LookingSimilarQuery,
   RankingInfo,
+  RecommendResponse,
+  RelatedProductsQuery,
   SearchClient,
   SearchOptions,
   SearchResponse,
   SnippetResult,
+  SupportedLanguage,
+  TrendingFacetsQuery,
+  TrendingItemsQuery,
+  PlainRecommendParameters as ClientPlainRecommendParameters,
 } from './types/algoliasearch';
-// @ts-ignore
-import type {
-  FrequentlyBoughtTogetherQuery as RecommendFrequentlyBoughtTogetherQuery,
-  LookingSimilarQuery as RecommendLookingSimilarQuery,
-  RelatedProductsQuery as RecommendRelatedProductsQuery,
-  TrendingFacetsQuery as RecommendTrendingFacetsQuery,
-  TrendingItemsQuery as RecommendTrendingItemsQuery,
-  RecommendQueriesResponse,
-} from '@algolia/recommend';
 
 /**
  * The algoliasearchHelper module is the function that will let its
@@ -539,7 +539,7 @@ declare namespace algoliasearchHelper {
     // types missing in @types/algoliasearch, so duplicated from v4
     ruleContexts?: string[];
     optionalFilters?: Array<string | string[]>;
-    queryLanguages?: string[];
+    queryLanguages?: SupportedLanguage[];
 
     /**
      * The relevancy threshold to apply to search in a virtual index [0-100]. A bigger
@@ -1021,7 +1021,7 @@ declare namespace algoliasearchHelper {
      * a list of language ISO codes (as a comma-separated string) for which stop words should be enable
      * https://www.algolia.com/doc/api-reference/api-parameters/removeStopWords/
      */
-    removeStopWords?: boolean | string[];
+    removeStopWords?: boolean | SupportedLanguage[];
     /**
      * List of attributes on which you want to disable the computation of exact criteria
      * default: []
@@ -1555,23 +1555,7 @@ declare namespace algoliasearchHelper {
     }
   }
 
-  // We remove `indexName` from the Recommend query types as the helper
-  // will fill in this value before sending the queries
-  type FrequentlyBoughtTogetherQuery = Omit<
-    RecommendFrequentlyBoughtTogetherQuery,
-    'indexName'
-  >;
-  type LookingSimilarQuery = Omit<RecommendLookingSimilarQuery, 'indexName'>;
-  type RelatedProductsQuery = Omit<RecommendRelatedProductsQuery, 'indexName'>;
-  type TrendingFacetsQuery = Omit<RecommendTrendingFacetsQuery, 'indexName'>;
-  type TrendingItemsQuery = Omit<RecommendTrendingItemsQuery, 'indexName'>;
-
-  export type PlainRecommendParameters =
-    | FrequentlyBoughtTogetherQuery
-    | LookingSimilarQuery
-    | RelatedProductsQuery
-    | TrendingFacetsQuery
-    | TrendingItemsQuery;
+  export type PlainRecommendParameters = ClientPlainRecommendParameters;
 
   export type RecommendParametersWithId<
     T extends PlainRecommendParameters = PlainRecommendParameters
@@ -1605,11 +1589,7 @@ declare namespace algoliasearchHelper {
     ): RecommendParameters;
   }
 
-  type RecommendResponse<TObject> =
-    RecommendQueriesResponse<TObject>['results'];
-
-  type RecommendResultItem<TObject = any> = RecommendResponse<TObject>[0];
-  type RecommendResultMap<T> = { [index: number]: RecommendResultItem<T> };
+  type RecommendResultMap<T> = { [index: number]: RecommendResponse<T> };
 
   export class RecommendResults<T = any> {
     constructor(state: RecommendParameters, results: RecommendResultMap<T>);
@@ -1617,7 +1597,7 @@ declare namespace algoliasearchHelper {
     _state: RecommendParameters;
     _rawResults: RecommendResultMap<T>;
 
-    [index: number]: RecommendResultItem<T>;
+    [index: number]: RecommendResponse<T>;
   }
 }
 

--- a/packages/algoliasearch-helper/test/datasets/SearchResults/getFacetValues.dataset.js
+++ b/packages/algoliasearch-helper/test/datasets/SearchResults/getFacetValues.dataset.js
@@ -15,6 +15,7 @@ if (require.main === module) {
     path.join(__dirname.replace('datasets', 'spec'), 'getFacetValues')
   );
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
   var helper = new HelperSaver(client, 'instant_search', {

--- a/packages/algoliasearch-helper/test/datasets/SearchResults/getRefinements.dataset.js
+++ b/packages/algoliasearch-helper/test/datasets/SearchResults/getRefinements.dataset.js
@@ -15,6 +15,7 @@ if (require.main === module) {
     path.join(__dirname.replace('datasets', 'spec'), 'getRefinements')
   );
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
   var helper = new HelperSaver(client, 'instant_search', {

--- a/packages/algoliasearch-helper/test/integration-utils.js
+++ b/packages/algoliasearch-helper/test/integration-utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var algoliasearch = require('algoliasearch');
+algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
 function setup(indexName, fn) {
   var appID = process.env.INTEGRATION_TEST_APPID;

--- a/packages/algoliasearch-helper/test/run.js
+++ b/packages/algoliasearch-helper/test/run.js
@@ -3,6 +3,7 @@
 var path = require('path');
 
 var algoliasearch = require('algoliasearch');
+algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 var jest = require('jest');
 
 var staticJestConfig = require('../jest.config');

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/client.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/client.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var algoliasearch = require('algoliasearch');
+algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
 var algoliaSearchHelper = require('../../../');
 var version = require('../../../src/version');

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/numericFilters.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/numericFilters.js
@@ -1,13 +1,14 @@
 'use strict';
 
-var algoliaSearch = require('algoliasearch');
+var algoliasearch = require('algoliasearch');
+algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
 var algoliasearchHelper = require('../../../index');
 
 var fakeClient = {};
 
 test('Numeric filters: numeric filters from constructor', function (done) {
-  var client = algoliaSearch('dsf', 'dsfdf');
+  var client = algoliasearch('dsf', 'dsfdf');
 
   client.search = function (queries) {
     var ps = queries[0].params;
@@ -42,7 +43,7 @@ test('Numeric filters: numeric filters from constructor', function (done) {
 });
 
 test('Numeric filters: numeric filters from setters', function (done) {
-  var client = algoliaSearch('dsf', 'dsfdf');
+  var client = algoliasearch('dsf', 'dsfdf');
 
   client.search = function (queries) {
     var ps = queries[0].params;

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/pendingSearch.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/pendingSearch.js
@@ -1,12 +1,13 @@
 'use strict';
 
-var algoliaSearch = require('algoliasearch');
+var algoliasearch = require('algoliasearch');
+algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
 var algoliasearchHelper = require('../../../index');
 
 test('When searchOnce with callback, hasPendingRequests is true', function (done) {
   var testData = require('../../datasets/SearchParameters/search.dataset')();
-  var client = algoliaSearch('dsf', 'dsfdf');
+  var client = algoliasearch('dsf', 'dsfdf');
 
   var triggerCb;
   client.search = function () {
@@ -39,7 +40,7 @@ test('When searchOnce with callback, hasPendingRequests is true', function (done
 
 test('When searchOnce with promises, hasPendingRequests is true', function (done) {
   var testData = require('../../datasets/SearchParameters/search.dataset')();
-  var client = algoliaSearch('dsf', 'dsfdf');
+  var client = algoliasearch('dsf', 'dsfdf');
 
   var triggerCb;
   client.search = function () {
@@ -71,7 +72,7 @@ test('When searchOnce with promises, hasPendingRequests is true', function (done
 });
 
 test('When searchForFacetValues, hasPendingRequests is true', function (done) {
-  var client = algoliaSearch('dsf', 'dsfdf');
+  var client = algoliasearch('dsf', 'dsfdf');
 
   var triggerCb;
   client.searchForFacetValues = function () {
@@ -110,7 +111,7 @@ test('When searchForFacetValues, hasPendingRequests is true', function (done) {
 
 test('When helper.search(), hasPendingRequests is true', function (done) {
   var testData = require('../../datasets/SearchParameters/search.dataset')();
-  var client = algoliaSearch('dsf', 'dsfdf');
+  var client = algoliasearch('dsf', 'dsfdf');
 
   var triggerCb;
   client.search = function () {
@@ -145,7 +146,7 @@ test('When helper.search(), hasPendingRequests is true', function (done) {
 
 test('When helper.search() and one request is discarded, hasPendingRequests is true unless all come back', function (done) {
   var testData = require('../../datasets/SearchParameters/search.dataset')();
-  var client = algoliaSearch('dsf', 'dsfdf');
+  var client = algoliasearch('dsf', 'dsfdf');
 
   var triggerCbs = [];
   client.search = function () {

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/attributes-order.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/attributes-order.js
@@ -4,6 +4,7 @@
 
 test('hierarchical facets: attributes order', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/breadcrumb.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/breadcrumb.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: using getHierarchicalFacetBreadcrumb()', function () {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 
@@ -35,6 +36,7 @@ test('hierarchical facets: using getHierarchicalFacetBreadcrumb()', function () 
 
 test('hierarchical facets: using getHierarchicalFacetBreadcrumb before the first refinement', function () {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 
@@ -62,6 +64,7 @@ test('hierarchical facets: using getHierarchicalFacetBreadcrumb before the first
 
 test('hierarchical facets: using getHierarchicalFacetBreadcrumb on an undefined facet', function () {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/custom-prefix-path.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/custom-prefix-path.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: custom prefix path', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/custom-separator.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/custom-separator.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: custom separator', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/do-not-show-parent-level.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/do-not-show-parent-level.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: do not show parent level', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/facet-value-length.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/facet-value-length.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: facet value called length', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
   var algoliasearchHelper = require('../../../');
 
   var appId = 'hierarchical-simple-appId';

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/no-refinement.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/no-refinement.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: no refinement', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/no-trim.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/no-trim.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: do not trim facetFilters values', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/objects-with-multiple-categories.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/objects-with-multiple-categories.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: objects with multiple categories', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/one-level.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/one-level.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: only one level deep', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/pagination.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/pagination.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: pagination', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/parent-toggleRefine.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/parent-toggleRefine.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: toggleRefine behavior', function () {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 
@@ -52,6 +53,7 @@ test('hierarchical facets: toggleRefine behavior', function () {
 
 test('hierarchical facets: toggleRefine behavior when root level', function () {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 
@@ -93,6 +95,7 @@ test('hierarchical facets: toggleRefine behavior when root level', function () {
 
 test('hierarchical facets: toggleRefine behavior when different root level', function () {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/refined-no-result.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/refined-no-result.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: no results', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/show-parent-level.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/show-parent-level.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: show parent level', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/simple-usage.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/simple-usage.js
@@ -2,6 +2,7 @@
 
 describe('hierarchical facets: simple usage', function () {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
   var algoliasearchHelper = require('../../../');
   var appId = 'hierarchical-toggleRefine-appId';
   var apiKey = 'hierarchical-toggleRefine-apiKey';

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/sort-by.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/sort-by.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: using sortBy', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/two-facets.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/two-facets.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: two hierarchical facets', function (done) {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/unknown-facet.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/unknown-facet.js
@@ -1,5 +1,6 @@
 'use strict';
 var algoliasearch = require('algoliasearch');
+algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
 var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/with-a-disjunctive-facet.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/with-a-disjunctive-facet.js
@@ -2,6 +2,7 @@
 
 test('hierarchical facets: combined with a disjunctive facet', function () {
   var algoliasearch = require('algoliasearch');
+  algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
   var algoliasearchHelper = require('../../../');
 

--- a/packages/algoliasearch-helper/test/types.ts
+++ b/packages/algoliasearch-helper/test/types.ts
@@ -1,13 +1,11 @@
-import algoliasearch from 'algoliasearch';
-
 import algoliasearchHelper, { SearchParameters, SearchResults } from '..';
 
 import type { AlgoliaSearchHelper } from '..';
+import type { SearchClient } from '../types/algoliasearch';
 
-const helper: AlgoliaSearchHelper = algoliasearchHelper(
-  algoliasearch('', ''),
-  ''
-);
+const client: SearchClient = {} as any;
+
+const helper: AlgoliaSearchHelper = algoliasearchHelper(client, '');
 
 helper.derive(
   () =>

--- a/packages/algoliasearch-helper/types/algoliasearch.d.ts
+++ b/packages/algoliasearch-helper/types/algoliasearch.d.ts
@@ -5,6 +5,8 @@
 // @ts-ignore
 import type * as ClientSearch from '@algolia/client-search';
 // @ts-ignore
+import type * as RecommendClient from '@algolia/recommend';
+// @ts-ignore
 import type * as AlgoliaSearch from 'algoliasearch';
 // @ts-ignore
 import type algoliasearch from 'algoliasearch/lite';
@@ -16,6 +18,12 @@ import type * as AlgoliaSearchLite from 'algoliasearch/lite';
 type AnyToUnknown<T> = (0 extends 1 & T ? true : false) extends true
   ? unknown
   : T;
+type IsNull<T> = [T] extends [null] ? true : false;
+type IsUnknown<T> = unknown extends T // `T` can be `unknown` or `any`
+  ? IsNull<T> extends false // `any` can be `null`, but `unknown` can't be
+    ? true
+    : false
+  : false;
 
 type SearchClientV4Shape = {
   transporter: unknown;
@@ -28,24 +36,32 @@ type SearchClientShape = {
 // @ts-ignore
 type ClientV3_4 = ReturnType<typeof algoliasearch>;
 
-type ClientLiteV5 = AnyToUnknown<typeof AlgoliaSearchLite> extends unknown
+type ClientLiteV5 = IsUnknown<
+  AnyToUnknown<typeof AlgoliaSearchLite>
+> extends true
   ? unknown
-  : AnyToUnknown<
+  : typeof AlgoliaSearchLite extends { liteClient: unknown }
+  ? AnyToUnknown<
       // @ts-ignore
       ReturnType<typeof AlgoliaSearchLite.liteClient>
-    >;
-type ClientFullV5 = AnyToUnknown<typeof AlgoliaSearch> extends unknown
+    >
+  : unknown;
+type ClientFullV5 = IsUnknown<AnyToUnknown<typeof AlgoliaSearch>> extends true
   ? unknown
-  : AnyToUnknown<
+  : typeof AlgoliaSearch extends { algoliasearch: unknown }
+  ? AnyToUnknown<
       // @ts-ignore
       ReturnType<typeof AlgoliaSearch.algoliasearch>
-    >;
-type ClientSearchV5 = AnyToUnknown<typeof ClientSearch> extends unknown
+    >
+  : unknown;
+type ClientSearchV5 = IsUnknown<AnyToUnknown<typeof ClientSearch>> extends true
   ? unknown
-  : AnyToUnknown<
+  : typeof ClientSearch extends { searchClient: unknown }
+  ? AnyToUnknown<
       // @ts-ignore
       ReturnType<typeof ClientSearch.searchClient>
-    >;
+    >
+  : unknown;
 type ClientV5 = ClientLiteV5 extends SearchClientShape
   ? ClientLiteV5
   : ClientSearchV5 extends SearchClientShape
@@ -66,6 +82,12 @@ type PickForClient<
   ClientV3_4 extends SearchClientV4Shape
   ? T['v4']
   : T['v3'];
+
+type ClientVersion = PickForClient<{
+  v3: '3';
+  v4: '4';
+  v5: '5';
+}>;
 
 type DefaultSearchClient = PickForClient<{
   v3: ClientV3_4;
@@ -132,7 +154,7 @@ export type SearchResponse<T> = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.SearchResponse<T>;
   // @ts-ignore
-  v5: AlgoliaSearch.SearchResponse; // TODO: should be generic https://github.com/algolia/api-clients-automation/issues/853
+  v5: AlgoliaSearch.SearchResponse<T>;
 }>;
 
 export type SearchResponses<T> = PickForClient<{
@@ -141,8 +163,113 @@ export type SearchResponses<T> = PickForClient<{
   // @ts-ignore
   v4: ClientSearch.MultipleQueriesResponse<T>;
   // @ts-ignore
-  v5: AlgoliaSearch.SearchResponses; // TODO: should be generic https://github.com/algolia/api-clients-automation/issues/853
+  v5: AlgoliaSearch.SearchResponses<T>;
 }>;
+
+export type RecommendResponse<T> = PickForClient<{
+  v3: any;
+  // @ts-ignore
+  v4: ClientSearch.SearchResponse<T>;
+  // @ts-ignore
+  v5: AlgoliaSearch.RecommendationsResults;
+}>;
+
+export type RecommendResponses<T> = PickForClient<{
+  v3: any;
+  // @ts-ignore
+  v4: { results: Array<RecommendResponse<T>> };
+  // @ts-ignore
+  v5: AlgoliaSearch.GetRecommendationsResponse;
+}>;
+
+// We remove `indexName` from the Recommend query types as the helper
+// will fill in this value before sending the queries
+type _OptionalKeys<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+type _RequiredKeys<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
+
+export type FrequentlyBoughtTogetherQuery = PickForClient<{
+  v3: any;
+  // @ts-ignore
+  v4: Omit<RecommendClient.FrequentlyBoughtTogetherQuery, 'indexName'>;
+  // @ts-ignore
+  v5: _OptionalKeys<
+    // @ts-ignore
+    Omit<AlgoliaSearch.BoughtTogetherQuery, 'model' | 'indexName'>,
+    'threshold'
+  >;
+}>;
+export type LookingSimilarQuery = PickForClient<{
+  v3: any;
+  // @ts-ignore
+  v4: Omit<RecommendClient.LookingSimilarQuery, 'indexName'>;
+  v5: _OptionalKeys<
+    // @ts-ignore
+    Omit<AlgoliaSearch.LookingSimilarQuery, 'model' | 'indexName'>,
+    'threshold'
+  >;
+}>;
+export type RelatedProductsQuery = PickForClient<{
+  v3: any;
+  // @ts-ignore
+  v4: Omit<RecommendClient.RelatedProductsQuery, 'indexName'>;
+  v5: _OptionalKeys<
+    // @ts-ignore
+    Omit<AlgoliaSearch.LookingSimilarQuery, 'model' | 'indexName'>,
+    'threshold'
+  >;
+}>;
+export type TrendingFacetsQuery = PickForClient<{
+  v3: any;
+  // @ts-ignore
+  v4: Omit<RecommendClient.TrendingFacetsQuery, 'indexName'>;
+  v5: _OptionalKeys<
+    // @ts-ignore
+    Omit<AlgoliaSearch.TrendingFacetsQuery, 'model' | 'indexName'>,
+    'threshold'
+  >;
+}>;
+export type TrendingItemsQuery = PickForClient<{
+  v3: any;
+  // @ts-ignore
+  v4: Omit<RecommendClient.TrendingItemsQuery, 'indexName'>;
+  v5: _OptionalKeys<
+    // @ts-ignore
+    Omit<AlgoliaSearch.TrendingItemsQuery, 'model' | 'indexName'>,
+    'threshold'
+  >;
+}>;
+
+export type RecommendOptions =
+  | _RequiredKeys<
+      FrequentlyBoughtTogetherQuery & {
+        indexName: string;
+        model: 'bought-together';
+      },
+      'threshold' | 'indexName' | 'model'
+    >
+  | _RequiredKeys<
+      LookingSimilarQuery & { indexName: string; model: 'looking-similar' },
+      'threshold' | 'indexName' | 'model'
+    >
+  | _RequiredKeys<
+      RelatedProductsQuery & { indexName: string; model: 'related-products' },
+      'threshold' | 'indexName' | 'model'
+    >
+  | _RequiredKeys<
+      TrendingFacetsQuery & { indexName: string; model: 'trending-facets' },
+      'threshold' | 'indexName' | 'model'
+    >
+  | _RequiredKeys<
+      TrendingItemsQuery & { indexName: string; model: 'trending-items' },
+      'threshold' | 'indexName' | 'model'
+    >;
+
+export type PlainRecommendParameters =
+  | FrequentlyBoughtTogetherQuery
+  | LookingSimilarQuery
+  | RelatedProductsQuery
+  | TrendingFacetsQuery
+  | TrendingItemsQuery;
 
 export type SearchForFacetValuesResponse = PickForClient<{
   // @ts-ignore
@@ -159,16 +286,33 @@ export type FindAnswersOptions = PickForClient<{
   v4: ClientSearch.FindAnswersOptions;
   v5: any; // answers only exists in v4
 }>;
-
 export type FindAnswersResponse<T> = PickForClient<{
   v3: any; // answers only exists in v4
   // @ts-ignore
   v4: ClientSearch.FindAnswersResponse<T>;
   v5: any; // answers only exists in v4
 }>;
+export type FindAnswers = PickForClient<{
+  v3: any; // answers only exists in v4
+  // @ts-ignore
+  v4: ReturnType<DefaultSearchClient['initIndex']>['findAnswers'];
+  v5: any; // answers only exists in v4
+}>;
+
+export type SupportedLanguage = PickForClient<{
+  v3: string;
+  v4: string;
+  // @ts-ignore
+  v5: AlgoliaSearch.SupportedLanguage;
+}>;
 
 export interface SearchClient {
-  search: DefaultSearchClient['search'];
+  search: <T>(
+    requests: Array<{ indexName: string; params: SearchOptions }>
+  ) => Promise<SearchResponses<T>>;
+  getRecommendations?: <T>(
+    requests: RecommendOptions[]
+  ) => Promise<RecommendResponses<T>>;
   searchForFacetValues?: DefaultSearchClient extends {
     searchForFacetValues: unknown;
   }
@@ -178,5 +322,4 @@ export interface SearchClient {
     ? DefaultSearchClient['initIndex']
     : never;
   addAlgoliaAgent?: DefaultSearchClient['addAlgoliaAgent'];
-  getRecommendations?: DefaultSearchClient['getRecommendations'];
 }

--- a/packages/algoliasearch-helper/types/algoliasearch.d.ts
+++ b/packages/algoliasearch-helper/types/algoliasearch.d.ts
@@ -177,7 +177,7 @@ export type RecommendResponse<T> = PickForClient<{
 export type RecommendResponses<T> = PickForClient<{
   v3: any;
   // @ts-ignore
-  v4: { results: Array<RecommendResponse<T>> };
+  v4: RecommendClient.RecommendQueriesResponse<T>;
   // @ts-ignore
   v5: AlgoliaSearch.GetRecommendationsResponse;
 }>;

--- a/packages/instantsearch-ui-components/src/types/Recommend.ts
+++ b/packages/instantsearch-ui-components/src/types/Recommend.ts
@@ -90,8 +90,7 @@ export type RecommendInnerComponentProps<TObject> = {
 
 export type RecordWithObjectID<TObject = Record<string, unknown>> = TObject & {
   objectID: string;
-  __position: number;
-  __queryID?: string;
+  // @TODO: once events are implemented, this type needs `__position` and `__queryID`
 };
 
 export type RecommendItemComponentProps<TObject> = {

--- a/packages/instantsearch.js/.storybook/decorators/withHits.ts
+++ b/packages/instantsearch.js/.storybook/decorators/withHits.ts
@@ -1,8 +1,21 @@
 import { action } from '@storybook/addon-actions';
-import algoliasearch from 'algoliasearch/lite';
+import {
+  // @ts-ignore fails in v3, v4
+  liteClient as namedConstructor,
+  default as defaultConstructor,
+} from 'algoliasearch/lite';
 import instantsearch from '../../src';
 import defaultPlayground from '../playgrounds/default';
-import { InstantSearch, InstantSearchOptions } from '../../src/types';
+import {
+  InstantSearch,
+  InstantSearchOptions,
+  SearchClient,
+} from '../../src/types';
+
+const algoliasearch = (namedConstructor || defaultConstructor) as unknown as (
+  appId: string,
+  apiKey: string
+) => SearchClient;
 
 type InstantSearchUMDModule = typeof instantsearch;
 

--- a/packages/instantsearch.js/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/packages/instantsearch.js/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -240,6 +240,8 @@ search.addWidgets([
         _highlightResult: {
           foobar: {
             value: `<script>${TAG_PLACEHOLDER.highlightPreTag}foobar${TAG_PLACEHOLDER.highlightPostTag}</script>`,
+            matchLevel: 'full' as const,
+            matchedWords: ['foobar'],
           },
         },
         objectID: '1',
@@ -252,6 +254,8 @@ search.addWidgets([
           _highlightResult: {
             foobar: {
               value: '&lt;script&gt;<mark>foobar</mark>&lt;/script&gt;',
+              matchLevel: 'full',
+              matchedWords: ['foobar'],
             },
           },
           objectID: '1',
@@ -268,7 +272,9 @@ search.addWidgets([
           {
             indexId: 'index0',
             results: new SearchResults(helper.state, [
-              createSingleSearchResponse({ hits }),
+              createSingleSearchResponse({
+                hits,
+              }),
             ]),
             helper,
           },
@@ -295,9 +301,12 @@ search.addWidgets([
 
     const hits = [
       {
+        foobar: 'foobar',
         _highlightResult: {
           foobar: {
             value: `<script>${TAG_PLACEHOLDER.highlightPreTag}foobar${TAG_PLACEHOLDER.highlightPostTag}</script>`,
+            matchLevel: 'full' as const,
+            matchedWords: ['foobar'],
           },
         },
         objectID: '1',

--- a/packages/instantsearch.js/src/connectors/configure/__tests__/connectConfigure-test.ts
+++ b/packages/instantsearch.js/src/connectors/configure/__tests__/connectConfigure-test.ts
@@ -289,7 +289,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
           configure: {
             refine() {},
             widgetParams: {
-              searchParameters: { removeStopWords: ['group'] },
+              searchParameters: { removeStopWords: ['en'] },
             },
           },
         },
@@ -300,7 +300,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/configure/j
         refine: expect.any(Function),
         widgetParams: {
           searchParameters: {
-            removeStopWords: ['group'],
+            removeStopWords: ['en'],
             facetFilters: ['brand:Samsung'],
           },
         },

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
@@ -9,16 +9,14 @@ import {
 import type {
   Connector,
   TransformItems,
-  Hit,
   BaseHit,
   Renderer,
   Unmounter,
   UnknownWidgetParams,
+  RecommendResponse,
+  AlgoliaHit,
 } from '../../types';
-import type {
-  PlainSearchParameters,
-  RecommendResultItem,
-} from 'algoliasearch-helper';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'frequently-bought-together',
@@ -31,7 +29,7 @@ export type FrequentlyBoughtTogetherRenderState<
   /**
    * The matched recommendations from Algolia API.
    */
-  items: Array<Hit<THit>>;
+  items: Array<AlgoliaHit<THit>>;
 };
 
 export type FrequentlyBoughtTogetherConnectorParams<
@@ -70,7 +68,10 @@ export type FrequentlyBoughtTogetherConnectorParams<
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: TransformItems<Hit<THit>, { results: RecommendResultItem }>;
+  transformItems?: TransformItems<
+    AlgoliaHit<THit>,
+    { results: RecommendResponse<AlgoliaHit<THit>> }
+  >;
 };
 
 export type FrequentlyBoughtTogetherWidgetDescription<
@@ -156,9 +157,12 @@ export default (function connectFrequentlyBoughtTogether<
           results.hits = escapeHits(results.hits);
         }
 
-        const transformedItems = transformItems(results.hits, {
-          results: results as RecommendResultItem,
-        });
+        const transformedItems = transformItems(
+          results.hits as Array<AlgoliaHit<THit>>,
+          {
+            results: results as RecommendResponse<AlgoliaHit<THit>>,
+          }
+        );
 
         return { items: transformedItems, widgetParams };
       },

--- a/packages/instantsearch.js/src/connectors/hits/__tests__/connectHits-test.ts
+++ b/packages/instantsearch.js/src/connectors/hits/__tests__/connectHits-test.ts
@@ -178,21 +178,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       expect.anything()
     );
 
-    const hits = [
-      {
-        objectID: '1',
-        _highlightResult: {
-          foobar: {
-            value: `<script>${TAG_PLACEHOLDER.highlightPreTag}foobar${TAG_PLACEHOLDER.highlightPostTag}</script>`,
-            matchLevel: 'partial',
-            matchedWords: ['foobar'],
-          },
-        },
-      },
-    ];
-
     const results = new SearchResults(helper.state, [
-      createSingleSearchResponse(createSingleSearchResponse({ hits })),
+      createSingleSearchResponse(
+        createSingleSearchResponse({
+          hits: [
+            {
+              objectID: '1',
+              _highlightResult: {
+                foobar: {
+                  value: `<script>${TAG_PLACEHOLDER.highlightPreTag}foobar${TAG_PLACEHOLDER.highlightPostTag}</script>`,
+                  matchLevel: 'partial',
+                  matchedWords: ['foobar'],
+                },
+              },
+            },
+          ],
+        })
+      ),
     ]);
     widget.render(
       createRenderOptions({

--- a/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
@@ -9,16 +9,14 @@ import {
 import type {
   Connector,
   TransformItems,
-  Hit,
   BaseHit,
   Renderer,
   Unmounter,
   UnknownWidgetParams,
+  RecommendResponse,
+  AlgoliaHit,
 } from '../../types';
-import type {
-  PlainSearchParameters,
-  RecommendResultItem,
-} from 'algoliasearch-helper';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'looking-similar',
@@ -31,7 +29,7 @@ export type LookingSimilarRenderState<
   /**
    * The matched recommendations from the Algolia API.
    */
-  items: Array<Hit<THit>>;
+  items: Array<AlgoliaHit<THit>>;
 };
 
 export type LookingSimilarConnectorParams<
@@ -72,7 +70,10 @@ export type LookingSimilarConnectorParams<
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: TransformItems<Hit<THit>, { results: RecommendResultItem }>;
+  transformItems?: TransformItems<
+    AlgoliaHit<THit>,
+    { results: RecommendResponse<AlgoliaHit<THit>> }
+  >;
 };
 
 export type LookingSimilarWidgetDescription<
@@ -160,8 +161,8 @@ export default (function connectLookingSimilar<
         }
 
         return {
-          items: transformItems(results.hits, {
-            results: results as RecommendResultItem,
+          items: transformItems(results.hits as Array<AlgoliaHit<THit>>, {
+            results: results as RecommendResponse<AlgoliaHit<THit>>,
           }),
           widgetParams,
         };

--- a/packages/instantsearch.js/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
+++ b/packages/instantsearch.js/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
@@ -1598,6 +1598,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const helper = jsHelper(
         createSearchClient({
+          // @ts-ignore v5 expects `search({ type: 'facet' })` only
           searchForFacetValues() {
             return Promise.resolve([
               {
@@ -1719,6 +1720,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const helper = jsHelper(
         createSearchClient({
+          // @ts-ignore v5 expects `search({ type: 'facet' })` only
           searchForFacetValues() {
             return Promise.resolve([
               {
@@ -1801,6 +1803,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const helper = jsHelper(
         createSearchClient({
+          // @ts-ignore v5 expects `search({ type: 'facet' })` only
           searchForFacetValues() {
             return Promise.resolve([
               {
@@ -1911,6 +1914,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const helper = jsHelper(
         createSearchClient({
+          // @ts-ignore v5 expects `search({ type: 'facet' })` only
           searchForFacetValues() {
             return Promise.resolve([
               {
@@ -2029,6 +2033,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const helper = jsHelper(
         createSearchClient({
+          // @ts-ignore v5 expects `search({ type: 'facet' })` only
           searchForFacetValues() {
             return Promise.resolve([
               {

--- a/packages/instantsearch.js/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
+++ b/packages/instantsearch.js/src/connectors/refinement-list/__tests__/connectRefinementList-test.ts
@@ -1598,7 +1598,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const helper = jsHelper(
         createSearchClient({
-          // @ts-ignore v5 expects `search({ type: 'facet' })` only
+          // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can replace this method and its usages with search({ type: 'facet })
           searchForFacetValues() {
             return Promise.resolve([
               {
@@ -1720,7 +1720,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const helper = jsHelper(
         createSearchClient({
-          // @ts-ignore v5 expects `search({ type: 'facet' })` only
+          // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can replace this method and its usages with search({ type: 'facet })
           searchForFacetValues() {
             return Promise.resolve([
               {
@@ -1803,7 +1803,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const helper = jsHelper(
         createSearchClient({
-          // @ts-ignore v5 expects `search({ type: 'facet' })` only
+          // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can replace this method and its usages with search({ type: 'facet })
           searchForFacetValues() {
             return Promise.resolve([
               {
@@ -1914,7 +1914,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const helper = jsHelper(
         createSearchClient({
-          // @ts-ignore v5 expects `search({ type: 'facet' })` only
+          // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can replace this method and its usages with search({ type: 'facet })
           searchForFacetValues() {
             return Promise.resolve([
               {
@@ -2033,7 +2033,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
 
       const helper = jsHelper(
         createSearchClient({
-          // @ts-ignore v5 expects `search({ type: 'facet' })` only
+          // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can replace this method and its usages with search({ type: 'facet })
           searchForFacetValues() {
             return Promise.resolve([
               {

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -9,16 +9,14 @@ import {
 import type {
   Connector,
   TransformItems,
-  Hit,
   BaseHit,
   Renderer,
   Unmounter,
   UnknownWidgetParams,
+  RecommendResponse,
+  AlgoliaHit,
 } from '../../types';
-import type {
-  PlainSearchParameters,
-  RecommendResultItem,
-} from 'algoliasearch-helper';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'related-products',
@@ -31,7 +29,7 @@ export type RelatedProductsRenderState<
   /**
    * The matched recommendations from the Algolia API.
    */
-  items: Array<Hit<THit>>;
+  items: Array<AlgoliaHit<THit>>;
 };
 
 export type RelatedProductsConnectorParams<
@@ -72,7 +70,10 @@ export type RelatedProductsConnectorParams<
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: TransformItems<Hit<THit>, { results: RecommendResultItem }>;
+  transformItems?: TransformItems<
+    AlgoliaHit<THit>,
+    { results: RecommendResponse<AlgoliaHit<THit>> }
+  >;
 };
 
 export type RelatedProductsWidgetDescription<
@@ -160,8 +161,8 @@ export default (function connectRelatedProducts<
         }
 
         return {
-          items: transformItems(results.hits, {
-            results: results as RecommendResultItem,
+          items: transformItems(results.hits as Array<AlgoliaHit<THit>>, {
+            results: results as RecommendResponse<AlgoliaHit<THit>>,
           }),
           widgetParams,
         };

--- a/packages/instantsearch.js/src/connectors/trending-items/__tests__/connectTrendingItems-test.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/__tests__/connectTrendingItems-test.ts
@@ -129,9 +129,8 @@ describe('connectTrendingItems', () => {
         new RecommendParameters().addTrendingItems({
           // @ts-expect-error
           $$id: widget.$$id,
-          // v5 expects only string values for facetName and facetValue
-          facetName: undefined as unknown as string,
-          facetValue: undefined as unknown as string,
+          facetName: undefined,
+          facetValue: undefined,
           maxRecommendations: 10,
           threshold: 95,
           queryParameters: { userToken: 'token' },

--- a/packages/instantsearch.js/src/connectors/trending-items/__tests__/connectTrendingItems-test.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/__tests__/connectTrendingItems-test.ts
@@ -129,8 +129,9 @@ describe('connectTrendingItems', () => {
         new RecommendParameters().addTrendingItems({
           // @ts-expect-error
           $$id: widget.$$id,
-          facetName: undefined,
-          facetValue: undefined,
+          // v5 expects only string values for facetName and facetValue
+          facetName: undefined as unknown as string,
+          facetValue: undefined as unknown as string,
           maxRecommendations: 10,
           threshold: 95,
           queryParameters: { userToken: 'token' },

--- a/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
@@ -10,16 +10,14 @@ import {
 import type {
   Connector,
   TransformItems,
-  Hit,
   BaseHit,
   Renderer,
   Unmounter,
   UnknownWidgetParams,
+  RecommendResponse,
+  AlgoliaHit,
 } from '../../types';
-import type {
-  PlainSearchParameters,
-  RecommendResultItem,
-} from 'algoliasearch-helper';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'trending-items',
@@ -32,7 +30,7 @@ export type TrendingItemsRenderState<
   /**
    * The matched recommendations from the Algolia API.
    */
-  items: Array<Hit<THit>>;
+  items: Array<AlgoliaHit<THit>>;
 };
 
 export type TrendingItemsConnectorParams<
@@ -84,7 +82,10 @@ export type TrendingItemsConnectorParams<
   /**
    * Function to transform the items passed to the templates.
    */
-  transformItems?: TransformItems<Hit<THit>, { results: RecommendResultItem }>;
+  transformItems?: TransformItems<
+    AlgoliaHit<THit>,
+    { results: RecommendResponse<AlgoliaHit<THit>> }
+  >;
 };
 
 export type TrendingItemsWidgetDescription<
@@ -180,8 +181,8 @@ export default (function connectTrendingItems<
         }
 
         return {
-          items: transformItems(results.hits, {
-            results: results as RecommendResultItem,
+          items: transformItems(results.hits as Array<AlgoliaHit<THit>>, {
+            results: results as RecommendResponse<AlgoliaHit<THit>>,
           }),
           widgetParams,
         };
@@ -194,8 +195,8 @@ export default (function connectTrendingItems<
 
       getWidgetParameters(state) {
         return state.removeParams(this.$$id!).addTrendingItems({
-          facetName,
-          facetValue,
+          facetName: facetName as string,
+          facetValue: facetValue as string,
           maxRecommendations: limit,
           threshold,
           fallbackParameters: {

--- a/packages/instantsearch.js/src/connectors/voice-search/__tests__/connectVoiceSearch-test.ts
+++ b/packages/instantsearch.js/src/connectors/voice-search/__tests__/connectVoiceSearch-test.ts
@@ -472,6 +472,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
         new SearchParameters({
           ignorePlurals: true,
           removeStopWords: true,
+          // @ts-ignore we send optionalWords as a string
           optionalWords: 'query',
           queryLanguages: undefined,
           index: '',
@@ -494,6 +495,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
           queryLanguages: ['en'],
           // regular
           removeStopWords: true,
+          // @ts-ignore we send optionalWords as a string
           optionalWords: 'query',
           ignorePlurals: true,
           query: 'query',
@@ -516,6 +518,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/voice-searc
         new SearchParameters({
           ignorePlurals: true,
           removeStopWords: true,
+          // @ts-ignore we send optionalWords as a string
           optionalWords: 'query',
           queryLanguages: undefined,
           index: '',

--- a/packages/instantsearch.js/src/connectors/voice-search/connectVoiceSearch.ts
+++ b/packages/instantsearch.js/src/connectors/voice-search/connectVoiceSearch.ts
@@ -106,6 +106,7 @@ const connectVoiceSearch: VoiceSearchConnector = function connectVoiceSearch(
               const queryLanguages = language
                 ? [language.split('-')[0]]
                 : undefined;
+              // @ts-ignore queryLanguages is allowed to be a string, not just an array
               helper.setQueryParameter('queryLanguages', queryLanguages);
 
               if (typeof additionalQueryParameters === 'function') {
@@ -113,7 +114,7 @@ const connectVoiceSearch: VoiceSearchConnector = function connectVoiceSearch(
                   helper.state.setQueryParameters({
                     ignorePlurals: true,
                     removeStopWords: true,
-                    // @ts-ignore (optionalWords only allows array in v3, while string is also valid)
+                    // @ts-ignore optionalWords is allowed to be a string too
                     optionalWords: query,
                     ...additionalQueryParameters({ query }),
                   })

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -486,7 +486,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
                     ? { _automaticInsights: true }
                     : undefined),
                   index: request.indexName,
-                  query: request.query,
+                  query: (request as any).query || request.params.query,
                   ...(request.indexName === 'indexNameWithAutomaticInsights'
                     ? { queryID: 'queryID' }
                     : undefined),

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -24,7 +24,7 @@ export function waitForResults(
   helper.setClient({
     ...client,
     search(queries) {
-      requestParamsList = queries.map(({ params }) => params!);
+      requestParamsList = queries.map(({ params }) => params);
       return client.search(queries);
     },
   });

--- a/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
@@ -1,5 +1,5 @@
-import algoliasearchV4 from 'algoliasearch';
 import algoliasearchV3 from 'algoliasearch-v3';
+import algoliasearchV4 from 'algoliasearch-v4';
 import { liteClient as algoliasearchV5 } from 'algoliasearch-v5/lite';
 
 import { getAppIdAndApiKey } from '../getAppIdAndApiKey';

--- a/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
@@ -93,7 +93,7 @@ export function hydrateSearchClient(
     client.search = (requests, ...methodArgs) => {
       const requestsWithSerializedParams = requests.map((request) => ({
         ...request,
-        params: serializeQueryParameters(request.params!),
+        params: serializeQueryParameters(request.params),
       }));
 
       return (client as ClientWithTransporter).transporter.responsesCache.get(

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -1,4 +1,5 @@
 import type { IndexWidget } from '../widgets';
+import type { RecommendResponse } from './algoliasearch';
 import type { InstantSearch } from './instantsearch';
 import type { IndexRenderState, WidgetRenderState } from './render-state';
 import type { IndexUiState, UiState } from './ui-state';
@@ -8,7 +9,6 @@ import type {
   SearchParameters,
   SearchResults,
   RecommendParameters,
-  RecommendResultItem,
 } from 'algoliasearch-helper';
 
 export type ScopedResult = {
@@ -161,7 +161,7 @@ type SearchWidget<TWidgetDescription extends WidgetDescription> = {
 };
 
 type RecommendRenderOptions = SharedRenderOptions & {
-  results: RecommendResultItem;
+  results: RecommendResponse<any>;
 };
 
 type RecommendWidget<

--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
@@ -20,11 +20,11 @@ import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   Template,
   WidgetFactory,
-  Hit,
+  AlgoliaHit,
   Renderer,
   BaseHit,
+  RecommendResponse,
 } from '../../types';
-import type { RecommendResultItem } from 'algoliasearch-helper';
 import type {
   RecommendClassNames,
   FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherUiProps,
@@ -81,7 +81,7 @@ const renderer =
             />
           )
         : undefined
-    ) as FrequentlyBoughtTogetherUiProps<Hit>['headerComponent'];
+    ) as FrequentlyBoughtTogetherUiProps<AlgoliaHit>['headerComponent'];
 
     const itemComponent = (
       templates.item
@@ -96,7 +96,7 @@ const renderer =
             );
           }
         : undefined
-    ) as FrequentlyBoughtTogetherUiProps<Hit>['itemComponent'];
+    ) as FrequentlyBoughtTogetherUiProps<AlgoliaHit>['itemComponent'];
 
     const emptyComponent = (
       templates.empty
@@ -109,7 +109,7 @@ const renderer =
             />
           )
         : undefined
-    ) as FrequentlyBoughtTogetherUiProps<Hit>['emptyComponent'];
+    ) as FrequentlyBoughtTogetherUiProps<AlgoliaHit>['emptyComponent'];
 
     const layoutComponent = (
       templates.layout
@@ -122,7 +122,7 @@ const renderer =
                 items: data.items,
                 templates: {
                   item: templates.item
-                    ? ({ item }: { item: Hit<THit> }) => (
+                    ? ({ item }: { item: AlgoliaHit<THit> }) => (
                         <TemplateComponent
                           {...renderState.templateProps}
                           templateKey="item"
@@ -140,11 +140,11 @@ const renderer =
             />
           )
         : undefined
-    ) as FrequentlyBoughtTogetherUiProps<Hit>['layout'];
+    ) as FrequentlyBoughtTogetherUiProps<AlgoliaHit<THit>>['layout'];
 
     render(
       <FrequentlyBoughtTogether
-        items={items}
+        items={items as Array<AlgoliaHit<THit>>}
         headerComponent={headerComponent}
         itemComponent={itemComponent}
         sendEvent={() => {}}
@@ -165,7 +165,7 @@ export type FrequentlyBoughtTogetherTemplates<
   /**
    * Template to use when there are no results.
    */
-  empty: Template<RecommendResultItem<Hit<THit>>>;
+  empty: Template<RecommendResponse<AlgoliaHit<THit>>>;
 
   /**
    * Template to use for the header of the widget.
@@ -174,7 +174,7 @@ export type FrequentlyBoughtTogetherTemplates<
     Pick<
       Parameters<
         NonNullable<
-          FrequentlyBoughtTogetherUiProps<Hit<THit>>['headerComponent']
+          FrequentlyBoughtTogetherUiProps<AlgoliaHit<THit>>['headerComponent']
         >
       >[0],
       'items'
@@ -184,7 +184,7 @@ export type FrequentlyBoughtTogetherTemplates<
   /**
    * Template to use for each result. This template will receive an object containing a single record.
    */
-  item: Template<Hit<THit>>;
+  item: Template<AlgoliaHit<THit>>;
 
   /**
    * Template to use to wrap all items.
@@ -192,12 +192,14 @@ export type FrequentlyBoughtTogetherTemplates<
   layout: Template<
     Pick<
       Parameters<
-        NonNullable<FrequentlyBoughtTogetherUiProps<Hit<THit>>['layout']>
+        NonNullable<FrequentlyBoughtTogetherUiProps<AlgoliaHit<THit>>['layout']>
       >[0],
       'items'
     > & {
       templates: {
-        item: FrequentlyBoughtTogetherUiProps<Hit>['itemComponent'];
+        item: FrequentlyBoughtTogetherUiProps<
+          AlgoliaHit<THit>
+        >['itemComponent'];
       };
       cssClasses: Pick<FrequentlyBoughtTogetherCSSClasses, 'list' | 'item'>;
     }

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -4,6 +4,7 @@
 
 import {
   createSearchClient,
+  createSingleRecommendResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils';
@@ -3484,7 +3485,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           recommendResults: {
             params: [{ $$id: 0, objectID: '1' }],
             results: {
-              0: createSingleSearchResponse({ hits: [{ objectID: '1' }] }),
+              0: createSingleRecommendResponse({
+                hits: [{ objectID: '1', _score: 0 }],
+              }),
             },
           },
         },
@@ -3497,7 +3500,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           0: {
             exhaustiveFacetsCount: true,
             exhaustiveNbHits: true,
-            hits: [{ objectID: '1' }],
+            hits: [{ objectID: '1', _score: 0 }],
             hitsPerPage: 20,
             nbHits: 1,
             nbPages: 1,
@@ -3513,7 +3516,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         0: {
           exhaustiveFacetsCount: true,
           exhaustiveNbHits: true,
-          hits: [{ objectID: '1' }],
+          hits: [{ objectID: '1', _score: 0 }],
           hitsPerPage: 20,
           nbHits: 1,
           nbPages: 1,

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -21,6 +21,7 @@ import type {
   SearchClient,
   IndexRenderState,
   RenderOptions,
+  RecommendResponse,
 } from '../../types';
 import type {
   AlgoliaSearchHelper as Helper,
@@ -30,7 +31,6 @@ import type {
   SearchResults,
   AlgoliaSearchHelper,
   RecommendParameters,
-  RecommendResultItem,
 } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -77,7 +77,7 @@ export type IndexWidget<TUiState extends UiState = UiState> = Omit<
   getResults: () => SearchResults | null;
   getResultsForWidget: (
     widget: IndexWidget | Widget
-  ) => SearchResults | RecommendResultItem | null;
+  ) => SearchResults | RecommendResponse<any> | null;
   getPreviousState: () => SearchParameters | null;
   getScopedResults: () => ScopedResult[];
   getParent: () => IndexWidget | null;

--- a/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
@@ -20,11 +20,11 @@ import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   Template,
   WidgetFactory,
-  Hit,
+  AlgoliaHit,
   Renderer,
   BaseHit,
+  RecommendResponse,
 } from '../../types';
-import type { RecommendResultItem } from 'algoliasearch-helper';
 import type {
   RecommendClassNames,
   LookingSimilarProps as LookingSimilarUiProps,
@@ -77,7 +77,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as LookingSimilarUiProps<Hit>['headerComponent'];
+    ) as LookingSimilarUiProps<AlgoliaHit>['headerComponent'];
 
     const itemComponent = (
       templates.item
@@ -92,7 +92,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             );
           }
         : undefined
-    ) as LookingSimilarUiProps<Hit>['itemComponent'];
+    ) as LookingSimilarUiProps<AlgoliaHit>['itemComponent'];
 
     const emptyComponent = (
       templates.empty
@@ -105,7 +105,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as LookingSimilarUiProps<Hit>['emptyComponent'];
+    ) as LookingSimilarUiProps<AlgoliaHit>['emptyComponent'];
 
     const layoutComponent = (
       templates.layout
@@ -118,7 +118,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
                 items: data.items,
                 templates: {
                   item: templates.item
-                    ? ({ item }: { item: Hit<THit> }) => (
+                    ? ({ item }: { item: AlgoliaHit<THit> }) => (
                         <TemplateComponent
                           {...renderState.templateProps}
                           templateKey="item"
@@ -136,11 +136,11 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as LookingSimilarUiProps<Hit>['layout'];
+    ) as LookingSimilarUiProps<AlgoliaHit<THit>>['layout'];
 
     render(
       <LookingSimilar
-        items={items}
+        items={items as Array<AlgoliaHit<THit>>}
         headerComponent={headerComponent}
         itemComponent={itemComponent}
         sendEvent={() => {}}
@@ -162,7 +162,7 @@ export type LookingSimilarTemplates<
   /**
    * Template to use when there are no results.
    */
-  empty: Template<RecommendResultItem<Hit<THit>>>;
+  empty: Template<RecommendResponse<AlgoliaHit<THit>>>;
 
   /**
    * Template to use for the header of the widget.
@@ -170,7 +170,7 @@ export type LookingSimilarTemplates<
   header: Template<
     Pick<
       Parameters<
-        NonNullable<LookingSimilarUiProps<Hit<THit>>['headerComponent']>
+        NonNullable<LookingSimilarUiProps<AlgoliaHit<THit>>['headerComponent']>
       >[0],
       'items'
     > & { cssClasses: RecommendClassNames }
@@ -179,18 +179,20 @@ export type LookingSimilarTemplates<
   /**
    * Template to use for each result. This template will receive an object containing a single record.
    */
-  item: Template<Hit<THit>>;
+  item: Template<AlgoliaHit<THit>>;
 
   /**
    * Template to use to wrap all items.
    */
   layout: Template<
     Pick<
-      Parameters<NonNullable<LookingSimilarUiProps<Hit<THit>>['layout']>>[0],
+      Parameters<
+        NonNullable<LookingSimilarUiProps<AlgoliaHit<THit>>['layout']>
+      >[0],
       'items'
     > & {
       templates: {
-        item: LookingSimilarUiProps<Hit>['itemComponent'];
+        item: LookingSimilarUiProps<AlgoliaHit<THit>>['itemComponent'];
       };
       cssClasses: Pick<LookingSimilarCSSClasses, 'list' | 'item'>;
     }

--- a/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
@@ -1182,7 +1182,7 @@ function createMockedSearchClient() {
         )
       );
     }),
-    // @ts-ignore v5 only accepts `search({ type: 'facet' })`, but v4, v3 has an explicit method
+    // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can replace this method and its usages with search({ type: 'facet })
     searchForFacetValues: jest.fn((requests) => {
       return Promise.resolve([
         createSFFVResponse({

--- a/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
@@ -1182,6 +1182,7 @@ function createMockedSearchClient() {
         )
       );
     }),
+    // @ts-ignore v5 only accepts `search({ type: 'facet' })`, but v4, v3 has an explicit method
     searchForFacetValues: jest.fn((requests) => {
       return Promise.resolve([
         createSFFVResponse({

--- a/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
@@ -20,11 +20,11 @@ import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   Template,
   WidgetFactory,
-  Hit,
+  AlgoliaHit,
   Renderer,
   BaseHit,
+  RecommendResponse,
 } from '../../types';
-import type { RecommendResultItem } from 'algoliasearch-helper';
 import type {
   RecommendClassNames,
   RelatedProductsProps as RelatedProductsUiProps,
@@ -87,7 +87,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as RelatedProductsUiProps<Hit>['headerComponent'];
+    ) as RelatedProductsUiProps<AlgoliaHit>['headerComponent'];
 
     const itemComponent = (
       templates.item
@@ -102,7 +102,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             );
           }
         : undefined
-    ) as RelatedProductsUiProps<Hit>['itemComponent'];
+    ) as RelatedProductsUiProps<AlgoliaHit>['itemComponent'];
 
     const emptyComponent = (
       templates.empty
@@ -115,7 +115,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as RelatedProductsUiProps<Hit>['emptyComponent'];
+    ) as RelatedProductsUiProps<AlgoliaHit>['emptyComponent'];
 
     const layoutComponent = (
       templates.layout
@@ -128,7 +128,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
                 items: data.items,
                 templates: {
                   item: templates.item
-                    ? ({ item }: { item: Hit<THit> }) => (
+                    ? ({ item }: { item: AlgoliaHit<THit> }) => (
                         <TemplateComponent
                           {...renderState.templateProps}
                           templateKey="item"
@@ -146,11 +146,11 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as RelatedProductsUiProps<Hit>['layout'];
+    ) as RelatedProductsUiProps<AlgoliaHit<THit>>['layout'];
 
     render(
       <RelatedProducts
-        items={items}
+        items={items as Array<AlgoliaHit<THit>>}
         sendEvent={() => {}}
         classNames={cssClasses}
         headerComponent={headerComponent}
@@ -172,7 +172,7 @@ export type RelatedProductsTemplates<
   /**
    * Template to use when there are no results.
    */
-  empty: Template<RecommendResultItem<Hit<THit>>>;
+  empty: Template<RecommendResponse<AlgoliaHit<THit>>>;
 
   /**
    * Template to use for the header of the widget.
@@ -180,7 +180,7 @@ export type RelatedProductsTemplates<
   header: Template<
     Pick<
       Parameters<
-        NonNullable<RelatedProductsUiProps<Hit<THit>>['headerComponent']>
+        NonNullable<RelatedProductsUiProps<AlgoliaHit<THit>>['headerComponent']>
       >[0],
       'items'
     > & { cssClasses: RecommendClassNames }
@@ -189,18 +189,20 @@ export type RelatedProductsTemplates<
   /**
    * Template to use for each result. This template will receive an object containing a single record.
    */
-  item: Template<Hit<THit>>;
+  item: Template<AlgoliaHit<THit>>;
 
   /**
    * Template to use to wrap all items.
    */
   layout: Template<
     Pick<
-      Parameters<NonNullable<RelatedProductsUiProps<Hit<THit>>['layout']>>[0],
+      Parameters<
+        NonNullable<RelatedProductsUiProps<AlgoliaHit<THit>>['layout']>
+      >[0],
       'items'
     > & {
       templates: {
-        item: RelatedProductsUiProps<Hit>['itemComponent'];
+        item: RelatedProductsUiProps<AlgoliaHit<THit>>['itemComponent'];
       };
       cssClasses: Pick<RelatedProductsCSSClasses, 'list' | 'item'>;
     }

--- a/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
@@ -20,11 +20,11 @@ import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   Template,
   WidgetFactory,
-  Hit,
+  AlgoliaHit,
   Renderer,
   BaseHit,
+  RecommendResponse,
 } from '../../types';
-import type { RecommendResultItem } from 'algoliasearch-helper';
 import type {
   RecommendClassNames,
   TrendingItemsProps as TrendingItemsUiProps,
@@ -87,7 +87,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as TrendingItemsUiProps<Hit>['headerComponent'];
+    ) as TrendingItemsUiProps<AlgoliaHit>['headerComponent'];
 
     const itemComponent = (
       templates.item
@@ -102,7 +102,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             );
           }
         : undefined
-    ) as TrendingItemsUiProps<Hit>['itemComponent'];
+    ) as TrendingItemsUiProps<AlgoliaHit>['itemComponent'];
 
     const emptyComponent = (
       templates.empty
@@ -115,7 +115,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as TrendingItemsUiProps<Hit>['emptyComponent'];
+    ) as TrendingItemsUiProps<AlgoliaHit>['emptyComponent'];
 
     const layoutComponent = (
       templates.layout
@@ -128,7 +128,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
                 items: data.items,
                 templates: {
                   item: templates.item
-                    ? ({ item }: { item: Hit<THit> }) => (
+                    ? ({ item }: { item: AlgoliaHit<THit> }) => (
                         <TemplateComponent
                           {...renderState.templateProps}
                           templateKey="item"
@@ -146,11 +146,11 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as TrendingItemsUiProps<Hit>['layout'];
+    ) as TrendingItemsUiProps<AlgoliaHit<THit>>['layout'];
 
     render(
       <TrendingItems
-        items={items}
+        items={items as Array<AlgoliaHit<THit>>}
         sendEvent={() => {}}
         classNames={cssClasses}
         headerComponent={headerComponent}
@@ -171,7 +171,7 @@ export type TrendingItemsTemplates<THit extends NonNullable<object> = BaseHit> =
     /**
      * Template to use when there are no results.
      */
-    empty: Template<RecommendResultItem<Hit<THit>>>;
+    empty: Template<RecommendResponse<AlgoliaHit<THit>>>;
 
     /**
      * Template to use for the header of the widget.
@@ -179,7 +179,7 @@ export type TrendingItemsTemplates<THit extends NonNullable<object> = BaseHit> =
     header: Template<
       Pick<
         Parameters<
-          NonNullable<TrendingItemsUiProps<Hit<THit>>['headerComponent']>
+          NonNullable<TrendingItemsUiProps<AlgoliaHit<THit>>['headerComponent']>
         >[0],
         'items'
       > & { cssClasses: RecommendClassNames }
@@ -188,18 +188,20 @@ export type TrendingItemsTemplates<THit extends NonNullable<object> = BaseHit> =
     /**
      * Template to use for each result. This template will receive an object containing a single record.
      */
-    item: Template<Hit<THit>>;
+    item: Template<AlgoliaHit<THit>>;
 
     /**
      * Template to use to wrap all items.
      */
     layout: Template<
       Pick<
-        Parameters<NonNullable<TrendingItemsUiProps<Hit<THit>>['layout']>>[0],
+        Parameters<
+          NonNullable<TrendingItemsUiProps<AlgoliaHit<THit>>['layout']>
+        >[0],
         'items'
       > & {
         templates: {
-          item: TrendingItemsUiProps<Hit>['itemComponent'];
+          item: TrendingItemsUiProps<AlgoliaHit<THit>>['itemComponent'];
         };
         cssClasses: Pick<TrendingItemsCSSClasses, 'list' | 'item'>;
       }

--- a/packages/instantsearch.js/src/widgets/voice-search/__tests__/voice-search-test.ts
+++ b/packages/instantsearch.js/src/widgets/voice-search/__tests__/voice-search-test.ts
@@ -2,9 +2,11 @@
  * @jest-environment jsdom
  */
 
-import { createSingleSearchResponse } from '@instantsearch/mocks';
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import { castToJestMock } from '@instantsearch/testutils/castToJestMock';
-import algoliasearch from 'algoliasearch';
 import algoliasearchHelper, {
   SearchResults,
   SearchParameters,
@@ -84,7 +86,7 @@ describe('voiceSearch()', () => {
   beforeEach(() => {
     render.mockClear();
 
-    helper = algoliasearchHelper(algoliasearch('APP_ID', 'API_KEY'), '', {});
+    helper = algoliasearchHelper(createSearchClient(), '', {});
     helper.setQuery = jest.fn();
     helper.search = jest.fn();
     helper.state = new SearchParameters({ query: '' });

--- a/packages/instantsearch.js/stories/geo-search.stories.ts
+++ b/packages/instantsearch.js/stories/geo-search.stories.ts
@@ -1,6 +1,5 @@
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/html';
-import algoliaPlaces from 'places.js';
 import injectScript from 'scriptjs';
 
 import { withHits, withLifecycle } from '../.storybook/decorators';
@@ -95,40 +94,6 @@ stories
       })
     )
   );
-
-// With Places
-stories.add(
-  'with position from Places',
-  withHitsAndConfigure(({ search, container, instantsearch }) =>
-    injectGoogleMaps(() => {
-      const placesElement = document.createElement('input');
-      const mapElement = document.createElement('div');
-      mapElement.style.marginTop = '20px';
-
-      container.appendChild(placesElement);
-      container.appendChild(mapElement);
-
-      search.addWidgets([
-        instantsearch.widgets.configure({
-          aroundRadius: 20000,
-        }),
-
-        instantsearch.widgets.places({
-          placesReference: algoliaPlaces,
-          container: placesElement,
-          defaultPosition: ['37.7793', '-122.419'],
-        }),
-
-        instantsearch.widgets.geoSearch({
-          googleReference: window.google,
-          container: mapElement,
-          enableClearMapRefinement: false,
-          initialZoom,
-        }),
-      ]);
-    })
-  )
-);
 
 // Only UI
 stories

--- a/packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx
@@ -9,7 +9,8 @@ import {
 } from '@instantsearch/mocks';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import algoliasearch from 'algoliasearch';
+import algoliasearchV4 from 'algoliasearch-v4';
+import { algoliasearch as algoliasearchV5 } from 'algoliasearch-v5';
 import { history } from 'instantsearch.js/es/lib/routers';
 import { simple } from 'instantsearch.js/es/lib/stateMappings';
 import React, { StrictMode } from 'react';
@@ -18,7 +19,7 @@ import { Hits, RefinementList, SearchBox } from 'react-instantsearch';
 import { InstantSearch } from '../InstantSearch';
 import { InstantSearchSSRProvider } from '../InstantSearchSSRProvider';
 
-import type { Hit as AlgoliaHit } from 'instantsearch.js';
+import type { Hit as AlgoliaHit, SearchClient } from 'instantsearch.js';
 
 function HitComponent({ hit }: { hit: AlgoliaHit }) {
   return <>{hit.objectID}</>;
@@ -471,66 +472,72 @@ describe('InstantSearchSSRProvider', () => {
     });
   });
 
-  test('caches the initial results to avoid a client-side request', async () => {
-    const send = jest.fn(() =>
-      Promise.resolve({
-        content: JSON.stringify(createMultiSearchResponse()),
-        isTimedOut: false,
-        status: 200,
-      })
-    );
-    const searchClient = algoliasearch('appId', 'apiKey', {
-      requester: { send },
-    });
-    const initialResults = {
-      indexName: {
-        state: {},
-        results: [
-          {
-            exhaustiveFacetsCount: true,
-            exhaustiveNbHits: true,
-            hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
-            hitsPerPage: 20,
-            index: 'indexName',
-            nbHits: 0,
-            nbPages: 0,
-            page: 0,
-            params: '',
-            processingTimeMS: 0,
-            query: '',
-          },
-        ],
-      },
-    };
-
-    function App() {
-      return (
-        <StrictMode>
-          <InstantSearchSSRProvider initialResults={initialResults}>
-            <InstantSearch searchClient={searchClient} indexName="indexName">
-              <SearchBox />
-            </InstantSearch>
-          </InstantSearchSSRProvider>
-        </StrictMode>
+  test.each([
+    ['v4', algoliasearchV4],
+    ['v5', algoliasearchV5],
+  ])(
+    'caches the initial results to avoid a client-side request (%s)',
+    async (_, ctor) => {
+      const send = jest.fn(() =>
+        Promise.resolve({
+          content: JSON.stringify(createMultiSearchResponse()),
+          isTimedOut: false,
+          status: 200,
+        })
       );
+      const searchClient = ctor('appId', 'apiKey', {
+        requester: { send },
+      }) as unknown as SearchClient;
+      const initialResults = {
+        indexName: {
+          state: {},
+          results: [
+            {
+              exhaustiveFacetsCount: true,
+              exhaustiveNbHits: true,
+              hits: [{ objectID: '1' }, { objectID: '2' }, { objectID: '3' }],
+              hitsPerPage: 20,
+              index: 'indexName',
+              nbHits: 0,
+              nbPages: 0,
+              page: 0,
+              params: '',
+              processingTimeMS: 0,
+              query: '',
+            },
+          ],
+        },
+      };
+
+      function App() {
+        return (
+          <StrictMode>
+            <InstantSearchSSRProvider initialResults={initialResults}>
+              <InstantSearch searchClient={searchClient} indexName="indexName">
+                <SearchBox />
+              </InstantSearch>
+            </InstantSearchSSRProvider>
+          </StrictMode>
+        );
+      }
+
+      render(<App />);
+
+      await waitFor(() => {
+        expect(send).toHaveBeenCalledTimes(0);
+      });
+
+      userEvent.type(screen.getByRole('searchbox'), 'i');
+
+      await waitFor(() => {
+        expect(send).toHaveBeenCalledTimes(1);
+      });
+
+      userEvent.clear(screen.getByRole('searchbox'));
+
+      await waitFor(() => {
+        expect(send).toHaveBeenCalledTimes(1);
+      });
     }
-
-    render(<App />);
-
-    await waitFor(() => {
-      expect(send).toHaveBeenCalledTimes(0);
-    });
-
-    userEvent.type(screen.getByRole('searchbox'), 'i');
-
-    await waitFor(() => {
-      expect(send).toHaveBeenCalledTimes(1);
-    });
-
-    userEvent.clear(screen.getByRole('searchbox'));
-
-    await waitFor(() => {
-      expect(send).toHaveBeenCalledTimes(1);
-    });
-  });
+  );
 });

--- a/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
@@ -36,7 +36,7 @@ export function InitializePromise({ nonce }: InitializePromiseProps) {
   search.mainHelper!.setClient({
     ...search.mainHelper!.getClient(),
     search(queries) {
-      requestParamsList = queries.map(({ params }) => params!);
+      requestParamsList = queries.map(({ params }) => params);
       return search.client.search(queries);
     },
   });

--- a/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
+++ b/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
@@ -9,11 +9,11 @@ import type {
   FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherPropsUiComponentProps,
   Pragma,
 } from 'instantsearch-ui-components';
-import type { Hit, BaseHit } from 'instantsearch.js';
+import type { AlgoliaHit, BaseHit } from 'instantsearch.js';
 import type { UseFrequentlyBoughtTogetherProps } from 'react-instantsearch-core';
 
 type UiProps<THit extends BaseHit> = Pick<
-  FrequentlyBoughtTogetherPropsUiComponentProps<Hit<THit>>,
+  FrequentlyBoughtTogetherPropsUiComponentProps<AlgoliaHit<THit>>,
   | 'items'
   | 'itemComponent'
   | 'headerComponent'
@@ -23,7 +23,7 @@ type UiProps<THit extends BaseHit> = Pick<
 >;
 
 export type FrequentlyBoughtTogetherProps<THit extends BaseHit> = Omit<
-  FrequentlyBoughtTogetherPropsUiComponentProps<Hit<THit>>,
+  FrequentlyBoughtTogetherPropsUiComponentProps<AlgoliaHit<THit>>,
   keyof UiProps<THit>
 > &
   UseFrequentlyBoughtTogetherProps<THit> & {

--- a/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
+++ b/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
@@ -6,11 +6,11 @@ import type {
   LookingSimilarProps as LookingSimilarPropsUiComponentProps,
   Pragma,
 } from 'instantsearch-ui-components';
-import type { Hit, BaseHit } from 'instantsearch.js';
+import type { AlgoliaHit, BaseHit } from 'instantsearch.js';
 import type { UseLookingSimilarProps } from 'react-instantsearch-core';
 
 type UiProps<THit extends BaseHit> = Pick<
-  LookingSimilarPropsUiComponentProps<Hit<THit>>,
+  LookingSimilarPropsUiComponentProps<AlgoliaHit<THit>>,
   | 'items'
   | 'itemComponent'
   | 'headerComponent'
@@ -20,7 +20,7 @@ type UiProps<THit extends BaseHit> = Pick<
 >;
 
 export type LookingSimilarProps<THit extends BaseHit> = Omit<
-  LookingSimilarPropsUiComponentProps<Hit<THit>>,
+  LookingSimilarPropsUiComponentProps<AlgoliaHit<THit>>,
   keyof UiProps<THit>
 > &
   UseLookingSimilarProps<THit> & {

--- a/packages/react-instantsearch/src/widgets/RelatedProducts.tsx
+++ b/packages/react-instantsearch/src/widgets/RelatedProducts.tsx
@@ -6,7 +6,7 @@ import type {
   RelatedProductsProps as RelatedProductsUiComponentProps,
   Pragma,
 } from 'instantsearch-ui-components';
-import type { Hit, BaseHit } from 'instantsearch.js';
+import type { AlgoliaHit, BaseHit } from 'instantsearch.js';
 import type { UseRelatedProductsProps } from 'react-instantsearch-core';
 
 type UiProps<TItem extends BaseHit> = Pick<
@@ -62,7 +62,7 @@ export function RelatedProducts<TItem extends BaseHit = BaseHit>({
   );
 
   const uiProps: UiProps<TItem> = {
-    items: items as Array<Hit<TItem>>,
+    items: items as Array<AlgoliaHit<TItem>>,
     itemComponent,
     headerComponent,
     emptyComponent,

--- a/packages/react-instantsearch/src/widgets/TrendingItems.tsx
+++ b/packages/react-instantsearch/src/widgets/TrendingItems.tsx
@@ -6,7 +6,7 @@ import type {
   TrendingItemsProps as TrendingItemsUiComponentProps,
   Pragma,
 } from 'instantsearch-ui-components';
-import type { Hit, BaseHit } from 'instantsearch.js';
+import type { AlgoliaHit, BaseHit } from 'instantsearch.js';
 import type { UseTrendingItemsProps } from 'react-instantsearch-core';
 
 type UiProps<TItem extends BaseHit> = Pick<
@@ -66,7 +66,7 @@ export function TrendingItems<TItem extends BaseHit = BaseHit>({
   );
 
   const uiProps: UiProps<TItem> = {
-    items: items as Array<Hit<TItem>>,
+    items: items as Array<AlgoliaHit<TItem>>,
     itemComponent,
     headerComponent,
     emptyComponent,

--- a/packages/react-instantsearch/src/widgets/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/RefinementList.test.tsx
@@ -104,6 +104,7 @@ function createMockedSearchClient(parameters: Record<string, any> = {}) {
         )
       );
     }),
+    // @ts-ignore v5 accepts only `search({ type: 'facet' })`, v3, v4 accept `searchForFacetValues`
     searchForFacetValues: jest.fn(() =>
       Promise.resolve([
         createSFFVResponse({

--- a/packages/react-instantsearch/src/widgets/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/RefinementList.test.tsx
@@ -104,7 +104,7 @@ function createMockedSearchClient(parameters: Record<string, any> = {}) {
         )
       );
     }),
-    // @ts-ignore v5 accepts only `search({ type: 'facet' })`, v3, v4 accept `searchForFacetValues`
+    // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can replace this method and its usages with search({ type: 'facet })
     searchForFacetValues: jest.fn(() =>
       Promise.resolve([
         createSFFVResponse({

--- a/packages/vue-instantsearch/.storybook/webpack.config.js
+++ b/packages/vue-instantsearch/.storybook/webpack.config.js
@@ -1,9 +1,6 @@
 const webpack = require('webpack');
 
 module.exports = ({ config, mode }) => {
-  // `mode` can either be 'DEVELOPMENT' or 'PRODUCTION'
-  // 'PRODUCTION' is used when building the static version of storybook.
-
   config.module.rules.push({
     test: /\.(js|ts|tsx)$/,
     exclude: /node_modules\/(?!(algoliasearch)\/).*/,
@@ -16,14 +13,6 @@ module.exports = ({ config, mode }) => {
       },
     ],
   });
-
-  config.plugins.push(
-    new webpack.DefinePlugin({
-      __DEV__: JSON.stringify(mode === 'DEVELOPMENT'),
-    })
-  );
-
-  config.resolve.extensions.push('.ts', '.tsx');
 
   return config;
 };

--- a/scripts/legacy/downgrade-algoliasearch-dependency.js
+++ b/scripts/legacy/downgrade-algoliasearch-dependency.js
@@ -23,7 +23,7 @@ console.log(
 // change main dependency
 shell.sed(
   '-i',
-  /"algoliasearch": "4.*"(,?)/,
+  /"algoliasearch": "5.*"(,?)/,
   '"algoliasearch": "3.35.1","@types/algoliasearch": "3.34.10"$1',
   packageJsonPaths
 );
@@ -31,17 +31,29 @@ shell.sed(
 // remove other v4 dependencies
 shell.sed(
   '-i',
-  /"@algolia\/(cache-.*|client-.*|logger-.*|requester-.*|transporter)": "4.*",?/,
+  /"@algolia\/(cache-.*|client-.*|logger-.*|requester-.*|transporter|recommend)": "(4|5).*",?/,
   '',
   packageJsonPaths
 );
 
-// remove v5 dependency
+// remove resolution
+shell.sed('-i', /"places.js\/algoliasearch": "5.*"(,?)/, '', packageJsonPaths);
+
+// replace import in examples
 shell.sed(
   '-i',
-  /"algoliasearch-v5": "npm:algoliasearch@5.*"(,?)/,
-  '',
-  packageJsonPaths
+  /import { liteClient as algoliasearch } from 'algoliasearch\/lite'/,
+  "import algoliasearch from 'algoliasearch/lite'",
+  ...shell.ls('examples/*/*/*.{js,ts,tsx,vue}'),
+  ...shell.ls('examples/*/*/{src,pages,app}/*.{js,ts,tsx,vue}')
+);
+
+// replace dependency in examples
+shell.sed(
+  '-i',
+  /"algoliasearch": ".*"(,)?/,
+  '"algoliasearch": "3.35.1","@types/algoliasearch": "3.34.10"$1',
+  ...shell.ls('examples/*/*/package.json')
 );
 
 shell.exec('yarn install');

--- a/scripts/legacy/downgrade-algoliasearch-v4.js
+++ b/scripts/legacy/downgrade-algoliasearch-v4.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const path = require('path');
+
+const shell = require('shelljs');
+
+const packageJsonPaths = [
+  path.resolve(__dirname, '../../package.json'),
+  ...JSON.parse(
+    shell.exec(
+      "yarn run --silent lerna list --json --all --ignore='example-*'",
+      {
+        silent: true,
+      }
+    ).stdout
+  ).map(({ location }) => path.resolve(location, 'package.json')),
+];
+
+console.log(
+  `Downgrading algoliasearch dependency to v4 in:
+- ${packageJsonPaths.join('\n- ')}`
+);
+
+// change main dependency
+shell.sed(
+  '-i',
+  /"algoliasearch": "5.*"(,?)/,
+  '"algoliasearch": "4.23.2"$1',
+  packageJsonPaths
+);
+
+// Downgrade other dependency
+shell.sed(
+  '-i',
+  /"@algolia\/client-search": "5.*"(,?)/,
+  '"@algolia/client-search": "4.23.2"$1',
+  packageJsonPaths
+);
+
+// remove resolution
+shell.sed('-i', /"@algolia\/client-common": "5.*"(,?)/, '', packageJsonPaths);
+shell.sed(
+  '-i',
+  /"places.js\/algoliasearch": "5.*"(,?)/,
+  '"places.js/algoliasearch": "4.23.2"$1',
+  packageJsonPaths
+);
+
+// replace import in examples
+shell.sed(
+  '-i',
+  /import { liteClient as algoliasearch } from 'algoliasearch\/lite'/,
+  "import algoliasearch from 'algoliasearch/lite'",
+  ...shell.ls('examples/*/*/*.{js,ts,tsx,vue}'),
+  ...shell.ls('examples/*/*/{src,pages,app}/*.{js,ts,tsx,vue}')
+);
+
+// replace dependency in examples
+shell.sed(
+  '-i',
+  /"algoliasearch": ".*"(,)?/,
+  '"algoliasearch": "4.23.2"$1',
+  ...shell.ls('examples/*/*/package.json')
+);
+
+shell.exec('yarn install');
+
+shell.exec('cp -r node_modules/algoliasearch-v4 node_modules/algoliasearch');

--- a/tests/common/connectors/pagination/routing.ts
+++ b/tests/common/connectors/pagination/routing.ts
@@ -41,7 +41,7 @@ export function createRoutingTests(
                 return createMultiSearchResponse(
                   ...requests.map(({ params }) =>
                     createSingleSearchResponse({
-                      page: params!.page,
+                      page: params.page,
                       nbPages: 20,
                     })
                   )

--- a/tests/common/shared/insights.ts
+++ b/tests/common/shared/insights.ts
@@ -39,7 +39,7 @@ export function createInsightsTests(
                       params,
                     }: Parameters<SearchClient['search']>[0][number]) =>
                       createSingleSearchResponse({
-                        // @ts-expect-error this key is private, thus not in the types
+                        // @ts-ignore this key doesn't exist in v3, v4 types
                         _automaticInsights: true,
                         hits: [{ objectID: '1' }],
                         facets: {
@@ -48,7 +48,7 @@ export function createInsightsTests(
                             Apple: 200,
                           },
                         },
-                        page: params!.page,
+                        page: params.page,
                         nbPages: 20,
                       })
                   )
@@ -131,7 +131,7 @@ export function createInsightsTests(
                             Apple: 200,
                           },
                         },
-                        page: params!.page,
+                        page: params.page,
                         nbPages: 20,
                       })
                   )

--- a/tests/common/shared/routing.ts
+++ b/tests/common/shared/routing.ts
@@ -51,7 +51,7 @@ export function createRoutingTests(
                           Apple: 200,
                         },
                       },
-                      page: params!.page,
+                      page: params.page,
                       nbPages: 20,
                     })
                   )

--- a/tests/common/widgets/infinite-hits/optimistic-ui.ts
+++ b/tests/common/widgets/infinite-hits/optimistic-ui.ts
@@ -33,11 +33,11 @@ export function createOptimisticUiTests(
                     createSingleSearchResponse({
                       hits: Array.from({ length: hitsPerPage }).map(
                         (_, index) => ({
-                          objectID: `${params!.page! * hitsPerPage + index}`,
+                          objectID: `${params.page! * hitsPerPage + index}`,
                         })
                       ),
-                      query: params!.query,
-                      page: params!.page,
+                      query: params.query,
+                      page: params.page,
                       nbPages: 20,
                     })
                 )
@@ -108,11 +108,11 @@ export function createOptimisticUiTests(
                     createSingleSearchResponse({
                       hits: Array.from({ length: hitsPerPage }).map(
                         (_, index) => ({
-                          objectID: `${params!.page! * hitsPerPage + index}`,
+                          objectID: `${params.page! * hitsPerPage + index}`,
                         })
                       ),
-                      query: params!.query,
-                      page: params!.page,
+                      query: params.query,
+                      page: params.page,
                       nbPages: 20,
                     })
                 )
@@ -186,11 +186,11 @@ export function createOptimisticUiTests(
                     createSingleSearchResponse({
                       hits: Array.from({ length: hitsPerPage }).map(
                         (_, index) => ({
-                          objectID: `${params!.page! * hitsPerPage + index}`,
+                          objectID: `${params.page! * hitsPerPage + index}`,
                         })
                       ),
-                      query: params!.query,
-                      page: params!.page,
+                      query: params.query,
+                      page: params.page,
                       nbPages: 20,
                     })
                 )

--- a/tests/common/widgets/instantsearch/algolia-agent.ts
+++ b/tests/common/widgets/instantsearch/algolia-agent.ts
@@ -1,15 +1,21 @@
-import algoliasearch from 'algoliasearch';
+import algoliasearchV3 from 'algoliasearch-v3';
+import algoliasearchV4 from 'algoliasearch-v4';
+import { algoliasearch as algoliasearchV5 } from 'algoliasearch-v5';
 
 import type { InstantSearchWidgetSetup } from '.';
 import type { TestOptions } from '../../common';
+import type { SearchClient } from 'instantsearch.js';
 
 export function createAlgoliaAgentTests(
   setup: InstantSearchWidgetSetup,
   _options: Required<TestOptions>
 ) {
   describe('algolia agent', () => {
-    test('sets the correct algolia agents', async () => {
-      const searchClient = algoliasearch('appId', 'apiKey');
+    test('sets the correct algolia agents with v3', async () => {
+      const searchClient = algoliasearchV3(
+        'appId',
+        'apiKey'
+      ) as unknown as SearchClient;
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -20,13 +26,69 @@ export function createAlgoliaAgentTests(
 
       const { algoliaAgents } = await setup(options);
 
-      const algoliaAgent: string = (searchClient as any).transporter
-        ? (searchClient as any).transporter.userAgent.value
-        : (searchClient as any)._ua;
+      const algoliaAgent: string = getAgent(searchClient);
+
+      expect(algoliaAgent.split(';').map((agent) => agent.trim())).toEqual(
+        expect.arrayContaining(algoliaAgents)
+      );
+    });
+
+    test('sets the correct algolia agents with v4', async () => {
+      const searchClient = algoliasearchV4(
+        'appId',
+        'apiKey'
+      ) as unknown as SearchClient;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {},
+      };
+
+      const { algoliaAgents } = await setup(options);
+
+      const algoliaAgent: string = getAgent(searchClient);
+
+      expect(algoliaAgent.split(';').map((agent) => agent.trim())).toEqual(
+        expect.arrayContaining(algoliaAgents)
+      );
+    });
+
+    test('sets the correct algolia agents', async () => {
+      const searchClient = algoliasearchV5(
+        'appId',
+        'apiKey'
+      ) as unknown as SearchClient;
+      const options = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {},
+      };
+
+      const { algoliaAgents } = await setup(options);
+
+      const algoliaAgent: string = getAgent(searchClient);
 
       expect(algoliaAgent.split(';').map((agent) => agent.trim())).toEqual(
         expect.arrayContaining(algoliaAgents)
       );
     });
   });
+}
+
+function getAgent(searchClient: any) {
+  if (searchClient.transporter && searchClient.transporter.userAgent) {
+    return searchClient.transporter.userAgent.value;
+  }
+  if (searchClient.transporter && searchClient.transporter.algoliaAgent) {
+    return searchClient.transporter.algoliaAgent.value;
+  }
+  if (searchClient._ua) {
+    return searchClient._ua;
+  }
+
+  throw new Error('Could not find the algolia agent');
 }

--- a/tests/common/widgets/pagination/optimistic-ui.ts
+++ b/tests/common/widgets/pagination/optimistic-ui.ts
@@ -26,7 +26,7 @@ export function createOptimisticUiTests(
               return createMultiSearchResponse(
                 ...requests.map(({ params }) =>
                   createSingleSearchResponse({
-                    page: params!.page,
+                    page: params.page,
                     nbPages: 20,
                   })
                 )
@@ -148,7 +148,7 @@ export function createOptimisticUiTests(
               return createMultiSearchResponse(
                 ...requests.map(({ params }) =>
                   createSingleSearchResponse({
-                    page: params!.page,
+                    page: params.page,
                     nbPages: 20,
                   })
                 )

--- a/tests/common/widgets/refinement-list/options.ts
+++ b/tests/common/widgets/refinement-list/options.ts
@@ -1,6 +1,6 @@
 import {
-  createAlgoliaSearchClient,
   createMultiSearchResponse,
+  createSearchClient,
   createSFFVResponse,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
@@ -1491,7 +1491,7 @@ const FACET_HITS = [
 ];
 
 function createMockedSearchClient(parameters: Record<string, any> = {}) {
-  return createAlgoliaSearchClient({
+  return createSearchClient({
     search: jest.fn((requests) => {
       return Promise.resolve(
         createMultiSearchResponse(
@@ -1532,7 +1532,7 @@ function createMockedSearchClient(parameters: Record<string, any> = {}) {
           facetHits: FACET_HITS,
         }),
       ])
-    ),
+    ) as any, // @TODO: for now casted as any, because v5 only has `type: facet` in search
     ...parameters,
   });
 }

--- a/tests/mocks/createAPIResponse.ts
+++ b/tests/mocks/createAPIResponse.ts
@@ -1,8 +1,9 @@
-import type { RecommendQueriesResponse } from '@algolia/recommend';
 import type {
   SearchResponse,
   SearchResponses,
   SearchForFacetValuesResponse,
+  RecommendResponse,
+  RecommendResponses,
 } from 'instantsearch.js';
 
 export const defaultRenderingContent: SearchResponse<any>['renderingContent'] =
@@ -88,8 +89,42 @@ export const createSFFVResponse = (
   ...args,
 });
 
+export const createSingleRecommendResponse = (
+  subset: Partial<RecommendResponse<any>> = {}
+): RecommendResponse<any> => {
+  const {
+    query = '',
+    page = 0,
+    hitsPerPage = 20,
+    hits = [],
+    nbHits = hits.length,
+    nbPages = Math.ceil(nbHits / hitsPerPage),
+    params = '',
+    exhaustiveNbHits = true,
+    exhaustiveFacetsCount = true,
+    processingTimeMS = 0,
+    ...rest
+  } = subset;
+
+  return {
+    page,
+    hitsPerPage,
+    nbHits,
+    nbPages,
+    processingTimeMS,
+    hits,
+    query,
+    params,
+    exhaustiveNbHits,
+    exhaustiveFacetsCount,
+    ...rest,
+  };
+};
+
 export const createRecommendResponse = (
-  requests: readonly any[]
-): RecommendQueriesResponse<any> => {
-  return { results: requests.map(createSingleSearchResponse) };
+  requests: any[]
+): RecommendResponses<any> => {
+  return {
+    results: requests.map(createSingleRecommendResponse),
+  };
 };

--- a/tests/mocks/createSearchClient.ts
+++ b/tests/mocks/createSearchClient.ts
@@ -20,7 +20,7 @@ export const createSearchClient = (
       )
     )
   ),
-  // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can remove this method and its usages to search({ type: 'facet })
+  // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can replace this method and its usages with search({ type: 'facet })
   searchForFacetValues: jest.fn(() => Promise.resolve([createSFFVResponse()])),
   // @ts-ignore this allows us to test insights initialization without warning
   applicationID: 'appId',

--- a/tests/mocks/createSearchClient.ts
+++ b/tests/mocks/createSearchClient.ts
@@ -20,6 +20,7 @@ export const createSearchClient = (
       )
     )
   ),
+  // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can remove this method and its usages to search({ type: 'facet })
   searchForFacetValues: jest.fn(() => Promise.resolve([createSFFVResponse()])),
   // @ts-ignore this allows us to test insights initialization without warning
   applicationID: 'appId',

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,14 +51,14 @@
   dependencies:
     "@algolia/cache-common" "4.23.2"
 
-"@algolia/client-abtesting@5.0.0-beta.8":
-  version "5.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@algolia/client-abtesting/-/client-abtesting-5.0.0-beta.8.tgz#07950e042e19abe473b6659660dbbaf3d5ae5750"
-  integrity sha512-SX9/v/1CinWhn8UyPS4zoiCuqLepAoaPiwiJvMal1q8huQzHPYgaQRGu5SwXf/jzUnXnWLiWakyZZ0WkGHj6yA==
+"@algolia/client-abtesting@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-abtesting/-/client-abtesting-5.0.0.tgz#c6d5727ee77d8ea0eac0d545a977c19155bb1c29"
+  integrity sha512-pVSwJ2QZ9hNeINjSWRQGwN/zAk16E6fOM4VGayIULyiJnaIaRjGT/UfMRiGsIuBFib2zviq83uO8GOnCUBmXnA==
   dependencies:
-    "@algolia/client-common" "5.0.0-beta.9"
-    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
-    "@algolia/requester-node-http" "5.0.0-beta.9"
+    "@algolia/client-common" "5.0.0"
+    "@algolia/requester-browser-xhr" "5.0.0"
+    "@algolia/requester-node-http" "5.0.0"
 
 "@algolia/client-account@4.23.2":
   version "4.23.2"
@@ -79,14 +79,14 @@
     "@algolia/requester-common" "4.23.2"
     "@algolia/transporter" "4.23.2"
 
-"@algolia/client-analytics@5.0.0-beta.8":
-  version "5.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-5.0.0-beta.8.tgz#86d110bed99ca28359bd4e70eaeff568cb6462bb"
-  integrity sha512-SzMg3FeF7do/+plUawHRw2Lr3/KebKF8rCkswdR907kUa/aMVCFzsginL3xc/k8bIxx6wU8fk5iKLeK1+Ykxnw==
+"@algolia/client-analytics@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-5.0.0.tgz#582d165cf6486e441646916635e5c74487ca3226"
+  integrity sha512-3A4JyblLorrxkYn6uOWyo7drDi3z7+Yzm45YP1MgOvzOCt0qWlEb6neIFLDe4UrBy24JqmRx54uNMBuYMOscgw==
   dependencies:
-    "@algolia/client-common" "5.0.0-beta.9"
-    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
-    "@algolia/requester-node-http" "5.0.0-beta.9"
+    "@algolia/client-common" "5.0.0"
+    "@algolia/requester-browser-xhr" "5.0.0"
+    "@algolia/requester-node-http" "5.0.0"
 
 "@algolia/client-common@4.23.2":
   version "4.23.2"
@@ -96,10 +96,10 @@
     "@algolia/requester-common" "4.23.2"
     "@algolia/transporter" "4.23.2"
 
-"@algolia/client-common@5.0.0-beta.9":
-  version "5.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-5.0.0-beta.9.tgz#f659c0fca45663a09f7bcf5eb36318ef5ab39b40"
-  integrity sha512-TWf6l4/pWMk8CgV+8A4zTe49XaygaCZ6ir8bwf4WnpDgAxx8Y5X/I6e7vPzl7sljQEEB9q1+qlkss1nxNeRJPw==
+"@algolia/client-common@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-5.0.0.tgz#ff52d29ed81cdafaa38655fc4ee958ca49f20aaf"
+  integrity sha512-6N5Qygv/Z/B+rPufnPDLNWgsMf1uubMU7iS52xLcQSLiGlTS4f9eLUrmNXSzHccP33uoFi6xN9craN1sZi5MPQ==
 
 "@algolia/client-personalization@4.23.2":
   version "4.23.2"
@@ -110,14 +110,14 @@
     "@algolia/requester-common" "4.23.2"
     "@algolia/transporter" "4.23.2"
 
-"@algolia/client-personalization@5.0.0-beta.8":
-  version "5.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-5.0.0-beta.8.tgz#18b624c9e268da3c36c5416e593e778cdaca338c"
-  integrity sha512-8mGxWE3TA3+2ekc+rM38JAwFfpwPyWyPxjjOe33afiFkmDliLrsGDAyoCasu7w34JhpuLeR1wfgo58g9s9+OLw==
+"@algolia/client-personalization@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-5.0.0.tgz#a5df3d5fce7a800145deca51cc10e8e9f037e568"
+  integrity sha512-Ns9pl+YGl0qZTbMqEKIO54GJqzyrMUmLfPB3/iEEkezKMMHXAsINrOuKTfhA6vyI0vhUJL3imOPo6vmXZBDZsA==
   dependencies:
-    "@algolia/client-common" "5.0.0-beta.9"
-    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
-    "@algolia/requester-node-http" "5.0.0-beta.9"
+    "@algolia/client-common" "5.0.0"
+    "@algolia/requester-browser-xhr" "5.0.0"
+    "@algolia/requester-node-http" "5.0.0"
 
 "@algolia/client-search@4.23.2":
   version "4.23.2"
@@ -128,14 +128,14 @@
     "@algolia/requester-common" "4.23.2"
     "@algolia/transporter" "4.23.2"
 
-"@algolia/client-search@5.0.0-beta.8":
-  version "5.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-5.0.0-beta.8.tgz#5abeb90de119ee868aa6a2d898c9d98cf8292258"
-  integrity sha512-Ub7CEFLDvCF13tq6imE7sEKnxmo177k4euXjaKGUMlznUf9qLWT5g6HuvBH4Nrxwaotima3cRnIw3zkq4JZORw==
+"@algolia/client-search@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-5.0.0.tgz#8d58f5daeffe9d19e0e0e9ebcdb5d23525edebe4"
+  integrity sha512-QdDYMzoxYZ3axzBy6CHe+M+NlOGvHEFTa2actchGnp25Uu0N6lyVNivT7nph+P1XoxgAD08cWbeJD3wWQXnpng==
   dependencies:
-    "@algolia/client-common" "5.0.0-beta.9"
-    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
-    "@algolia/requester-node-http" "5.0.0-beta.9"
+    "@algolia/client-common" "5.0.0"
+    "@algolia/requester-browser-xhr" "5.0.0"
+    "@algolia/requester-node-http" "5.0.0"
 
 "@algolia/events@^4.0.1":
   version "4.0.1"
@@ -171,14 +171,14 @@
     "@algolia/requester-node-http" "4.23.2"
     "@algolia/transporter" "4.23.2"
 
-"@algolia/recommend@5.0.0-beta.8":
-  version "5.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@algolia/recommend/-/recommend-5.0.0-beta.8.tgz#eff81537479a3390a33ddbffcbf82ae194160019"
-  integrity sha512-B7tuqYF2YlPmRH5jfDbbC3V1sq8X3a7oadwzAOPGGC1qwi2tO8BoBLM2iIwJRAAesw4NRVeBVDDmdsdiStHeEQ==
+"@algolia/recommend@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@algolia/recommend/-/recommend-5.0.0.tgz#df3c63f7de2ddf6658a67308a7a5f4b805c87687"
+  integrity sha512-aEXg4RPFIRrJjrtri782W7XFNkarxoN9X42FwYYP1bz15jKu2vrIqzGlQoNCNWuZP7WwYyUAoTtixwLRJq8grQ==
   dependencies:
-    "@algolia/client-common" "5.0.0-beta.9"
-    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
-    "@algolia/requester-node-http" "5.0.0-beta.9"
+    "@algolia/client-common" "5.0.0"
+    "@algolia/requester-browser-xhr" "5.0.0"
+    "@algolia/requester-node-http" "5.0.0"
 
 "@algolia/requester-browser-xhr@4.23.2":
   version "4.23.2"
@@ -187,12 +187,12 @@
   dependencies:
     "@algolia/requester-common" "4.23.2"
 
-"@algolia/requester-browser-xhr@5.0.0-beta.9":
-  version "5.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.0.0-beta.9.tgz#7b43b57cfabe9328e54fb4a96dd10026d27329f1"
-  integrity sha512-zw/ZmZv/CLjLqBUfukk5kR8N/xF/TbUt6xLdXF1LkaEJDj7BWU1RqMMDeSU5SEcehPMqNumfzFjpaz8D0rZ/jw==
+"@algolia/requester-browser-xhr@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.0.0.tgz#ddce386fd8635d79a1803c44b749289ff690db80"
+  integrity sha512-oOoQhSpg/RGiGHjn/cqtYpHBkkd+5M/DCi1jmfW+ZOvLVx21QVt6PbWIJoKJF85moNFo4UG9pMBU35R1MaxUKQ==
   dependencies:
-    "@algolia/client-common" "5.0.0-beta.9"
+    "@algolia/client-common" "5.0.0"
 
 "@algolia/requester-common@4.23.2":
   version "4.23.2"
@@ -206,12 +206,12 @@
   dependencies:
     "@algolia/requester-common" "4.23.2"
 
-"@algolia/requester-node-http@5.0.0-beta.9":
-  version "5.0.0-beta.9"
-  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-5.0.0-beta.9.tgz#afc04a658c1b624e03e378ea076020a51e737637"
-  integrity sha512-/32llTTdZ0zMNwn8I8FA12Pw4wZW93AvoHU/8Si2UR8S+FyL8dAkwgmQAvRZinNXD/Bo45Mpjwgydhx9UNZNBA==
+"@algolia/requester-node-http@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-5.0.0.tgz#708961cb2c069e5ed3bae83aef144ec8b3300b57"
+  integrity sha512-FwCdugzpnW0wxbgWPauAz5vhmWGQnjZa5DCl9PBbIoDNEy/NIV8DmiL9CEA+LljQdDidG0l0ijojcTNaRRtPvQ==
   dependencies:
-    "@algolia/client-common" "5.0.0-beta.9"
+    "@algolia/client-common" "5.0.0"
 
 "@algolia/transporter@4.23.2":
   version "4.23.2"
@@ -8083,19 +8083,19 @@ algoliasearch-helper@3.14.0:
     semver "^5.1.0"
     tunnel-agent "^0.6.0"
 
-"algoliasearch-v5@npm:algoliasearch@5.0.0-beta.8":
-  version "5.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-5.0.0-beta.8.tgz#df9ae7351f4d16ef20f04c7ed90203bfb8bdc9df"
-  integrity sha512-HeHubssxYRD9OEBySLXM8DdsrDthdyVSogncyQkxO3U+EYfg94Fxe7Kn9ooDm4sX88HS+lOaIV3I+JSwpvoy6A==
+"algoliasearch-v5@npm:algoliasearch@5.0.0", algoliasearch@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-5.0.0.tgz#caa7cb9a5116291763c93f3e7ca0fc284b5784f8"
+  integrity sha512-j/RYIyKy7D6Vu/o142+6Gka1lXtu0j/Hj/Mw5oaPpOscOcE4jn29k465pcWYNC34HMxA4W8chiDk9cqw8nszag==
   dependencies:
-    "@algolia/client-abtesting" "5.0.0-beta.8"
-    "@algolia/client-analytics" "5.0.0-beta.8"
-    "@algolia/client-common" "5.0.0-beta.9"
-    "@algolia/client-personalization" "5.0.0-beta.8"
-    "@algolia/client-search" "5.0.0-beta.8"
-    "@algolia/recommend" "5.0.0-beta.8"
-    "@algolia/requester-browser-xhr" "5.0.0-beta.9"
-    "@algolia/requester-node-http" "5.0.0-beta.9"
+    "@algolia/client-abtesting" "5.0.0"
+    "@algolia/client-analytics" "5.0.0"
+    "@algolia/client-common" "5.0.0"
+    "@algolia/client-personalization" "5.0.0"
+    "@algolia/client-search" "5.0.0"
+    "@algolia/recommend" "5.0.0"
+    "@algolia/requester-browser-xhr" "5.0.0"
+    "@algolia/requester-node-http" "5.0.0"
 
 algoliasearch@4, algoliasearch@4.23.2:
   version "4.23.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8083,21 +8083,8 @@ algoliasearch-helper@3.14.0:
     semver "^5.1.0"
     tunnel-agent "^0.6.0"
 
-"algoliasearch-v5@npm:algoliasearch@5.0.0", algoliasearch@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-5.0.0.tgz#caa7cb9a5116291763c93f3e7ca0fc284b5784f8"
-  integrity sha512-j/RYIyKy7D6Vu/o142+6Gka1lXtu0j/Hj/Mw5oaPpOscOcE4jn29k465pcWYNC34HMxA4W8chiDk9cqw8nszag==
-  dependencies:
-    "@algolia/client-abtesting" "5.0.0"
-    "@algolia/client-analytics" "5.0.0"
-    "@algolia/client-common" "5.0.0"
-    "@algolia/client-personalization" "5.0.0"
-    "@algolia/client-search" "5.0.0"
-    "@algolia/recommend" "5.0.0"
-    "@algolia/requester-browser-xhr" "5.0.0"
-    "@algolia/requester-node-http" "5.0.0"
-
-algoliasearch@4, algoliasearch@4.23.2:
+"algoliasearch-v4@npm:algoliasearch@4.23.2", algoliasearch@4, algoliasearch@4.23.2:
+  name algoliasearch-v4
   version "4.23.2"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.23.2.tgz#3b7bc93d98f3965628c73a06cbf9203531324a9d"
   integrity sha512-8aCl055IsokLuPU8BzLjwzXjb7ty9TPcUFFOk0pYOwsE5DMVhE3kwCMFtsCFKcnoPZK7oObm+H5mbnSO/9ioxQ==
@@ -8118,26 +8105,19 @@ algoliasearch@4, algoliasearch@4.23.2:
     "@algolia/requester-node-http" "4.23.2"
     "@algolia/transporter" "4.23.2"
 
-algoliasearch@^3.35.1:
-  version "3.35.1"
-  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.35.1.tgz#297d15f534a3507cab2f5dfb996019cac7568f0c"
-  integrity sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==
+"algoliasearch-v5@npm:algoliasearch@5.0.0", algoliasearch@5.0.0, algoliasearch@^3.35.1:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-5.0.0.tgz#caa7cb9a5116291763c93f3e7ca0fc284b5784f8"
+  integrity sha512-j/RYIyKy7D6Vu/o142+6Gka1lXtu0j/Hj/Mw5oaPpOscOcE4jn29k465pcWYNC34HMxA4W8chiDk9cqw8nszag==
   dependencies:
-    agentkeepalive "^2.2.0"
-    debug "^2.6.9"
-    envify "^4.0.0"
-    es6-promise "^4.1.0"
-    events "^1.1.0"
-    foreach "^2.0.5"
-    global "^4.3.2"
-    inherits "^2.0.1"
-    isarray "^2.0.1"
-    load-script "^1.0.0"
-    object-keys "^1.0.11"
-    querystring-es3 "^0.2.1"
-    reduce "^1.0.1"
-    semver "^5.1.0"
-    tunnel-agent "^0.6.0"
+    "@algolia/client-abtesting" "5.0.0"
+    "@algolia/client-analytics" "5.0.0"
+    "@algolia/client-common" "5.0.0"
+    "@algolia/client-personalization" "5.0.0"
+    "@algolia/client-search" "5.0.0"
+    "@algolia/recommend" "5.0.0"
+    "@algolia/requester-browser-xhr" "5.0.0"
+    "@algolia/requester-node-http" "5.0.0"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -30990,15 +30970,15 @@ typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.7.tgz#799207136a37f3b3efb8c66c40010d032714dc73"
   integrity sha512-ueeb9YybpjhivjbHP2LdFDAjbS948fGEPj+ACAMs4xCMmh72OCOMQWBQKlaN4ZNQ04yfLSDLSx1tGRIoWimObQ==
 
-typescript@*, typescript@5.4.2:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
-  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
-
-typescript@5.5.2:
+typescript@*, typescript@5.5.2:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
   integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
+
+typescript@5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 "typescript@^3 || ^4":
   version "4.9.4"


### PR DESCRIPTION
**Summary**

This PR updates all algoliasearch dependencies in examples to algoliasearch@5 and ensures full compatibility locally with algoliasearch v5

FX-2922

fixes https://github.com/algolia/algoliasearch-client-javascript/issues/1537
fixes https://github.com/algolia/instantsearch/issues/6329