### PR TITLE
refactor(instantsearch-ui-components): rename `view` prop into `layout`

### DIFF
--- a/packages/instantsearch-ui-components/src/components/FrequentlyBoughtTogether.tsx
+++ b/packages/instantsearch-ui-components/src/components/FrequentlyBoughtTogether.tsx
@@ -6,7 +6,7 @@ import {
   createDefaultEmptyComponent,
   createDefaultHeaderComponent,
   createDefaultItemComponent,
-  createListViewComponent,
+  createListComponent,
 } from './recommend-shared';
 
 import type {
@@ -43,7 +43,7 @@ export function createFrequentlyBoughtTogetherComponent({
         createElement,
         Fragment,
       }),
-      view: View = createListViewComponent({ createElement, Fragment }),
+      layout: Layout = createListComponent({ createElement, Fragment }),
       items,
       status,
       translations: userTranslations,
@@ -91,7 +91,7 @@ export function createFrequentlyBoughtTogetherComponent({
           translations={translations}
         />
 
-        <View
+        <Layout
           classNames={cssClasses}
           translations={translations}
           itemComponent={ItemComponent}

--- a/packages/instantsearch-ui-components/src/components/LookingSimilar.tsx
+++ b/packages/instantsearch-ui-components/src/components/LookingSimilar.tsx
@@ -6,7 +6,7 @@ import {
   createDefaultEmptyComponent,
   createDefaultHeaderComponent,
   createDefaultItemComponent,
-  createListViewComponent,
+  createListComponent,
 } from './recommend-shared';
 
 import type {
@@ -43,7 +43,7 @@ export function createLookingSimilarComponent({
         createElement,
         Fragment,
       }),
-      view: View = createListViewComponent({ createElement, Fragment }),
+      layout: Layout = createListComponent({ createElement, Fragment }),
       items,
       status,
       translations: userTranslations,
@@ -88,7 +88,7 @@ export function createLookingSimilarComponent({
           translations={translations}
         />
 
-        <View
+        <Layout
           classNames={cssClasses}
           translations={translations}
           itemComponent={ItemComponent}

--- a/packages/instantsearch-ui-components/src/components/RelatedProducts.tsx
+++ b/packages/instantsearch-ui-components/src/components/RelatedProducts.tsx
@@ -6,7 +6,7 @@ import {
   createDefaultEmptyComponent,
   createDefaultHeaderComponent,
   createDefaultItemComponent,
-  createListViewComponent,
+  createListComponent,
 } from './recommend-shared';
 
 import type {
@@ -43,7 +43,7 @@ export function createRelatedProductsComponent({
         createElement,
         Fragment,
       }),
-      view: View = createListViewComponent({ createElement, Fragment }),
+      layout: Layout = createListComponent({ createElement, Fragment }),
       items,
       status,
       translations: userTranslations,
@@ -88,7 +88,7 @@ export function createRelatedProductsComponent({
           translations={translations}
         />
 
-        <View
+        <Layout
           classNames={cssClasses}
           translations={translations}
           itemComponent={ItemComponent}

--- a/packages/instantsearch-ui-components/src/components/TrendingItems.tsx
+++ b/packages/instantsearch-ui-components/src/components/TrendingItems.tsx
@@ -6,7 +6,7 @@ import {
   createDefaultEmptyComponent,
   createDefaultHeaderComponent,
   createDefaultItemComponent,
-  createListViewComponent,
+  createListComponent,
 } from './recommend-shared';
 
 import type {
@@ -43,7 +43,7 @@ export function createTrendingItemsComponent({
         createElement,
         Fragment,
       }),
-      view: View = createListViewComponent({ createElement, Fragment }),
+      layout: Layout = createListComponent({ createElement, Fragment }),
       items,
       status,
       translations: userTranslations,
@@ -88,7 +88,7 @@ export function createTrendingItemsComponent({
           translations={translations}
         />
 
-        <View
+        <Layout
           classNames={cssClasses}
           translations={translations}
           itemComponent={ItemComponent}

--- a/packages/instantsearch-ui-components/src/components/__tests__/FrequentlyBoughtTogether.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/FrequentlyBoughtTogether.test.tsx
@@ -20,7 +20,7 @@ const ItemComponent: FrequentlyBoughtTogetherProps<RecordWithObjectID>['itemComp
   ({ item }) => <div>{item.objectID}</div>;
 
 describe('FrequentlyBoughtTogether', () => {
-  test('renders items with default view and header', () => {
+  test('renders items with default layout and header', () => {
     const { container } = render(
       <FrequentlyBoughtTogether
         status="idle"
@@ -140,13 +140,13 @@ describe('FrequentlyBoughtTogether', () => {
     `);
   });
 
-  test('renders custom view', () => {
+  test('renders custom layout', () => {
     const { container } = render(
       <FrequentlyBoughtTogether
         status="idle"
         items={[{ objectID: '1', __position: 1 }]}
         itemComponent={ItemComponent}
-        view={(props) => (
+        layout={(props) => (
           <div className={props.classNames.container}>
             <ol className={props.classNames.list}>
               {props.items.map((item) => (

--- a/packages/instantsearch-ui-components/src/components/__tests__/LookingSimilar.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/LookingSimilar.test.tsx
@@ -20,7 +20,7 @@ const ItemComponent: LookingSimilarProps<RecordWithObjectID>['itemComponent'] =
   ({ item }) => <div>{item.objectID}</div>;
 
 describe('LookingSimilar', () => {
-  test('renders items with default view and header', () => {
+  test('renders items with default layout and header', () => {
     const { container } = render(
       <LookingSimilar
         status="idle"
@@ -140,13 +140,13 @@ describe('LookingSimilar', () => {
     `);
   });
 
-  test('renders custom view', () => {
+  test('renders custom layout', () => {
     const { container } = render(
       <LookingSimilar
         status="idle"
         items={[{ objectID: '1', __position: 1 }]}
         itemComponent={ItemComponent}
-        view={(props) => (
+        layout={(props) => (
           <div className={props.classNames.container}>
             <ol className={props.classNames.list}>
               {props.items.map((item) => (

--- a/packages/instantsearch-ui-components/src/components/__tests__/RelatedProducts.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/RelatedProducts.test.tsx
@@ -20,7 +20,7 @@ const ItemComponent: RelatedProductsProps<RecordWithObjectID>['itemComponent'] =
   ({ item }) => <div>{item.objectID}</div>;
 
 describe('RelatedProducts', () => {
-  test('renders items with default view and header', () => {
+  test('renders items with default layout and header', () => {
     const { container } = render(
       <RelatedProducts
         status="idle"
@@ -140,13 +140,13 @@ describe('RelatedProducts', () => {
     `);
   });
 
-  test('renders custom view', () => {
+  test('renders custom layout', () => {
     const { container } = render(
       <RelatedProducts
         status="idle"
         items={[{ objectID: '1', __position: 1 }]}
         itemComponent={ItemComponent}
-        view={(props) => (
+        layout={(props) => (
           <div className={props.classNames.container}>
             <ol className={props.classNames.list}>
               {props.items.map((item) => (

--- a/packages/instantsearch-ui-components/src/components/__tests__/TrendingItems.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/TrendingItems.test.tsx
@@ -20,7 +20,7 @@ const ItemComponent: TrendingItemsProps<RecordWithObjectID>['itemComponent'] =
   ({ item }) => <div>{item.objectID}</div>;
 
 describe('TrendingItems', () => {
-  test('renders items with default view and header', () => {
+  test('renders items with default layout and header', () => {
     const { container } = render(
       <TrendingItems
         status="idle"
@@ -140,13 +140,13 @@ describe('TrendingItems', () => {
     `);
   });
 
-  test('renders custom view', () => {
+  test('renders custom layout', () => {
     const { container } = render(
       <TrendingItems
         status="idle"
         items={[{ objectID: '1', __position: 1 }]}
         itemComponent={ItemComponent}
-        view={(props) => (
+        layout={(props) => (
           <div className={props.classNames.container}>
             <ol className={props.classNames.list}>
               {props.items.map((item) => (

--- a/packages/instantsearch-ui-components/src/components/recommend-shared/List.tsx
+++ b/packages/instantsearch-ui-components/src/components/recommend-shared/List.tsx
@@ -5,12 +5,12 @@ import type {
   RecommendTranslations,
   RecordWithObjectID,
   Renderer,
-  RecommendViewProps,
+  RecommendLayoutProps,
 } from '../../types';
 
-export function createListViewComponent({ createElement }: Renderer) {
-  return function ListView<TItem extends RecordWithObjectID>(
-    userProps: RecommendViewProps<
+export function createListComponent({ createElement }: Renderer) {
+  return function List<TItem extends RecordWithObjectID>(
+    userProps: RecommendLayoutProps<
       TItem,
       RecommendTranslations,
       Partial<RecommendClassNames>

--- a/packages/instantsearch-ui-components/src/components/recommend-shared/index.ts
+++ b/packages/instantsearch-ui-components/src/components/recommend-shared/index.ts
@@ -1,4 +1,4 @@
 export * from './DefaultEmpty';
 export * from './DefaultHeader';
 export * from './DefaultItem';
-export * from './ListView';
+export * from './List';

--- a/packages/instantsearch-ui-components/src/types/Recommend.ts
+++ b/packages/instantsearch-ui-components/src/types/Recommend.ts
@@ -38,7 +38,7 @@ export type RecommendTranslations = {
   sliderLabel: string;
 };
 
-export type RecommendViewProps<
+export type RecommendLayoutProps<
   TItem extends RecordWithObjectID,
   TTranslations extends Record<string, string>,
   TClassNames extends Record<string, string>
@@ -72,8 +72,8 @@ export type RecommendComponentProps<
   status: RecommendStatus;
   translations?: Partial<RecommendTranslations>;
   sendEvent: SendEventForHits;
-  view?: (
-    props: RecommendViewProps<
+  layout?: (
+    props: RecommendLayoutProps<
       RecordWithObjectID<TObject>,
       Required<RecommendTranslations>,
       Record<string, string>

--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
@@ -136,7 +136,7 @@ const renderer =
             />
           )
         : undefined
-    ) as FrequentlyBoughtTogetherUiProps<Hit>['view'];
+    ) as FrequentlyBoughtTogetherUiProps<Hit>['layout'];
 
     render(
       <FrequentlyBoughtTogether
@@ -146,7 +146,7 @@ const renderer =
         sendEvent={() => {}}
         classNames={cssClasses}
         emptyComponent={emptyComponent}
-        view={layoutComponent}
+        layout={layoutComponent}
         status={instantSearchInstance.status}
       />,
       containerNode
@@ -188,7 +188,7 @@ export type FrequentlyBoughtTogetherTemplates<
   layout: Template<
     Pick<
       Parameters<
-        NonNullable<FrequentlyBoughtTogetherUiProps<Hit<THit>>['view']>
+        NonNullable<FrequentlyBoughtTogetherUiProps<Hit<THit>>['layout']>
       >[0],
       'items'
     > & {

--- a/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
@@ -132,7 +132,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as LookingSimilarUiProps<Hit>['view'];
+    ) as LookingSimilarUiProps<Hit>['layout'];
 
     render(
       <LookingSimilar
@@ -142,7 +142,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
         sendEvent={() => {}}
         classNames={cssClasses}
         emptyComponent={emptyComponent}
-        view={layoutComponent}
+        layout={layoutComponent}
         status={instantSearchInstance.status}
       />,
       containerNode
@@ -182,7 +182,7 @@ export type LookingSimilarTemplates<
    */
   layout: Template<
     Pick<
-      Parameters<NonNullable<LookingSimilarUiProps<Hit<THit>>['view']>>[0],
+      Parameters<NonNullable<LookingSimilarUiProps<Hit<THit>>['layout']>>[0],
       'items'
     > & {
       templates: {

--- a/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
@@ -142,7 +142,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as RelatedProductsUiProps<Hit>['view'];
+    ) as RelatedProductsUiProps<Hit>['layout'];
 
     render(
       <RelatedProducts
@@ -152,7 +152,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
         headerComponent={headerComponent}
         itemComponent={itemComponent}
         emptyComponent={emptyComponent}
-        view={layoutComponent}
+        layout={layoutComponent}
         status={instantSearchInstance.status}
       />,
       containerNode
@@ -192,7 +192,7 @@ export type RelatedProductsTemplates<
    */
   layout: Template<
     Pick<
-      Parameters<NonNullable<RelatedProductsUiProps<Hit<THit>>['view']>>[0],
+      Parameters<NonNullable<RelatedProductsUiProps<Hit<THit>>['layout']>>[0],
       'items'
     > & {
       templates: {

--- a/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
@@ -142,7 +142,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as TrendingItemsUiProps<Hit>['view'];
+    ) as TrendingItemsUiProps<Hit>['layout'];
 
     render(
       <TrendingItems
@@ -152,7 +152,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
         headerComponent={headerComponent}
         itemComponent={itemComponent}
         emptyComponent={emptyComponent}
-        view={layoutComponent}
+        layout={layoutComponent}
         status={instantSearchInstance.status}
       />,
       containerNode
@@ -191,7 +191,7 @@ export type TrendingItemsTemplates<THit extends NonNullable<object> = BaseHit> =
      */
     layout: Template<
       Pick<
-        Parameters<NonNullable<TrendingItemsUiProps<Hit<THit>>['view']>>[0],
+        Parameters<NonNullable<TrendingItemsUiProps<Hit<THit>>['layout']>>[0],
         'items'
       > & {
         templates: {


### PR DESCRIPTION
This renames the `view` prop used in the Recommend UI components into `layout` to fit the API we chose for templating.