### PR TITLE
fix(ExperimentalConfigureRelatedItems): deprecate in favor of RelatedItems

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "67.75 kB"
+      "maxSize": "68 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "68.25 kB"
+      "maxSize": "68.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",

--- a/packages/instantsearch.js/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
+++ b/packages/instantsearch.js/src/connectors/configure-related-items/connectConfigureRelatedItems.ts
@@ -159,4 +159,5 @@ See https://www.algolia.com/doc/api-reference/api-parameters/optionalFilters/
     };
   };
 
+/** @deprecated use connectRelatedItems instead */
 export default connectConfigureRelatedItems;

--- a/packages/instantsearch.js/src/connectors/index.ts
+++ b/packages/instantsearch.js/src/connectors/index.ts
@@ -1,12 +1,19 @@
 import { deprecate } from '../lib/utils';
 
 import connectAnswers from './answers/connectAnswers';
+import connectConfigureRelatedItems from './configure-related-items/connectConfigureRelatedItems';
 import connectDynamicWidgets from './dynamic-widgets/connectDynamicWidgets';
 
 /** @deprecated answers is no longer supported */
 export const EXPERIMENTAL_connectAnswers = deprecate(
   connectAnswers,
   'answers is no longer supported'
+);
+
+/** @deprecated use connectRelatedItems instead */
+export const EXPERIMENTAL_connectConfigureRelatedItems = deprecate(
+  connectConfigureRelatedItems,
+  'use connectRelatedItems instead'
 );
 
 /** @deprecated use connectDynamicWidgets */
@@ -41,7 +48,6 @@ export { default as connectBreadcrumb } from './breadcrumb/connectBreadcrumb';
 export { default as connectGeoSearch } from './geo-search/connectGeoSearch';
 export { default as connectPoweredBy } from './powered-by/connectPoweredBy';
 export { default as connectConfigure } from './configure/connectConfigure';
-export { default as EXPERIMENTAL_connectConfigureRelatedItems } from './configure-related-items/connectConfigureRelatedItems';
 export { default as connectAutocomplete } from './autocomplete/connectAutocomplete';
 export { default as connectQueryRules } from './query-rules/connectQueryRules';
 export { default as connectVoiceSearch } from './voice-search/connectVoiceSearch';

--- a/packages/instantsearch.js/src/connectors/index.ts
+++ b/packages/instantsearch.js/src/connectors/index.ts
@@ -13,7 +13,7 @@ export const EXPERIMENTAL_connectAnswers = deprecate(
 /** @deprecated use connectRelatedItems instead */
 export const EXPERIMENTAL_connectConfigureRelatedItems = deprecate(
   connectConfigureRelatedItems,
-  'use connectRelatedItems instead'
+  'EXPERIMENTAL_connectConfigureRelatedItems is deprecated and will be removed in a next minor version of InstantSearch. Please use connectRelatedItems instead.'
 );
 
 /** @deprecated use connectDynamicWidgets */

--- a/packages/instantsearch.js/src/widgets/configure-related-items/configure-related-items.ts
+++ b/packages/instantsearch.js/src/widgets/configure-related-items/configure-related-items.ts
@@ -28,4 +28,5 @@ const configureRelatedItems: ConfigureRelatedItemsWidget =
     };
   };
 
+/** @deprecated use relatedItems instead */
 export default configureRelatedItems;

--- a/packages/instantsearch.js/src/widgets/index.ts
+++ b/packages/instantsearch.js/src/widgets/index.ts
@@ -1,12 +1,19 @@
 import { deprecate } from '../lib/utils';
 
 import answers from './answers/answers';
+import configureRelatedItems from './configure-related-items/configure-related-items';
 import dynamicWidgets from './dynamic-widgets/dynamic-widgets';
 
 /** @deprecated answers is no longer supported */
 export const EXPERIMENTAL_answers = deprecate(
   answers,
   'answers is no longer supported'
+);
+
+/** @deprecated use relatedItems instead */
+export const EXPERIMENTAL_configureRelatedItems = deprecate(
+  configureRelatedItems,
+  'use relatedItems instead'
 );
 
 /** @deprecated use dynamicWidgets */
@@ -21,7 +28,6 @@ export { default as breadcrumb } from './breadcrumb/breadcrumb';
 export { default as clearRefinements } from './clear-refinements/clear-refinements';
 export { default as configure } from './configure/configure';
 export { default as currentRefinements } from './current-refinements/current-refinements';
-export { default as EXPERIMENTAL_configureRelatedItems } from './configure-related-items/configure-related-items';
 export { default as geoSearch } from './geo-search/geo-search';
 export { default as hierarchicalMenu } from './hierarchical-menu/hierarchical-menu';
 export { default as hits } from './hits/hits';

--- a/packages/instantsearch.js/src/widgets/index.ts
+++ b/packages/instantsearch.js/src/widgets/index.ts
@@ -13,7 +13,7 @@ export const EXPERIMENTAL_answers = deprecate(
 /** @deprecated use relatedItems instead */
 export const EXPERIMENTAL_configureRelatedItems = deprecate(
   configureRelatedItems,
-  'use relatedItems instead'
+  'EXPERIMENTAL_configureRelatedItems is deprecated and will be removed in a next minor version of InstantSearch. Please use relatedItems instead.'
 );
 
 /** @deprecated use dynamicWidgets */


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Deprecate ConfigureRelatedItems, its API is fairly confusing and we never saw significant usage. Instead what you can do is:

- use relatedItems or connectRelatedItems (this uses recommend instead of search, but fits all use cases better)
- use a regular configure with `filters: 'attributeName:attributeValue<score=i>'` fetched from the object

If you're using configureRelatedItems, please reach out and we can find a suitable alternative for you.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

EXPERIMENTAL_configureRelatedItems and its connector are marked as deprecated and will be removed in a next minor version

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
