### PR TITLE
chore(examples): fix version

### DIFF
--- a/examples/js/algolia-experiences/package.json
+++ b/examples/js/algolia-experiences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-algolia-experiences",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "start": "BABEL_ENV=parcel parcel *.html",
@@ -9,7 +9,7 @@
   },
   "browserslist": "firefox 68, chrome 78, IE 11",
   "dependencies": {
-    "algolia-experiences": "1.3.0",
+    "algolia-experiences": "1.4.0",
     "instantsearch.css": "8.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
fix the version used in the example, to avoid accidentally relying on the package from npm