### PR TITLE
feat(react-instantsearch): add `Carousel` layout component

### DIFF
--- a/examples/react/getting-started/index.html
+++ b/examples/react/getting-started/index.html
@@ -9,15 +9,6 @@
 
     <link rel="shortcut icon" href="favicon.png" />
 
-    <!--
-      Do not use @8 in production, use a complete version like x.x.x, see website for latest version:
-      https://www.algolia.com/doc/guides/building-search-ui/installation/js/#load-the-styles
-    -->
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/instantsearch.css@8/themes/satellite-min.css"
-    />
-
     <title>React InstantSearch — Getting started</title>
   </head>
 

--- a/examples/react/getting-started/package.json
+++ b/examples/react/getting-started/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "algoliasearch": "4.23.2",
     "instantsearch.js": "4.73.4",
+    "instantsearch.css": "8.4.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-instantsearch": "7.12.4"

--- a/examples/react/getting-started/products.html
+++ b/examples/react/getting-started/products.html
@@ -9,15 +9,6 @@
 
     <link rel="shortcut icon" href="favicon.png" />
 
-    <!--
-      Do not use @8 in production, use a complete version like x.x.x, see website for latest version:
-      https://www.algolia.com/doc/guides/building-search-ui/installation/js/#load-the-styles
-    -->
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/instantsearch.css@8/themes/satellite-min.css"
-    />
-
     <title>React InstantSearch — Getting started</title>
   </head>
 

--- a/examples/react/getting-started/src/App.css
+++ b/examples/react/getting-started/src/App.css
@@ -19,7 +19,7 @@ em {
   align-items: center;
   min-height: 50px;
   padding: 0.5rem 1rem;
-  background-image: linear-gradient(284deg, #fedd4e, #fcb43a);
+  background-image: linear-gradient(to right, #8e43e7, #00aeff);
   color: #fff;
   margin-bottom: 1rem;
 }
@@ -61,16 +61,11 @@ em {
   flex: 3;
 }
 
-.ais-Highlight-highlighted {
-  color: inherit;
-  font-size: inherit;
-}
-
 #searchbox {
   margin-bottom: 2rem;
 }
 
-#pagination {
+.pagination {
   margin: 2rem auto;
   text-align: center;
 }

--- a/examples/react/getting-started/src/App.css
+++ b/examples/react/getting-started/src/App.css
@@ -19,7 +19,7 @@ em {
   align-items: center;
   min-height: 50px;
   padding: 0.5rem 1rem;
-  background-image: linear-gradient(to right, #8e43e7, #00aeff);
+  background-image: linear-gradient(284deg, #fedd4e, #fcb43a);
   color: #fff;
   margin-bottom: 1rem;
 }
@@ -61,11 +61,16 @@ em {
   flex: 3;
 }
 
-.searchbox {
+.ais-Highlight-highlighted {
+  color: inherit;
+  font-size: inherit;
+}
+
+#searchbox {
   margin-bottom: 2rem;
 }
 
-.pagination {
+#pagination {
   margin: 2rem auto;
   text-align: center;
 }
@@ -87,16 +92,10 @@ em {
   flex-shrink: 0;
 }
 
-.ais-TrendingItems-list,
-.ais-RelatedProducts-list {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
-}
-
 .ais-TrendingItems-item,
 .ais-RelatedProducts-item {
   align-items: start;
+  height: 100%;
 }
 
 .ais-TrendingItems-item img,
@@ -112,4 +111,51 @@ em {
   flex-direction: column;
   height: 100%;
   justify-content: space-between;
+}
+
+.ais-TrendingItems-item h2,
+.ais-RelatedProducts-item h2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.2;
+}
+
+.ais-Carousel-item {
+  padding: 0.5rem;
+}
+
+.ais-Carousel-list {
+  margin: -0.5rem;
+  grid-auto-columns: calc(22% - 0.5rem);
+}
+
+.ais-Carousel::before,
+.ais-Carousel::after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0.5rem;
+  display: block;
+  background: rgb(255, 255, 255);
+  content: '';
+}
+
+.ais-Carousel::before {
+  left: -0.5rem;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 1) 0%,
+    rgba(255, 255, 255, 0) 100%
+  );
+}
+
+.ais-Carousel::after {
+  right: -0.5rem;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 1) 100%
+  );
 }

--- a/examples/react/getting-started/src/App.tsx
+++ b/examples/react/getting-started/src/App.tsx
@@ -11,10 +11,12 @@ import {
   SearchBox,
   TrendingItems,
 } from 'react-instantsearch';
+import { Carousel } from 'react-instantsearch/src/templates/Carousel';
 
 import { Panel } from './Panel';
 
 import './App.css';
+import 'instantsearch.css/themes/satellite.css';
 
 const searchClient = algoliasearch(
   'latency',
@@ -58,7 +60,11 @@ export function App() {
                 <Pagination />
               </div>
               <div>
-                <TrendingItems itemComponent={ItemComponent} limit={4} />
+                <TrendingItems
+                  itemComponent={ItemComponent}
+                  limit={6}
+                  layoutComponent={(props) => <Carousel {...props} />}
+                />
               </div>
             </div>
           </div>

--- a/examples/react/getting-started/src/App.tsx
+++ b/examples/react/getting-started/src/App.tsx
@@ -63,7 +63,7 @@ export function App() {
                 <TrendingItems
                   itemComponent={ItemComponent}
                   limit={6}
-                  layoutComponent={(props) => <Carousel {...props} />}
+                  layoutComponent={Carousel}
                 />
               </div>
             </div>

--- a/examples/react/getting-started/src/App.tsx
+++ b/examples/react/getting-started/src/App.tsx
@@ -10,8 +10,8 @@ import {
   RefinementList,
   SearchBox,
   TrendingItems,
+  Carousel,
 } from 'react-instantsearch';
-import { Carousel } from 'react-instantsearch/src/templates/Carousel';
 
 import { Panel } from './Panel';
 

--- a/examples/react/getting-started/src/Product.tsx
+++ b/examples/react/getting-started/src/Product.tsx
@@ -6,8 +6,8 @@ import {
   Hits,
   InstantSearch,
   RelatedProducts,
+  Carousel,
 } from 'react-instantsearch';
-import { Carousel } from 'react-instantsearch/src/templates/Carousel';
 
 import './App.css';
 import 'instantsearch.css/themes/satellite.css';

--- a/examples/react/getting-started/src/Product.tsx
+++ b/examples/react/getting-started/src/Product.tsx
@@ -51,9 +51,7 @@ export function Product({ pid }: { pid: string }) {
             emptyComponent={() => <></>}
             objectIDs={[pid]}
             limit={6}
-            layoutComponent={(props) => {
-              return <Carousel {...props} />;
-            }}
+            layoutComponent={Carousel}
           />
         </InstantSearch>
       </div>

--- a/examples/react/getting-started/src/Product.tsx
+++ b/examples/react/getting-started/src/Product.tsx
@@ -7,8 +7,10 @@ import {
   InstantSearch,
   RelatedProducts,
 } from 'react-instantsearch';
+import { Carousel } from 'react-instantsearch/src/templates/Carousel';
 
 import './App.css';
+import 'instantsearch.css/themes/satellite.css';
 
 const searchClient = algoliasearch(
   'latency',
@@ -48,7 +50,10 @@ export function Product({ pid }: { pid: string }) {
             itemComponent={ItemComponent}
             emptyComponent={() => <></>}
             objectIDs={[pid]}
-            limit={4}
+            limit={6}
+            layoutComponent={(props) => {
+              return <Carousel {...props} />;
+            }}
           />
         </InstantSearch>
       </div>

--- a/packages/instantsearch-ui-components/src/types/Recommend.ts
+++ b/packages/instantsearch-ui-components/src/types/Recommend.ts
@@ -40,7 +40,7 @@ export type RecommendTranslations = {
 
 export type RecommendLayoutProps<
   TItem extends RecordWithObjectID,
-  TTranslations extends Record<string, string>,
+  TTranslations extends Partial<Record<string, string>>,
   TClassNames extends Record<string, string>
 > = {
   classNames: TClassNames;
@@ -57,7 +57,8 @@ export type RecommendLayoutProps<
 
 export type RecommendComponentProps<
   TObject,
-  TComponentProps extends Record<string, unknown> = Record<string, unknown>
+  TComponentProps extends Record<string, unknown> = Record<string, unknown>,
+  TLayoutTranslations extends Record<string, string> = Record<string, string>
 > = {
   itemComponent?: (
     props: RecommendItemComponentProps<RecordWithObjectID<TObject>> &
@@ -75,7 +76,7 @@ export type RecommendComponentProps<
   layout?: (
     props: RecommendLayoutProps<
       RecordWithObjectID<TObject>,
-      Required<RecommendTranslations>,
+      Partial<TLayoutTranslations>,
       Record<string, string>
     > &
       TComponentProps

--- a/packages/react-instantsearch/src/index.ts
+++ b/packages/react-instantsearch/src/index.ts
@@ -1,2 +1,3 @@
 export * from 'react-instantsearch-core';
 export * from './widgets';
+export * from './templates';

--- a/packages/react-instantsearch/src/templates/Carousel.tsx
+++ b/packages/react-instantsearch/src/templates/Carousel.tsx
@@ -4,23 +4,26 @@ import {
 } from 'instantsearch-ui-components';
 import React, { createElement, Fragment, useRef } from 'react';
 
-import type { CarouselProps, Pragma } from 'instantsearch-ui-components';
+import type {
+  CarouselProps as CarouselUiProps,
+  Pragma,
+} from 'instantsearch-ui-components';
 
 const CarouselUiComponent = createCarouselComponent({
   createElement: createElement as Pragma,
   Fragment,
 });
 
-export type CarouseulProps<TObject extends Record<string, unknown>> = Omit<
-  CarouselProps<TObject>,
+export type CarouselProps<TObject extends Record<string, unknown>> = Omit<
+  CarouselUiProps<TObject>,
   'listRef' | 'nextButtonRef' | 'previousButtonRef' | 'carouselIdRef'
 >;
 
 export function Carousel<TObject extends Record<string, unknown>>(
-  props: CarouseulProps<TObject>
+  props: CarouselProps<TObject>
 ) {
   const carouselRefs: Pick<
-    CarouselProps<TObject>,
+    CarouselUiProps<TObject>,
     'listRef' | 'nextButtonRef' | 'previousButtonRef' | 'carouselIdRef'
   > = {
     listRef: useRef(null),

--- a/packages/react-instantsearch/src/templates/Carousel.tsx
+++ b/packages/react-instantsearch/src/templates/Carousel.tsx
@@ -1,0 +1,33 @@
+import {
+  createCarouselComponent,
+  generateCarouselId,
+} from 'instantsearch-ui-components';
+import React, { createElement, Fragment, useRef } from 'react';
+
+import type { CarouselProps, Pragma } from 'instantsearch-ui-components';
+
+const CarouselUiComponent = createCarouselComponent({
+  createElement: createElement as Pragma,
+  Fragment,
+});
+
+export type CarouseulProps<TObject extends Record<string, unknown>> = Omit<
+  CarouselProps<TObject>,
+  'listRef' | 'nextButtonRef' | 'previousButtonRef' | 'carouselIdRef'
+>;
+
+export function Carousel<TObject extends Record<string, unknown>>(
+  props: CarouseulProps<TObject>
+) {
+  const carouselRefs: Pick<
+    CarouselProps<TObject>,
+    'listRef' | 'nextButtonRef' | 'previousButtonRef' | 'carouselIdRef'
+  > = {
+    listRef: useRef(null),
+    nextButtonRef: useRef(null),
+    previousButtonRef: useRef(null),
+    carouselIdRef: useRef(generateCarouselId()),
+  };
+
+  return <CarouselUiComponent {...carouselRefs} {...props} />;
+}

--- a/packages/react-instantsearch/src/templates/__tests__/Carousel.test.tsx
+++ b/packages/react-instantsearch/src/templates/__tests__/Carousel.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { Carousel } from '../Carousel';
+
+describe('Carousel', () => {
+  test('renders with default props', () => {
+    const { container } = render(
+      <Carousel
+        items={[
+          { objectID: '1', __position: 1 },
+          { objectID: '2', __position: 2 },
+        ]}
+        itemComponent={({ item }) => <p>{item.objectID}</p>}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+    <div>
+      <div
+        class="ais-Carousel"
+      >
+        <button
+          aria-controls="ais-Carousel-0"
+          aria-label="Previous"
+          class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+          hidden=""
+          title="Previous"
+        >
+          <svg
+            fill="none"
+            height="16"
+            viewBox="0 0 8 16"
+            width="8"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M7.13809 0.744078C7.39844 1.06951 7.39844 1.59715 7.13809 1.92259L2.27616 8L7.13809 14.0774C7.39844 14.4028 7.39844 14.9305 7.13809 15.2559C6.87774 15.5814 6.45563 15.5814 6.19528 15.2559L0.861949 8.58926C0.6016 8.26382 0.6016 7.73618 0.861949 7.41074L6.19528 0.744078C6.45563 0.418641 6.87774 0.418641 7.13809 0.744078Z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </button>
+        <ol
+          aria-label="Items"
+          aria-live="polite"
+          aria-roledescription="carousel"
+          class="ais-Carousel-list"
+          id="ais-Carousel-0"
+          tabindex="0"
+        >
+          <li
+            aria-label="1 of 2"
+            aria-roledescription="slide"
+            class="ais-Carousel-item"
+          >
+            <p>
+              1
+            </p>
+          </li>
+          <li
+            aria-label="2 of 2"
+            aria-roledescription="slide"
+            class="ais-Carousel-item"
+          >
+            <p>
+              2
+            </p>
+          </li>
+        </ol>
+        <button
+          aria-controls="ais-Carousel-0"
+          aria-label="Next"
+          class="ais-Carousel-navigation ais-Carousel-navigation--next"
+          title="Next"
+        >
+          <svg
+            fill="none"
+            height="16"
+            viewBox="0 0 8 16"
+            width="8"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M0.861908 15.2559C0.601559 14.9305 0.601559 14.4028 0.861908 14.0774L5.72384 8L0.861908 1.92259C0.601559 1.59715 0.601559 1.06952 0.861908 0.744079C1.12226 0.418642 1.54437 0.418642 1.80472 0.744079L7.13805 7.41074C7.3984 7.73618 7.3984 8.26382 7.13805 8.58926L1.80472 15.2559C1.54437 15.5814 1.12226 15.5814 0.861908 15.2559Z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    `);
+  });
+
+  test('adds custom class names', () => {
+    const { container } = render(
+      <Carousel
+        items={[
+          { objectID: '1', __position: 1 },
+          { objectID: '2', __position: 2 },
+        ]}
+        itemComponent={({ item }) => <p>{item.objectID}</p>}
+        classNames={{
+          root: 'ROOT',
+          list: 'LIST',
+          item: 'ITEM',
+          navigation: 'NAVIGATION',
+          navigationPrevious: 'NAVIGATION_PREVIOUS',
+          navigationNext: 'NAVIGATION_NEXT',
+        }}
+      />
+    );
+
+    expect(container.querySelector('.ais-Carousel')).toHaveClass('ROOT');
+    expect(container.querySelector('.ais-Carousel-list')).toHaveClass('LIST');
+    expect(container.querySelector('.ais-Carousel-item')).toHaveClass('ITEM');
+    expect(container.querySelector('.ais-Carousel-navigation')).toHaveClass(
+      'NAVIGATION'
+    );
+    expect(
+      container.querySelector('.ais-Carousel-navigation--previous')
+    ).toHaveClass('NAVIGATION_PREVIOUS');
+    expect(
+      container.querySelector('.ais-Carousel-navigation--next')
+    ).toHaveClass('NAVIGATION_NEXT');
+  });
+
+  test('adds custom icon components', () => {
+    const { container } = render(
+      <Carousel
+        items={[
+          { objectID: '1', __position: 1 },
+          { objectID: '2', __position: 2 },
+        ]}
+        itemComponent={({ item }) => <p>{item.objectID}</p>}
+        previousIconComponent={() => <p>Previous</p>}
+        nextIconComponent={() => <p>Next</p>}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+    <div>
+      <div
+        class="ais-Carousel"
+      >
+        <button
+          aria-controls="ais-Carousel-2"
+          aria-label="Previous"
+          class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+          hidden=""
+          title="Previous"
+        >
+          <p>
+            Previous
+          </p>
+        </button>
+        <ol
+          aria-label="Items"
+          aria-live="polite"
+          aria-roledescription="carousel"
+          class="ais-Carousel-list"
+          id="ais-Carousel-2"
+          tabindex="0"
+        >
+          <li
+            aria-label="1 of 2"
+            aria-roledescription="slide"
+            class="ais-Carousel-item"
+          >
+            <p>
+              1
+            </p>
+          </li>
+          <li
+            aria-label="2 of 2"
+            aria-roledescription="slide"
+            class="ais-Carousel-item"
+          >
+            <p>
+              2
+            </p>
+          </li>
+        </ol>
+        <button
+          aria-controls="ais-Carousel-2"
+          aria-label="Next"
+          class="ais-Carousel-navigation ais-Carousel-navigation--next"
+          title="Next"
+        >
+          <p>
+            Next
+          </p>
+        </button>
+      </div>
+    </div>
+    `);
+  });
+
+  test('adds custom translations', () => {
+    const { container } = render(
+      <Carousel
+        items={[
+          { objectID: '1', __position: 1 },
+          { objectID: '2', __position: 2 },
+        ]}
+        itemComponent={({ item }) => <p>{item.objectID}</p>}
+        translations={{
+          nextButtonLabel: 'Next button label',
+          nextButtonTitle: 'Next button title',
+          previousButtonLabel: 'Previous button label',
+          previousButtonTitle: 'Previous button title',
+          listLabel: 'List label',
+        }}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+    <div>
+      <div
+        class="ais-Carousel"
+      >
+        <button
+          aria-controls="ais-Carousel-3"
+          aria-label="Previous button label"
+          class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+          hidden=""
+          title="Previous button title"
+        >
+          <svg
+            fill="none"
+            height="16"
+            viewBox="0 0 8 16"
+            width="8"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M7.13809 0.744078C7.39844 1.06951 7.39844 1.59715 7.13809 1.92259L2.27616 8L7.13809 14.0774C7.39844 14.4028 7.39844 14.9305 7.13809 15.2559C6.87774 15.5814 6.45563 15.5814 6.19528 15.2559L0.861949 8.58926C0.6016 8.26382 0.6016 7.73618 0.861949 7.41074L6.19528 0.744078C6.45563 0.418641 6.87774 0.418641 7.13809 0.744078Z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </button>
+        <ol
+          aria-label="List label"
+          aria-live="polite"
+          aria-roledescription="carousel"
+          class="ais-Carousel-list"
+          id="ais-Carousel-3"
+          tabindex="0"
+        >
+          <li
+            aria-label="1 of 2"
+            aria-roledescription="slide"
+            class="ais-Carousel-item"
+          >
+            <p>
+              1
+            </p>
+          </li>
+          <li
+            aria-label="2 of 2"
+            aria-roledescription="slide"
+            class="ais-Carousel-item"
+          >
+            <p>
+              2
+            </p>
+          </li>
+        </ol>
+        <button
+          aria-controls="ais-Carousel-3"
+          aria-label="Next button label"
+          class="ais-Carousel-navigation ais-Carousel-navigation--next"
+          title="Next button title"
+        >
+          <svg
+            fill="none"
+            height="16"
+            viewBox="0 0 8 16"
+            width="8"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M0.861908 15.2559C0.601559 14.9305 0.601559 14.4028 0.861908 14.0774L5.72384 8L0.861908 1.92259C0.601559 1.59715 0.601559 1.06952 0.861908 0.744079C1.12226 0.418642 1.54437 0.418642 1.80472 0.744079L7.13805 7.41074C7.3984 7.73618 7.3984 8.26382 7.13805 8.58926L1.80472 15.2559C1.54437 15.5814 1.12226 15.5814 0.861908 15.2559Z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    `);
+  });
+});

--- a/packages/react-instantsearch/src/templates/index.ts
+++ b/packages/react-instantsearch/src/templates/index.ts
@@ -1,0 +1,1 @@
+export * from './Carousel';

--- a/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
+++ b/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
@@ -18,6 +18,7 @@ type UiProps<THit extends BaseHit> = Pick<
   | 'itemComponent'
   | 'headerComponent'
   | 'emptyComponent'
+  | 'layout'
   | 'status'
   | 'sendEvent'
 >;
@@ -30,6 +31,7 @@ export type FrequentlyBoughtTogetherProps<THit extends BaseHit> = Omit<
     itemComponent?: FrequentlyBoughtTogetherPropsUiComponentProps<THit>['itemComponent'];
     headerComponent?: FrequentlyBoughtTogetherPropsUiComponentProps<THit>['headerComponent'];
     emptyComponent?: FrequentlyBoughtTogetherPropsUiComponentProps<THit>['emptyComponent'];
+    layoutComponent?: FrequentlyBoughtTogetherPropsUiComponentProps<THit>['layout'];
   };
 
 const FrequentlyBoughtTogetherUiComponent =
@@ -48,6 +50,7 @@ export function FrequentlyBoughtTogether<THit extends BaseHit = BaseHit>({
   itemComponent,
   headerComponent,
   emptyComponent,
+  layoutComponent,
   ...props
 }: FrequentlyBoughtTogetherProps<THit>) {
   const { status } = useInstantSearch();
@@ -68,6 +71,7 @@ export function FrequentlyBoughtTogether<THit extends BaseHit = BaseHit>({
     itemComponent,
     headerComponent,
     emptyComponent,
+    layout: layoutComponent,
     status,
     sendEvent: () => {},
   };

--- a/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
+++ b/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
@@ -15,6 +15,7 @@ type UiProps<THit extends BaseHit> = Pick<
   | 'itemComponent'
   | 'headerComponent'
   | 'emptyComponent'
+  | 'layout'
   | 'status'
   | 'sendEvent'
 >;
@@ -27,6 +28,7 @@ export type LookingSimilarProps<THit extends BaseHit> = Omit<
     itemComponent?: LookingSimilarPropsUiComponentProps<THit>['itemComponent'];
     headerComponent?: LookingSimilarPropsUiComponentProps<THit>['headerComponent'];
     emptyComponent?: LookingSimilarPropsUiComponentProps<THit>['emptyComponent'];
+    layoutComponent?: LookingSimilarPropsUiComponentProps<THit>['layout'];
   };
 
 const LookingSimilarUiComponent = createLookingSimilarComponent({
@@ -45,6 +47,7 @@ export function LookingSimilar<THit extends BaseHit = BaseHit>({
   itemComponent,
   headerComponent,
   emptyComponent,
+  layoutComponent,
   ...props
 }: LookingSimilarProps<THit>) {
   const { status } = useInstantSearch();
@@ -66,6 +69,7 @@ export function LookingSimilar<THit extends BaseHit = BaseHit>({
     itemComponent,
     headerComponent,
     emptyComponent,
+    layout: layoutComponent,
     status,
     sendEvent: () => {},
   };

--- a/packages/react-instantsearch/src/widgets/RelatedProducts.tsx
+++ b/packages/react-instantsearch/src/widgets/RelatedProducts.tsx
@@ -15,6 +15,7 @@ type UiProps<TItem extends BaseHit> = Pick<
   | 'itemComponent'
   | 'headerComponent'
   | 'emptyComponent'
+  | 'layout'
   | 'status'
   | 'sendEvent'
 >;
@@ -27,6 +28,7 @@ export type RelatedProductsProps<TItem extends BaseHit> = Omit<
     itemComponent?: RelatedProductsUiComponentProps<TItem>['itemComponent'];
     headerComponent?: RelatedProductsUiComponentProps<TItem>['headerComponent'];
     emptyComponent?: RelatedProductsUiComponentProps<TItem>['emptyComponent'];
+    layoutComponent?: RelatedProductsUiComponentProps<TItem>['layout'];
   };
 
 const RelatedProductsUiComponent = createRelatedProductsComponent({
@@ -45,6 +47,7 @@ export function RelatedProducts<TItem extends BaseHit = BaseHit>({
   itemComponent,
   headerComponent,
   emptyComponent,
+  layoutComponent,
   ...props
 }: RelatedProductsProps<TItem>) {
   const { status } = useInstantSearch();
@@ -66,6 +69,7 @@ export function RelatedProducts<TItem extends BaseHit = BaseHit>({
     itemComponent,
     headerComponent,
     emptyComponent,
+    layout: layoutComponent,
     status,
     sendEvent: () => {},
   };

--- a/packages/react-instantsearch/src/widgets/TrendingItems.tsx
+++ b/packages/react-instantsearch/src/widgets/TrendingItems.tsx
@@ -15,6 +15,7 @@ type UiProps<TItem extends BaseHit> = Pick<
   | 'itemComponent'
   | 'headerComponent'
   | 'emptyComponent'
+  | 'layout'
   | 'status'
   | 'sendEvent'
 >;
@@ -27,6 +28,7 @@ export type TrendingItemsProps<TItem extends BaseHit> = Omit<
     itemComponent?: TrendingItemsUiComponentProps<TItem>['itemComponent'];
     headerComponent?: TrendingItemsUiComponentProps<TItem>['headerComponent'];
     emptyComponent?: TrendingItemsUiComponentProps<TItem>['emptyComponent'];
+    layoutComponent?: TrendingItemsUiComponentProps<TItem>['layout'];
   };
 
 const TrendingItemsUiComponent = createTrendingItemsComponent({
@@ -46,6 +48,7 @@ export function TrendingItems<TItem extends BaseHit = BaseHit>({
   itemComponent,
   headerComponent,
   emptyComponent,
+  layoutComponent,
   ...props
 }: TrendingItemsProps<TItem>) {
   const facetParameters =
@@ -70,6 +73,7 @@ export function TrendingItems<TItem extends BaseHit = BaseHit>({
     itemComponent,
     headerComponent,
     emptyComponent,
+    layout: layoutComponent,
     status,
     sendEvent: () => {},
   };

--- a/packages/react-instantsearch/src/widgets/__tests__/FrequentlyBoughtTogether.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/FrequentlyBoughtTogether.test.tsx
@@ -7,6 +7,7 @@ import { InstantSearchTestWrapper } from '@instantsearch/testutils';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
+import { Carousel } from '../../templates/Carousel';
 import { FrequentlyBoughtTogether } from '../FrequentlyBoughtTogether';
 
 describe('FrequentlyBoughtTogether', () => {
@@ -80,5 +81,150 @@ describe('FrequentlyBoughtTogether', () => {
     const root = container.firstChild;
     expect(root).toHaveClass('MyFrequentlyBoughtTogether', 'ROOT');
     expect(root).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('renders custom layout component', async () => {
+    const client = createRecommendSearchClient({
+      minimal: true,
+    });
+    const { container } = render(
+      <InstantSearchTestWrapper searchClient={client}>
+        <FrequentlyBoughtTogether
+          objectIDs={['1']}
+          layoutComponent={({ items }) => (
+            <ul>
+              {items.map((item) => (
+                <li key={item.objectID}>
+                  <p>{item.objectID}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        />
+      </InstantSearchTestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ais-FrequentlyBoughtTogether'))
+        .toMatchInlineSnapshot(`
+        <section
+          class="ais-FrequentlyBoughtTogether"
+        >
+          <h3
+            class="ais-FrequentlyBoughtTogether-title"
+          >
+            Frequently bought together
+          </h3>
+          <ul>
+            <li>
+              <p>
+                1
+              </p>
+            </li>
+            <li>
+              <p>
+                2
+              </p>
+            </li>
+          </ul>
+        </section>
+        `);
+    });
+  });
+
+  test('renders Carousel as a layout component', async () => {
+    const client = createRecommendSearchClient({
+      minimal: true,
+    });
+    const { container } = render(
+      <InstantSearchTestWrapper searchClient={client}>
+        <FrequentlyBoughtTogether
+          objectIDs={['1']}
+          itemComponent={({ item }) => <p>{item.objectID}</p>}
+          layoutComponent={(props) => (
+            <Carousel
+              {...props}
+              previousIconComponent={() => <p>Previous</p>}
+              nextIconComponent={() => <p>Next</p>}
+            />
+          )}
+        />
+      </InstantSearchTestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ais-FrequentlyBoughtTogether'))
+        .toMatchInlineSnapshot(`
+        <section
+          class="ais-FrequentlyBoughtTogether"
+        >
+          <h3
+            class="ais-FrequentlyBoughtTogether-title"
+          >
+            Frequently bought together
+          </h3>
+          <div
+            class="ais-Carousel ais-FrequentlyBoughtTogether"
+          >
+            <button
+              aria-controls="ais-Carousel-0"
+              aria-label="Previous"
+              class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+              hidden=""
+              title="Previous"
+            >
+              <p>
+                Previous
+              </p>
+            </button>
+            <ol
+              aria-label="Items"
+              aria-live="polite"
+              aria-roledescription="carousel"
+              class="ais-Carousel-list ais-FrequentlyBoughtTogether-list"
+              id="ais-Carousel-0"
+              tabindex="0"
+            >
+              <li
+                aria-label="1 of 2"
+                aria-roledescription="slide"
+                class="ais-Carousel-item ais-FrequentlyBoughtTogether-item"
+              >
+                <p>
+                  1
+                </p>
+              </li>
+              <li
+                aria-label="2 of 2"
+                aria-roledescription="slide"
+                class="ais-Carousel-item ais-FrequentlyBoughtTogether-item"
+              >
+                <p>
+                  2
+                </p>
+              </li>
+            </ol>
+            <button
+              aria-controls="ais-Carousel-0"
+              aria-label="Next"
+              class="ais-Carousel-navigation ais-Carousel-navigation--next"
+              title="Next"
+            >
+              <p>
+                Next
+              </p>
+            </button>
+          </div>
+        </section>
+        `);
+    });
   });
 });

--- a/packages/react-instantsearch/src/widgets/__tests__/LookingSimilar.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/LookingSimilar.test.tsx
@@ -7,6 +7,7 @@ import { InstantSearchTestWrapper } from '@instantsearch/testutils';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
+import { Carousel } from '../../templates/Carousel';
 import { LookingSimilar } from '../LookingSimilar';
 
 describe('LookingSimilar', () => {
@@ -77,5 +78,150 @@ describe('LookingSimilar', () => {
     const root = container.firstChild;
     expect(root).toHaveClass('MyLookingSimilar', 'ROOT');
     expect(root).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('renders custom layout component', async () => {
+    const client = createRecommendSearchClient({
+      minimal: true,
+    });
+    const { container } = render(
+      <InstantSearchTestWrapper searchClient={client}>
+        <LookingSimilar
+          objectIDs={['1']}
+          layoutComponent={({ items }) => (
+            <ul>
+              {items.map((item) => (
+                <li key={item.objectID}>
+                  <p>{item.objectID}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        />
+      </InstantSearchTestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ais-LookingSimilar'))
+        .toMatchInlineSnapshot(`
+        <section
+          class="ais-LookingSimilar"
+        >
+          <h3
+            class="ais-LookingSimilar-title"
+          >
+            Looking similar
+          </h3>
+          <ul>
+            <li>
+              <p>
+                1
+              </p>
+            </li>
+            <li>
+              <p>
+                2
+              </p>
+            </li>
+          </ul>
+        </section>
+        `);
+    });
+  });
+
+  test('renders Carousel as a layout component', async () => {
+    const client = createRecommendSearchClient({
+      minimal: true,
+    });
+    const { container } = render(
+      <InstantSearchTestWrapper searchClient={client}>
+        <LookingSimilar
+          objectIDs={['1']}
+          itemComponent={({ item }) => <p>{item.objectID}</p>}
+          layoutComponent={(props) => (
+            <Carousel
+              {...props}
+              previousIconComponent={() => <p>Previous</p>}
+              nextIconComponent={() => <p>Next</p>}
+            />
+          )}
+        />
+      </InstantSearchTestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ais-LookingSimilar'))
+        .toMatchInlineSnapshot(`
+        <section
+          class="ais-LookingSimilar"
+        >
+          <h3
+            class="ais-LookingSimilar-title"
+          >
+            Looking similar
+          </h3>
+          <div
+            class="ais-Carousel ais-LookingSimilar"
+          >
+            <button
+              aria-controls="ais-Carousel-0"
+              aria-label="Previous"
+              class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+              hidden=""
+              title="Previous"
+            >
+              <p>
+                Previous
+              </p>
+            </button>
+            <ol
+              aria-label="Items"
+              aria-live="polite"
+              aria-roledescription="carousel"
+              class="ais-Carousel-list ais-LookingSimilar-list"
+              id="ais-Carousel-0"
+              tabindex="0"
+            >
+              <li
+                aria-label="1 of 2"
+                aria-roledescription="slide"
+                class="ais-Carousel-item ais-LookingSimilar-item"
+              >
+                <p>
+                  1
+                </p>
+              </li>
+              <li
+                aria-label="2 of 2"
+                aria-roledescription="slide"
+                class="ais-Carousel-item ais-LookingSimilar-item"
+              >
+                <p>
+                  2
+                </p>
+              </li>
+            </ol>
+            <button
+              aria-controls="ais-Carousel-0"
+              aria-label="Next"
+              class="ais-Carousel-navigation ais-Carousel-navigation--next"
+              title="Next"
+            >
+              <p>
+                Next
+              </p>
+            </button>
+          </div>
+        </section>
+        `);
+    });
   });
 });

--- a/packages/react-instantsearch/src/widgets/__tests__/RelatedProducts.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/RelatedProducts.test.tsx
@@ -7,6 +7,7 @@ import { InstantSearchTestWrapper } from '@instantsearch/testutils';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
+import { Carousel } from '../../templates/Carousel';
 import { RelatedProducts } from '../RelatedProducts';
 
 describe('RelatedProducts', () => {
@@ -80,5 +81,156 @@ describe('RelatedProducts', () => {
     const root = container.firstChild;
     expect(root).toHaveClass('MyRelatedProducts', 'ROOT');
     expect(root).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('renders with a custom layout', async () => {
+    const client = createRecommendSearchClient({
+      minimal: true,
+    });
+
+    const { container } = render(
+      <InstantSearchTestWrapper searchClient={client}>
+        <RelatedProducts
+          objectIDs={['1']}
+          layoutComponent={({ items }) => {
+            return (
+              <ul>
+                {items.map((item) => (
+                  <li key={item.objectID}>
+                    <p>{item.objectID}</p>
+                  </li>
+                ))}
+              </ul>
+            );
+          }}
+        />
+      </InstantSearchTestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ais-RelatedProducts'))
+        .toMatchInlineSnapshot(`
+        <section
+          class="ais-RelatedProducts"
+        >
+          <h3
+            class="ais-RelatedProducts-title"
+          >
+            Related products
+          </h3>
+          <ul>
+            <li>
+              <p>
+                1
+              </p>
+            </li>
+            <li>
+              <p>
+                2
+              </p>
+            </li>
+          </ul>
+        </section>
+        `);
+    });
+  });
+
+  test('renders with Carousel layout', async () => {
+    const client = createRecommendSearchClient({
+      minimal: true,
+    });
+
+    const { container } = render(
+      <InstantSearchTestWrapper searchClient={client}>
+        <RelatedProducts
+          objectIDs={['1']}
+          itemComponent={({ item }) => <p>{item.objectID}</p>}
+          layoutComponent={(props) => {
+            return (
+              <Carousel
+                {...props}
+                previousIconComponent={() => <p>Previous</p>}
+                nextIconComponent={() => <p>Next</p>}
+              />
+            );
+          }}
+        />
+      </InstantSearchTestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ais-RelatedProducts'))
+        .toMatchInlineSnapshot(`
+        <section
+          class="ais-RelatedProducts"
+        >
+          <h3
+            class="ais-RelatedProducts-title"
+          >
+            Related products
+          </h3>
+          <div
+            class="ais-Carousel ais-RelatedProducts"
+          >
+            <button
+              aria-controls="ais-Carousel-0"
+              aria-label="Previous"
+              class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+              hidden=""
+              title="Previous"
+            >
+              <p>
+                Previous
+              </p>
+            </button>
+            <ol
+              aria-label="Items"
+              aria-live="polite"
+              aria-roledescription="carousel"
+              class="ais-Carousel-list ais-RelatedProducts-list"
+              id="ais-Carousel-0"
+              tabindex="0"
+            >
+              <li
+                aria-label="1 of 2"
+                aria-roledescription="slide"
+                class="ais-Carousel-item ais-RelatedProducts-item"
+              >
+                <p>
+                  1
+                </p>
+              </li>
+              <li
+                aria-label="2 of 2"
+                aria-roledescription="slide"
+                class="ais-Carousel-item ais-RelatedProducts-item"
+              >
+                <p>
+                  2
+                </p>
+              </li>
+            </ol>
+            <button
+              aria-controls="ais-Carousel-0"
+              aria-label="Next"
+              class="ais-Carousel-navigation ais-Carousel-navigation--next"
+              title="Next"
+            >
+              <p>
+                Next
+              </p>
+            </button>
+          </div>
+        </section>
+        `);
+    });
   });
 });

--- a/packages/react-instantsearch/src/widgets/__tests__/TrendingItems.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/TrendingItems.test.tsx
@@ -7,6 +7,7 @@ import { InstantSearchTestWrapper } from '@instantsearch/testutils';
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
+import { Carousel } from '../../templates/Carousel';
 import { TrendingItems } from '../TrendingItems';
 
 describe('TrendingItems', () => {
@@ -76,5 +77,148 @@ describe('TrendingItems', () => {
     const root = container.firstChild;
     expect(root).toHaveClass('MyTrendingItems', 'ROOT');
     expect(root).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('renders custom layout component', async () => {
+    const client = createRecommendSearchClient({
+      minimal: true,
+    });
+    const { container } = render(
+      <InstantSearchTestWrapper searchClient={client}>
+        <TrendingItems
+          layoutComponent={({ items }) => (
+            <ul>
+              {items.map((item) => (
+                <li key={item.objectID}>
+                  <p>{item.objectID}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        />
+      </InstantSearchTestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ais-TrendingItems'))
+        .toMatchInlineSnapshot(`
+        <section
+          class="ais-TrendingItems"
+        >
+          <h3
+            class="ais-TrendingItems-title"
+          >
+            Trending items
+          </h3>
+          <ul>
+            <li>
+              <p>
+                1
+              </p>
+            </li>
+            <li>
+              <p>
+                2
+              </p>
+            </li>
+          </ul>
+        </section>
+        `);
+    });
+  });
+
+  test('renders Carousel as a layout component', async () => {
+    const client = createRecommendSearchClient({
+      minimal: true,
+    });
+    const { container } = render(
+      <InstantSearchTestWrapper searchClient={client}>
+        <TrendingItems
+          itemComponent={({ item }) => <p>{item.objectID}</p>}
+          layoutComponent={(props) => (
+            <Carousel
+              {...props}
+              previousIconComponent={() => <p>Previous</p>}
+              nextIconComponent={() => <p>Next</p>}
+            />
+          )}
+        />
+      </InstantSearchTestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('.ais-TrendingItems'))
+        .toMatchInlineSnapshot(`
+        <section
+          class="ais-TrendingItems"
+        >
+          <h3
+            class="ais-TrendingItems-title"
+          >
+            Trending items
+          </h3>
+          <div
+            class="ais-Carousel ais-TrendingItems"
+          >
+            <button
+              aria-controls="ais-Carousel-0"
+              aria-label="Previous"
+              class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+              hidden=""
+              title="Previous"
+            >
+              <p>
+                Previous
+              </p>
+            </button>
+            <ol
+              aria-label="Items"
+              aria-live="polite"
+              aria-roledescription="carousel"
+              class="ais-Carousel-list ais-TrendingItems-list"
+              id="ais-Carousel-0"
+              tabindex="0"
+            >
+              <li
+                aria-label="1 of 2"
+                aria-roledescription="slide"
+                class="ais-Carousel-item ais-TrendingItems-item"
+              >
+                <p>
+                  1
+                </p>
+              </li>
+              <li
+                aria-label="2 of 2"
+                aria-roledescription="slide"
+                class="ais-Carousel-item ais-TrendingItems-item"
+              >
+                <p>
+                  2
+                </p>
+              </li>
+            </ol>
+            <button
+              aria-controls="ais-Carousel-0"
+              aria-label="Next"
+              class="ais-Carousel-navigation ais-Carousel-navigation--next"
+              title="Next"
+            >
+              <p>
+                Next
+              </p>
+            </button>
+          </div>
+        </section>
+        `);
+    });
   });
 });


### PR DESCRIPTION
This adds the the `Carousel` layout component and enables the `layoutComponent` prop in Recommend widgets. React getting started example has been update to use `Carousel` as well.

<img width="951" alt="image" src="https://github.com/user-attachments/assets/4388e3b4-bd25-40f6-9e60-690796dc09e6">


https://algolia.atlassian.net/browse/FX-2819

TODO: fix Recommend widget prop types