### PR TITLE
fix(next-app-router): prevent client-side search when rerendering

### DIFF
--- a/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
+++ b/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
@@ -47,6 +47,8 @@ export function InstantSearchNext<
   ...instantSearchProps
 }: InstantSearchNextProps<TUiState, TRouteState>) {
   const isMounting = useRef(true);
+  const isServer = typeof window === 'undefined';
+
   useEffect(() => {
     isMounting.current = false;
     return () => {
@@ -77,9 +79,9 @@ This message will only be displayed in development mode.`
     <InstantSearchRSCContext.Provider value={promiseRef}>
       <InstantSearchSSRProvider initialResults={initialResults}>
         <InstantSearch {...instantSearchProps} routing={routing}>
-          {!initialResults && <InitializePromise nonce={nonce} />}
+          {isServer && <InitializePromise nonce={nonce} />}
           {children}
-          {!initialResults && <TriggerSearch />}
+          {isServer && <TriggerSearch />}
         </InstantSearch>
       </InstantSearchSSRProvider>
     </InstantSearchRSCContext.Provider>

--- a/packages/react-instantsearch-nextjs/src/__tests__/InstantSearchNext.test.tsx
+++ b/packages/react-instantsearch-nextjs/src/__tests__/InstantSearchNext.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { SearchBox } from 'react-instantsearch';
+
+import { InstantSearchNext } from '../InstantSearchNext';
+
+test('it rerenders without triggering a client-side search', async () => {
+  const client = createSearchClient();
+
+  function Component() {
+    return (
+      <InstantSearchNext searchClient={client} indexName="indexName">
+        <SearchBox />
+      </InstantSearchNext>
+    );
+  }
+
+  const { rerender } = render(<Component />);
+
+  await act(async () => {
+    await wait(0);
+  });
+
+  rerender(<Component />);
+
+  await act(async () => {
+    await wait(0);
+  });
+
+  expect(client.search).toHaveBeenCalledTimes(0);
+});


### PR DESCRIPTION
**Summary**

This PR updates `<InstantSearchNext>` so it only performs initial search in a server environment.

We previously relied on the availability of the initial results (injected in the document), but they are deleted once hydration is complete, which falsely triggers a client-side search when rerendering the component.