### PR TITLE
fix(deps): update dependency search-insights to 2.15.0

### DIFF
--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -37,7 +37,7 @@
     "instantsearch-ui-components": "0.7.0",
     "preact": "^10.10.0",
     "qs": "^6.5.1 < 6.10",
-    "search-insights": "^2.13.0"
+    "search-insights": "^2.15.0"
   },
   "peerDependencies": {
     "algoliasearch": ">= 3.1 < 6"

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -607,7 +607,7 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
     });
 
     test('insights: options passes options to middleware', () => {
-      const insightsClient = Object.assign(jest.fn(), { version: '2.13.0' });
+      const insightsClient = Object.assign(jest.fn(), { version: '2.15.0' });
       const search = new InstantSearch({
         searchClient: createSearchClientWithAutomaticInsightsOptedIn(),
         indexName: 'test',

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -183,7 +183,7 @@ describe('insights', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.13.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.15.0/dist/search-insights.min.js"
           />
         </body>
       `);
@@ -226,7 +226,7 @@ describe('insights', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.13.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.15.0/dist/search-insights.min.js"
           />
         </body>
       `);
@@ -246,7 +246,7 @@ describe('insights', () => {
       expect(document.body).toMatchInlineSnapshot(`
         <body>
           <script
-            src="https://cdn.jsdelivr.net/npm/search-insights@2.13.0/dist/search-insights.min.js"
+            src="https://cdn.jsdelivr.net/npm/search-insights@2.15.0/dist/search-insights.min.js"
           />
         </body>
       `);

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -40,7 +40,7 @@ export type InsightsProps<
   $$automatic?: boolean;
 };
 
-const ALGOLIA_INSIGHTS_VERSION = '2.13.0';
+const ALGOLIA_INSIGHTS_VERSION = '2.15.0';
 const ALGOLIA_INSIGHTS_SRC = `https://cdn.jsdelivr.net/npm/search-insights@${ALGOLIA_INSIGHTS_VERSION}/dist/search-insights.min.js`;
 
 export type InsightsClientWithGlobals = InsightsClient & {

--- a/packages/react-instantsearch-core/src/__tests__/insights.test.tsx
+++ b/packages/react-instantsearch-core/src/__tests__/insights.test.tsx
@@ -29,7 +29,7 @@ describe('insights', () => {
       <body>
         <div />
         <script
-          src="https://cdn.jsdelivr.net/npm/search-insights@2.13.0/dist/search-insights.min.js"
+          src="https://cdn.jsdelivr.net/npm/search-insights@2.15.0/dist/search-insights.min.js"
         />
       </body>
     `);

--- a/tests/common/shared/insights.ts
+++ b/tests/common/shared/insights.ts
@@ -25,7 +25,7 @@ export function createInsightsTests(
         const delay = 100;
         const margin = 10;
         const attribute = 'one';
-        window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+        window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
 
         const options = {
           instantSearchOptions: {
@@ -109,7 +109,7 @@ export function createInsightsTests(
         const delay = 100;
         const margin = 10;
         const attribute = 'one';
-        window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+        window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
 
         const options = {
           instantSearchOptions: {

--- a/tests/common/widgets/hits/insights.ts
+++ b/tests/common/widgets/hits/insights.ts
@@ -26,7 +26,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -140,7 +140,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 25;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -276,7 +276,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -358,7 +358,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -447,7 +447,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -533,7 +533,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -630,7 +630,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -712,7 +712,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',

--- a/tests/common/widgets/infinite-hits/insights.ts
+++ b/tests/common/widgets/infinite-hits/insights.ts
@@ -26,7 +26,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -140,7 +140,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 25;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -276,7 +276,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -358,7 +358,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -447,7 +447,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -533,7 +533,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -630,7 +630,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',
@@ -712,7 +712,7 @@ export function createInsightsTests(
       const delay = 100;
       const margin = 10;
       const hitsPerPage = 2;
-      window.aa = Object.assign(jest.fn(), { version: '2.13.0' });
+      window.aa = Object.assign(jest.fn(), { version: '2.15.0' });
       const options = {
         instantSearchOptions: {
           indexName: 'indexName',

--- a/tests/mocks/createInsightsClient.ts
+++ b/tests/mocks/createInsightsClient.ts
@@ -15,8 +15,8 @@ try {
   delete window.AlgoliaAnalyticsObject;
 } catch (error) {} // eslint-disable-line no-empty
 
-export function createInsights<TVersion extends string | undefined = '2.13.0'>({
-  forceVersion = '2.13.0',
+export function createInsights<TVersion extends string | undefined = '2.15.0'>({
+  forceVersion = '2.15.0',
 }: {
   forceVersion?: TVersion;
 } = {}) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -28077,10 +28077,10 @@ scule@^0.2.1:
   resolved "https://registry.yarnpkg.com/scule/-/scule-0.2.1.tgz#0c1dc847b18e07219ae9a3832f2f83224e2079dc"
   integrity sha512-M9gnWtn3J0W+UhJOHmBxBTwv8mZCan5i1Himp60t6vvZcor0wr+IM0URKmIglsWJ7bRujNAVVN77fp+uZaWoKg==
 
-search-insights@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.13.0.tgz#a79fdcf4b5dad2fba8975b06f2ebc37a865032b7"
-  integrity sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==
+search-insights@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.15.0.tgz#61c7db9d13218ee966937ad2462385b05c0df624"
+  integrity sha512-ch2sPCUDD4sbPQdknVl9ALSi9H7VyoeVbsxznYz6QV55jJ8CI3EtwpO1i84keN4+hF5IeHWIeGvc08530JkVXQ==
 
 section-matter@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Summary**

Updates search-insights to 2.15.0 which contains features to simplify query id tracking from clicks for use in conversion events.

**Result**

Updated usage in the insights middleware as well as the local dependency