### PR TITLE
fix(routing): manually push changed path

### DIFF
--- a/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
+++ b/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
@@ -1,6 +1,6 @@
 import historyRouter from 'instantsearch.js/es/lib/routers/history';
 import { headers } from 'next/headers';
-import { usePathname, useSearchParams, useRouter } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { useRef, useEffect } from 'react';
 
 import type { InstantSearchNextProps } from './InstantSearchNext';
@@ -17,7 +17,6 @@ export function useInstantSearchRouting<
 ) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const router = useRouter();
   const routingRef =
     useRef<InstantSearchProps<TUiState, TRouteState>['routing']>();
   const onUpdateRef = useRef<() => void>();
@@ -54,7 +53,7 @@ export function useInstantSearchRouting<
       if (this.isDisposed) {
         return;
       }
-      router.push(url, { scroll: false });
+      history.pushState({}, '', url);
     };
     browserHistoryOptions.start = function start(onUpdate) {
       onUpdateRef.current = onUpdate;


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Instead of using next's `router.push` function, we're transitioning back to `history.pushState`. This works better in many edge cases as it prevents a whole page refresh and rerender.


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

No unexpected rerenders when changing state.

Possible intended side effect of this fix is of course that any global change handlers or code running in render won't run anymore when changing instantsearch state. This can be worked around by using the `onStateChange` function or a middleware.

Back navigation still works as expected.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
