### PR TITLE
fix: import `index` from its specific file

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "50.5 kB"
+      "maxSize": "51 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -7,7 +7,7 @@ import {
   isMetadataEnabled,
 } from '../middlewares/createMetadataMiddleware';
 import { createRouterMiddleware } from '../middlewares/createRouterMiddleware';
-import { index } from '../widgets';
+import index from '../widgets/index/index';
 
 import createHelpers from './createHelpers';
 import {


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Import `index` from its entry point, not from the `widgets` file

This avoids side effects or other widgets being imported when only the InstantSearch component is imported.


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**


fixes #6309

This was introduced by accident in https://github.com/algolia/instantsearch/commit/89dd7ae4d45dea4dafbe451e55b01f2e45caf07e#diff-ab6f88a95338456e6f91ca8aa8699155153f09b67f8b2aab1bca4708e47eb9bfR10

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
