### PR TITLE
fix(react-instantsearch-nextjs): fix incorrect usage of headers

### DIFF
--- a/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
+++ b/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
@@ -1,5 +1,6 @@
+'use client';
+
 import { safelyRunOnBrowser } from 'instantsearch.js/es/lib/utils';
-import { headers } from 'next/headers';
 import React, { useEffect, useRef } from 'react';
 import {
   InstantSearch,
@@ -36,6 +37,7 @@ export type InstantSearchNextProps<
   TRouteState = TUiState
 > = Omit<InstantSearchProps<TUiState, TRouteState>, 'routing'> & {
   routing?: InstantSearchNextRouting<TUiState, TRouteState> | boolean;
+  nonce?: string;
 };
 
 export function InstantSearchNext<
@@ -44,6 +46,7 @@ export function InstantSearchNext<
 >({
   children,
   routing: passedRouting,
+  nonce,
   ...instantSearchProps
 }: InstantSearchNextProps<TUiState, TRouteState>) {
   const isMounting = useRef(true);
@@ -56,7 +59,7 @@ export function InstantSearchNext<
   }, []);
 
   const nonce = safelyRunOnBrowser(() => undefined, {
-    fallback: () => headers().get('x-nonce') || undefined,
+    fallback: () => nonce,
   });
 
   const routing = useInstantSearchRouting(passedRouting, isMounting);

--- a/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
+++ b/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
@@ -46,7 +46,7 @@ export function InstantSearchNext<
 >({
   children,
   routing: passedRouting,
-  nonce,
+  nonce: _nonce,
   ...instantSearchProps
 }: InstantSearchNextProps<TUiState, TRouteState>) {
   const isMounting = useRef(true);
@@ -59,7 +59,7 @@ export function InstantSearchNext<
   }, []);
 
   const nonce = safelyRunOnBrowser(() => undefined, {
-    fallback: () => nonce,
+    fallback: () => _nonce,
   });
 
   const routing = useInstantSearchRouting(passedRouting, isMounting);

--- a/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
+++ b/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
@@ -20,48 +20,51 @@ export function useInstantSearchRouting<
   const routingRef =
     useRef<InstantSearchProps<TUiState, TRouteState>['routing']>();
   const onUpdateRef = useRef<() => void>();
+  
+  useEffect(() => {
+    if (passedRouting && !routingRef.current) {
+      let browserHistoryOptions: Partial<BrowserHistoryArgs<TRouteState>> = {};
+  
+      browserHistoryOptions.getLocation = () => {
+        if (isMounting.current) {
+          return new URL(
+            `${window.location.protocol}//${window.location.host}${pathname}?${searchParams}`
+          ) as unknown as Location;
+        }
+  
+        return window.location;
+      };
+      browserHistoryOptions.push = function push(
+        this: ReturnType<typeof historyRouter>,
+        url
+      ) {
+        // This is to skip the push with empty routeState on dispose as it would clear params set on a <Link>
+        if (this.isDisposed) {
+          return;
+        }
+        router.push(url, { scroll: false });
+      };
+      browserHistoryOptions.start = function start(onUpdate) {
+        onUpdateRef.current = onUpdate;
+      };
+  
+      routingRef.current = {};
+      if (typeof passedRouting === 'object') {
+        browserHistoryOptions = {
+          ...browserHistoryOptions,
+          ...passedRouting.router,
+        };
+        routingRef.current.stateMapping = passedRouting.stateMapping;
+      }
+      routingRef.current.router = historyRouter(browserHistoryOptions);
+    }
+  }, []);
+  
   useEffect(() => {
     if (onUpdateRef.current) {
       onUpdateRef.current();
     }
   }, [pathname, searchParams]);
-
-  if (passedRouting && !routingRef.current) {
-    let browserHistoryOptions: Partial<BrowserHistoryArgs<TRouteState>> = {};
-
-    browserHistoryOptions.getLocation = () => {
-      if (isMounting.current) {
-        return new URL(
-          `${window.location.protocol}//${window.location.host}${pathname}?${searchParams}`
-        ) as unknown as Location;
-      }
-
-      return window.location;
-    };
-    browserHistoryOptions.push = function push(
-      this: ReturnType<typeof historyRouter>,
-      url
-    ) {
-      // This is to skip the push with empty routeState on dispose as it would clear params set on a <Link>
-      if (this.isDisposed) {
-        return;
-      }
-      router.push(url, { scroll: false });
-    };
-    browserHistoryOptions.start = function start(onUpdate) {
-      onUpdateRef.current = onUpdate;
-    };
-
-    routingRef.current = {};
-    if (typeof passedRouting === 'object') {
-      browserHistoryOptions = {
-        ...browserHistoryOptions,
-        ...passedRouting.router,
-      };
-      routingRef.current.stateMapping = passedRouting.stateMapping;
-    }
-    routingRef.current.router = historyRouter(browserHistoryOptions);
-  }
 
   return routingRef.current;
 }

--- a/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
+++ b/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
@@ -1,5 +1,4 @@
 import historyRouter from 'instantsearch.js/es/lib/routers/history';
-import { headers } from 'next/headers';
 import { usePathname, useSearchParams, useRouter } from 'next/navigation';
 import { useRef, useEffect } from 'react';
 
@@ -31,13 +30,6 @@ export function useInstantSearchRouting<
     let browserHistoryOptions: Partial<BrowserHistoryArgs<TRouteState>> = {};
 
     browserHistoryOptions.getLocation = () => {
-      if (typeof window === 'undefined') {
-        const url = `${
-          headers().get('x-forwarded-proto') || 'http'
-        }://${headers().get('host')}${pathname}?${searchParams}`;
-        return new URL(url) as unknown as Location;
-      }
-
       if (isMounting.current) {
         return new URL(
           `${window.location.protocol}//${window.location.host}${pathname}?${searchParams}`


### PR DESCRIPTION
**Summary**

Currently, NextJS App Router will throw this error when using with react-instantsearch-nextjs

```
⨯ Error: `headers` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context
```

This is because the `headers` are [only for server component](https://nextjs.org/docs/app/api-reference/functions/headers) - not in a client component. The InstantSearchNext component is a client component, hence this error.

![image](https://github.com/user-attachments/assets/42ff9552-2d88-4646-88b0-03ddd54520c9)

This PR is to fix this issue by clearly stating InstantSearchNext is a client component, and put the nonce value into InstantSearchNext props