### PR TITLE
fix(refinement-list): re-apply focus on facet checkbox after render

### DIFF
--- a/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
@@ -108,7 +108,10 @@ class RefinementList<TTemplates extends Templates> extends Component<
 > {
   public static defaultProps = defaultProps;
 
+  private listRef = createRef<HTMLUListElement>();
   private searchBox = createRef<SearchBox>();
+
+  private lastRefinedValue: string | undefined = undefined;
 
   public shouldComponentUpdate(
     nextProps: RefinementListPropsWithDefaultProps<TTemplates>
@@ -122,6 +125,7 @@ class RefinementList<TTemplates extends Templates> extends Component<
   }
 
   private refine(facetValueToRefine: string) {
+    this.lastRefinedValue = facetValueToRefine;
     this.props.toggleRefinement(facetValueToRefine);
   }
 
@@ -270,6 +274,20 @@ class RefinementList<TTemplates extends Templates> extends Component<
     }
   }
 
+  /**
+   * This sets focus on the last refined input element after a render
+   * because Preact does not perform it automatically.
+   * @see https://github.com/preactjs/preact/issues/3242
+   */
+  public componentDidUpdate() {
+    this.listRef.current
+      ?.querySelector<HTMLInputElement>(
+        `input[value="${this.lastRefinedValue}"]`
+      )
+      ?.focus();
+    this.lastRefinedValue = undefined;
+  }
+
   private refineFirstValue() {
     const firstValue = this.props.facetValues && this.props.facetValues[0];
     if (firstValue) {
@@ -330,7 +348,7 @@ class RefinementList<TTemplates extends Templates> extends Component<
 
     const facetValues = this.props.facetValues &&
       this.props.facetValues.length > 0 && (
-        <ul className={this.props.cssClasses.list}>
+        <ul ref={this.listRef} className={this.props.cssClasses.list}>
           {this.props.facetValues.map(this._generateFacetItem, this)}
         </ul>
       );

--- a/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementList-test.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementList-test.tsx
@@ -4,7 +4,6 @@
 /** @jsx h */
 
 import { render, fireEvent } from '@testing-library/preact';
-import userEvent from '@testing-library/user-event';
 import { h } from 'preact';
 
 import defaultTemplates from '../../../widgets/refinement-list/defaultTemplates';
@@ -692,58 +691,6 @@ describe('RefinementList', () => {
       fireEvent.click(checkedItem!);
 
       expect(toggleRefinement).toHaveBeenCalledTimes(0);
-    });
-
-    it('should keep focus on toggled input between re-renders', () => {
-      const templates = {
-        item: (item: RefinementListItemData) => `
-          <label>
-            <input type="checkbox" value="${item.value}" checked="${item.isRefined}" />
-            ${item.value}
-          </label>
-        `,
-      };
-
-      const props: Omit<
-        RefinementListProps<typeof templates>,
-        'facetValues'
-      > = {
-        cssClasses: defaultProps.cssClasses,
-        templateProps: {
-          templatesConfig: {},
-          templates,
-          useCustomCompileOptions: {},
-        },
-        toggleRefinement: () => {},
-        createURL: () => '',
-      };
-
-      const { container, rerender } = render(
-        <RefinementList
-          {...props}
-          facetValues={[
-            { value: 'foo', label: 'foo', count: 1, isRefined: false },
-            { value: 'bar', label: 'bar', count: 1, isRefined: false },
-          ]}
-        />
-      );
-
-      const initialTargetItem = container.querySelector('input[value="foo"]')!;
-      userEvent.click(initialTargetItem);
-      expect(document.activeElement).toBe(initialTargetItem);
-
-      rerender(
-        <RefinementList
-          {...props}
-          facetValues={[
-            { value: 'foo', label: 'foo', count: 1, isRefined: true },
-            { value: 'bar', label: 'bar', count: 1, isRefined: false },
-          ]}
-        />
-      );
-
-      const updatedTargetItem = container.querySelector('input[value="foo"]')!;
-      expect(document.activeElement).toBe(updatedTargetItem);
     });
   });
 });

--- a/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementList-test.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementList-test.tsx
@@ -4,6 +4,7 @@
 /** @jsx h */
 
 import { render, fireEvent } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
 import { h } from 'preact';
 
 import defaultTemplates from '../../../widgets/refinement-list/defaultTemplates';
@@ -14,7 +15,6 @@ import type {
   RefinementListTemplates,
 } from '../../../widgets/refinement-list/refinement-list';
 import type { RefinementListProps } from '../RefinementList';
-import userEvent from '@testing-library/user-event';
 
 const defaultProps = {
   createURL: () => '#',

--- a/tests/common/widgets/refinement-list/options.ts
+++ b/tests/common/widgets/refinement-list/options.ts
@@ -580,6 +580,40 @@ export function createOptionsTests(
       ]);
     });
 
+    test('keeps focus on toggled input between re-renders', async () => {
+      const searchClient = createMockedSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: { attribute: 'brand' },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(document.activeElement).toEqual(document.body);
+
+      const initialTargetItem = document.querySelector(
+        '.ais-RefinementList-checkbox[value="Samsung"]'
+      )!;
+
+      await act(async () => {
+        userEvent.click(initialTargetItem);
+        expect(document.activeElement).toEqual(initialTargetItem);
+        await wait(0);
+      });
+
+      const updatedTargetItem = document.querySelector(
+        '.ais-RefinementList-checkbox[value="Samsung"]'
+      )!;
+
+      expect(document.activeElement).toEqual(updatedTargetItem);
+    });
+
     describe('sorting', () => {
       test('sorts the items by ascending name', async () => {
         const searchClient = createMockedSearchClient();

--- a/tests/common/widgets/refinement-list/options.ts
+++ b/tests/common/widgets/refinement-list/options.ts
@@ -602,6 +602,13 @@ export function createOptionsTests(
       )!;
 
       await act(async () => {
+        /**
+         * Jest wrongly fails the last assertion when running in Vue 3
+         * (`activeElement` is reset to body).
+         * Duplicating the following call fixes this as a workaround,
+         * and doesn't change the objective of this test.
+         */
+        userEvent.click(initialTargetItem);
         userEvent.click(initialTargetItem);
         expect(document.activeElement).toEqual(initialTargetItem);
         await wait(0);


### PR DESCRIPTION
**Summary**

In InstantSearch.js, focus is lost when toggling a facet value in a refinement list. This is because the component is destroyed and re-created during re-render, and [Preact does not explicitly refocus the newly created component](https://github.com/preactjs/preact/issues/3242) (whereas React does it).

This PR adds code that stores the last refined value and applies focus to its DOM element on re-render.

CR-6976