### PR TITLE
chore(storybook): fix vue panel

### DIFF
--- a/packages/vue-instantsearch/stories/Panel.stories.js
+++ b/packages/vue-instantsearch/stories/Panel.stories.js
@@ -8,9 +8,10 @@ storiesOf('ais-panel', module)
     template: `
       <ais-panel>
         <template v-slot:header>Brand</template>
-        <ais-refinement-list attribute="brand" />
+        This is the body of the Panel.
+        <template v-slot:footer>Footer</template>
       </ais-panel>
-  `,
+    `,
   }))
   .add('text content', () => ({
     template: `


### PR DESCRIPTION
Something is wrong with the webpack setup in storybook, where it transpiles https://github.com/algolia/instantsearch/blob/18959b47f2f541f410e091a0cb7140f40e0956c2/packages/vue-instantsearch/src/mixins/panel.js#L28-L32

```js
// from
    this.emitter.on(PANEL_CHANGE_EVENT, (value) => {
      this.updateCanRefine(value);
    });
// to
    this.emitter.on(PANEL_CHANGE_EVENT, function (value) {
      this.updateCanRefine(value);
    });
```

Which is obviously wrong (`this` is undefined instead of the component). This bundling fail isn't happening in any other components, stories or examples, so just avoiding the issue is best

reported in: https://algolia.slack.com/archives/C2XP6HBKQ/p1722600762388799