### PR TITLE
fix(insights): deduplicate view events

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "68.5 kB"
+      "maxSize": "68.75 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",

--- a/tests/common/widgets/hits/insights.ts
+++ b/tests/common/widgets/hits/insights.ts
@@ -81,7 +81,7 @@ export function createInsightsTests(
 
       // View event called for each index once
       {
-        expect(window.aa).toHaveBeenCalledTimes(3);
+        expect(window.aa).toHaveBeenCalledTimes(2);
         expect(window.aa).toHaveBeenCalledWith(
           'viewedObjectIDs',
           {
@@ -130,9 +130,7 @@ export function createInsightsTests(
           await wait(0);
         });
 
-        // @TODO: This is a bug, we should not send a view event when the results are the same.
-        // see: https://github.com/algolia/instantsearch/issues/5442
-        expect(window.aa).toHaveBeenCalledTimes(3);
+        expect(window.aa).toHaveBeenCalledTimes(2);
       }
     });
 
@@ -195,7 +193,7 @@ export function createInsightsTests(
 
       // View event called for each index, batched in chunks of 20
       {
-        expect(window.aa).toHaveBeenCalledTimes(6);
+        expect(window.aa).toHaveBeenCalledTimes(4);
         expect(window.aa).toHaveBeenCalledWith(
           'viewedObjectIDs',
           {

--- a/tests/common/widgets/infinite-hits/insights.ts
+++ b/tests/common/widgets/infinite-hits/insights.ts
@@ -81,7 +81,7 @@ export function createInsightsTests(
 
       // View event called for each index once
       {
-        expect(window.aa).toHaveBeenCalledTimes(3);
+        expect(window.aa).toHaveBeenCalledTimes(2);
         expect(window.aa).toHaveBeenCalledWith(
           'viewedObjectIDs',
           {
@@ -130,9 +130,7 @@ export function createInsightsTests(
           await wait(0);
         });
 
-        // @TODO: This is a bug, we should not send a view event when the results are the same.
-        // see: https://github.com/algolia/instantsearch/issues/5442
-        expect(window.aa).toHaveBeenCalledTimes(3);
+        expect(window.aa).toHaveBeenCalledTimes(2);
       }
     });
 
@@ -195,7 +193,7 @@ export function createInsightsTests(
 
       // View event called for each index, batched in chunks of 20
       {
-        expect(window.aa).toHaveBeenCalledTimes(6);
+        expect(window.aa).toHaveBeenCalledTimes(4);
         expect(window.aa).toHaveBeenCalledWith(
           'viewedObjectIDs',
           {


### PR DESCRIPTION
**Summary**

[CR-6960](https://algolia.atlassian.net/browse/CR-6960)

Fixes #5442

**Result**

Only did it for view events because they're the only ones that we got issues for.
Tried to make it a bit more future proof for when we implement it with intersection observer, we look for differences between what we try to send vs what was already sent.
It resets when we receive a new query.


[CR-6960]: https://algolia.atlassian.net/browse/CR-6960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ