### PR TITLE
fix(instantsearch): remove EXPERIMENTAL_use

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -439,16 +439,6 @@ See documentation: ${createDocumentationLink({
     return this;
   }
 
-  // @major we shipped with EXPERIMENTAL_use, but have changed that to just `use` now
-  public EXPERIMENTAL_use(...middleware: Middleware[]): this {
-    warning(
-      false,
-      'The middleware API is now considered stable, so we recommend replacing `EXPERIMENTAL_use` with `use` before upgrading to the next major version.'
-    );
-
-    return this.use(...middleware);
-  }
-
   /**
    * Adds a widget to the search instance.
    * A widget can be added either before or after InstantSearch has started.

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -294,29 +294,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
 `);
   });
 
-  it('warns dev with EXPERIMENTAL_use', () => {
-    const searchClient = createSearchClient({
-      addAlgoliaAgent: jest.fn(),
-    });
-
-    const search = new InstantSearch({
-      indexName: 'indexName',
-      searchClient,
-    });
-
-    const middleware = () => ({
-      onStateChange: () => {},
-      subscribe: () => {},
-      unsubscribe: () => {},
-    });
-
-    expect(() => {
-      search.EXPERIMENTAL_use(middleware);
-    }).toWarnDev(
-      '[InstantSearch.js]: The middleware API is now considered stable, so we recommend replacing `EXPERIMENTAL_use` with `use` before upgrading to the next major version.'
-    );
-  });
-
   it('does not warn dev with use', () => {
     const searchClient = createSearchClient({
       addAlgoliaAgent: jest.fn(),

--- a/packages/instantsearch.js/test/createInstantSearch.ts
+++ b/packages/instantsearch.js/test/createInstantSearch.ts
@@ -59,7 +59,6 @@ export const createInstantSearch = (
     removeWidget: jest.fn(),
     removeWidgets: jest.fn(),
     use: jest.fn(),
-    EXPERIMENTAL_use: jest.fn(),
     unuse: jest.fn(),
     // methods from EventEmitter
     addListener: jest.fn(),


### PR DESCRIPTION
Instead you can use `use` to add a middleware

BREAKING CHANGE: EXPERIMENTAL_use function is replaced with use function