### PR TITLE
poc(composition): implementation on widget-level

### DIFF
--- a/examples/js/getting-started/src/app.js
+++ b/examples/js/getting-started/src/app.js
@@ -1,79 +1,63 @@
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
-import { carousel } from 'instantsearch.js/es/templates';
 import {
+  composition,
   configure,
   hits,
   pagination,
   panel,
   refinementList,
   searchBox,
-  trendingItems,
 } from 'instantsearch.js/es/widgets';
 
 import 'instantsearch.css/themes/satellite.css';
 
 const searchClient = algoliasearch(
-  'latency',
-  '6be0576ff61c053d5f9a3225e2a90f76'
+  'DIYPADIATS',
+  'c96176e1b36590680fb3d36bc480d592',
+  { authMode: 'WithinHeaders' }
 );
 
 const search = instantsearch({
-  indexName: 'instant_search',
+  indexName: 'asos_FR',
+  routing: true,
   searchClient,
   insights: true,
 });
 
 search.addWidgets([
-  searchBox({
-    container: '#searchbox',
-  }),
-  hits({
-    container: '#hits',
-    templates: {
-      item: (hit, { html, components }) => html`
-        <article>
-          <h1>
-            <a href="/products.html?pid=${hit.objectID}"
-              >${components.Highlight({ hit, attribute: 'name' })}</a
-            >
-          </h1>
-          <p>${components.Highlight({ hit, attribute: 'description' })}</p>
-          <a href="/products.html?pid=${hit.objectID}">See product</a>
-        </article>
-      `,
-    },
-  }),
-  configure({
-    hitsPerPage: 8,
-  }),
-  panel({
-    templates: { header: 'brand' },
-  })(refinementList)({
-    container: '#brand-list',
-    attribute: 'brand',
-  }),
-  pagination({
-    container: '#pagination',
-  }),
-  trendingItems({
-    container: '#trending',
-    limit: 6,
-    templates: {
-      item: (item, { html }) => html`
-        <div>
+  composition({ compositionId: 'asos_FR' }).addWidgets([
+    searchBox({
+      container: '#searchbox',
+    }),
+    hits({
+      container: '#hits',
+      templates: {
+        item: (hit, { html }) => html`
           <article>
-            <div>
-              <img src="${item.image}" />
-              <h2>${item.name}</h2>
-            </div>
-            <a href="/products.html?pid=${item.objectID}">See product</a>
+            <h1>
+              <a href="/products.html?pid=${hit.objectID}">${hit.name}</a>
+            </h1>
+            <p>${hit.colour}</p>
+            <p>€${hit.price}</p>
+            <p>${hit.brand}</p>
           </article>
-        </div>
-      `,
-      layout: carousel(),
-    },
-  }),
+        `,
+      },
+    }),
+    configure({
+      hitsPerPage: 8,
+    }),
+    panel({
+      templates: { header: () => 'brand' },
+    })(refinementList)({
+      container: '#brand-list',
+      attribute: 'brand',
+    }),
+    pagination({
+      container: '#pagination',
+    }),
+  ]),
 ]);
 
 search.start();

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -193,6 +193,22 @@ type RecommendWidget<
   >;
 };
 
+type CompositionWidget<
+  TWidgetDescription extends WidgetDescription & WidgetParams
+> = {
+  dependsOn: 'composition';
+  getCompositionId: () => string;
+  getHelper: () => Helper;
+  getWidgetParameters?: (
+    state: SearchParameters,
+    widgetParametersOptions: {
+      uiState: Expand<
+        Partial<TWidgetDescription['indexUiState'] & IndexUiState>
+      >;
+    }
+  ) => SearchParameters;
+};
+
 type RequiredWidgetLifeCycle<TWidgetDescription extends WidgetDescription> = {
   /**
    * Identifier for connectors and widgets.
@@ -334,7 +350,11 @@ export type Widget<
     UiStateLifeCycle<TWidgetDescription> &
     RenderStateLifeCycle<TWidgetDescription>
 > &
-  (SearchWidget<TWidgetDescription> | RecommendWidget<TWidgetDescription>);
+  (
+    | SearchWidget<TWidgetDescription>
+    | RecommendWidget<TWidgetDescription>
+    | CompositionWidget<TWidgetDescription>
+  );
 
 export type { IndexWidget } from '../widgets';
 

--- a/packages/instantsearch.js/src/widgets/composition/composition.ts
+++ b/packages/instantsearch.js/src/widgets/composition/composition.ts
@@ -1,0 +1,144 @@
+import algoliasearchHelper from 'algoliasearch-helper';
+
+import type {
+  InitOptions,
+  RenderOptions,
+  UiState,
+  IndexUiState,
+  Widget,
+} from '../../types';
+import type {
+  SearchParameters,
+  AlgoliaSearchHelper as Helper,
+} from 'algoliasearch-helper';
+
+export default function composition(props: { compositionId: string }) {
+  const localWidgets: Widget[] = [];
+  const helper = algoliasearchHelper({} as any, props.compositionId);
+  helper.search = () => helper;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let localUiState = {};
+
+  return {
+    $$type: 'ais.composition',
+    $$widgetType: 'ais.composition',
+    dependsOn: 'composition',
+    getHelper() {
+      return helper;
+    },
+    getCompositionId() {
+      return props.compositionId;
+    },
+    addWidgets(widgets: Widget[]) {
+      if (!Array.isArray(widgets)) {
+        throw new Error('The `addWidgets` method expects an array of widgets.');
+      }
+      if (widgets.some((widget) => widget.$$type === 'ais.index')) {
+        throw new Error(
+          "You can't nest an index widget inside a composition widget."
+        );
+      }
+
+      if (widgets.some((widget) => widget.$$type === 'ais.hitsPerPage')) {
+        throw new Error(
+          "You can't nest a hitsPerPage widget inside a composition widget."
+        );
+      }
+
+      localWidgets.push(...widgets);
+
+      return this;
+    },
+    getWidgetParameters(
+      initialSearchParameters: SearchParameters,
+      options: { uiState: IndexUiState }
+    ) {
+      return localWidgets.reduce((state, widget) => {
+        if (
+          !widget.getWidgetSearchParameters ||
+          widget.$$type === 'ais.index'
+        ) {
+          return state;
+        }
+
+        if (widget.dependsOn === 'search' && widget.getWidgetParameters) {
+          return widget.getWidgetParameters(state, options);
+        }
+
+        return widget.getWidgetSearchParameters(state, options);
+      }, initialSearchParameters);
+    },
+    getWidgetUiState(
+      uiState: UiState,
+      options: { searchParameters: SearchParameters; helper: Helper }
+    ) {
+      return localWidgets.reduce<IndexUiState>((state, widget) => {
+        if (!widget.getWidgetUiState) {
+          return state;
+        }
+
+        return widget.getWidgetUiState(state, options);
+      }, uiState);
+    },
+    init(params: InitOptions) {
+      params.helper = helper;
+      localUiState = params.uiState[props.compositionId] || {};
+
+      helper.search = () => {
+        params.instantSearchInstance.scheduleSearch();
+        return helper;
+      };
+      helper.on('change', (event) => {
+        const { state } = event;
+
+        const _uiState = (event as any)._uiState;
+
+        localUiState = getLocalWidgetsUiState(
+          localWidgets,
+          {
+            searchParameters: state,
+            helper,
+          },
+          _uiState || {}
+        );
+
+        // We don't trigger an internal change when controlled because it
+        // becomes the responsibility of `setUiState`.
+        if (!params.instantSearchInstance.onStateChange) {
+          params.instantSearchInstance.onInternalStateChange();
+        }
+      });
+
+      localWidgets.forEach((widget) => {
+        widget.init?.(params);
+      });
+    },
+    render(params: RenderOptions) {
+      params.helper = helper;
+      localWidgets.forEach((widget) => {
+        widget.render?.(params);
+      });
+    },
+  };
+}
+
+function getLocalWidgetsUiState(
+  widgets: Widget[],
+  options: {
+    searchParameters: SearchParameters;
+    helper: Helper;
+  },
+  initialUiState: IndexUiState
+) {
+  return widgets.reduce<IndexUiState>((uiState, widget) => {
+    if (!widget.getWidgetUiState || widget.$$type === 'ais.index') {
+      return uiState;
+    }
+
+    if (widget.dependsOn === 'search' && widget.getWidgetUiState) {
+      return widget.getWidgetUiState(uiState, options);
+    }
+
+    return uiState;
+  }, initialUiState);
+}

--- a/packages/instantsearch.js/src/widgets/index.ts
+++ b/packages/instantsearch.js/src/widgets/index.ts
@@ -58,3 +58,4 @@ export { default as trendingItems } from './trending-items/trending-items';
 export { default as voiceSearch } from './voice-search/voice-search';
 export { default as frequentlyBoughtTogether } from './frequently-bought-together/frequently-bought-together';
 export { default as lookingSimilar } from './looking-similar/looking-similar';
+export { default as composition } from './composition/composition';


### PR DESCRIPTION
Implementation that has as goal to implement a widget called "composition", that mostly works the same as an index, but instead it calls the composition API

doesn't work:
- routing (probably something small about where getWidgetUiState gets called)
- facets (not implemented, likely works)
- possibly life cycle and caching, can be solved by doing the search inside the widget directly?

Overall i think this could be a workable solution but seems quite complex
