### PR TITLE
feat(templates): re-introduce simple strings as text

### DIFF
--- a/packages/instantsearch.js/src/lib/templating/__tests__/renderTemplate.test.ts
+++ b/packages/instantsearch.js/src/lib/templating/__tests__/renderTemplate.test.ts
@@ -1,11 +1,13 @@
 import { renderTemplate } from '../renderTemplate';
 
+import type { Template } from '../../../types';
+
 describe('renderTemplate', () => {
   it('expect to process templates as function', () => {
     const templateKey = 'test';
     const data = { type: 'functions' };
-    const templates = {
-      test: (d: typeof data) => `it works with ${d.type}`,
+    const templates: { [key: string]: Template<typeof data> } = {
+      test: (d) => `it works with ${d.type}`,
     };
 
     const actual = renderTemplate({
@@ -22,8 +24,8 @@ describe('renderTemplate', () => {
   it('expect to process templates as html function', () => {
     const templateKey = 'test';
     const data = { type: 'functions' };
-    const templates = {
-      test: (d: typeof data, { html }) => html`<p>it works with ${d.type}</p>`,
+    const templates: { [key: string]: Template<typeof data> } = {
+      test: (d, { html }) => html`<p>it works with ${d.type}</p>`,
     };
 
     const actual = renderTemplate({

--- a/packages/instantsearch.js/src/lib/templating/__tests__/renderTemplate.test.ts
+++ b/packages/instantsearch.js/src/lib/templating/__tests__/renderTemplate.test.ts
@@ -19,6 +19,40 @@ describe('renderTemplate', () => {
     expect(actual).toBe(expectation);
   });
 
+  it('expect to process templates as html function', () => {
+    const templateKey = 'test';
+    const data = { type: 'functions' };
+    const templates = {
+      test: (d: typeof data, { html }) => html`<p>it works with ${d.type}</p>`,
+    };
+
+    const actual = renderTemplate({
+      templateKey,
+      templates,
+      data,
+    });
+
+    expect(actual).toEqual(expect.objectContaining({ type: 'p' }));
+  });
+
+  it('expect to process templates as string', () => {
+    const templateKey = 'test';
+    const data = { type: 'functions' };
+    const templates = {
+      test: 'it works with simple strings',
+    };
+
+    const actual = renderTemplate({
+      templateKey,
+      templates,
+      data,
+    });
+
+    const expectation = 'it works with simple strings';
+
+    expect(actual).toBe(expectation);
+  });
+
   it('expect to throw when the template is not a function', () => {
     const actual0 = () =>
       renderTemplate({
@@ -40,21 +74,12 @@ describe('renderTemplate', () => {
         templates: { test: 10 },
       });
 
-    const actual3 = () =>
-      renderTemplate({
-        templateKey: 'test',
-        // @ts-expect-error wrong usage
-        templates: { test: 'test' },
-      });
-
     const expectation0 = `Template must be 'function', was 'undefined' (key: test)`;
     const expectation1 = `Template must be 'function', was 'object' (key: test)`;
     const expectation2 = `Template must be 'function', was 'number' (key: test)`;
-    const expectation3 = `Template must be 'function', was 'string' (key: test)`;
 
     expect(() => actual0()).toThrow(expectation0);
     expect(() => actual1()).toThrow(expectation1);
     expect(() => actual2()).toThrow(expectation2);
-    expect(() => actual3()).toThrow(expectation3);
   });
 });

--- a/packages/instantsearch.js/src/lib/templating/renderTemplate.ts
+++ b/packages/instantsearch.js/src/lib/templating/renderTemplate.ts
@@ -6,6 +6,7 @@ import {
   ReverseSnippet,
   Snippet,
 } from '../../helpers/components';
+import { warning } from '../utils';
 
 import type { Templates } from '../../types';
 import type { SendEventForHits } from '../utils/createSendEventForHits';
@@ -22,6 +23,14 @@ export function renderTemplate({
   sendEvent?: SendEventForHits;
 }) {
   const template = templates[templateKey];
+
+  if (typeof template === 'string') {
+    warning(
+      template.indexOf('<') === -1,
+      `Template '${templateKey}' is a string, it will be rendered as text, not as html`
+    );
+    return template;
+  }
 
   if (typeof template !== 'function') {
     throw new Error(

--- a/packages/instantsearch.js/src/types/templates.ts
+++ b/packages/instantsearch.js/src/types/templates.ts
@@ -34,5 +34,9 @@ export type TemplateWithSendEvent<TTemplateData = void> = (
 ) => VNode | VNode[] | string;
 
 export type Templates = {
-  [key: string]: Template<any> | TemplateWithSendEvent<any> | undefined;
+  [key: string]:
+    | Template<any>
+    | TemplateWithSendEvent<any>
+    | string
+    | undefined;
 };


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

I think simple strings can be very useful in panels, or other simple templates. We should of course warn if there's html-looking text, as that's likely a mistake in migration.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

simple strings in templates are passed as text nodes; a warning is given if that text has a `<` in it

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
