### PR TITLE
ci: add downgrade script for algoliasearch v4 and steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
             ./scripts/legacy/downgrade-algoliasearch-v4.js
       - run:
           name: Unit & Integration tests
-          command: yarn run test
+          command: yarn run test:ci
       - run:
           name: Type Checking
           command: yarn run type-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,10 @@ workflows:
       - unit tests:
           requires:
             - build
-      - legacy algoliasearch:
+      - legacy algoliasearch v3:
+          requires:
+            - build
+      - legacy algoliasearch v4:
           requires:
             - build
       - vue v3:
@@ -97,7 +100,8 @@ workflows:
             - lint
             - unit tests
             - examples
-            - legacy algoliasearch
+            - legacy algoliasearch v3
+            - legacy algoliasearch v4
             - helper docs
             - e2e tests
           filters:
@@ -202,7 +206,7 @@ jobs:
           name: Type Checking
           command: yarn run type-check
 
-  legacy algoliasearch:
+  legacy algoliasearch v3:
     <<: *defaults
     steps:
       - checkout
@@ -220,6 +224,25 @@ jobs:
       - run:
           name: Type Checking
           command: yarn run type-check:v3
+
+  legacy algoliasearch v4:
+    <<: *defaults
+    steps:
+      - checkout
+      - *attach_workspace
+      - *install_yarn_version
+      - *restore_yarn_cache
+      - *run_yarn_install
+      - run:
+          name: Update dependencies
+          command: |
+            ./scripts/legacy/downgrade-algoliasearch-v4.js
+      - run:
+          name: Unit & Integration tests
+          command: yarn run test
+      - run:
+          name: Type Checking
+          command: yarn run type-check
 
   vue v3:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,7 @@ jobs:
 
   legacy algoliasearch v4:
     <<: *defaults
+    resource_class: large
     steps:
       - checkout
       - *attach_workspace
@@ -240,6 +241,8 @@ jobs:
       - run:
           name: Unit & Integration tests
           command: yarn run test:ci
+      - store_test_results:
+          path: junit/jest/
       - run:
           name: Type Checking
           command: yarn run type-check

--- a/packages/algoliasearch-helper/types/algoliasearch.d.ts
+++ b/packages/algoliasearch-helper/types/algoliasearch.d.ts
@@ -177,7 +177,7 @@ export type RecommendResponse<T> = PickForClient<{
 export type RecommendResponses<T> = PickForClient<{
   v3: any;
   // @ts-ignore
-  v4: { results: Array<RecommendResponse<T>> };
+  v4: RecommendClient.RecommendQueriesResponse<T>;
   // @ts-ignore
   v5: AlgoliaSearch.GetRecommendationsResponse;
 }>;

--- a/scripts/legacy/downgrade-algoliasearch-v4.js
+++ b/scripts/legacy/downgrade-algoliasearch-v4.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const path = require('path');
+
+const shell = require('shelljs');
+
+const packageJsonPaths = [
+  path.resolve(__dirname, '../../package.json'),
+  ...JSON.parse(
+    shell.exec(
+      "yarn run --silent lerna list --json --all --ignore='example-*'",
+      {
+        silent: true,
+      }
+    ).stdout
+  ).map(({ location }) => path.resolve(location, 'package.json')),
+];
+
+console.log(
+  `Downgrading algoliasearch dependency to v4 in:
+- ${packageJsonPaths.join('\n- ')}`
+);
+
+// change main dependency
+shell.sed(
+  '-i',
+  /"algoliasearch": "5.*"(,?)/,
+  '"algoliasearch": "4.23.2"$1',
+  packageJsonPaths
+);
+
+// Downgrade other dependency
+shell.sed(
+  '-i',
+  /"@algolia\/client-search": "5.*"(,?)/,
+  '"@algolia/client-search": "4.23.2"$1',
+  packageJsonPaths
+);
+
+// remove resolution
+shell.sed('-i', /"@algolia\/client-common": "5.*"(,?)/, '', packageJsonPaths);
+shell.sed(
+  '-i',
+  /"places.js\/algoliasearch": "5.*"(,?)/,
+  '"places.js/algoliasearch": "4.23.2"$1',
+  packageJsonPaths
+);
+
+// replace import in examples
+shell.sed(
+  '-i',
+  /import { liteClient as algoliasearch } from 'algoliasearch\/lite'/,
+  "import algoliasearch from 'algoliasearch/lite'",
+  ...shell.ls('examples/*/*/*.{js,ts,tsx,vue}'),
+  ...shell.ls('examples/*/*/{src,pages,app}/*.{js,ts,tsx,vue}')
+);
+
+// replace dependency in examples
+shell.sed(
+  '-i',
+  /"algoliasearch": ".*"(,)?/,
+  '"algoliasearch": "4.23.2"$1',
+  ...shell.ls('examples/*/*/package.json')
+);
+
+shell.exec('yarn install');
+
+shell.exec('cp -r node_modules/algoliasearch-v4 node_modules/algoliasearch');


### PR DESCRIPTION
**Summary**

#### [FX-2929](https://algolia.atlassian.net/browse/FX-2929)

**Result**

We run the same tests and type checking as for v5 as they were written for v4 anyway, it does work


[FX-2929]: https://algolia.atlassian.net/browse/FX-2929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ