### PR TITLE
fix(instantsearch.js): forward widget classes to carousel

### DIFF
--- a/examples/js/getting-started/src/app.css
+++ b/examples/js/getting-started/src/app.css
@@ -78,8 +78,20 @@
 
 .ais-TrendingItems-item,
 .ais-RelatedProducts-item {
+  background: none !important;
+  align-items: stretch !important;
+  padding: 0 !important;
+  box-shadow: none !important;
+}
+
+.ais-TrendingItems-item > div,
+.ais-RelatedProducts-item > div {
   align-items: start;
-  height: 100%;
+  background: #fff;
+  align-items: center;
+  padding: 1.5rem;
+  display: flex;
+  box-shadow: 0 0 0 1px #23263b0d, 0 1px 3px #23263b26;
 }
 
 .ais-TrendingItems-item img,
@@ -107,12 +119,12 @@
 }
 
 .ais-Carousel-item {
-  padding: 0.5rem;
+  padding: 0.5rem !important;
 }
 
 .ais-Carousel-list {
-  margin: -0.5rem;
-  grid-auto-columns: calc(22% - 0.5rem);
+  margin: -0.5rem !important;
+  grid-auto-columns: calc(22% - 0.5rem) !important;
 }
 
 .ais-Carousel::before,

--- a/examples/js/getting-started/src/app.js
+++ b/examples/js/getting-started/src/app.js
@@ -61,7 +61,7 @@ search.addWidgets([
     limit: 6,
     templates: {
       item: (item, { html }) => html`
-        <div class="ais-TrendingItems-item">
+        <div>
           <article>
             <div>
               <img src="${item.image}" />

--- a/examples/js/getting-started/src/products.js
+++ b/examples/js/getting-started/src/products.js
@@ -42,7 +42,7 @@ search.addWidgets([
     limit: 6,
     templates: {
       item: (item, { html }) => html`
-        <div class="ais-RelatedProducts-item">
+        <div>
           <article>
             <div>
               <img src="${item.image}" />

--- a/packages/instantsearch.js/src/templates/__tests__/carousel.test.tsx
+++ b/packages/instantsearch.js/src/templates/__tests__/carousel.test.tsx
@@ -224,4 +224,42 @@ describe('carousel', () => {
       </div>
     `);
   });
+
+  test('forwards additional CSS classes', () => {
+    const template = carousel({
+      cssClasses: {
+        root: 'ROOT',
+        list: 'LIST',
+        item: 'ITEM',
+        navigation: 'NAVIGATION',
+        navigationNext: 'NAVIGATION_NEXT',
+        navigationPrevious: 'NAVIGATION_PREVIOUS',
+      },
+    });
+
+    const { container } = render(
+      template({
+        items: [
+          { objectID: '1', __position: 1 },
+          { objectID: '2', __position: 2 },
+        ],
+        templates: {
+          item({ item }) {
+            return <p>{item}</p>;
+          },
+        },
+        cssClasses: {
+          list: 'EXTRA_LIST',
+          item: 'EXTRA_ITEM',
+        },
+      })
+    );
+
+    expect(container.querySelector('.ais-Carousel-list')).toHaveClass(
+      'LIST EXTRA_LIST'
+    );
+    expect(container.querySelector('.ais-Carousel-item')).toHaveClass(
+      'ITEM EXTRA_ITEM'
+    );
+  });
 });

--- a/packages/instantsearch.js/src/templates/carousel/carousel.tsx
+++ b/packages/instantsearch.js/src/templates/carousel/carousel.tsx
@@ -55,7 +55,7 @@ type CarouselTemplateProps<TObject extends Record<string, unknown>> = Pick<
   templates: {
     item?: CarouselUiProps<TObject>['itemComponent'];
   };
-  cssClasses: Partial<CarouselUiProps<TObject>['classNames']>;
+  cssClasses?: Partial<CarouselUiProps<TObject>['classNames']>;
 };
 
 export function carousel<TObject extends Record<string, unknown>>({
@@ -65,7 +65,7 @@ export function carousel<TObject extends Record<string, unknown>>({
   return function CarouselTemplate({
     items,
     templates: widgetTemplates,
-    cssClasses: widgetCssClasses,
+    cssClasses: widgetCssClasses = {},
   }: CarouselTemplateProps<TObject>) {
     const { previous, next } = templates;
 

--- a/packages/instantsearch.js/src/templates/carousel/carousel.tsx
+++ b/packages/instantsearch.js/src/templates/carousel/carousel.tsx
@@ -3,6 +3,7 @@
 import { html } from 'htm/preact';
 import {
   createCarouselComponent,
+  cx,
   generateCarouselId,
 } from 'instantsearch-ui-components';
 import { Fragment, h } from 'preact';
@@ -54,6 +55,7 @@ type CarouselTemplateProps<TObject extends Record<string, unknown>> = Pick<
   templates: {
     item?: CarouselUiProps<TObject>['itemComponent'];
   };
+  cssClasses: Partial<CarouselUiProps<TObject>['classNames']>;
 };
 
 export function carousel<TObject extends Record<string, unknown>>({
@@ -62,14 +64,15 @@ export function carousel<TObject extends Record<string, unknown>>({
 }: CreateCarouselTemplateProps<TObject> = {}) {
   return function CarouselTemplate({
     items,
-    templates: userTemplates,
+    templates: widgetTemplates,
+    cssClasses: widgetCssClasses,
   }: CarouselTemplateProps<TObject>) {
     const { previous, next } = templates;
 
     return (
       <CarouselWithRefs
         items={items}
-        itemComponent={userTemplates.item}
+        itemComponent={widgetTemplates.item}
         previousIconComponent={
           (previous
             ? () => previous({ html })
@@ -80,7 +83,13 @@ export function carousel<TObject extends Record<string, unknown>>({
             ? () => next({ html })
             : undefined) as CarouselUiProps<TObject>['nextIconComponent']
         }
-        classNames={cssClasses}
+        classNames={{
+          ...cssClasses,
+          ...{
+            list: cx(cssClasses?.list, widgetCssClasses?.list),
+            item: cx(cssClasses?.item, widgetCssClasses?.item),
+          },
+        }}
       />
     );
   };

--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/__tests__/frequently-bought-together.test.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/__tests__/frequently-bought-together.test.tsx
@@ -309,7 +309,7 @@ describe('frequentlyBoughtTogether', () => {
       `);
     });
 
-    test('renders with a carousel layout using `html`', async () => {
+    test('renders with a carousel layout without options using `html`', async () => {
       const container = document.createElement('div');
       const searchClient = createRecommendSearchClient();
       const options: Parameters<typeof frequentlyBoughtTogether>[0] = {
@@ -319,11 +319,124 @@ describe('frequentlyBoughtTogether', () => {
           item(hit, { html }) {
             return html`<p>${hit.objectID}</p>`;
           },
+          layout: carousel(),
+        },
+      };
+
+      const search = instantsearch({ indexName: 'indexName', searchClient });
+      const widget = frequentlyBoughtTogether(options);
+
+      search.addWidgets([widget]);
+      search.start();
+
+      await wait(0);
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <section
+            class="ais-FrequentlyBoughtTogether"
+          >
+            <h3
+              class="ais-FrequentlyBoughtTogether-title"
+            >
+              Frequently bought together
+            </h3>
+            <div
+              class="ais-Carousel"
+            >
+              <button
+                aria-controls="ais-Carousel-0"
+                aria-label="Previous"
+                class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+                hidden=""
+                title="Previous"
+              >
+                <svg
+                  fill="none"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  width="8"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M7.13809 0.744078C7.39844 1.06951 7.39844 1.59715 7.13809 1.92259L2.27616 8L7.13809 14.0774C7.39844 14.4028 7.39844 14.9305 7.13809 15.2559C6.87774 15.5814 6.45563 15.5814 6.19528 15.2559L0.861949 8.58926C0.6016 8.26382 0.6016 7.73618 0.861949 7.41074L6.19528 0.744078C6.45563 0.418641 6.87774 0.418641 7.13809 0.744078Z"
+                    fill="currentColor"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </button>
+              <ol
+                aria-label="Items"
+                aria-live="polite"
+                aria-roledescription="carousel"
+                class="ais-Carousel-list ais-FrequentlyBoughtTogether-list"
+                id="ais-Carousel-0"
+                tabindex="0"
+              >
+                <li
+                  aria-label="1 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ais-FrequentlyBoughtTogether-item"
+                >
+                  <p>
+                    1
+                  </p>
+                </li>
+                <li
+                  aria-label="2 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ais-FrequentlyBoughtTogether-item"
+                >
+                  <p>
+                    2
+                  </p>
+                </li>
+              </ol>
+              <button
+                aria-controls="ais-Carousel-0"
+                aria-label="Next"
+                class="ais-Carousel-navigation ais-Carousel-navigation--next"
+                title="Next"
+              >
+                <svg
+                  fill="none"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  width="8"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M0.861908 15.2559C0.601559 14.9305 0.601559 14.4028 0.861908 14.0774L5.72384 8L0.861908 1.92259C0.601559 1.59715 0.601559 1.06952 0.861908 0.744079C1.12226 0.418642 1.54437 0.418642 1.80472 0.744079L7.13805 7.41074C7.3984 7.73618 7.3984 8.26382 7.13805 8.58926L1.80472 15.2559C1.54437 15.5814 1.12226 15.5814 0.861908 15.2559Z"
+                    fill="currentColor"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+          </section>
+        </div>
+      `);
+    });
+
+    test('renders with a carousel layout with options using `html`', async () => {
+      const container = document.createElement('div');
+      const searchClient = createRecommendSearchClient();
+      const options: Parameters<typeof frequentlyBoughtTogether>[0] = {
+        container,
+        objectIDs: ['1'],
+        cssClasses: {
+          list: 'WIDGET_LIST',
+          item: 'WIDGET_ITEM',
+        },
+        templates: {
+          item(hit, { html }) {
+            return html`<p>${hit.objectID}</p>`;
+          },
           layout: carousel({
             cssClasses: {
               root: 'ROOT',
-              list: 'LIST',
-              item: 'ITEM',
+              list: 'LAYOUT_LIST',
+              item: 'LAYOUT_ITEM',
               navigation: 'NAVIGATION',
               navigationNext: 'NAVIGATION_NEXT',
               navigationPrevious: 'NAVIGATION_PREVIOUS',
@@ -362,7 +475,7 @@ describe('frequentlyBoughtTogether', () => {
               class="ais-Carousel ROOT"
             >
               <button
-                aria-controls="ais-Carousel-0"
+                aria-controls="ais-Carousel-1"
                 aria-label="Previous"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--previous NAVIGATION_PREVIOUS"
                 hidden=""
@@ -376,14 +489,14 @@ describe('frequentlyBoughtTogether', () => {
                 aria-label="Items"
                 aria-live="polite"
                 aria-roledescription="carousel"
-                class="ais-Carousel-list LIST"
-                id="ais-Carousel-0"
+                class="ais-Carousel-list LAYOUT_LIST ais-FrequentlyBoughtTogether-list WIDGET_LIST"
+                id="ais-Carousel-1"
                 tabindex="0"
               >
                 <li
                   aria-label="1 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item LAYOUT_ITEM ais-FrequentlyBoughtTogether-item WIDGET_ITEM"
                 >
                   <p>
                     1
@@ -392,7 +505,7 @@ describe('frequentlyBoughtTogether', () => {
                 <li
                   aria-label="2 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item LAYOUT_ITEM ais-FrequentlyBoughtTogether-item WIDGET_ITEM"
                 >
                   <p>
                     2
@@ -400,7 +513,7 @@ describe('frequentlyBoughtTogether', () => {
                 </li>
               </ol>
               <button
-                aria-controls="ais-Carousel-0"
+                aria-controls="ais-Carousel-1"
                 aria-label="Next"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
                 title="Next"
@@ -562,7 +675,7 @@ describe('frequentlyBoughtTogether', () => {
       `);
     });
 
-    test('renders with a carousel layout using JSX', async () => {
+    test('renders with a carousel layout without options using JSX', async () => {
       const container = document.createElement('div');
       const searchClient = createRecommendSearchClient();
       const options: Parameters<typeof frequentlyBoughtTogether>[0] = {
@@ -572,11 +685,124 @@ describe('frequentlyBoughtTogether', () => {
           item(hit) {
             return <p>{hit.objectID}</p>;
           },
+          layout: carousel(),
+        },
+      };
+
+      const search = instantsearch({ indexName: 'indexName', searchClient });
+      const widget = frequentlyBoughtTogether(options);
+
+      search.addWidgets([widget]);
+      search.start();
+
+      await wait(0);
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <section
+            class="ais-FrequentlyBoughtTogether"
+          >
+            <h3
+              class="ais-FrequentlyBoughtTogether-title"
+            >
+              Frequently bought together
+            </h3>
+            <div
+              class="ais-Carousel"
+            >
+              <button
+                aria-controls="ais-Carousel-2"
+                aria-label="Previous"
+                class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+                hidden=""
+                title="Previous"
+              >
+                <svg
+                  fill="none"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  width="8"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M7.13809 0.744078C7.39844 1.06951 7.39844 1.59715 7.13809 1.92259L2.27616 8L7.13809 14.0774C7.39844 14.4028 7.39844 14.9305 7.13809 15.2559C6.87774 15.5814 6.45563 15.5814 6.19528 15.2559L0.861949 8.58926C0.6016 8.26382 0.6016 7.73618 0.861949 7.41074L6.19528 0.744078C6.45563 0.418641 6.87774 0.418641 7.13809 0.744078Z"
+                    fill="currentColor"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </button>
+              <ol
+                aria-label="Items"
+                aria-live="polite"
+                aria-roledescription="carousel"
+                class="ais-Carousel-list ais-FrequentlyBoughtTogether-list"
+                id="ais-Carousel-2"
+                tabindex="0"
+              >
+                <li
+                  aria-label="1 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ais-FrequentlyBoughtTogether-item"
+                >
+                  <p>
+                    1
+                  </p>
+                </li>
+                <li
+                  aria-label="2 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ais-FrequentlyBoughtTogether-item"
+                >
+                  <p>
+                    2
+                  </p>
+                </li>
+              </ol>
+              <button
+                aria-controls="ais-Carousel-2"
+                aria-label="Next"
+                class="ais-Carousel-navigation ais-Carousel-navigation--next"
+                title="Next"
+              >
+                <svg
+                  fill="none"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  width="8"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M0.861908 15.2559C0.601559 14.9305 0.601559 14.4028 0.861908 14.0774L5.72384 8L0.861908 1.92259C0.601559 1.59715 0.601559 1.06952 0.861908 0.744079C1.12226 0.418642 1.54437 0.418642 1.80472 0.744079L7.13805 7.41074C7.3984 7.73618 7.3984 8.26382 7.13805 8.58926L1.80472 15.2559C1.54437 15.5814 1.12226 15.5814 0.861908 15.2559Z"
+                    fill="currentColor"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+          </section>
+        </div>
+      `);
+    });
+
+    test('renders with a carousel layout with options using JSX', async () => {
+      const container = document.createElement('div');
+      const searchClient = createRecommendSearchClient();
+      const options: Parameters<typeof frequentlyBoughtTogether>[0] = {
+        container,
+        objectIDs: ['1'],
+        cssClasses: {
+          list: 'WIDGET_LIST',
+          item: 'WIDGET_ITEM',
+        },
+        templates: {
+          item(hit) {
+            return <p>{hit.objectID}</p>;
+          },
           layout: carousel({
             cssClasses: {
               root: 'ROOT',
-              list: 'LIST',
-              item: 'ITEM',
+              list: 'LAYOUT_LIST',
+              item: 'LAYOUT_ITEM',
               navigation: 'NAVIGATION',
               navigationNext: 'NAVIGATION_NEXT',
               navigationPrevious: 'NAVIGATION_PREVIOUS',
@@ -615,7 +841,7 @@ describe('frequentlyBoughtTogether', () => {
               class="ais-Carousel ROOT"
             >
               <button
-                aria-controls="ais-Carousel-1"
+                aria-controls="ais-Carousel-3"
                 aria-label="Previous"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--previous NAVIGATION_PREVIOUS"
                 hidden=""
@@ -629,14 +855,14 @@ describe('frequentlyBoughtTogether', () => {
                 aria-label="Items"
                 aria-live="polite"
                 aria-roledescription="carousel"
-                class="ais-Carousel-list LIST"
-                id="ais-Carousel-1"
+                class="ais-Carousel-list LAYOUT_LIST ais-FrequentlyBoughtTogether-list WIDGET_LIST"
+                id="ais-Carousel-3"
                 tabindex="0"
               >
                 <li
                   aria-label="1 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item LAYOUT_ITEM ais-FrequentlyBoughtTogether-item WIDGET_ITEM"
                 >
                   <p>
                     1
@@ -645,7 +871,7 @@ describe('frequentlyBoughtTogether', () => {
                 <li
                   aria-label="2 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item LAYOUT_ITEM ais-FrequentlyBoughtTogether-item WIDGET_ITEM"
                 >
                   <p>
                     2
@@ -653,7 +879,7 @@ describe('frequentlyBoughtTogether', () => {
                 </li>
               </ol>
               <button
-                aria-controls="ais-Carousel-1"
+                aria-controls="ais-Carousel-3"
                 aria-label="Next"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
                 title="Next"

--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
@@ -132,6 +132,10 @@ const renderer =
                       )
                     : undefined,
                 },
+                cssClasses: {
+                  list: data.classNames.list,
+                  item: data.classNames.item,
+                },
               }}
             />
           )
@@ -195,6 +199,7 @@ export type FrequentlyBoughtTogetherTemplates<
       templates: {
         item: FrequentlyBoughtTogetherUiProps<Hit>['itemComponent'];
       };
+      cssClasses: Pick<FrequentlyBoughtTogetherCSSClasses, 'list' | 'item'>;
     }
   >;
 }>;

--- a/packages/instantsearch.js/src/widgets/looking-similar/__tests__/looking-similar.test.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/__tests__/looking-similar.test.tsx
@@ -310,7 +310,7 @@ describe('lookingSimilar', () => {
       `);
     });
 
-    test('renders with a carousel layout using `html`', async () => {
+    test('renders with a carousel layout without options using `html`', async () => {
       const container = document.createElement('div');
       const searchClient = createRecommendSearchClient();
       const options: Parameters<typeof lookingSimilar>[0] = {
@@ -377,14 +377,14 @@ describe('lookingSimilar', () => {
                 aria-label="Items"
                 aria-live="polite"
                 aria-roledescription="carousel"
-                class="ais-Carousel-list LIST"
+                class="ais-Carousel-list LIST ais-LookingSimilar-list"
                 id="ais-Carousel-0"
                 tabindex="0"
               >
                 <li
                   aria-label="1 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-LookingSimilar-item"
                 >
                   <p>
                     1
@@ -393,7 +393,7 @@ describe('lookingSimilar', () => {
                 <li
                   aria-label="2 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-LookingSimilar-item"
                 >
                   <p>
                     2
@@ -402,6 +402,112 @@ describe('lookingSimilar', () => {
               </ol>
               <button
                 aria-controls="ais-Carousel-0"
+                aria-label="Next"
+                class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
+                title="Next"
+              >
+                <p>
+                  Next
+                </p>
+              </button>
+            </div>
+          </section>
+        </div>
+      `);
+    });
+
+    test('renders with a carousel layout with options using `html`', async () => {
+      const container = document.createElement('div');
+      const searchClient = createRecommendSearchClient();
+      const options: Parameters<typeof lookingSimilar>[0] = {
+        container,
+        objectIDs: ['1'],
+        templates: {
+          item(hit, { html }) {
+            return html`<p>${hit.objectID}</p>`;
+          },
+          layout: carousel({
+            cssClasses: {
+              root: 'ROOT',
+              list: 'LIST',
+              item: 'ITEM',
+              navigation: 'NAVIGATION',
+              navigationNext: 'NAVIGATION_NEXT',
+              navigationPrevious: 'NAVIGATION_PREVIOUS',
+            },
+            templates: {
+              previous({ html }) {
+                return html`<p>Previous</p>`;
+              },
+              next({ html }) {
+                return html`<p>Next</p>`;
+              },
+            },
+          }),
+        },
+      };
+
+      const search = instantsearch({ indexName: 'indexName', searchClient });
+      const widget = lookingSimilar(options);
+
+      search.addWidgets([widget]);
+      search.start();
+
+      await wait(0);
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <section
+            class="ais-LookingSimilar"
+          >
+            <h3
+              class="ais-LookingSimilar-title"
+            >
+              Looking similar
+            </h3>
+            <div
+              class="ais-Carousel ROOT"
+            >
+              <button
+                aria-controls="ais-Carousel-1"
+                aria-label="Previous"
+                class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--previous NAVIGATION_PREVIOUS"
+                hidden=""
+                title="Previous"
+              >
+                <p>
+                  Previous
+                </p>
+              </button>
+              <ol
+                aria-label="Items"
+                aria-live="polite"
+                aria-roledescription="carousel"
+                class="ais-Carousel-list LIST ais-LookingSimilar-list"
+                id="ais-Carousel-1"
+                tabindex="0"
+              >
+                <li
+                  aria-label="1 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ITEM ais-LookingSimilar-item"
+                >
+                  <p>
+                    1
+                  </p>
+                </li>
+                <li
+                  aria-label="2 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ITEM ais-LookingSimilar-item"
+                >
+                  <p>
+                    2
+                  </p>
+                </li>
+              </ol>
+              <button
+                aria-controls="ais-Carousel-1"
                 aria-label="Next"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
                 title="Next"
@@ -563,7 +669,7 @@ describe('lookingSimilar', () => {
       `);
     });
 
-    test('renders with a carousel layout using JSX', async () => {
+    test('renders with a carousel layout without options using JSX', async () => {
       const container = document.createElement('div');
       const searchClient = createRecommendSearchClient();
       const options: Parameters<typeof lookingSimilar>[0] = {
@@ -616,7 +722,7 @@ describe('lookingSimilar', () => {
               class="ais-Carousel ROOT"
             >
               <button
-                aria-controls="ais-Carousel-1"
+                aria-controls="ais-Carousel-2"
                 aria-label="Previous"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--previous NAVIGATION_PREVIOUS"
                 hidden=""
@@ -630,14 +736,14 @@ describe('lookingSimilar', () => {
                 aria-label="Items"
                 aria-live="polite"
                 aria-roledescription="carousel"
-                class="ais-Carousel-list LIST"
-                id="ais-Carousel-1"
+                class="ais-Carousel-list LIST ais-LookingSimilar-list"
+                id="ais-Carousel-2"
                 tabindex="0"
               >
                 <li
                   aria-label="1 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-LookingSimilar-item"
                 >
                   <p>
                     1
@@ -646,7 +752,7 @@ describe('lookingSimilar', () => {
                 <li
                   aria-label="2 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-LookingSimilar-item"
                 >
                   <p>
                     2
@@ -654,7 +760,113 @@ describe('lookingSimilar', () => {
                 </li>
               </ol>
               <button
-                aria-controls="ais-Carousel-1"
+                aria-controls="ais-Carousel-2"
+                aria-label="Next"
+                class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
+                title="Next"
+              >
+                <p>
+                  Next
+                </p>
+              </button>
+            </div>
+          </section>
+        </div>
+      `);
+    });
+
+    test('renders with a carousel layout with options using JSX', async () => {
+      const container = document.createElement('div');
+      const searchClient = createRecommendSearchClient();
+      const options: Parameters<typeof lookingSimilar>[0] = {
+        container,
+        objectIDs: ['1'],
+        templates: {
+          item(hit) {
+            return <p>{hit.objectID}</p>;
+          },
+          layout: carousel({
+            cssClasses: {
+              root: 'ROOT',
+              list: 'LIST',
+              item: 'ITEM',
+              navigation: 'NAVIGATION',
+              navigationNext: 'NAVIGATION_NEXT',
+              navigationPrevious: 'NAVIGATION_PREVIOUS',
+            },
+            templates: {
+              previous() {
+                return <p>Previous</p>;
+              },
+              next() {
+                return <p>Next</p>;
+              },
+            },
+          }),
+        },
+      };
+
+      const search = instantsearch({ indexName: 'indexName', searchClient });
+      const widget = lookingSimilar(options);
+
+      search.addWidgets([widget]);
+      search.start();
+
+      await wait(0);
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <section
+            class="ais-LookingSimilar"
+          >
+            <h3
+              class="ais-LookingSimilar-title"
+            >
+              Looking similar
+            </h3>
+            <div
+              class="ais-Carousel ROOT"
+            >
+              <button
+                aria-controls="ais-Carousel-3"
+                aria-label="Previous"
+                class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--previous NAVIGATION_PREVIOUS"
+                hidden=""
+                title="Previous"
+              >
+                <p>
+                  Previous
+                </p>
+              </button>
+              <ol
+                aria-label="Items"
+                aria-live="polite"
+                aria-roledescription="carousel"
+                class="ais-Carousel-list LIST ais-LookingSimilar-list"
+                id="ais-Carousel-3"
+                tabindex="0"
+              >
+                <li
+                  aria-label="1 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ITEM ais-LookingSimilar-item"
+                >
+                  <p>
+                    1
+                  </p>
+                </li>
+                <li
+                  aria-label="2 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ITEM ais-LookingSimilar-item"
+                >
+                  <p>
+                    2
+                  </p>
+                </li>
+              </ol>
+              <button
+                aria-controls="ais-Carousel-3"
                 aria-label="Next"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
                 title="Next"

--- a/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
@@ -128,6 +128,10 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
                       )
                     : undefined,
                 },
+                cssClasses: {
+                  list: data.classNames.list,
+                  item: data.classNames.item,
+                },
               }}
             />
           )
@@ -187,7 +191,7 @@ export type LookingSimilarTemplates<
     > & {
       templates: {
         item: LookingSimilarUiProps<Hit>['itemComponent'];
-      };
+      } & { cssClasses: Pick<LookingSimilarCSSClasses, 'list' | 'item'> };
     }
   >;
 }>;

--- a/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
@@ -191,7 +191,8 @@ export type LookingSimilarTemplates<
     > & {
       templates: {
         item: LookingSimilarUiProps<Hit>['itemComponent'];
-      } & { cssClasses: Pick<LookingSimilarCSSClasses, 'list' | 'item'> };
+      };
+      cssClasses: Pick<LookingSimilarCSSClasses, 'list' | 'item'>;
     }
   >;
 }>;

--- a/packages/instantsearch.js/src/widgets/related-products/__tests__/related-products.test.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/__tests__/related-products.test.tsx
@@ -309,7 +309,116 @@ describe('relatedProducts', () => {
       `);
     });
 
-    test('renders with a carousel layout using `html`', async () => {
+    test('renders with a carousel layout without options using `html`', async () => {
+      const container = document.createElement('div');
+      const searchClient = createRecommendSearchClient();
+      const options: Parameters<typeof relatedProducts>[0] = {
+        container,
+        objectIDs: ['1'],
+        templates: {
+          item(hit, { html }) {
+            return html`<p>${hit.objectID}</p>`;
+          },
+          layout: carousel(),
+        },
+      };
+
+      const search = instantsearch({ indexName: 'indexName', searchClient });
+      const widget = relatedProducts(options);
+
+      search.addWidgets([widget]);
+      search.start();
+
+      await wait(0);
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <section
+            class="ais-RelatedProducts"
+          >
+            <h3
+              class="ais-RelatedProducts-title"
+            >
+              Related products
+            </h3>
+            <div
+              class="ais-Carousel"
+            >
+              <button
+                aria-controls="ais-Carousel-0"
+                aria-label="Previous"
+                class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+                hidden=""
+                title="Previous"
+              >
+                <svg
+                  fill="none"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  width="8"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M7.13809 0.744078C7.39844 1.06951 7.39844 1.59715 7.13809 1.92259L2.27616 8L7.13809 14.0774C7.39844 14.4028 7.39844 14.9305 7.13809 15.2559C6.87774 15.5814 6.45563 15.5814 6.19528 15.2559L0.861949 8.58926C0.6016 8.26382 0.6016 7.73618 0.861949 7.41074L6.19528 0.744078C6.45563 0.418641 6.87774 0.418641 7.13809 0.744078Z"
+                    fill="currentColor"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </button>
+              <ol
+                aria-label="Items"
+                aria-live="polite"
+                aria-roledescription="carousel"
+                class="ais-Carousel-list ais-RelatedProducts-list"
+                id="ais-Carousel-0"
+                tabindex="0"
+              >
+                <li
+                  aria-label="1 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ais-RelatedProducts-item"
+                >
+                  <p>
+                    1
+                  </p>
+                </li>
+                <li
+                  aria-label="2 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ais-RelatedProducts-item"
+                >
+                  <p>
+                    2
+                  </p>
+                </li>
+              </ol>
+              <button
+                aria-controls="ais-Carousel-0"
+                aria-label="Next"
+                class="ais-Carousel-navigation ais-Carousel-navigation--next"
+                title="Next"
+              >
+                <svg
+                  fill="none"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  width="8"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M0.861908 15.2559C0.601559 14.9305 0.601559 14.4028 0.861908 14.0774L5.72384 8L0.861908 1.92259C0.601559 1.59715 0.601559 1.06952 0.861908 0.744079C1.12226 0.418642 1.54437 0.418642 1.80472 0.744079L7.13805 7.41074C7.3984 7.73618 7.3984 8.26382 7.13805 8.58926L1.80472 15.2559C1.54437 15.5814 1.12226 15.5814 0.861908 15.2559Z"
+                    fill="currentColor"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+          </section>
+        </div>
+      `);
+    });
+
+    test('renders with a carousel layout with options using `html`', async () => {
       const container = document.createElement('div');
       const searchClient = createRecommendSearchClient();
       const options: Parameters<typeof relatedProducts>[0] = {
@@ -362,7 +471,7 @@ describe('relatedProducts', () => {
               class="ais-Carousel ROOT"
             >
               <button
-                aria-controls="ais-Carousel-0"
+                aria-controls="ais-Carousel-1"
                 aria-label="Previous"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--previous NAVIGATION_PREVIOUS"
                 hidden=""
@@ -376,14 +485,14 @@ describe('relatedProducts', () => {
                 aria-label="Items"
                 aria-live="polite"
                 aria-roledescription="carousel"
-                class="ais-Carousel-list LIST"
-                id="ais-Carousel-0"
+                class="ais-Carousel-list LIST ais-RelatedProducts-list"
+                id="ais-Carousel-1"
                 tabindex="0"
               >
                 <li
                   aria-label="1 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-RelatedProducts-item"
                 >
                   <p>
                     1
@@ -392,7 +501,7 @@ describe('relatedProducts', () => {
                 <li
                   aria-label="2 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-RelatedProducts-item"
                 >
                   <p>
                     2
@@ -400,7 +509,7 @@ describe('relatedProducts', () => {
                 </li>
               </ol>
               <button
-                aria-controls="ais-Carousel-0"
+                aria-controls="ais-Carousel-1"
                 aria-label="Next"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
                 title="Next"
@@ -560,7 +669,116 @@ describe('relatedProducts', () => {
       `);
     });
 
-    test('renders with a carousel layout using JSX', async () => {
+    test('renders with a carousel layout without options using JSX', async () => {
+      const container = document.createElement('div');
+      const searchClient = createRecommendSearchClient();
+      const options: Parameters<typeof relatedProducts>[0] = {
+        container,
+        objectIDs: ['1'],
+        templates: {
+          item(hit) {
+            return <p>{hit.objectID}</p>;
+          },
+          layout: carousel(),
+        },
+      };
+
+      const search = instantsearch({ indexName: 'indexName', searchClient });
+      const widget = relatedProducts(options);
+
+      search.addWidgets([widget]);
+      search.start();
+
+      await wait(0);
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <section
+            class="ais-RelatedProducts"
+          >
+            <h3
+              class="ais-RelatedProducts-title"
+            >
+              Related products
+            </h3>
+            <div
+              class="ais-Carousel"
+            >
+              <button
+                aria-controls="ais-Carousel-2"
+                aria-label="Previous"
+                class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+                hidden=""
+                title="Previous"
+              >
+                <svg
+                  fill="none"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  width="8"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M7.13809 0.744078C7.39844 1.06951 7.39844 1.59715 7.13809 1.92259L2.27616 8L7.13809 14.0774C7.39844 14.4028 7.39844 14.9305 7.13809 15.2559C6.87774 15.5814 6.45563 15.5814 6.19528 15.2559L0.861949 8.58926C0.6016 8.26382 0.6016 7.73618 0.861949 7.41074L6.19528 0.744078C6.45563 0.418641 6.87774 0.418641 7.13809 0.744078Z"
+                    fill="currentColor"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </button>
+              <ol
+                aria-label="Items"
+                aria-live="polite"
+                aria-roledescription="carousel"
+                class="ais-Carousel-list ais-RelatedProducts-list"
+                id="ais-Carousel-2"
+                tabindex="0"
+              >
+                <li
+                  aria-label="1 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ais-RelatedProducts-item"
+                >
+                  <p>
+                    1
+                  </p>
+                </li>
+                <li
+                  aria-label="2 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ais-RelatedProducts-item"
+                >
+                  <p>
+                    2
+                  </p>
+                </li>
+              </ol>
+              <button
+                aria-controls="ais-Carousel-2"
+                aria-label="Next"
+                class="ais-Carousel-navigation ais-Carousel-navigation--next"
+                title="Next"
+              >
+                <svg
+                  fill="none"
+                  height="16"
+                  viewBox="0 0 8 16"
+                  width="8"
+                >
+                  <path
+                    clipRule="evenodd"
+                    d="M0.861908 15.2559C0.601559 14.9305 0.601559 14.4028 0.861908 14.0774L5.72384 8L0.861908 1.92259C0.601559 1.59715 0.601559 1.06952 0.861908 0.744079C1.12226 0.418642 1.54437 0.418642 1.80472 0.744079L7.13805 7.41074C7.3984 7.73618 7.3984 8.26382 7.13805 8.58926L1.80472 15.2559C1.54437 15.5814 1.12226 15.5814 0.861908 15.2559Z"
+                    fill="currentColor"
+                    fillRule="evenodd"
+                  />
+                </svg>
+              </button>
+            </div>
+          </section>
+        </div>
+      `);
+    });
+
+    test('renders with a carousel layout with options using JSX', async () => {
       const container = document.createElement('div');
       const searchClient = createRecommendSearchClient();
       const options: Parameters<typeof relatedProducts>[0] = {
@@ -613,7 +831,7 @@ describe('relatedProducts', () => {
               class="ais-Carousel ROOT"
             >
               <button
-                aria-controls="ais-Carousel-1"
+                aria-controls="ais-Carousel-3"
                 aria-label="Previous"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--previous NAVIGATION_PREVIOUS"
                 hidden=""
@@ -627,14 +845,14 @@ describe('relatedProducts', () => {
                 aria-label="Items"
                 aria-live="polite"
                 aria-roledescription="carousel"
-                class="ais-Carousel-list LIST"
-                id="ais-Carousel-1"
+                class="ais-Carousel-list LIST ais-RelatedProducts-list"
+                id="ais-Carousel-3"
                 tabindex="0"
               >
                 <li
                   aria-label="1 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-RelatedProducts-item"
                 >
                   <p>
                     1
@@ -643,7 +861,7 @@ describe('relatedProducts', () => {
                 <li
                   aria-label="2 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-RelatedProducts-item"
                 >
                   <p>
                     2
@@ -651,7 +869,7 @@ describe('relatedProducts', () => {
                 </li>
               </ol>
               <button
-                aria-controls="ais-Carousel-1"
+                aria-controls="ais-Carousel-3"
                 aria-label="Next"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
                 title="Next"

--- a/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
@@ -138,6 +138,10 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
                       )
                     : undefined,
                 },
+                cssClasses: {
+                  list: data.classNames.list,
+                  item: data.classNames.item,
+                },
               }}
             />
           )
@@ -198,6 +202,7 @@ export type RelatedProductsTemplates<
       templates: {
         item: RelatedProductsUiProps<Hit>['itemComponent'];
       };
+      cssClasses: Pick<RelatedProductsCSSClasses, 'list' | 'item'>;
     }
   >;
 }>;

--- a/packages/instantsearch.js/src/widgets/trending-items/__tests__/trending-items.test.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/__tests__/trending-items.test.tsx
@@ -303,7 +303,7 @@ describe('trendingItems', () => {
       `);
     });
 
-    test('renders with a carousel layout using `html`', async () => {
+    test('renders with a carousel layout without options using `html`', async () => {
       const container = document.createElement('div');
       const searchClient = createRecommendSearchClient();
       const options: Parameters<typeof trendingItems>[0] = {
@@ -369,14 +369,14 @@ describe('trendingItems', () => {
                 aria-label="Items"
                 aria-live="polite"
                 aria-roledescription="carousel"
-                class="ais-Carousel-list LIST"
+                class="ais-Carousel-list LIST ais-TrendingItems-list"
                 id="ais-Carousel-0"
                 tabindex="0"
               >
                 <li
                   aria-label="1 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-TrendingItems-item"
                 >
                   <p>
                     1
@@ -385,7 +385,7 @@ describe('trendingItems', () => {
                 <li
                   aria-label="2 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-TrendingItems-item"
                 >
                   <p>
                     2
@@ -394,6 +394,111 @@ describe('trendingItems', () => {
               </ol>
               <button
                 aria-controls="ais-Carousel-0"
+                aria-label="Next"
+                class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
+                title="Next"
+              >
+                <p>
+                  Next
+                </p>
+              </button>
+            </div>
+          </section>
+        </div>
+      `);
+    });
+
+    test('renders with a carousel layout with options using `html`', async () => {
+      const container = document.createElement('div');
+      const searchClient = createRecommendSearchClient();
+      const options: Parameters<typeof trendingItems>[0] = {
+        container,
+        templates: {
+          item(hit, { html }) {
+            return html`<p>${hit.objectID}</p>`;
+          },
+          layout: carousel({
+            cssClasses: {
+              root: 'ROOT',
+              list: 'LIST',
+              item: 'ITEM',
+              navigation: 'NAVIGATION',
+              navigationNext: 'NAVIGATION_NEXT',
+              navigationPrevious: 'NAVIGATION_PREVIOUS',
+            },
+            templates: {
+              previous({ html }) {
+                return html`<p>Previous</p>`;
+              },
+              next({ html }) {
+                return html`<p>Next</p>`;
+              },
+            },
+          }),
+        },
+      };
+
+      const search = instantsearch({ indexName: 'indexName', searchClient });
+      const widget = trendingItems(options);
+
+      search.addWidgets([widget]);
+      search.start();
+
+      await wait(0);
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <section
+            class="ais-TrendingItems"
+          >
+            <h3
+              class="ais-TrendingItems-title"
+            >
+              Trending items
+            </h3>
+            <div
+              class="ais-Carousel ROOT"
+            >
+              <button
+                aria-controls="ais-Carousel-1"
+                aria-label="Previous"
+                class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--previous NAVIGATION_PREVIOUS"
+                hidden=""
+                title="Previous"
+              >
+                <p>
+                  Previous
+                </p>
+              </button>
+              <ol
+                aria-label="Items"
+                aria-live="polite"
+                aria-roledescription="carousel"
+                class="ais-Carousel-list LIST ais-TrendingItems-list"
+                id="ais-Carousel-1"
+                tabindex="0"
+              >
+                <li
+                  aria-label="1 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ITEM ais-TrendingItems-item"
+                >
+                  <p>
+                    1
+                  </p>
+                </li>
+                <li
+                  aria-label="2 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ITEM ais-TrendingItems-item"
+                >
+                  <p>
+                    2
+                  </p>
+                </li>
+              </ol>
+              <button
+                aria-controls="ais-Carousel-1"
                 aria-label="Next"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
                 title="Next"
@@ -551,7 +656,7 @@ describe('trendingItems', () => {
       `);
     });
 
-    test('renders with a carousel layout using JSX', async () => {
+    test('renders with a carousel layout without options using JSX', async () => {
       const container = document.createElement('div');
       const searchClient = createRecommendSearchClient();
       const options: Parameters<typeof trendingItems>[0] = {
@@ -603,7 +708,7 @@ describe('trendingItems', () => {
               class="ais-Carousel ROOT"
             >
               <button
-                aria-controls="ais-Carousel-1"
+                aria-controls="ais-Carousel-2"
                 aria-label="Previous"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--previous NAVIGATION_PREVIOUS"
                 hidden=""
@@ -617,14 +722,14 @@ describe('trendingItems', () => {
                 aria-label="Items"
                 aria-live="polite"
                 aria-roledescription="carousel"
-                class="ais-Carousel-list LIST"
-                id="ais-Carousel-1"
+                class="ais-Carousel-list LIST ais-TrendingItems-list"
+                id="ais-Carousel-2"
                 tabindex="0"
               >
                 <li
                   aria-label="1 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-TrendingItems-item"
                 >
                   <p>
                     1
@@ -633,7 +738,7 @@ describe('trendingItems', () => {
                 <li
                   aria-label="2 of 2"
                   aria-roledescription="slide"
-                  class="ais-Carousel-item ITEM"
+                  class="ais-Carousel-item ITEM ais-TrendingItems-item"
                 >
                   <p>
                     2
@@ -641,7 +746,112 @@ describe('trendingItems', () => {
                 </li>
               </ol>
               <button
-                aria-controls="ais-Carousel-1"
+                aria-controls="ais-Carousel-2"
+                aria-label="Next"
+                class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
+                title="Next"
+              >
+                <p>
+                  Next
+                </p>
+              </button>
+            </div>
+          </section>
+        </div>
+      `);
+    });
+
+    test('renders with a carousel layout with options using JSX', async () => {
+      const container = document.createElement('div');
+      const searchClient = createRecommendSearchClient();
+      const options: Parameters<typeof trendingItems>[0] = {
+        container,
+        templates: {
+          item(hit) {
+            return <p>{hit.objectID}</p>;
+          },
+          layout: carousel({
+            cssClasses: {
+              root: 'ROOT',
+              list: 'LIST',
+              item: 'ITEM',
+              navigation: 'NAVIGATION',
+              navigationNext: 'NAVIGATION_NEXT',
+              navigationPrevious: 'NAVIGATION_PREVIOUS',
+            },
+            templates: {
+              previous() {
+                return <p>Previous</p>;
+              },
+              next() {
+                return <p>Next</p>;
+              },
+            },
+          }),
+        },
+      };
+
+      const search = instantsearch({ indexName: 'indexName', searchClient });
+      const widget = trendingItems(options);
+
+      search.addWidgets([widget]);
+      search.start();
+
+      await wait(0);
+
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          <section
+            class="ais-TrendingItems"
+          >
+            <h3
+              class="ais-TrendingItems-title"
+            >
+              Trending items
+            </h3>
+            <div
+              class="ais-Carousel ROOT"
+            >
+              <button
+                aria-controls="ais-Carousel-3"
+                aria-label="Previous"
+                class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--previous NAVIGATION_PREVIOUS"
+                hidden=""
+                title="Previous"
+              >
+                <p>
+                  Previous
+                </p>
+              </button>
+              <ol
+                aria-label="Items"
+                aria-live="polite"
+                aria-roledescription="carousel"
+                class="ais-Carousel-list LIST ais-TrendingItems-list"
+                id="ais-Carousel-3"
+                tabindex="0"
+              >
+                <li
+                  aria-label="1 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ITEM ais-TrendingItems-item"
+                >
+                  <p>
+                    1
+                  </p>
+                </li>
+                <li
+                  aria-label="2 of 2"
+                  aria-roledescription="slide"
+                  class="ais-Carousel-item ITEM ais-TrendingItems-item"
+                >
+                  <p>
+                    2
+                  </p>
+                </li>
+              </ol>
+              <button
+                aria-controls="ais-Carousel-3"
                 aria-label="Next"
                 class="ais-Carousel-navigation NAVIGATION ais-Carousel-navigation--next NAVIGATION_NEXT"
                 title="Next"

--- a/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
@@ -200,7 +200,8 @@ export type TrendingItemsTemplates<THit extends NonNullable<object> = BaseHit> =
       > & {
         templates: {
           item: TrendingItemsUiProps<Hit>['itemComponent'];
-        } & { cssClasses: Pick<TrendingItemsCSSClasses, 'list' | 'item'> };
+        };
+        cssClasses: Pick<TrendingItemsCSSClasses, 'list' | 'item'>;
       }
     >;
   }>;

--- a/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
@@ -138,6 +138,10 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
                       )
                     : undefined,
                 },
+                cssClasses: {
+                  list: data.classNames.list,
+                  item: data.classNames.item,
+                },
               }}
             />
           )
@@ -196,7 +200,7 @@ export type TrendingItemsTemplates<THit extends NonNullable<object> = BaseHit> =
       > & {
         templates: {
           item: TrendingItemsUiProps<Hit>['itemComponent'];
-        };
+        } & { cssClasses: Pick<TrendingItemsCSSClasses, 'list' | 'item'> };
       }
     >;
   }>;


### PR DESCRIPTION
This fixes an issue where the widget classes for the list and items weren't properly forwarded to the layout.

I only pass the `list` and `item` ones because the other ones aren't necessary, and because the `root` one isn't supposed to be added to the layout root.