### PR TITLE
fix(vue2): `augmentedCreateElement` should pass HTML attributes

### DIFF
--- a/packages/vue-instantsearch/src/util/__tests__/renderCompat.test.js
+++ b/packages/vue-instantsearch/src/util/__tests__/renderCompat.test.js
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { mount } from '../../../test/utils';
+import { renderCompat } from '../vue-compat';
+
+describe('renderCompat', () => {
+  it('should handle function components that return multiple children', () => {
+    const wrapper = mount({
+      render: renderCompat((h) => {
+        function Component({ text }) {
+          return h(
+            'div',
+            { attrs: { 'data-text': text } },
+            h('span', {}, ['1']),
+            h('span', {}, '2')
+          );
+        }
+        return h(Component, { text: 'Hello world' });
+      }),
+    });
+
+    expect(wrapper.html()).toMatchInlineSnapshot(`
+      <div data-text="Hello world">
+        <span>
+          1
+        </span>
+        <span>
+          2
+        </span>
+      </div>
+    `);
+  });
+
+  it('should map props to attrs when using a HTML tag', () => {
+    const wrapper = mount({
+      render: renderCompat((h) => {
+        return h('img', {
+          src: 'http://algolia.com/image.png',
+          alt: 'Some image',
+        });
+      }),
+    });
+
+    expect(wrapper.html()).toMatchInlineSnapshot(`
+      <img src="http://algolia.com/image.png"
+           alt="Some image"
+      >
+    `);
+  });
+});

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
@@ -21,6 +21,23 @@ const augmentCreateElement =
       );
     }
 
+    if (typeof tag === 'string') {
+      const { on, style, attrs, domProps, nativeOn, key, ...rest } = props;
+      return createElement(
+        tag,
+        {
+          class: className || props.class,
+          attrs: attrs || rest,
+          on,
+          nativeOn,
+          style,
+          domProps,
+          key,
+        },
+        children
+      );
+    }
+
     return createElement(
       tag,
       Object.assign(props, { class: className || props.class }),


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This was causing an issue for https://github.com/algolia/instantsearch/pull/6281

**Result**

When the tag is a string, we pick the actual vue2 props and assume the rest are attributes. We still have to pass `attrs` if passed for compatibility with actual vue render functions.
Now the function should be compatible with both `createElement` and Vue's `h` signatures
