### PR TITLE
ci: prevent PR with "do not merge" label from being merged

### DIFF
--- a/.github/workflows/enforce-do-not-merge-label.yml
+++ b/.github/workflows/enforce-do-not-merge-label.yml
@@ -1,0 +1,18 @@
+name: Check Do Not Merge Label
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+jobs:
+  fail-for-do-not-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if PR is labelled with "do not merge"
+        if: contains(github.event.pull_request.labels.*.name, '🚨　DO NOT MERGE')
+        run: |
+          echo "This PR is labelled with "do not merge"."
+          exit 1


### PR DESCRIPTION
**Summary**

Small utility job that prevents merging PRs when they have the "DO NOT MERGE" label applied. Copied from AlgoliaWeb.