### PR TITLE
docs(instantsearch.js): use `carousel` template

### DIFF
--- a/examples/js/getting-started/index.html
+++ b/examples/js/getting-started/index.html
@@ -10,14 +10,6 @@
 
     <link rel="shortcut icon" href="./favicon.png" />
 
-    <!--
-      Do not use @8 in production, use a complete version like x.x.x, see website for latest version:
-      https://www.algolia.com/doc/guides/building-search-ui/installation/js/#load-the-styles
-    -->
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/instantsearch.css@8/themes/satellite-min.css"
-    />
     <link rel="stylesheet" href="./src/index.css" />
     <link rel="stylesheet" href="./src/app.css" />
 

--- a/examples/js/getting-started/package.json
+++ b/examples/js/getting-started/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "algoliasearch": "4.23.2",
+    "instantsearch.css": "8.4.0",
     "instantsearch.js": "4.73.4"
   },
   "devDependencies": {

--- a/examples/js/getting-started/products.html
+++ b/examples/js/getting-started/products.html
@@ -10,14 +10,6 @@
 
     <link rel="shortcut icon" href="./favicon.png" />
 
-    <!--
-      Do not use @8 in production, use a complete version like x.x.x, see website for latest version:
-      https://www.algolia.com/doc/guides/building-search-ui/installation/js/#load-the-styles
-    -->
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/instantsearch.css@8/themes/satellite-min.css"
-    />
     <link rel="stylesheet" href="./src/index.css" />
     <link rel="stylesheet" href="./src/app.css" />
 

--- a/examples/js/getting-started/src/app.css
+++ b/examples/js/getting-started/src/app.css
@@ -76,16 +76,10 @@
   flex-shrink: 0;
 }
 
-.ais-TrendingItems-list,
-.ais-RelatedProducts-list {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
-}
-
 .ais-TrendingItems-item,
 .ais-RelatedProducts-item {
   align-items: start;
+  height: 100%;
 }
 
 .ais-TrendingItems-item img,
@@ -101,4 +95,51 @@
   flex-direction: column;
   height: 100%;
   justify-content: space-between;
+}
+
+.ais-TrendingItems-item h2,
+.ais-RelatedProducts-item h2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.2;
+}
+
+.ais-Carousel-item {
+  padding: 0.5rem;
+}
+
+.ais-Carousel-list {
+  margin: -0.5rem;
+  grid-auto-columns: calc(22% - 0.5rem);
+}
+
+.ais-Carousel::before,
+.ais-Carousel::after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0.5rem;
+  display: block;
+  background: rgb(255, 255, 255);
+  content: '';
+}
+
+.ais-Carousel::before {
+  left: -0.5rem;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 1) 0%,
+    rgba(255, 255, 255, 0) 100%
+  );
+}
+
+.ais-Carousel::after {
+  right: -0.5rem;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 1) 100%
+  );
 }

--- a/examples/js/getting-started/src/app.js
+++ b/examples/js/getting-started/src/app.js
@@ -10,6 +10,8 @@ import {
   trendingItems,
 } from 'instantsearch.js/es/widgets';
 
+import 'instantsearch.css/themes/satellite.css';
+
 const searchClient = algoliasearch(
   'latency',
   '6be0576ff61c053d5f9a3225e2a90f76'

--- a/examples/js/getting-started/src/app.js
+++ b/examples/js/getting-started/src/app.js
@@ -1,5 +1,6 @@
 import algoliasearch from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
+import { carousel } from 'instantsearch.js/es/templates';
 import {
   configure,
   hits,
@@ -57,17 +58,20 @@ search.addWidgets([
   }),
   trendingItems({
     container: '#trending',
-    limit: 4,
+    limit: 6,
     templates: {
       item: (item, { html }) => html`
-        <article>
-          <div>
-            <img src="${item.image}" />
-            <h2>${item.name}</h2>
-          </div>
-          <a href="/products.html?pid=${item.objectID}">See product</a>
-        </article>
+        <div class="ais-TrendingItems-item">
+          <article>
+            <div>
+              <img src="${item.image}" />
+              <h2>${item.name}</h2>
+            </div>
+            <a href="/products.html?pid=${item.objectID}">See product</a>
+          </article>
+        </div>
       `,
+      layout: carousel(),
     },
   }),
 ]);

--- a/examples/js/getting-started/src/products.js
+++ b/examples/js/getting-started/src/products.js
@@ -1,7 +1,7 @@
 import algoliasearch from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
-import { configure, hits, relatedProducts } from 'instantsearch.js/es/widgets';
 import { carousel } from 'instantsearch.js/es/templates';
+import { configure, hits, relatedProducts } from 'instantsearch.js/es/widgets';
 
 const searchParams = new URLSearchParams(document.location.search);
 

--- a/examples/js/getting-started/src/products.js
+++ b/examples/js/getting-started/src/products.js
@@ -39,16 +39,18 @@ search.addWidgets([
   relatedProducts({
     container: '#related-products',
     objectIDs: [pid],
-    limit: 4,
+    limit: 6,
     templates: {
       item: (item, { html }) => html`
-        <article>
-          <div>
-            <img src="${item.image}" />
-            <h2>${item.name}</h2>
-          </div>
-          <a href="/products.html?pid=${item.objectID}">See product</a>
-        </article>
+        <div class="ais-RelatedProducts-item">
+          <article>
+            <div>
+              <img src="${item.image}" />
+              <h2>${item.name}</h2>
+            </div>
+            <a href="/products.html?pid=${item.objectID}">See product</a>
+          </article>
+        </div>
       `,
       layout: carousel(),
     },

--- a/examples/js/getting-started/src/products.js
+++ b/examples/js/getting-started/src/products.js
@@ -1,6 +1,7 @@
 import algoliasearch from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
 import { configure, hits, relatedProducts } from 'instantsearch.js/es/widgets';
+import { carousel } from 'instantsearch.js/es/templates';
 
 const searchParams = new URLSearchParams(document.location.search);
 
@@ -47,6 +48,7 @@ search.addWidgets([
           <a href="/products.html?pid=${item.objectID}">See product</a>
         </article>
       `,
+      layout: carousel(),
     },
   }),
   configure({

--- a/examples/js/getting-started/src/products.js
+++ b/examples/js/getting-started/src/products.js
@@ -3,6 +3,8 @@ import instantsearch from 'instantsearch.js';
 import { carousel } from 'instantsearch.js/es/templates';
 import { configure, hits, relatedProducts } from 'instantsearch.js/es/widgets';
 
+import 'instantsearch.css/themes/satellite.css';
+
 const searchParams = new URLSearchParams(document.location.search);
 
 const pid = searchParams.get('pid');


### PR DESCRIPTION
This uses the new `carousel` template in the **Getting Started** example for InstantSearch.js.

<img width="1004" alt="Capture d’écran 2024-08-07 à 19 34 17" src="https://github.com/user-attachments/assets/aee7080a-8ff4-4805-9380-7ee6ecdebf86">
