### PR TITLE
fix(geoSearch): correct type of MarkerOptions

### DIFF
--- a/packages/instantsearch.js/package.json
+++ b/packages/instantsearch.js/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@algolia/events": "^4.0.1",
     "@types/dom-speech-recognition": "^0.0.1",
-    "@types/google.maps": "^3.45.3",
+    "@types/google.maps": "^3.55.12",
     "@types/hogan.js": "^3.0.0",
     "@types/qs": "^6.5.3",
     "algoliasearch-helper": "3.22.3",

--- a/packages/instantsearch.js/src/widgets/geo-search/GeoSearchRenderer.d.ts
+++ b/packages/instantsearch.js/src/widgets/geo-search/GeoSearchRenderer.d.ts
@@ -29,7 +29,7 @@ type GeoSearchRendererParams = {
   cssClasses: ComponentCSSClasses<GeoSearchWidgetParams['cssClasses']>;
   createMarker: CreateMarker;
   markerOptions: GeoSearchMarker<
-    typeof google.maps.MarkerOptions | Partial<HTMLMarkerArguments>
+    google.maps.MarkerOptions | Partial<HTMLMarkerArguments>
   >;
   enableRefine: GeoSearchWidgetParams['enableRefine'];
   enableClearMapRefinement: GeoSearchWidgetParams['enableClearMapRefinement'];

--- a/packages/instantsearch.js/src/widgets/geo-search/__tests__/geo-search-test.ts
+++ b/packages/instantsearch.js/src/widgets/geo-search/__tests__/geo-search-test.ts
@@ -132,7 +132,9 @@ describe('GeoSearch', () => {
     lastRenderArgs(fn).widgetParams.renderState;
 
   const simulateMapReadyEvent = (google: typeof window['google']) => {
-    castToJestMock(google.maps.event.addListenerOnce).mock.calls[0][2]();
+    castToJestMock(
+      google.maps.event.addListenerOnce.bind(google.maps.event)
+    ).mock.calls[0][2]();
   };
 
   const simulateEvent = (

--- a/packages/instantsearch.js/src/widgets/geo-search/__tests__/geo-search-test.ts
+++ b/packages/instantsearch.js/src/widgets/geo-search/__tests__/geo-search-test.ts
@@ -132,9 +132,8 @@ describe('GeoSearch', () => {
     lastRenderArgs(fn).widgetParams.renderState;
 
   const simulateMapReadyEvent = (google: typeof window['google']) => {
-    castToJestMock(
-      google.maps.event.addListenerOnce.bind(google.maps.event)
-    ).mock.calls[0][2]();
+    // eslint-disable-next-line jest/unbound-method
+    castToJestMock(google.maps.event.addListenerOnce).mock.calls[0][2]();
   };
 
   const simulateEvent = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6323,10 +6323,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/google.maps@^3.45.3":
-  version "3.45.6"
-  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.45.6.tgz#441a7bc76424243b307596fc8d282a435a979ebd"
-  integrity sha512-BzGzxs8UXFxeP8uN/0nRgGbsbpYQxSCKsv/7S8OitU7wwhfFcqQSm5aAcL1nbwueMiJ/VVmIZKPq69s0kX5W+Q==
+"@types/google.maps@^3.55.12":
+  version "3.55.12"
+  resolved "https://registry.yarnpkg.com/@types/google.maps/-/google.maps-3.55.12.tgz#66b50be48533d116dddb3d705d277d06457735b0"
+  integrity sha512-Q8MsLE+YYIrE1H8wdN69YHHAF8h7ApvF5MiMXh/zeCpP9Ut745mV9M0F4X4eobZ2WJe9k8tW2ryYjLa87IO2Sg==
 
 "@types/googlemaps@^3.30.16":
   version "3.30.16"


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

change MarkerOption from `typeof` to a direct access.

This isn't really exposed to the user, but I believe this broke when they moved from a namespace to an interface.



**Result**

No type error in examples provided in the original issue
Still using Marker, not AdvancedMarker (despite Marker being deprecated), changing this would likely be a breaking change.

fixes #6253

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
