### PR TITLE
fix(imports): prevent circular import

### DIFF
--- a/packages/react-instantsearch-core/rollup.config.js
+++ b/packages/react-instantsearch-core/rollup.config.js
@@ -57,6 +57,12 @@ const createConfiguration = ({ name, minify = false } = {}) => ({
     banner: createBanner(name),
     sourcemap: true,
   },
+  onwarn(warning, warn) {
+    if (warning.code === 'CIRCULAR_DEPENDENCY')
+      throw new Error(warning.message);
+
+    warn(warning);
+  },
   plugins: plugins.concat(
     clear([
       minify &&

--- a/packages/react-instantsearch-core/src/lib/useIndex.ts
+++ b/packages/react-instantsearch-core/src/lib/useIndex.ts
@@ -1,9 +1,8 @@
 import index from 'instantsearch.js/es/widgets/index/index';
 import { useMemo } from 'react';
 
-import { useIndexContext } from '../lib/useIndexContext';
-
 import { useForceUpdate } from './useForceUpdate';
+import { useIndexContext } from './useIndexContext';
 import { useInstantSearchServerContext } from './useInstantSearchServerContext';
 import { useInstantSearchSSRContext } from './useInstantSearchSSRContext';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';

--- a/packages/react-instantsearch-core/src/lib/useIndexContext.ts
+++ b/packages/react-instantsearch-core/src/lib/useIndexContext.ts
@@ -1,8 +1,7 @@
 import { useContext } from 'react';
 
-import { invariant } from '../lib/invariant';
-
 import { IndexContext } from './IndexContext';
+import { invariant } from './invariant';
 
 import type { IndexWidget, UiState } from 'instantsearch.js';
 import type { Context } from 'react';

--- a/packages/react-instantsearch-core/src/lib/useInstantSearchContext.ts
+++ b/packages/react-instantsearch-core/src/lib/useInstantSearchContext.ts
@@ -1,8 +1,7 @@
 import { useContext } from 'react';
 
-import { invariant } from '../lib/invariant';
-
 import { InstantSearchContext } from './InstantSearchContext';
+import { invariant } from './invariant';
 
 import type { InternalInstantSearch } from './useInstantSearchApi';
 import type { UiState } from 'instantsearch.js';

--- a/packages/react-instantsearch-core/src/lib/useStableValue.ts
+++ b/packages/react-instantsearch-core/src/lib/useStableValue.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { dequal } from '../lib/dequal';
+import { dequal } from './dequal';
 
 export function useStableValue<TValue>(value: TValue) {
   const [stableValue, setStableValue] = useState<TValue>(() => value);

--- a/packages/react-instantsearch-core/src/server/getServerState.tsx
+++ b/packages/react-instantsearch-core/src/server/getServerState.tsx
@@ -5,12 +5,11 @@ import {
 import { walkIndex, resetWidgetId } from 'instantsearch.js/es/lib/utils';
 import React from 'react';
 
-import { InstantSearchServerContext, InstantSearchSSRProvider } from '..';
+import { InstantSearchServerContext } from '../components/InstantSearchServerContext';
+import { InstantSearchSSRProvider } from '../components/InstantSearchSSRProvider';
 
-import type {
-  InstantSearchServerContextApi,
-  InstantSearchServerState,
-} from '..';
+import type { InstantSearchServerContextApi } from '../components/InstantSearchServerContext';
+import type { InstantSearchServerState } from '../components/InstantSearchSSRProvider';
 import type { InstantSearch, UiState } from 'instantsearch.js';
 import type { ReactNode } from 'react';
 

--- a/packages/react-instantsearch/rollup.config.js
+++ b/packages/react-instantsearch/rollup.config.js
@@ -57,6 +57,12 @@ const createConfiguration = ({ name, minify = false } = {}) => ({
     banner: createBanner(name),
     sourcemap: true,
   },
+  onwarn(warning, warn) {
+    if (warning.code === 'CIRCULAR_DEPENDENCY')
+      throw new Error(warning.message);
+
+    warn(warning);
+  },
   plugins: plugins.concat(
     clear([
       minify &&

--- a/packages/vue-instantsearch/rollup.config.js
+++ b/packages/vue-instantsearch/rollup.config.js
@@ -156,6 +156,12 @@ export * from './src/instantsearch.js';`
         },
       },
     ],
+    onwarn(warning, warn) {
+      if (warning.code === 'CIRCULAR_DEPENDENCY')
+        throw new Error(warning.message);
+
+      warn(warning);
+    },
     plugins: [
       ...plugins,
       resolve({


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

A circular dependency can cause issues, which is happening here because getServerState is importing from the index, but it's also exported from that same index.

**Result**

fixes #6292

also copied the code we have in InstantSearch.js to prevent circular dependency into react and vue instantsearch. Before the fix the build failed thanks to these onwarn changes.

This PR removes the circular dependency and also goes through all imports in React InstantSearch core and makes sure they're consistent (but the only circle was in getServerState).


<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
