### PR TITLE
fix(next-app-router): remove search.dispose

### DIFF
--- a/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
@@ -118,7 +118,6 @@ export function InitializePromise({ nonce }: InitializePromiseProps) {
             return;
           }
           injectInitialResults();
-          search.dispose();
         })
     );
   }


### PR DESCRIPTION
**Summary**

Fixes #6393 
 
Thought this might help in mitigating memory leaks but it doesn't seem to do anything. So instead of fixing the error we night as well just remove the `dispose` call.
