### PR TITLE
chore: Add Usage Trend of InstantSearch Family

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ It is part of the InstantSearch family which is designed for different platforms
 | [`react-instantsearch-core`](packages/react-instantsearch-core) | [![react-instantsearch-core npm version](https://img.shields.io/npm/v/react-instantsearch-core.svg?style=flat-square)](https://npmjs.org/package/react-instantsearch-core) | Runtime-independent React InstantSearch version |
 | [`vue-instantsearch`](packages/vue-instantsearch) | [![vue-instantsearch npm version](https://img.shields.io/npm/v/vue-instantsearch.svg?style=flat-square)](https://npmjs.org/package/vue-instantsearch) | Vue InstantSearch |
 
-[Usage Trend of InstantSearch Family](https://npm-compare.com/algoliasearch-helper,create-instantsearch-app,instantsearch.css,instantsearch.js,react-instantsearch,react-instantsearch-core,vue-instantsearch/#timeRange=THREE_YEARS)
+## Usage Trend
+
+[Usage Trend of instantsearch.js](https://npm-compare.com/instantsearch.js#timeRange=THREE_YEARS)
+  
+<a href="https://npm-compare.com/instantsearch.js#timeRange=THREE_YEARS" target="_blank">
+  <img src="https://npm-compare.com/img/npm-trend/THREE_YEARS/instantsearch.js.png" width="890px" alt="NPM Usage Trend of instantsearch.js" />
+</a>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ It is part of the InstantSearch family which is designed for different platforms
 | [`react-instantsearch-core`](packages/react-instantsearch-core) | [![react-instantsearch-core npm version](https://img.shields.io/npm/v/react-instantsearch-core.svg?style=flat-square)](https://npmjs.org/package/react-instantsearch-core) | Runtime-independent React InstantSearch version |
 | [`vue-instantsearch`](packages/vue-instantsearch) | [![vue-instantsearch npm version](https://img.shields.io/npm/v/vue-instantsearch.svg?style=flat-square)](https://npmjs.org/package/vue-instantsearch) | Vue InstantSearch |
 
+[Usage Trend of InstantSearch Family](https://npm-compare.com/algoliasearch-helper,create-instantsearch-app,instantsearch.css,instantsearch.js,react-instantsearch,react-instantsearch-core,vue-instantsearch/#timeRange=THREE_YEARS)
+
 ## Contributing
 
 We welcome all contributors, from casual to regular 💙


### PR DESCRIPTION
I’d like to suggest adding a link to the README that shows the usage trend of the InstantSearch family of packages. This link will direct users to a dynamic chart that visualizes the download trends of related packages over the past three years, helping new users evaluate the popularity and adoption of InstantSearch tools.

As a maintainer of npm-compare.com, I’m also happy to implement any other features that could benefit your project, if you find them useful.

Thanks for considering my suggestion!