### PR TITLE
chore(ci): persist algolia experiences bundles for other jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ jobs:
       - persist_to_workspace:
           root: *workspace_root
           paths:
+            - packages/algolia-experiences/dist
             - packages/algoliasearch-helper/dist
             - packages/instantsearch.js/es
             - packages/instantsearch.js/cjs


### PR DESCRIPTION
**Summary**

This PR persists the built version of algolia experiences to the workspace so it can be used to build the website examples.

**Result**

CI does not fail at the `examples` step anymore.