### PR TITLE
feat(experiences): add a default layout carousel for recommend widgets

### DIFF
--- a/examples/js/algolia-experiences/package.json
+++ b/examples/js/algolia-experiences/package.json
@@ -8,6 +8,10 @@
     "website:examples": "BABEL_ENV=parcel parcel build *.html --public-url . --dist-dir=../../../website/examples/js/algolia-experiences"
   },
   "browserslist": "firefox 68, chrome 78, IE 11",
+  "dependencies": {
+    "algolia-experiences": "1.3.0",
+    "instantsearch.css": "8.5.1"
+  },
   "devDependencies": {
     "@babel/core": "7.15.5",
     "@parcel/core": "2.10.0",

--- a/packages/algolia-experiences/src/__tests__/render.test.ts
+++ b/packages/algolia-experiences/src/__tests__/render.test.ts
@@ -11,6 +11,7 @@ import instantsearch from 'instantsearch.js';
 import { configToIndex, injectStyles } from '../render';
 
 import type { Configuration } from '../types';
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
 
 describe('injectStyles', () => {
   it('should inject styles', () => {
@@ -234,6 +235,155 @@ describe('configToIndex', () => {
       `);
     });
   });
+
+  describe('layout widgets', () => {
+    it('maps children to item template with a carousel layout', async () => {
+      const searchClient = createRecommendSearchClient({
+        minimal: true,
+      });
+      const search = instantsearch({ searchClient });
+      const element = document.createElement('div');
+      const config: Configuration = {
+        id: 'foo',
+        indexName: 'bar',
+        name: 'Foo',
+        blocks: [
+          {
+            type: 'ais.trendingItems',
+            parameters: {},
+            children: [
+              {
+                type: 'div',
+                parameters: {
+                  class: [
+                    { type: 'string', value: 'item-' },
+                    { type: 'attribute', path: ['objectID'] },
+                  ],
+                },
+                children: [
+                  {
+                    type: 'paragraph',
+                    parameters: {
+                      text: [
+                        { type: 'string', value: 'cols: ' },
+                        { type: 'highlight', path: ['name'] },
+                      ],
+                    },
+                  },
+                  {
+                    type: 'image',
+                    parameters: {
+                      src: [{ type: 'attribute', path: ['image'] }],
+                      alt: [{ type: 'string', value: 'alt value' }],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const result = configToIndex(config, element);
+      expect(result).toHaveLength(1);
+      expect(result[0].getWidgets()).toHaveLength(1);
+
+      expect(element.innerHTML).toMatchInlineSnapshot(`
+        <div>
+        </div>
+      `);
+
+      search.addWidgets(result);
+      search.start();
+      await wait(100);
+
+      expect(element.innerHTML).toMatchInlineSnapshot(`
+      <div>
+        <section class="ais-TrendingItems">
+          <h3 class="ais-TrendingItems-title">
+            Trending items
+          </h3>
+          <div class="ais-Carousel">
+            <button title="Previous"
+                    aria-label="Previous"
+                    hidden
+                    aria-controls="ais-Carousel-0"
+                    class="ais-Carousel-navigation ais-Carousel-navigation--previous"
+            >
+              <svg width="8"
+                   height="16"
+                   viewbox="0 0 8 16"
+                   fill="none"
+              >
+                <path fillrule="evenodd"
+                      cliprule="evenodd"
+                      fill="currentColor"
+                      d="M7.13809 0.744078C7.39844 1.06951 7.39844 1.59715 7.13809 1.92259L2.27616 8L7.13809 14.0774C7.39844 14.4028 7.39844 14.9305 7.13809 15.2559C6.87774 15.5814 6.45563 15.5814 6.19528 15.2559L0.861949 8.58926C0.6016 8.26382 0.6016 7.73618 0.861949 7.41074L6.19528 0.744078C6.45563 0.418641 6.87774 0.418641 7.13809 0.744078Z"
+                >
+                </path>
+              </svg>
+            </button>
+            <ol class="ais-Carousel-list ais-TrendingItems-list"
+                tabindex="0"
+                id="ais-Carousel-0"
+                aria-roledescription="carousel"
+                aria-label="Items"
+                aria-live="polite"
+            >
+              <li class="ais-Carousel-item ais-TrendingItems-item"
+                  aria-roledescription="slide"
+                  aria-label="1 of 2"
+              >
+                <div class="item-1">
+                  <p>
+                    cols:
+                    <span class="ais-Highlight">
+                    </span>
+                  </p>
+                  <img src
+                       alt="alt value"
+                  >
+                </div>
+              </li>
+              <li class="ais-Carousel-item ais-TrendingItems-item"
+                  aria-roledescription="slide"
+                  aria-label="2 of 2"
+              >
+                <div class="item-2">
+                  <p>
+                    cols:
+                    <span class="ais-Highlight">
+                    </span>
+                  </p>
+                  <img src
+                       alt="alt value"
+                  >
+                </div>
+              </li>
+            </ol>
+            <button title="Next"
+                    aria-label="Next"
+                    aria-controls="ais-Carousel-0"
+                    class="ais-Carousel-navigation ais-Carousel-navigation--next"
+            >
+              <svg width="8"
+                   height="16"
+                   viewbox="0 0 8 16"
+                   fill="none"
+              >
+                <path fillrule="evenodd"
+                      cliprule="evenodd"
+                      fill="currentColor"
+                      d="M0.861908 15.2559C0.601559 14.9305 0.601559 14.4028 0.861908 14.0774L5.72384 8L0.861908 1.92259C0.601559 1.59715 0.601559 1.06952 0.861908 0.744079C1.12226 0.418642 1.54437 0.418642 1.80472 0.744079L7.13805 7.41074C7.3984 7.73618 7.3984 8.26382 7.13805 8.58926L1.80472 15.2559C1.54437 15.5814 1.12226 15.5814 0.861908 15.2559Z"
+                >
+                </path>
+              </svg>
+            </button>
+          </div>
+        </section>
+      </div>
+      `);
+    })
+  })
 
   describe('panel widgets', () => {
     it('maps header parameter to panel header', async () => {

--- a/packages/algolia-experiences/src/__tests__/render.test.ts
+++ b/packages/algolia-experiences/src/__tests__/render.test.ts
@@ -5,13 +5,13 @@ import {
   createMultiSearchResponse,
   createSearchClient,
 } from '@instantsearch/mocks';
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
 import { wait } from '@instantsearch/testutils';
 import instantsearch from 'instantsearch.js';
 
 import { configToIndex, injectStyles } from '../render';
 
 import type { Configuration } from '../types';
-import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
 
 describe('injectStyles', () => {
   it('should inject styles', () => {
@@ -382,8 +382,8 @@ describe('configToIndex', () => {
         </section>
       </div>
       `);
-    })
-  })
+    });
+  });
 
   describe('panel widgets', () => {
     it('maps header parameter to panel header', async () => {

--- a/packages/algolia-experiences/src/render.tsx
+++ b/packages/algolia-experiences/src/render.tsx
@@ -1,7 +1,7 @@
 /** @jsx h */
 import { getPropertyByPath } from 'instantsearch.js/es/lib/utils';
-import { index, panel } from 'instantsearch.js/es/widgets';
 import { carousel } from 'instantsearch.js/es/templates';
+import { index, panel } from 'instantsearch.js/es/widgets';
 import { h, Fragment } from 'preact';
 
 import { banner } from './banner';

--- a/packages/algolia-experiences/src/render.tsx
+++ b/packages/algolia-experiences/src/render.tsx
@@ -1,6 +1,7 @@
 /** @jsx h */
 import { getPropertyByPath } from 'instantsearch.js/es/lib/utils';
 import { index, panel } from 'instantsearch.js/es/widgets';
+import { carousel } from 'instantsearch.js/es/templates';
 import { h, Fragment } from 'preact';
 
 import { banner } from './banner';
@@ -48,15 +49,23 @@ export function configToIndex(config: Configuration, container: HTMLElement) {
 const hitWidgets = new Set<TemplateWidgetTypes>([
   'ais.hits',
   'ais.infiniteHits',
-  'ais.frequentlyBoughtTogether',
-  'ais.lookingSimilar',
-  'ais.relatedProducts',
-  'ais.trendingItems',
 ]);
 function isTemplateWidget(
   child: Block
 ): child is Block & { children: TemplateChild[] } {
   return hitWidgets.has(child.type as any);
+}
+
+const layoutWidgets = new Set<TemplateWidgetTypes>([
+  'ais.frequentlyBoughtTogether',
+  'ais.lookingSimilar',
+  'ais.relatedProducts',
+  'ais.trendingItems',
+]);
+function isLayoutWidget(
+  child: Block
+): child is Block & { children: TemplateChild[] } {
+  return layoutWidgets.has(child.type as any);
 }
 
 const panelWidgets = new Set<PanelWidgetTypes>([
@@ -209,6 +218,63 @@ function blockToWidget(child: Block, container: HTMLElement): Widget[] {
 
             return child.children.map(renderChild);
           },
+        },
+      }),
+    ];
+  }
+
+  if (isLayoutWidget(child)) {
+    // type cast is needed here because the spread adding `container` and `templates` loses the type discriminant
+    const parameters = child.parameters as Parameters<
+      typeof widgets['ais.trendingItems']
+    >[0];
+    const widget = widgets[
+      child.type
+    ] as unknown as typeof widgets['ais.trendingItems'];
+
+    return [
+      widget({
+        ...parameters,
+        container: widgetContainer,
+        templates: {
+          item: (hit: any, { components }) => {
+            if (!child.children.length) {
+              return <code> no item template given</code>;
+            }
+
+            function renderChild(ch: TemplateChild) {
+              const Tag = tagNames.get(ch.type) as keyof JSX.IntrinsicElements;
+              if (!Tag) {
+                return <Fragment></Fragment>;
+              }
+
+              let children: ComponentChildren = null;
+              if ('text' in ch.parameters) {
+                children = ch.parameters.text.map((text) =>
+                  renderText(text, hit, components)
+                );
+              } else if ('children' in ch) {
+                children = ch.children.map(renderChild);
+              }
+
+              const attributes = Object.fromEntries(
+                Object.entries(ch.parameters)
+                  .filter(
+                    (tuple): tuple is [string, TemplateAttribute] =>
+                      tuple[0] !== 'text'
+                  )
+                  .map(([key, value]) => [
+                    key,
+                    value.map((item) => renderAttribute(item, hit)).join(''),
+                  ])
+              );
+
+              return <Tag {...attributes}>{children}</Tag>;
+            }
+
+            return child.children.map(renderChild);
+          },
+          layout: carousel(),
         },
       }),
     ];


### PR DESCRIPTION
**Summary**
This adds a default Carousel layout for recommend widgets in experiences

Additionally, dependencies have been added to the experiences example to fix the build order in `yarn build`

[FX-3109]


[FX-3109]: https://algolia.atlassian.net/browse/FX-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ