### PR TITLE
fix(dependencies): replace qs by neoqs

### DIFF
--- a/examples/vue/ssr/package.json
+++ b/examples/vue/ssr/package.json
@@ -11,7 +11,7 @@
     "algoliasearch": "4.23.2",
     "core-js": "2",
     "instantsearch.css": "8.3.0",
-    "qs": "6.9.7",
+    "neoqs": "6.2.12",
     "vue": "2.7.14",
     "vue-instantsearch": "4.19.0",
     "vue-router": "^3.0.2",

--- a/examples/vue/ssr/src/main.js
+++ b/examples/vue/ssr/src/main.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-nested-ternary */
 import algoliasearch from 'algoliasearch/lite';
-import qs from 'qs';
+import * as qs from 'neoqs/legacy';
 import Vue from 'vue';
 import { createServerRootMixin } from 'vue-instantsearch';
 import _renderToString from 'vue-server-renderer/basic';

--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -30,13 +30,12 @@
     "@types/dom-speech-recognition": "^0.0.1",
     "@types/google.maps": "^3.45.3",
     "@types/hogan.js": "^3.0.0",
-    "@types/qs": "^6.5.3",
     "algoliasearch-helper": "3.22.3",
     "hogan.js": "^3.0.2",
     "htm": "^3.0.0",
     "instantsearch-ui-components": "0.7.0",
     "preact": "^10.10.0",
-    "qs": "^6.5.1 < 6.10",
+    "neoqs": "^6.2.12",
     "search-insights": "^2.15.0"
   },
   "peerDependencies": {

--- a/packages/instantsearch.js/src/lib/__tests__/RoutingManager-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/RoutingManager-test.ts
@@ -4,7 +4,7 @@
 
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
-import qs from 'qs';
+import * as qs from 'neoqs/legacy';
 
 import instantsearch from '../..';
 import { createWidget } from '../../../test/createWidget';

--- a/packages/instantsearch.js/src/lib/routers/history.ts
+++ b/packages/instantsearch.js/src/lib/routers/history.ts
@@ -1,4 +1,4 @@
-import qs from 'qs';
+import * as qs from 'neoqs/legacy';
 
 import { createDocumentationLink, safelyRunOnBrowser, warning } from '../utils';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNEXT",
     "module": "es2020",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "noEmit": true,
     "strict": true,
     "jsx": "react",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6578,11 +6578,6 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
 
-"@types/qs@^6.5.3":
-  version "6.9.7"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
-  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
-
 "@types/reach__router@^1.2.3":
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.2.5.tgz#add874f43b9733175be2b19de59602b91cc90860"
@@ -22668,6 +22663,11 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+neoqs@6.2.12, neoqs@^6.2.12:
+  version "6.2.12"
+  resolved "https://registry.yarnpkg.com/neoqs/-/neoqs-6.2.12.tgz#182a3664e1efa7cb4de50478cc6f9f798e9d8eff"
+  integrity sha512-lI3BSbH3Xqu4/IKJvt7kXdfTnZPg4shcQT5yeYWktrfOEigajrjjh1IvC4TrqCUk4wZpQuRzKUFbpNgBy/cNLQ==
+
 nested-error-stacks@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz#d2cc9fc5235ddb371fc44d506234339c8e4b0a4b"
@@ -26036,17 +26036,12 @@ qs@6.5.2, qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-qs@6.7.0:
+qs@6.7.0, qs@^6.6.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@6.9.7, "qs@^6.5.1 < 6.10":
-  version "6.9.7"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
-  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
-
-qs@^6.10.0, qs@^6.11.0, qs@^6.6.0:
+qs@^6.10.0, qs@^6.11.0:
   version "6.11.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
   integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
@@ -30990,15 +30985,15 @@ typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.7.tgz#799207136a37f3b3efb8c66c40010d032714dc73"
   integrity sha512-ueeb9YybpjhivjbHP2LdFDAjbS948fGEPj+ACAMs4xCMmh72OCOMQWBQKlaN4ZNQ04yfLSDLSx1tGRIoWimObQ==
 
-typescript@*, typescript@5.4.2:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
-  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
-
-typescript@5.5.2:
+typescript@*, typescript@5.5.2:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
   integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
+
+typescript@5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 "typescript@^3 || ^4":
   version "4.9.4"


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Replace qs by neoqs

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->


neoqs is API-compatible with qs in the legacy mode, and thus this isn't a breaking change. Of course if someone was already using qs and relying on it being deduplicated with the InstantSearch version.

URLs parsed and created by qs and neoqs are compatible