### PR TITLE
feat(index): make IndexOptions['uiState'] and UiState react to generic

### DIFF
--- a/packages/instantsearch.js/src/types/ui-state.ts
+++ b/packages/instantsearch.js/src/types/ui-state.ts
@@ -37,8 +37,10 @@ type ConnectorUiStates = AutocompleteWidgetDescription['indexUiState'] &
 
 type WidgetUiStates = PlacesWidgetDescription['indexUiState'];
 
-export type IndexUiState = Partial<ConnectorUiStates & WidgetUiStates>;
+export type IndexUiState<TExtraUiState = unknown> = Partial<
+  ConnectorUiStates & WidgetUiStates & TExtraUiState
+>;
 
-export type UiState = {
-  [indexId: string]: IndexUiState;
+export type UiState<TExtraUiState = unknown> = {
+  [indexId: string]: IndexUiState<TExtraUiState>;
 };

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -37,8 +37,10 @@ type SharedRenderOptions = {
   ) => string;
 };
 
-export type InitOptions = SharedRenderOptions & {
-  uiState: UiState;
+export type InitOptions<
+  TWidgetDescription extends WidgetDescription = { $$type: string }
+> = SharedRenderOptions & {
+  uiState: UiState<TWidgetDescription['indexUiState']>;
   results?: undefined;
 };
 
@@ -153,9 +155,7 @@ type SearchWidget<TWidgetDescription extends WidgetDescription> = {
   getWidgetParameters?: (
     state: SearchParameters,
     widgetParametersOptions: {
-      uiState: Expand<
-        Partial<TWidgetDescription['indexUiState'] & IndexUiState>
-      >;
+      uiState: Expand<IndexUiState<TWidgetDescription['indexUiState']>>;
     }
   ) => SearchParameters;
 };
@@ -172,9 +172,7 @@ type RecommendWidget<
   getWidgetParameters: (
     state: RecommendParameters,
     widgetParametersOptions: {
-      uiState: Expand<
-        Partial<TWidgetDescription['indexUiState'] & IndexUiState>
-      >;
+      uiState: Expand<IndexUiState<TWidgetDescription['indexUiState']>>;
     }
   ) => RecommendParameters;
   getRenderState: (
@@ -202,7 +200,7 @@ type RequiredWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
   /**
    * Called once before the first search.
    */
-  init?: (options: InitOptions) => void;
+  init?: (options: InitOptions<TWidgetDescription>) => void;
   /**
    * Whether `render` should be called
    */
@@ -247,12 +245,12 @@ type RequiredUiStateLifeCycle<TWidgetDescription extends WidgetDescription> = {
    * @param widgetStateOptions - Extra information to calculate uiState.
    */
   getWidgetUiState: (
-    uiState: Expand<Partial<TWidgetDescription['indexUiState'] & IndexUiState>>,
+    uiState: Expand<IndexUiState<TWidgetDescription['indexUiState']>>,
     widgetUiStateOptions: {
       searchParameters: SearchParameters;
       helper: Helper;
     }
-  ) => Partial<IndexUiState & TWidgetDescription['indexUiState']>;
+  ) => IndexUiState<TWidgetDescription['indexUiState']>;
 
   /**
    * This function is required for a widget to be taken in account for routing.
@@ -276,9 +274,7 @@ type RequiredUiStateLifeCycle<TWidgetDescription extends WidgetDescription> = {
   getWidgetSearchParameters: (
     state: SearchParameters,
     widgetSearchParametersOptions: {
-      uiState: Expand<
-        Partial<TWidgetDescription['indexUiState'] & IndexUiState>
-      >;
+      uiState: Expand<IndexUiState<TWidgetDescription['indexUiState']>>;
     }
   ) => SearchParameters;
 };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

If you're reading `uiState` (initial ui state) inside init of a widget, it should be the generic UiState which includes this widget's  ui state as well.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

- UiState generic to add a specific widget's IndexUiState
- IndexUiState generic to add a specific widget's IndexUiState
- InitOptions generic with WidgetDescription
- init({ uiState }) correctly typed including the specific widget's ui state

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
