### PR TITLE
fix(typescript): make recommendResults.params non-nullable

### DIFF
--- a/packages/instantsearch.js/src/types/results.ts
+++ b/packages/instantsearch.js/src/types/results.ts
@@ -102,7 +102,7 @@ type InitialResult = {
   state?: PlainSearchParameters;
   results?: SearchResults['_rawResults'];
   recommendResults?: {
-    params: RecommendParametersOptions['params'];
+    params: NonNullable<RecommendParametersOptions['params']>;
     results: RecommendResults['_rawResults'];
   };
   requestParams?: SearchOptions[];


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

fixes https://github.com/algolia/instantsearch/issues/6295

`params` is declared [here](https://github.com/algolia/instantsearch/blob/60c3f2066bc24d7af7884094b3f7293bf77d5d2a/packages/instantsearch.js/src/lib/server.ts#L105). As `JSON.parse` can never return `undefined`, this value can never be `undefined` either.

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

I manually changed the type inside of the node_module in a Remix project and there was no type complaint anymore