### PR TITLE
fix(client): use client.search in sffv for v5

### DIFF
--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -371,7 +371,10 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function (
   maxFacetHits,
   userState
 ) {
-  var clientHasSFFV = typeof this.client.searchForFacetValues === 'function';
+  var clientHasSFFV =
+    typeof this.client.searchForFacetValues === 'function' &&
+    // v5 has a wrong sffv signature
+    typeof this.client.searchForFacets !== 'function';
   var clientHasInitIndex = typeof this.client.initIndex === 'function';
   if (
     !clientHasSFFV &&

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/pendingSearch.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/pendingSearch.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var algoliasearch = require('algoliasearch');
+var isV5 = (algoliasearch.apiClientVersion || '')[0] === '5';
 algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
 var algoliasearchHelper = require('../../../index');
@@ -71,43 +72,85 @@ test('When searchOnce with promises, hasPendingRequests is true', function (done
   triggerCb();
 });
 
-test('When searchForFacetValues, hasPendingRequests is true', function (done) {
-  var client = algoliasearch('dsf', 'dsfdf');
+if (!isV5) {
+  test('When searchForFacetValues, hasPendingRequests is true (v3, v4)', function (done) {
+    var client = algoliasearch('dsf', 'dsfdf');
 
-  var triggerCb;
-  client.searchForFacetValues = function () {
-    return new Promise(function (resolve) {
-      triggerCb = function () {
-        resolve([
-          {
-            exhaustiveFacetsCount: true,
-            facetHits: [],
-            processingTimeMS: 3,
-          },
-        ]);
-      };
+    let triggerCb;
+    client.searchForFacetValues = function () {
+      return new Promise(function (resolve) {
+        triggerCb = function () {
+          resolve([
+            {
+              exhaustiveFacetsCount: true,
+              facetHits: [],
+              processingTimeMS: 3,
+            },
+          ]);
+        };
+      });
+    };
+
+    var helper = algoliasearchHelper(client, 'test_hotels-node');
+    var countNoMoreSearch = 0;
+    helper.on('searchQueueEmpty', function () {
+      countNoMoreSearch += 1;
     });
-  };
 
-  var helper = algoliasearchHelper(client, 'test_hotels-node');
-  var countNoMoreSearch = 0;
-  helper.on('searchQueueEmpty', function () {
-    countNoMoreSearch += 1;
-  });
-
-  expect(helper.hasPendingRequests()).toBe(false);
-
-  helper.searchForFacetValues('').then(function () {
     expect(helper.hasPendingRequests()).toBe(false);
-    expect(countNoMoreSearch).toBe(1);
-    done();
+
+    helper.searchForFacetValues('').then(function () {
+      expect(helper.hasPendingRequests()).toBe(false);
+      expect(countNoMoreSearch).toBe(1);
+      done();
+    });
+
+    expect(helper.hasPendingRequests()).toBe(true);
+    expect(countNoMoreSearch).toBe(0);
+
+    triggerCb();
   });
+} else {
+  test('When searchForFacetValues, hasPendingRequests is true (v5)', function (done) {
+    var client = algoliasearch('dsf', 'dsfdf');
 
-  expect(helper.hasPendingRequests()).toBe(true);
-  expect(countNoMoreSearch).toBe(0);
+    let triggerCb;
+    client.search = function () {
+      return new Promise(function (resolve) {
+        triggerCb = function () {
+          resolve({
+            results: [
+              {
+                exhaustiveFacetsCount: true,
+                facetHits: [],
+                processingTimeMS: 3,
+              },
+            ],
+          });
+        };
+      });
+    };
 
-  triggerCb();
-});
+    var helper = algoliasearchHelper(client, 'test_hotels-node');
+    var countNoMoreSearch = 0;
+    helper.on('searchQueueEmpty', function () {
+      countNoMoreSearch += 1;
+    });
+
+    expect(helper.hasPendingRequests()).toBe(false);
+
+    helper.searchForFacetValues('').then(function () {
+      expect(helper.hasPendingRequests()).toBe(false);
+      expect(countNoMoreSearch).toBe(1);
+      done();
+    });
+
+    expect(helper.hasPendingRequests()).toBe(true);
+    expect(countNoMoreSearch).toBe(0);
+
+    triggerCb();
+  });
+}
 
 test('When helper.search(), hasPendingRequests is true', function (done) {
   var testData = require('../../datasets/SearchParameters/search.dataset')();

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -56,6 +56,26 @@ test('searchForFacetValues calls the index method if no client method', function
   });
 });
 
+test('searchForFacetValues calls client.search if client.searchForFacets exists', function () {
+  var clientSearch = jest.fn(function () {
+    return Promise.resolve({
+      results: [makeFakeSearchForFacetValuesResponse()],
+    });
+  });
+
+  var fakeClient = {
+    searchForFacets: jest.fn(),
+    searchForFacetValues: jest.fn(),
+    search: clientSearch,
+  };
+
+  var helper = algoliasearchHelper(fakeClient, 'index');
+
+  return helper.searchForFacetValues('facet', 'query', 1).then(function () {
+    expect(clientSearch).toHaveBeenCalledTimes(1);
+  });
+});
+
 test('searchForFacetValues resolve with the correct response from client', function () {
   var fakeClient = {
     addAlgoliaAgent: function () {},

--- a/packages/algoliasearch-helper/types/algoliasearch.d.ts
+++ b/packages/algoliasearch-helper/types/algoliasearch.d.ts
@@ -306,6 +306,17 @@ export type SupportedLanguage = PickForClient<{
   v5: AlgoliaSearch.SupportedLanguage;
 }>;
 
+// v5 only has the `searchForFacetValues` method in the `search` client, not in `lite`.
+// We need to check both clients to get the correct type.
+// (this is not actually used in the codebase, but it's here for completeness)
+type SearchForFacetValuesV5 = ClientSearchV5 | ClientFullV5 extends {
+  searchForFacetValues: unknown;
+}
+  ?
+      | ClientSearchV5['searchForFacetValues']
+      | ClientFullV5['searchForFacetValues']
+  : never;
+
 export interface SearchClient {
   search: <T>(
     requests: Array<{ indexName: string; params: SearchOptions }>
@@ -317,7 +328,7 @@ export interface SearchClient {
     searchForFacetValues: unknown;
   }
     ? DefaultSearchClient['searchForFacetValues']
-    : never;
+    : SearchForFacetValuesV5;
   initIndex?: DefaultSearchClient extends { initIndex: unknown }
     ? DefaultSearchClient['initIndex']
     : never;

--- a/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
@@ -1187,6 +1187,7 @@ function createMockedSearchClient() {
       return Promise.resolve([
         createSFFVResponse({
           facetHits:
+            // @ts-ignore for v5, which has a different definition of `searchForFacetValues`
             requests[0].params.facetQuery === 'query with no results'
               ? []
               : [


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

v5 has a `searchForFacetValues` function, but it's single-index only. We thus need to detect it and use `client.search` directly. In a future major we can change this and only use `client.search`

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

- v5 allows sffv in the type for the full client (repro: https://github.com/WavyWalk/reproduce-algolia-v5/blob/typing-5-3-0/src/App.tsx#L11)
- sffv isn't called in v5, but client.search instead

fixes https://github.com/algolia/algoliasearch-client-javascript/issues/1550

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
