### PR TITLE
fix(cache): support nested hierarchical refinements

### DIFF
--- a/packages/algoliasearch-helper/src/requestBuilder.js
+++ b/packages/algoliasearch-helper/src/requestBuilder.js
@@ -109,11 +109,10 @@ var requestBuilder = {
             params.facetFilters = filteredFacetFilters.concat(
               parent.attribute + ':' + parent.value
             );
+          } else if (filteredFacetFilters.length > 0) {
+            params.facetFilters = filteredFacetFilters;
           } else {
-            params.facetFilters =
-              filteredFacetFilters.length > 0
-                ? filteredFacetFilters
-                : undefined;
+            delete params.facetFilters;
           }
 
           queries.push({ indexName: index, params: params });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Fixes last comment in #6258

**Result**

Instead of explicitly setting it to `undefined`, we delete it so that it matches the serialized params
