### PR TITLE
feat(experiences): add `environment` setting and default to prod

### DIFF
--- a/packages/algolia-experiences/src/__tests__/get-configuration.test.ts
+++ b/packages/algolia-experiences/src/__tests__/get-configuration.test.ts
@@ -1,8 +1,12 @@
-import { fetchConfiguration } from '../get-configuration';
+import { API_BASE, fetchConfiguration } from '../get-configuration';
 
 describe('fetchConfiguration', () => {
   it('should fetch and cache the configuration', async () => {
-    const settings = { appId: 'appId', apiKey: 'apiKey' };
+    const settings = {
+      appId: 'appId',
+      apiKey: 'apiKey',
+      environment: 'prod' as const,
+    };
 
     // @ts-ignore
     global.fetch = jest.fn(() =>
@@ -27,5 +31,35 @@ describe('fetchConfiguration', () => {
     await fetchConfiguration('1', settings);
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fetch from the relevant environment', async () => {
+    const settings = {
+      appId: 'appId',
+      apiKey: 'apiKey',
+      environment: 'beta' as const,
+    };
+
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: '2',
+            name: 'name',
+            indexName: 'indexName',
+            blocks: [],
+            createdAt: 'createdAt',
+            updatedAt: 'updatedAt',
+          }),
+      })
+    );
+
+    await fetchConfiguration('2', settings);
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      `${API_BASE.beta}/experiences/2`,
+      expect.anything()
+    );
   });
 });

--- a/packages/algolia-experiences/src/__tests__/get-information.test.ts
+++ b/packages/algolia-experiences/src/__tests__/get-information.test.ts
@@ -14,7 +14,21 @@ describe('getSettings', () => {
       <meta name="algolia-configuration" content='{"appId":"appId","apiKey":"apiKey"}'>
     `;
 
-    expect(getSettings()).toEqual({ appId: 'appId', apiKey: 'apiKey' });
+    expect(getSettings()).toEqual({
+      appId: 'appId',
+      apiKey: 'apiKey',
+      environment: 'prod',
+    });
+
+    document.head.innerHTML = `
+      <meta name="algolia-configuration" content='{"appId":"appId","apiKey":"apiKey", "environment": "beta"}'>
+    `;
+
+    expect(getSettings()).toEqual({
+      appId: 'appId',
+      apiKey: 'apiKey',
+      environment: 'beta',
+    });
   });
 
   test('should throw if no meta tag found', () => {

--- a/packages/algolia-experiences/src/get-configuration.ts
+++ b/packages/algolia-experiences/src/get-configuration.ts
@@ -5,7 +5,7 @@ const cache = new Map<string, Configuration>();
 
 export function fetchConfiguration(
   id: string,
-  settings: Required<Settings>
+  settings: Settings
 ): Promise<Configuration> {
   if (cache.has(id)) {
     return Promise.resolve(cache.get(id)!);
@@ -32,7 +32,7 @@ export const API_BASE = {
   prod: 'https://experiences.algolia.com/1',
 };
 
-type ApiParams<TEndpointParams> = Required<Settings> & TEndpointParams;
+type ApiParams<TEndpointParams> = Settings & TEndpointParams;
 
 type RequestParams = ApiParams<{
   endpoint: string;

--- a/packages/algolia-experiences/src/get-configuration.ts
+++ b/packages/algolia-experiences/src/get-configuration.ts
@@ -26,7 +26,7 @@ export type Experience = {
   updatedAt: string;
 };
 
-const API_BASE = {
+export const API_BASE = {
   local: 'http://localhost:3000/1',
   beta: 'https://experiences-beta.algolia.com/1',
   prod: 'https://experiences.algolia.com/1',

--- a/packages/algolia-experiences/src/get-configuration.ts
+++ b/packages/algolia-experiences/src/get-configuration.ts
@@ -5,7 +5,7 @@ const cache = new Map<string, Configuration>();
 
 export function fetchConfiguration(
   id: string,
-  settings: Settings
+  settings: Required<Settings>
 ): Promise<Configuration> {
   if (cache.has(id)) {
     return Promise.resolve(cache.get(id)!);
@@ -26,15 +26,13 @@ export type Experience = {
   updatedAt: string;
 };
 
-const LOCAL = false;
-const API_BASE = LOCAL
-  ? 'http://localhost:3000/1'
-  : 'https://experiences-beta.algolia.com/1';
+const API_BASE = {
+  local: 'http://localhost:3000/1',
+  beta: 'https://experiences-beta.algolia.com/1',
+  prod: 'https://experiences.algolia.com/1',
+};
 
-type ApiParams<TEndpointParams> = {
-  appId: string;
-  apiKey: string;
-} & TEndpointParams;
+type ApiParams<TEndpointParams> = Required<Settings> & TEndpointParams;
 
 type RequestParams = ApiParams<{
   endpoint: string;
@@ -47,10 +45,12 @@ export function deleteExperience({
   id,
   appId,
   apiKey,
+  environment,
 }: DeleteExperienceParams) {
   return buildRequest({
     appId,
     apiKey,
+    environment,
     endpoint: `experiences/${id}`,
     method: 'DELETE',
   });
@@ -61,10 +61,12 @@ export function getExperience({
   id,
   appId,
   apiKey,
+  environment,
 }: GetExperienceParams): Promise<Experience> {
   return buildRequest({
     appId,
     apiKey,
+    environment,
     endpoint: `experiences/${id}`,
   });
 }
@@ -74,10 +76,12 @@ export function upsertExperience({
   experience,
   appId,
   apiKey,
+  environment,
 }: UpsertExperienceParams): Promise<Pick<Experience, 'id'>> {
   return buildRequest({
     appId,
     apiKey,
+    environment,
     endpoint: `experiences`,
     method: 'POST',
     data: experience,
@@ -88,10 +92,12 @@ export type ListExperiencesParams = ApiParams<Record<string, never>>;
 export function listExperiences({
   appId,
   apiKey,
+  environment,
 }: ListExperiencesParams): Promise<Experience[]> {
   return buildRequest({
     appId,
     apiKey,
+    environment,
     endpoint: 'experiences',
   });
 }
@@ -99,11 +105,12 @@ export function listExperiences({
 function buildRequest({
   appId,
   apiKey,
+  environment,
   endpoint,
   method = 'GET',
   data,
 }: RequestParams) {
-  return fetch(`${API_BASE}/${endpoint}`, {
+  return fetch(`${API_BASE[environment]}/${endpoint}`, {
     method,
     headers: {
       'X-Algolia-Application-ID': appId,

--- a/packages/algolia-experiences/src/get-information.ts
+++ b/packages/algolia-experiences/src/get-information.ts
@@ -1,9 +1,10 @@
 export type Settings = {
   appId: string;
   apiKey: string;
+  environment?: 'local' | 'beta' | 'prod';
 };
 
-export function getSettings(): Settings {
+export function getSettings(): Required<Settings> {
   const metaConfiguration = document.querySelector<HTMLMetaElement>(
     'meta[name="algolia-configuration"]'
   );
@@ -12,13 +13,17 @@ export function getSettings(): Settings {
     throw new Error('No meta tag found');
   }
 
-  const { appId, apiKey } = JSON.parse(metaConfiguration.content);
+  const {
+    appId,
+    apiKey,
+    environment = 'prod',
+  } = JSON.parse(metaConfiguration.content) as unknown as Settings;
 
   if (!appId || !apiKey) {
     throw new Error('Missing appId or apiKey in the meta tag');
   }
 
-  return { appId, apiKey };
+  return { appId, apiKey, environment };
 }
 
 export function getElements() {

--- a/packages/algolia-experiences/src/get-information.ts
+++ b/packages/algolia-experiences/src/get-information.ts
@@ -1,10 +1,10 @@
 export type Settings = {
   appId: string;
   apiKey: string;
-  environment?: 'local' | 'beta' | 'prod';
+  environment: 'local' | 'beta' | 'prod';
 };
 
-export function getSettings(): Required<Settings> {
+export function getSettings(): Settings {
   const metaConfiguration = document.querySelector<HTMLMetaElement>(
     'meta[name="algolia-configuration"]'
   );


### PR DESCRIPTION
**Summary**

This PR makes it easier to switch API environments by setting an `environment` parameter in `algolia-configuration`. It defaults to `prod`.
