### PR TITLE
fix(client): ensure client.search is bound

### DIFF
--- a/packages/instantsearch.js/src/lib/utils/__tests__/hydrateSearchClient-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/hydrateSearchClient-test.ts
@@ -249,7 +249,7 @@ describe('hydrateSearchClient', () => {
 
   it('should not throw if search requires to be bound (v5)', async () => {
     const send = jest.fn().mockResolvedValue({ status: 200, content: '{}' });
-    const searchClient = algoliasearchV5('appId', 'apiKey', {
+    const searchClient: any = algoliasearchV5('appId', 'apiKey', {
       requester: {
         send,
       },
@@ -264,7 +264,7 @@ describe('hydrateSearchClient', () => {
 
   it('should not throw if search requires to be bound (v4)', async () => {
     const send = jest.fn().mockResolvedValue({ status: 200, content: '{}' });
-    const searchClient = algoliasearchV4('appId', 'apiKey', {
+    const searchClient: any = algoliasearchV4('appId', 'apiKey', {
       requester: {
         send,
       },

--- a/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
@@ -85,7 +85,7 @@ export function hydrateSearchClient(
   if ('transporter' in client && !client._cacheHydrated) {
     client._cacheHydrated = true;
 
-    const baseMethod = client.search as unknown as (
+    const baseMethod = client.search.bind(client) as unknown as (
       query: any,
       ...args: any[]
     ) => any;


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

in 5.2.5 of algoliasearch, a change in the code is made, and `client.search` needs to be called with the correct `this`, which isn't the case if you say `const search = client.search`



**Result**

fixes #6350
fixes algolia/algoliasearch-client-javascript#1549

possibly also solves #6348, to investigate afterwards


<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
