### PR TITLE
fix(instantsearch.js): fix user token not being set in time for the first query

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "51 kB"
+      "maxSize": "51.25 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "180.50 kB"
+      "maxSize": "181 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "83.25 kB"
+      "maxSize": "83.50 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "181.25 kB"
+      "maxSize": "181.50 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "181 kB"
+      "maxSize": "181.25 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "180.25 kB"
+      "maxSize": "180.50 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -489,6 +489,7 @@ describe('network requests', () => {
             "params": {
               "clickAnalytics": true,
               "query": "",
+              "userToken": "cookie-key",
             },
           },
         ]
@@ -563,6 +564,7 @@ describe('network requests', () => {
             "params": {
               "clickAnalytics": true,
               "query": "",
+              "userToken": "cookie-key",
             },
           },
         ]

--- a/packages/instantsearch.js/src/lib/utils/uuid.ts
+++ b/packages/instantsearch.js/src/lib/utils/uuid.ts
@@ -1,0 +1,15 @@
+/**
+ * Create UUID according to
+ * https://www.ietf.org/rfc/rfc4122.txt.
+ *
+ * @returns Generated UUID.
+ */
+export function createUUID(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    /* eslint-disable no-bitwise */
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    /* eslint-enable */
+    return v.toString(16);
+  });
+}

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -442,37 +442,6 @@ describe('insights', () => {
       );
     });
 
-    it.skip('warns when userToken is not set', () => {
-      const { insightsClient, instantSearchInstance } = createTestEnvironment();
-
-      instantSearchInstance.use(
-        createInsightsMiddleware({
-          insightsClient,
-          insightsInitParams: {
-            useCookie: false,
-            anonymousUserToken: false,
-          },
-        })
-      );
-
-      expect(() =>
-        instantSearchInstance.sendEventToInsights({
-          eventType: 'view',
-          insightsMethod: 'viewedObjectIDs',
-          payload: {
-            eventName: 'Hits Viewed',
-            index: '',
-            objectIDs: ['1', '2'],
-          },
-          widgetType: 'ais.hits',
-        })
-      ).toWarnDev(
-        `[InstantSearch.js]: Cannot send event to Algolia Insights because \`userToken\` is not set.
-
-See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-further/send-insights-events/js/#setting-the-usertoken`
-      );
-    });
-
     it('applies clickAnalytics if $$automatic: undefined', () => {
       const { insightsClient, instantSearchInstance } = createTestEnvironment();
       instantSearchInstance.use(

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -268,9 +268,9 @@ export function createInsightsMiddleware<
         const anonymousUserToken = getInsightsAnonymousUserTokenInternal();
         if (anonymousUserToken) {
           // When `aa('init', { ... })` is called, it creates an anonymous user token in cookie.
-          // We can set it as userToken. We also need to set the insights userToken to this cookie
-          // value since, if that's not set before a sendEvent, insights automatically generates a
-          // new anonymous token, causing a state change and an unnecessary query on instantsearch.
+          // We can set it as userToken on instantsearch and insights. If it's not set as an insights
+          // userToken before a sendEvent, insights automatically generates a new anonymous token,
+          // causing a state change and an unnecessary query on instantsearch.
           setUserToken(anonymousUserToken, anonymousUserToken, undefined);
         }
 

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -323,10 +323,16 @@ export function createInsightsMiddleware<
         let authenticatedUserTokenFromInit: string | undefined;
         let userTokenFromInit: string | undefined;
 
-        // By the time the first query is sent, the token would not be set by the insights
-        // onChange callbacks. It is explicitly being set here so that the first query
-        // has the initial tokens set and inturn a second query isn't automatically made
-        // when the onChange callback actually changes the state.
+        // With SSR, the token could be be set on the state. We make sure
+        // that insights is in sync with that token since, there is no
+        // insights lib on the server.
+        const tokenFromSearchParameters = initialParameters.userToken;
+
+        // When the first query is sent, the token is possibly not yet be set by
+        // the insights onChange callbacks (if insights isn't yet loaded).
+        // It is explicitly being set here so that the first query has the
+        // initial tokens set and ensure a second query isn't automatically
+        // made when the onChange callback actually changes the state.
         if (insightsInitParams) {
           if (insightsInitParams.authenticatedUserToken) {
             authenticatedUserTokenFromInit =
@@ -343,7 +349,7 @@ export function createInsightsMiddleware<
           authenticatedUserTokenFromInit || userTokenFromInit;
         const tokenBeforeInit =
           authenticatedUserTokenBeforeInit || userTokenBeforeInit;
-        const queuedToken = queuedAuthenticatedUserToken || queuedUserToken;
+        const tokenFromQueue = queuedAuthenticatedUserToken || queuedUserToken;
 
         if (tokenFromInit) {
           setUserToken(
@@ -351,10 +357,10 @@ export function createInsightsMiddleware<
             userTokenFromInit,
             authenticatedUserTokenFromInit
           );
-        } else if (initialParameters.userToken) {
+        } else if (tokenFromSearchParameters) {
           setUserToken(
-            initialParameters.userToken,
-            initialParameters.userToken,
+            tokenFromSearchParameters,
+            tokenFromSearchParameters,
             undefined
           );
         } else if (tokenBeforeInit) {
@@ -363,9 +369,9 @@ export function createInsightsMiddleware<
             userTokenBeforeInit,
             authenticatedUserTokenBeforeInit
           );
-        } else if (queuedToken) {
+        } else if (tokenFromQueue) {
           setUserToken(
-            queuedToken,
+            tokenFromQueue,
             queuedUserToken,
             queuedAuthenticatedUserToken
           );

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -222,7 +222,7 @@ export function createInsightsMiddleware<
           userToken?: string | number,
           tokenType?: TokenType,
           immediate = false,
-          unsetAuthToken = false
+          unsetAuthenticatedUserToken = false
         ) => {
           const normalizedUserToken = normalizeUserToken(userToken);
 
@@ -252,7 +252,7 @@ export function createInsightsMiddleware<
             currentTokenType &&
             currentTokenType === 'authenticated' &&
             tokenType === 'default' &&
-            unsetAuthToken
+            !unsetAuthenticatedUserToken
           ) {
             return;
           }

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -289,6 +289,21 @@ export function createInsightsMiddleware<
           );
         }
 
+        // By the time the first query is sent, the token would not be set by the insights
+        // onChange callbacks. It is explicitly being set here so that the first query
+        // has the initial tokens set and inturn a second query isn't automatically made
+        // when the onChange callback actually changes the state.
+        if (
+          typeof instantSearchInstance._insights !== 'boolean' &&
+          instantSearchInstance._insights?.insightsInitParams
+        ) {
+          if (instantSearchInstance._insights.insightsInitParams.authenticatedUserToken) {
+            setUserTokenToSearch(instantSearchInstance._insights.insightsInitParams.authenticatedUserToken, true);
+          } else if (instantSearchInstance._insights.insightsInitParams.userToken) {
+            setUserTokenToSearch(instantSearchInstance._insights.insightsInitParams.userToken, true);
+          }
+        }
+
         // This updates userToken which is set explicitly by `aa('setUserToken', userToken)`
         insightsClient('onUserTokenChange', setUserTokenToSearch, {
           immediate: true,

--- a/packages/instantsearch.js/src/types/insights.ts
+++ b/packages/instantsearch.js/src/types/insights.ts
@@ -56,7 +56,7 @@ type QueueItemMap = {
   ];
 };
 
-type QueueItem = QueueItemMap[keyof QueueItemMap];
+export type QueueItem = QueueItemMap[keyof QueueItemMap];
 
 export type InsightsClient = _InsightsClient & {
   queue?: QueueItem[];

--- a/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
@@ -608,4 +608,48 @@ describe('getServerState', () => {
       </div>
     `);
   });
+
+  describe('insights', () => {
+    test('userToken is set when insights has been set to true', async () => {
+      const searchClient = createSearchClient({});
+      const spiedSearch = jest.spyOn(searchClient, 'search');
+
+      function App({
+        serverState,
+      }: {
+        serverState?: InstantSearchServerState;
+      }) {
+        return (
+          <InstantSearchSSRProvider {...serverState}>
+            <InstantSearch
+              searchClient={searchClient}
+              // initialUiState={{
+              //   instant_search: {
+              //     refinementList: {
+              //       categories: ['refined!'],
+              //     },
+              //   },
+              // }}
+              indexName="index"
+              insights={true}
+            >
+              <RefinementList attribute="brand" />
+              <SearchBox />
+
+              <h2>instant_search</h2>
+              <Hits hitComponent={Hit} />
+            </InstantSearch>
+          </InstantSearchSSRProvider>
+        );
+      }
+
+      await getServerState(<App />, { renderToString });
+
+      expect(spiedSearch).toHaveBeenCalledTimes(1);
+
+      const userToken = (spiedSearch.mock.calls[0][0] as any)[0].params
+        ?.userToken;
+      expect(userToken).toEqual(expect.stringMatching(/^anonymous-/));
+    });
+  });
 });

--- a/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
@@ -623,13 +623,6 @@ describe('getServerState', () => {
           <InstantSearchSSRProvider {...serverState}>
             <InstantSearch
               searchClient={searchClient}
-              // initialUiState={{
-              //   instant_search: {
-              //     refinementList: {
-              //       categories: ['refined!'],
-              //     },
-              //   },
-              // }}
               indexName="index"
               insights={true}
             >

--- a/tests/common/shared/insights.ts
+++ b/tests/common/shared/insights.ts
@@ -76,7 +76,7 @@ export function createInsightsTests(
         });
 
         // initial calls because the middleware is attached
-        expect(window.aa).toHaveBeenCalledTimes(6);
+        expect(window.aa).toHaveBeenCalledTimes(7);
         expect(window.aa).toHaveBeenCalledWith(
           'addAlgoliaAgent',
           'insights-middleware'
@@ -151,7 +151,7 @@ export function createInsightsTests(
         await setup(options);
 
         // initial calls because the middleware is attached
-        expect(window.aa).toHaveBeenCalledTimes(5);
+        expect(window.aa).toHaveBeenCalledTimes(6);
         expect(window.aa).toHaveBeenCalledWith(
           'addAlgoliaAgent',
           'insights-middleware'
@@ -164,7 +164,7 @@ export function createInsightsTests(
         });
 
         // Once result is available
-        expect(window.aa).toHaveBeenCalledTimes(6);
+        expect(window.aa).toHaveBeenCalledTimes(7);
         expect(window.aa).toHaveBeenCalledWith(
           'viewedObjectIDs',
           {


### PR DESCRIPTION
[FX-2955]

**Summary**
Double queries happen when the state of instantsearch and insights no longer matches at the time of the first query on page load.

- The `search-insights` `onUserTokenChange` and `onAuthenticatedUserTokenChange` callbacks are not able to set the `user-token` by the time the first search query is sent. When the `user-token` is changed by these callbacks, the state has changed from the first query. If a new query is scheduled after this(for example with dynamic widgets), the cache misses due to the changed state and second query is made.

- When `useCookie` is set to true, insights needs to create a anonymous token and save it as a cookie. Instantsearch would have the token updated with the callback from before, but this does not happen in time for the first query. So anonymous token generation and saving in cookies is now also handled by instantsearch.

- The insights queue is now being access in the middleware's `started` function to make sure any token set before instantsearch was started are part of the state by the time the first query is made.


[FX-2955]: https://algolia.atlassian.net/browse/FX-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ