### PR TITLE
feat(experiences): implement custom element

### DIFF
--- a/examples/js/algolia-experiences/custom-element.html
+++ b/examples/js/algolia-experiences/custom-element.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Algolia Experiences demo</title>
+    <link
+      rel="stylesheet"
+      href="/packages/instantsearch.css/themes/satellite-min.css"
+    />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+          Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue',
+          sans-serif;
+      }
+      main {
+        max-width: 80em;
+        margin: 0 auto;
+      }
+      .ais-Hits-list,
+      .ais-TrendingItems-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 1em;
+      }
+      .ais-TrendingItems-item,
+      .ais-Hits-item {
+        padding: 0;
+      }
+      .ais-TrendingItems-item a,
+      .ais-Hits-item a {
+        width: 100%;
+        padding: 1.5em;
+        text-decoration: none;
+        color: inherit;
+        display: flex;
+        flex-direction: column;
+      }
+      .ais-TrendingItems-item img,
+      .ais-Hits-item img {
+        width: 100%;
+        height: 10em;
+        border-radius: 4px;
+        object-fit: contain;
+      }
+      .__flex {
+        display: flex;
+        gap: 1em;
+        justify-content: space-between;
+      }
+      .__bold {
+        font-weight: bold;
+      }
+      div:has(> .ais-Pagination) {
+        display: flex;
+      }
+      .ais-Pagination {
+        margin: 1em auto;
+      }
+    </style>
+    <script src="/packages/algolia-experiences/dist/algolia-experiences.development.js"></script>
+    <meta
+      name="algolia-configuration"
+      content='{"appId":"F4T6CUV2AH","apiKey":"72d500963987bc97ff899d350a00f7a8"}'
+    />
+    <script>
+      let isMounted = false;
+      function toggle() {
+        if (isMounted) {
+          document.querySelector('algolia-experience').remove();
+          isMounted = false;
+          return;
+        }
+        const element = document.createElement('template');
+        document.querySelector('main').appendChild(element);
+        element.outerHTML = `
+          <algolia-experience experience-id="category:historical" />
+        `;
+        isMounted = true;
+      }
+    </script>
+  </head>
+  <body>
+    <main>
+      <h2>Buy historical books now!</h2>
+      <button onclick="toggle()">Toggle</button>
+    </main>
+  </body>
+</html>

--- a/examples/js/algolia-experiences/package.json
+++ b/examples/js/algolia-experiences/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "start": "BABEL_ENV=parcel parcel index.html local.html",
-    "build": "BABEL_ENV=parcel parcel build index.html local.html --public-url .",
-    "website:examples": "BABEL_ENV=parcel parcel build index.html local.html --public-url . --dist-dir=../../../website/examples/js/algolia-experiences"
+    "start": "BABEL_ENV=parcel parcel index.html local.html custom-element.html",
+    "build": "BABEL_ENV=parcel parcel build index.html local.html custom-element.html --public-url .",
+    "website:examples": "BABEL_ENV=parcel parcel build index.html local.html custom-element.html --public-url . --dist-dir=../../../website/examples/js/algolia-experiences"
   },
   "browserslist": "firefox 68, chrome 78, IE 11",
   "devDependencies": {

--- a/packages/algolia-experiences/src/index.ts
+++ b/packages/algolia-experiences/src/index.ts
@@ -1,5 +1,9 @@
 import { setupInstantSearch } from './setup-instantsearch';
 
 if (typeof window === 'object') {
-  document.addEventListener('DOMContentLoaded', setupInstantSearch);
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupInstantSearch);
+  } else {
+    setupInstantSearch();
+  }
 }


### PR DESCRIPTION
[FX-3008](https://algolia.atlassian.net/browse/FX-3008)

**Summary**

To allow usage within an SPA, be it completely client-side rendered or not (with Next.js for example), we need to provide a way for an experience to be loaded at any time.

**Result**

Created a custom element that fetches its own configuration and renders. Code looks a bit awkward since I reused functions meant for multiple configurations.
We should probably implement some caching later for configurations.