### PR TITLE
feat(infinite-hits): add banners to vue flavor

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "67.5 kB"
+      "maxSize": "67.75 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
@@ -34,7 +34,7 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",
-      "maxSize": "20 kB"
+      "maxSize": "20.25 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/cjs/index.js",

--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -589,9 +589,7 @@ const testOptions = {
   createBreadcrumbWidgetTests: undefined,
   createMenuWidgetTests: undefined,
   createPaginationWidgetTests: undefined,
-  createInfiniteHitsWidgetTests: {
-    skippedTests: { 'banner option': true },
-  },
+  createInfiniteHitsWidgetTests: undefined,
   createHitsWidgetTests: {
     skippedTests: { 'banner option': true },
   },

--- a/packages/vue-instantsearch/src/components/InfiniteHits.vue
+++ b/packages/vue-instantsearch/src/components/InfiniteHits.vue
@@ -22,6 +22,7 @@
     <slot
       :items="state.items"
       :results="state.results"
+      :banner="state.banner"
       :is-last-page="state.isLastPage"
       :refine-previous="refinePrevious"
       :refine-next="refineNext"
@@ -29,6 +30,32 @@
       :insights="state.insights"
       :send-event="state.sendEvent"
     >
+      <template
+        v-if="showBanner && state.banner && state.banner.image.urls[0].url"
+      >
+        <slot name="banner" :banner="state.banner">
+          <aside :class="suit('banner')">
+            <a
+              v-if="state.banner.link"
+              :href="state.banner.link.url"
+              :target="state.banner.link.target"
+              :class="suit('banner-link')"
+            >
+              <img
+                :src="state.banner.image.urls[0].url"
+                :alt="state.banner.image.title"
+                :class="suit('banner-image')"
+              />
+            </a>
+            <img
+              v-else
+              :src="state.banner.image.urls[0].url"
+              :alt="state.banner.image.title"
+              :class="suit('banner-image')"
+            />
+          </aside>
+        </slot>
+      </template>
       <ol :class="suit('list')">
         <li
           v-for="(item, index) in state.items"
@@ -91,6 +118,10 @@ export default {
     createSuitMixin({ name: 'InfiniteHits' }),
   ],
   props: {
+    showBanner: {
+      type: Boolean,
+      default: true,
+    },
     showPrevious: {
       type: Boolean,
       default: false,
@@ -111,6 +142,7 @@ export default {
   computed: {
     widgetParams() {
       return {
+        showBanner: this.showBanner,
         showPrevious: this.showPrevious,
         escapeHTML: this.escapeHTML,
         transformItems: this.transformItems,

--- a/packages/vue-instantsearch/src/components/__tests__/InfiniteHits.js
+++ b/packages/vue-instantsearch/src/components/__tests__/InfiniteHits.js
@@ -11,6 +11,7 @@ jest.mock('../../mixins/widget');
 
 const defaultState = {
   widgetParams: {
+    showBanner: true,
     showPrevious: false,
     escapeHTML: true,
     transformItems: (items) => items,
@@ -81,6 +82,79 @@ it('renders correctly with a custom item rendering', () => {
         </template>
       </InfiniteHits>
     `,
+  });
+
+  expect(wrapper.html()).toMatchSnapshot();
+});
+
+it('renders correctly with banner data', () => {
+  __setState({
+    ...defaultState,
+    banner: {
+      image: {
+        urls: [{ url: 'https://via.placeholder.com/550x250' }],
+      },
+      link: {
+        url: 'https://www.algolia.com',
+      },
+    },
+  });
+
+  const wrapper = mount({
+    components: { InfiniteHits },
+    template: `<InfiniteHits />`,
+  });
+
+  expect(wrapper.html()).toMatchSnapshot();
+});
+
+it('renders correctly with banner data and custom banner rendering', () => {
+  __setState({
+    ...defaultState,
+    banner: {
+      image: {
+        urls: [{ url: 'https://via.placeholder.com/550x250' }],
+      },
+      link: {
+        url: 'https://www.algolia.com',
+      },
+    },
+  });
+
+  const wrapper = mount({
+    components: { InfiniteHits },
+    template: `
+      <InfiniteHits>
+        <template v-slot:banner="{ banner }">
+          <img :src="banner.image.urls[0].url" />
+        </template>
+      </InfiniteHits>
+    `,
+  });
+
+  expect(wrapper.html()).toMatchSnapshot();
+});
+
+it('does not render a banner when showBanner is false', () => {
+  __setState({
+    ...defaultState,
+    banner: {
+      image: {
+        urls: [{ url: 'https://via.placeholder.com/550x250' }],
+      },
+      link: {
+        url: 'https://www.algolia.com',
+      },
+    },
+    widgetParams: {
+      ...defaultState.widgetParams,
+      showBanner: false,
+    },
+  });
+
+  const wrapper = mount({
+    components: { InfiniteHits },
+    template: `<InfiniteHits />`,
   });
 
   expect(wrapper.html()).toMatchSnapshot();

--- a/packages/vue-instantsearch/src/components/__tests__/__snapshots__/InfiniteHits.js.snap
+++ b/packages/vue-instantsearch/src/components/__tests__/__snapshots__/InfiniteHits.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not render a banner when showBanner is false 1`] = `
+<div class="ais-InfiniteHits">
+  <aside class="ais-InfiniteHits-banner">
+    <a class="ais-InfiniteHits-banner-link"
+       href="https://www.algolia.com"
+    >
+      <img class="ais-InfiniteHits-banner-image"
+           src="https://via.placeholder.com/550x250"
+      >
+    </a>
+  </aside>
+  <ol class="ais-InfiniteHits-list">
+    <li class="ais-InfiniteHits-item">
+      objectID: 00001, index: 0
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00002, index: 1
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00003, index: 2
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00004, index: 3
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00005, index: 4
+    </li>
+  </ol>
+  <button class="ais-InfiniteHits-loadMore">
+    Show more results
+  </button>
+</div>
+`;
+
 exports[`renders correctly with a custom item rendering 1`] = `
 <div class="ais-InfiniteHits">
   <ol class="ais-InfiniteHits-list">
@@ -54,5 +88,65 @@ exports[`renders correctly with a custom rendering 1`] = `
       00005
     </div>
   </div>
+</div>
+`;
+
+exports[`renders correctly with banner data 1`] = `
+<div class="ais-InfiniteHits">
+  <aside class="ais-InfiniteHits-banner">
+    <a class="ais-InfiniteHits-banner-link"
+       href="https://www.algolia.com"
+    >
+      <img class="ais-InfiniteHits-banner-image"
+           src="https://via.placeholder.com/550x250"
+      >
+    </a>
+  </aside>
+  <ol class="ais-InfiniteHits-list">
+    <li class="ais-InfiniteHits-item">
+      objectID: 00001, index: 0
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00002, index: 1
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00003, index: 2
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00004, index: 3
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00005, index: 4
+    </li>
+  </ol>
+  <button class="ais-InfiniteHits-loadMore">
+    Show more results
+  </button>
+</div>
+`;
+
+exports[`renders correctly with banner data and custom banner rendering 1`] = `
+<div class="ais-InfiniteHits">
+  <img src="https://via.placeholder.com/550x250">
+  <ol class="ais-InfiniteHits-list">
+    <li class="ais-InfiniteHits-item">
+      objectID: 00001, index: 0
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00002, index: 1
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00003, index: 2
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00004, index: 3
+    </li>
+    <li class="ais-InfiniteHits-item">
+      objectID: 00005, index: 4
+    </li>
+  </ol>
+  <button class="ais-InfiniteHits-loadMore">
+    Show more results
+  </button>
 </div>
 `;

--- a/tests/common/widgets/infinite-hits/options.ts
+++ b/tests/common/widgets/infinite-hits/options.ts
@@ -9,8 +9,6 @@ import {
 } from '@instantsearch/testutils';
 import userEvent from '@testing-library/user-event';
 
-import { skippableDescribe } from '../../common';
-
 import type { InfiniteHitsWidgetSetup } from '.';
 import type { TestOptions } from '../../common';
 import type { MockSearchClient } from '@instantsearch/mocks';
@@ -53,7 +51,7 @@ function normalizeSnapshot(html: string) {
 
 export function createOptionsTests(
   setup: InfiniteHitsWidgetSetup,
-  { act, skippedTests }: Required<TestOptions>
+  { act }: Required<TestOptions>
 ) {
   describe('options', () => {
     test('renders with default props', async () => {
@@ -108,88 +106,86 @@ export function createOptionsTests(
       );
     });
 
-    skippableDescribe('banner option', skippedTests, () => {
-      test('renders default banner element with banner widget renderingContent', async () => {
-        const searchClient = createMockedSearchClient({
-          renderingContent: {
-            // @TODO: remove once algoliasearch js client has been updated
-            // @ts-expect-error
-            widgets: {
-              banners: [
-                {
-                  image: {
-                    urls: [{ url: 'https://via.placeholder.com/550x250' }],
-                  },
-                  link: {
-                    url: 'https://www.algolia.com',
-                  },
+    test('renders default banner element with banner widget renderingContent', async () => {
+      const searchClient = createMockedSearchClient({
+        renderingContent: {
+          // @TODO: remove once algoliasearch js client has been updated
+          // @ts-expect-error
+          widgets: {
+            banners: [
+              {
+                image: {
+                  urls: [{ url: 'https://via.placeholder.com/550x250' }],
                 },
-              ],
-            },
+                link: {
+                  url: 'https://www.algolia.com',
+                },
+              },
+            ],
           },
-        });
-
-        await setup({
-          instantSearchOptions: {
-            indexName: 'indexName',
-            searchClient,
-          },
-          widgetParams: {},
-        });
-
-        await act(async () => {
-          await wait(0);
-        });
-
-        expect(
-          document.querySelector('#hits-with-defaults .ais-InfiniteHits')
-        ).toMatchNormalizedInlineSnapshot(
-          normalizeSnapshot,
-          `
-          <div
-            class="ais-InfiniteHits"
-          >
-            <aside
-              class="ais-InfiniteHits-banner"
-            >
-              <a
-                class="ais-InfiniteHits-banner-link"
-                href="https://www.algolia.com"
-              >
-                <img
-                  class="ais-InfiniteHits-banner-image"
-                  src="https://via.placeholder.com/550x250"
-                />
-              </a>
-            </aside>
-            <ol
-              class="ais-InfiniteHits-list"
-            >
-              <li
-                class="ais-InfiniteHits-item"
-              >
-                {"objectID":"0"}
-              </li>
-              <li
-                class="ais-InfiniteHits-item"
-              >
-                {"objectID":"1"}
-              </li>
-              <li
-                class="ais-InfiniteHits-item"
-              >
-                {"objectID":"2"}
-              </li>
-            </ol>
-            <button
-              class="ais-InfiniteHits-loadMore"
-            >
-              Show more results
-            </button>
-          </div>
-          `
-        );
+        },
       });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {},
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(
+        document.querySelector('#hits-with-defaults .ais-InfiniteHits')
+      ).toMatchNormalizedInlineSnapshot(
+        normalizeSnapshot,
+        `
+        <div
+          class="ais-InfiniteHits"
+        >
+          <aside
+            class="ais-InfiniteHits-banner"
+          >
+            <a
+              class="ais-InfiniteHits-banner-link"
+              href="https://www.algolia.com"
+            >
+              <img
+                class="ais-InfiniteHits-banner-image"
+                src="https://via.placeholder.com/550x250"
+              />
+            </a>
+          </aside>
+          <ol
+            class="ais-InfiniteHits-list"
+          >
+            <li
+              class="ais-InfiniteHits-item"
+            >
+              {"objectID":"0"}
+            </li>
+            <li
+              class="ais-InfiniteHits-item"
+            >
+              {"objectID":"1"}
+            </li>
+            <li
+              class="ais-InfiniteHits-item"
+            >
+              {"objectID":"2"}
+            </li>
+          </ol>
+          <button
+            class="ais-InfiniteHits-loadMore"
+          >
+            Show more results
+          </button>
+        </div>
+        `
+      );
     });
 
     test('renders transformed items', async () => {

--- a/tests/common/widgets/infinite-hits/options.ts
+++ b/tests/common/widgets/infinite-hits/options.ts
@@ -45,6 +45,8 @@ function normalizeSnapshot(html: string) {
           return `{"objectID":"${captured[1]}"}`;
         }
       )
+      // Vue InstantSearch adds new line between banner and hits
+      .replace(/>\s*</g, '><')
       .replace(/"__position":\d,/g, '')
   );
 }


### PR DESCRIPTION
**Summary**

This PR adds the new top banner to the Vue `InfiniteHits` widget and updates associated tests. The top banner feature has already been added to `Hits` and `InfiniteHits` for the JS and React flavors of InstantSearch.

This widget is slightly different from the React version by using a `showBanner` prop (defaulted to `true`) since relying on whether a parent component passed included content with the banner slot could be difficult. I'm open to changing this implementation if anyone has a recommended approach though.

[Jira issue](https://algolia.atlassian.net/browse/EMERCH-1560)

**Result**

Getting Started example app:
![image](https://github.com/algolia/instantsearch/assets/10552296/ac3b436e-146a-429d-ad9c-d95ed285baa0)

