### PR TITLE
fix(insights): ensure the same token is used when rendered multiple times server side

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "181.50 kB"
+      "maxSize": "185 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "65 kB"
+      "maxSize": "65.50 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/examples/react/next-app-router/app/Search.tsx
+++ b/examples/react/next-app-router/app/Search.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { Hit as AlgoliaHit } from 'instantsearch.js';
 import React from 'react';
 import {
@@ -13,8 +12,7 @@ import {
 import { InstantSearchNext } from 'react-instantsearch-nextjs';
 
 import { Panel } from '../components/Panel';
-
-const client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+import { client } from '../lib/client';
 
 type HitProps = {
   hit: AlgoliaHit<{

--- a/examples/react/next-app-router/app/page.tsx
+++ b/examples/react/next-app-router/app/page.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 
+import { responsesCache } from '../lib/client';
+
 import Search from './Search';
 
 export const dynamic = 'force-dynamic';
 
 export default function Page() {
+  responsesCache.clear();
+
   return <Search />;
 }

--- a/examples/react/next-app-router/lib/client.tsx
+++ b/examples/react/next-app-router/lib/client.tsx
@@ -1,0 +1,9 @@
+import { createMemoryCache } from '@algolia/client-common';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
+
+export const responsesCache = createMemoryCache();
+export const client = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76',
+  { responsesCache }
+);

--- a/examples/react/next-routing/pages/index.tsx
+++ b/examples/react/next-routing/pages/index.tsx
@@ -1,3 +1,4 @@
+import { createMemoryCache } from '@algolia/client-common';
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { Hit as AlgoliaHit } from 'instantsearch.js';
 import { GetServerSideProps } from 'next';
@@ -21,7 +22,10 @@ import { createInstantSearchRouterNext } from 'react-instantsearch-router-nextjs
 
 import { Panel } from '../components/Panel';
 
-const client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+const requestsCache = createMemoryCache();
+const client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76', {
+  requestsCache,
+});
 
 type HitProps = {
   hit: AlgoliaHit<{
@@ -99,6 +103,7 @@ export const getServerSideProps: GetServerSideProps<HomePageProps> =
     const serverState = await getServerState(<HomePage url={url} />, {
       renderToString,
     });
+    requestsCache.clear();
 
     return {
       props: {

--- a/examples/react/next-routing/pages/test.tsx
+++ b/examples/react/next-routing/pages/test.tsx
@@ -1,4 +1,5 @@
 // This is only to test `onStateChange` does not get called twice
+import { createMemoryCache } from '@algolia/client-common';
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { GetServerSideProps } from 'next';
 import Head from 'next/head';
@@ -16,7 +17,10 @@ import {
 } from 'react-instantsearch';
 import { createInstantSearchRouterNext } from 'react-instantsearch-router-nextjs';
 
-const client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+const requestsCache = createMemoryCache();
+const client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76', {
+  requestsCache,
+});
 
 type HomePageProps = {
   serverState?: InstantSearchServerState;
@@ -74,6 +78,7 @@ export const getServerSideProps: GetServerSideProps<HomePageProps> =
     const serverState = await getServerState(<HomePage url={url} />, {
       renderToString,
     });
+    requestsCache.clear();
 
     return {
       props: {

--- a/examples/react/next/pages/index.tsx
+++ b/examples/react/next/pages/index.tsx
@@ -1,3 +1,4 @@
+import { createMemoryCache } from '@algolia/client-common';
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
 import { Hit as AlgoliaHit } from 'instantsearch.js';
 import { GetServerSideProps } from 'next';
@@ -20,7 +21,10 @@ import { createInstantSearchRouterNext } from 'react-instantsearch-router-nextjs
 
 import { Panel } from '../components/Panel';
 
-const client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+const responsesCache = createMemoryCache();
+const client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76', {
+  responsesCache,
+});
 
 type HitProps = {
   hit: AlgoliaHit<{
@@ -63,6 +67,9 @@ export default function HomePage({ serverState, url }: HomePageProps) {
           }),
         }}
         insights={true}
+        future={{
+          preserveSharedStateOnUnmount: true,
+        }}
       >
         <div className="Container">
           <div>
@@ -93,6 +100,8 @@ export const getServerSideProps: GetServerSideProps<HomePageProps> =
     const serverState = await getServerState(<HomePage url={url} />, {
       renderToString,
     });
+
+    responsesCache.clear();
 
     return {
       props: {

--- a/examples/react/ssr/src/searchClient.js
+++ b/examples/react/ssr/src/searchClient.js
@@ -1,6 +1,11 @@
+import { createMemoryCache } from '@algolia/client-common';
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
 
+export const requestsCache = createMemoryCache();
 export const searchClient = algoliasearch(
   'latency',
-  '6be0576ff61c053d5f9a3225e2a90f76'
+  '6be0576ff61c053d5f9a3225e2a90f76',
+  {
+    requestsCache,
+  }
 );

--- a/examples/react/ssr/src/server.js
+++ b/examples/react/ssr/src/server.js
@@ -6,6 +6,7 @@ import { renderToString } from 'react-dom/server';
 import { getServerState } from 'react-instantsearch';
 
 import App from './App';
+import { requestsCache } from './searchClient';
 
 const app = express();
 
@@ -18,6 +19,7 @@ app.get('/', async (req, res) => {
   const serverState = await getServerState(<App location={location} />, {
     renderToString,
   });
+  requestsCache.clear();
   const html = renderToString(
     <App serverState={serverState} location={location} />
   );

--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1099,6 +1099,12 @@ declare namespace algoliasearchHelper {
      */
     optionalFilters?: Array<string | string[]>;
     /**
+     * Unique pseudonymous or anonymous user identifier.
+     * This helps with analytics and click and conversion events.
+     * For more information, see [user token](https://www.algolia.com/doc/guides/sending-events/concepts/usertoken/).
+     */
+    userToken?: string;
+    /**
      * If set to false, this query will not be taken into account in the analytics feature.
      * default true
      * https://www.algolia.com/doc/api-reference/api-parameters/analytics/

--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -449,46 +449,18 @@ describe('getInitialResults', () => {
     ]);
 
     const initialResults = getInitialResults(search.mainIndex, requestParams);
-    expect(initialResults).toEqual({
-      indexName: {
-        requestParams: [
-          {
-            clickAnalytics: true,
-            query: 'apple',
-            userToken: expect.stringMatching(/^anonymous-/),
-          },
-        ],
-        results: [
-          {
-            exhaustiveFacetsCount: true,
-            exhaustiveNbHits: true,
-            hits: [],
-            hitsPerPage: 20,
-            nbHits: 0,
-            nbPages: 0,
-            page: 0,
-            params: '',
-            processingTimeMS: 0,
-            query: '',
-          },
-        ],
-        state: {
-          disjunctiveFacets: [],
-          disjunctiveFacetsRefinements: {},
-          facets: [],
-          facetsExcludes: {},
-          facetsRefinements: {},
-          hierarchicalFacets: [],
-          hierarchicalFacetsRefinements: {},
-          index: 'indexName',
-          numericRefinements: {},
-          query: 'apple',
-          tagRefinements: [],
-          clickAnalytics: true,
-          userToken: expect.stringMatching(/^anonymous-/),
-        },
-      },
-    });
+    expect(initialResults.indexName!.requestParams).toEqual([
+      expect.objectContaining({
+        clickAnalytics: true,
+        userToken: expect.stringMatching(/^anonymous-/),
+      }),
+    ]);
+    expect(initialResults.indexName!.state).toEqual(
+      expect.objectContaining({
+        clickAnalytics: true,
+        userToken: expect.stringMatching(/^anonymous-/),
+      })
+    );
     expect(initialResults.indexName.requestParams![0].userToken).toEqual(
       initialResults.indexName.state!.userToken
     );

--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -421,4 +421,65 @@ describe('getInitialResults', () => {
       ]
     `);
   });
+
+  test('injects clickAnalytics and userToken into the state', async () => {
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+      initialUiState: {
+        indexName: {
+          query: 'apple',
+        },
+      },
+      insights: true,
+    });
+
+    search.addWidgets([connectSearchBox(() => {})({})]);
+
+    search.start();
+
+    const requestParams = await waitForResults(search);
+
+    expect(requestParams).toEqual([
+      {
+        clickAnalytics: true,
+        query: 'apple',
+        userToken: expect.stringMatching(/^anonymous-/),
+      },
+    ]);
+
+    expect(getInitialResults(search.mainIndex)).toEqual({
+      indexName: {
+        results: [
+          {
+            exhaustiveFacetsCount: true,
+            exhaustiveNbHits: true,
+            hits: [],
+            hitsPerPage: 20,
+            nbHits: 0,
+            nbPages: 0,
+            page: 0,
+            params: '',
+            processingTimeMS: 0,
+            query: '',
+          },
+        ],
+        state: {
+          disjunctiveFacets: [],
+          disjunctiveFacetsRefinements: {},
+          facets: [],
+          facetsExcludes: {},
+          facetsRefinements: {},
+          hierarchicalFacets: [],
+          hierarchicalFacetsRefinements: {},
+          index: 'indexName',
+          numericRefinements: {},
+          query: 'apple',
+          tagRefinements: [],
+          clickAnalytics: true,
+          userToken: expect.stringMatching(/^anonymous-/),
+        },
+      },
+    });
+  });
 });

--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -448,8 +448,16 @@ describe('getInitialResults', () => {
       },
     ]);
 
-    expect(getInitialResults(search.mainIndex)).toEqual({
+    const initialResults = getInitialResults(search.mainIndex, requestParams);
+    expect(initialResults).toEqual({
       indexName: {
+        requestParams: [
+          {
+            clickAnalytics: true,
+            query: 'apple',
+            userToken: expect.stringMatching(/^anonymous-/),
+          },
+        ],
         results: [
           {
             exhaustiveFacetsCount: true,
@@ -481,5 +489,8 @@ describe('getInitialResults', () => {
         },
       },
     });
+    expect(initialResults.indexName.requestParams![0].userToken).toEqual(
+      initialResults.indexName.state!.userToken
+    );
   });
 });

--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -449,20 +449,16 @@ describe('getInitialResults', () => {
     ]);
 
     const initialResults = getInitialResults(search.mainIndex, requestParams);
-    expect(initialResults.indexName!.requestParams).toEqual([
-      expect.objectContaining({
-        clickAnalytics: true,
-        userToken: expect.stringMatching(/^anonymous-/),
-      }),
-    ]);
-    expect(initialResults.indexName!.state).toEqual(
-      expect.objectContaining({
-        clickAnalytics: true,
-        userToken: expect.stringMatching(/^anonymous-/),
-      })
-    );
-    expect(initialResults.indexName.requestParams![0].userToken).toEqual(
-      initialResults.indexName.state!.userToken
-    );
+
+    const indexRequestParams = initialResults.indexName!.requestParams![0];
+    expect(indexRequestParams.clickAnalytics).toBe(true);
+    expect(indexRequestParams.userToken).toMatch(/^anonymous-/);
+
+    const indexState = initialResults.indexName!.state!;
+    expect(indexState.clickAnalytics).toBe(true);
+    expect(indexState.userToken).toMatch(/^anonymous-/);
+
+    expect(indexRequestParams.userToken).toEqual(requestParams[0].userToken);
+    expect(indexState.userToken).toEqual(indexRequestParams.userToken);
   });
 });

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -96,7 +96,11 @@ export function getInitialResults(
         // We convert the Helper state to a plain object to pass parsable data
         // structures from server to client.
         ...(searchResults && {
-          state: { ...searchResults._state },
+          state: {
+            ...searchResults._state,
+            clickAnalytics: requestParams?.[0]?.clickAnalytics,
+            userToken: requestParams?.[0]?.userToken,
+          },
           results: searchResults._rawResults,
         }),
         ...(recommendResults && {

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -925,6 +925,28 @@ describe('insights', () => {
       expect(getUserToken()).toBe('def');
     });
 
+    it('uses `userToken` from initial results', () => {
+      const { insightsClient, instantSearchInstance, getUserToken } =
+        createTestEnvironment();
+
+      instantSearchInstance._initialResults = {
+        [instantSearchInstance.indexName]: {
+          state: {
+            userToken: 'from-initial-results',
+            clickAnalytics: true,
+          },
+        },
+      };
+
+      instantSearchInstance.use(
+        createInsightsMiddleware({
+          insightsClient,
+        })
+      );
+
+      expect(getUserToken()).toEqual('from-initial-results');
+    });
+
     describe('authenticatedUserToken', () => {
       describe('before `init`', () => {
         it('uses the `authenticatedUserToken` as the `userToken` when defined', () => {

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -14,6 +14,7 @@ import type {
   InsightsMethod,
   InsightsMethodMap,
   InternalMiddleware,
+  InstantSearch,
 } from '../types';
 import type {
   AlgoliaSearchHelper,
@@ -222,10 +223,7 @@ export function createInsightsMiddleware<
           });
         }
 
-        initialParameters = {
-          userToken: (helper.state as PlainSearchParameters).userToken,
-          clickAnalytics: helper.state.clickAnalytics,
-        };
+        initialParameters = getInitialParameters(instantSearchInstance);
 
         // We don't want to force clickAnalytics when the insights is enabled from the search response.
         // This means we don't enable insights for indices that don't opt in
@@ -519,6 +517,23 @@ See documentation: https://www.algolia.com/doc/guides/building-search-ui/going-f
         }
       },
     };
+  };
+}
+
+function getInitialParameters(
+  instantSearchInstance: InstantSearch
+): PlainSearchParameters {
+  // in SSR, the initial state we use in this domain is set on the main index
+  const stateFromInitialResults =
+    instantSearchInstance._initialResults?.[instantSearchInstance.indexName]
+      ?.state || {};
+
+  const stateFromHelper = instantSearchInstance.mainHelper!.state;
+
+  return {
+    userToken: stateFromInitialResults.userToken || stateFromHelper.userToken,
+    clickAnalytics:
+      stateFromInitialResults.clickAnalytics || stateFromHelper.clickAnalytics,
   };
 }
 

--- a/packages/react-instantsearch-core/src/server/__tests__/__snapshots__/getServerState.test.tsx.snap
+++ b/packages/react-instantsearch-core/src/server/__tests__/__snapshots__/getServerState.test.tsx.snap
@@ -57,6 +57,7 @@ exports[`getServerState returns initialResults 1`] = `
       },
     ],
     "state": {
+      "clickAnalytics": undefined,
       "disjunctiveFacets": [
         "brand",
       ],
@@ -77,6 +78,7 @@ exports[`getServerState returns initialResults 1`] = `
       "numericRefinements": {},
       "query": "iphone",
       "tagRefinements": [],
+      "userToken": undefined,
     },
   },
   "instant_search_price_asc": {
@@ -134,6 +136,7 @@ exports[`getServerState returns initialResults 1`] = `
       },
     ],
     "state": {
+      "clickAnalytics": undefined,
       "disjunctiveFacets": [],
       "disjunctiveFacetsRefinements": {},
       "facets": [],
@@ -146,6 +149,7 @@ exports[`getServerState returns initialResults 1`] = `
       "index": "instant_search_price_asc",
       "numericRefinements": {},
       "tagRefinements": [],
+      "userToken": undefined,
     },
   },
   "instant_search_price_desc": {
@@ -203,6 +207,7 @@ exports[`getServerState returns initialResults 1`] = `
       },
     ],
     "state": {
+      "clickAnalytics": undefined,
       "disjunctiveFacets": [],
       "disjunctiveFacetsRefinements": {},
       "facets": [],
@@ -215,6 +220,7 @@ exports[`getServerState returns initialResults 1`] = `
       "index": "instant_search_price_desc",
       "numericRefinements": {},
       "tagRefinements": [],
+      "userToken": undefined,
     },
   },
   "instant_search_rating_desc": {
@@ -272,6 +278,7 @@ exports[`getServerState returns initialResults 1`] = `
       },
     ],
     "state": {
+      "clickAnalytics": undefined,
       "disjunctiveFacets": [],
       "disjunctiveFacetsRefinements": {},
       "facets": [],
@@ -284,6 +291,7 @@ exports[`getServerState returns initialResults 1`] = `
       "index": "instant_search_rating_desc",
       "numericRefinements": {},
       "tagRefinements": [],
+      "userToken": undefined,
     },
   },
 }

--- a/scripts/legacy/downgrade-algoliasearch-v4.js
+++ b/scripts/legacy/downgrade-algoliasearch-v4.js
@@ -59,6 +59,14 @@ shell.sed(
   ...shell.ls('examples/*/*/{src,pages,app}/*.{js,ts,tsx,vue}')
 );
 
+// replace common import in examples
+shell.sed(
+  '-i',
+  /import { createMemoryCache } from '@algolia\/client-common'/,
+  "import { createInMemoryCache as createMemoryCache } from '@algolia/client-common';",
+  ...shell.ls('examples/*/*/{src,pages,app}/*.{js,ts,tsx,vue}')
+);
+
 // replace dependency in examples
 shell.sed(
   '-i',

--- a/scripts/legacy/downgrade-algoliasearch-v4.js
+++ b/scripts/legacy/downgrade-algoliasearch-v4.js
@@ -56,7 +56,7 @@ shell.sed(
   /import { liteClient as algoliasearch } from 'algoliasearch\/lite'/,
   "import algoliasearch from 'algoliasearch/lite'",
   ...shell.ls('examples/*/*/*.{js,ts,tsx,vue}'),
-  ...shell.ls('examples/*/*/{src,pages,app}/*.{js,ts,tsx,vue}')
+  ...shell.ls('examples/*/*/{src,lib,pages,app}/*.{js,ts,tsx,vue}')
 );
 
 // replace common import in examples

--- a/scripts/legacy/downgrade-algoliasearch-v4.js
+++ b/scripts/legacy/downgrade-algoliasearch-v4.js
@@ -64,7 +64,7 @@ shell.sed(
   '-i',
   /import { createMemoryCache } from '@algolia\/client-common';/,
   "import { createInMemoryCache as createMemoryCache } from '@algolia/cache-in-memory';",
-  ...shell.ls('examples/*/*/{src,pages,app}/*.{js,ts,tsx,vue}')
+  ...shell.ls('examples/*/*/{src,lib,pages,app}/*.{js,ts,tsx,vue}')
 );
 
 // replace dependency in examples

--- a/scripts/legacy/downgrade-algoliasearch-v4.js
+++ b/scripts/legacy/downgrade-algoliasearch-v4.js
@@ -62,8 +62,8 @@ shell.sed(
 // replace common import in examples
 shell.sed(
   '-i',
-  /import { createMemoryCache } from '@algolia\/client-common'/,
-  "import { createInMemoryCache as createMemoryCache } from '@algolia/client-common';",
+  /import { createMemoryCache } from '@algolia\/client-common';/,
+  "import { createInMemoryCache as createMemoryCache } from '@algolia/cache-in-memory';",
   ...shell.ls('examples/*/*/{src,pages,app}/*.{js,ts,tsx,vue}')
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,12 +241,14 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5", "@babel/code-frame@^7.22.5", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.5.tgz#234d98e1551960604f1246e6475891a570ad5658"
-  integrity sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5", "@babel/code-frame@^7.22.5", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
+  integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
   dependencies:
-    "@babel/highlight" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.25.9"
+    js-tokens "^4.0.0"
+    picocolors "^1.0.0"
 
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.14.0", "@babel/compat-data@^7.15.0", "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.1", "@babel/compat-data@^7.20.5", "@babel/compat-data@^7.22.9":
   version "7.22.9"
@@ -317,15 +319,16 @@
     json5 "^2.2.2"
     semver "^6.3.1"
 
-"@babel/generator@^7.15.4", "@babel/generator@^7.18.2", "@babel/generator@^7.22.7", "@babel/generator@^7.22.9", "@babel/generator@^7.4.0", "@babel/generator@^7.5.0", "@babel/generator@^7.7.2", "@babel/generator@^7.9.0":
-  version "7.22.9"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.9.tgz#572ecfa7a31002fa1de2a9d91621fd895da8493d"
-  integrity sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==
+"@babel/generator@^7.15.4", "@babel/generator@^7.18.2", "@babel/generator@^7.22.9", "@babel/generator@^7.25.9", "@babel/generator@^7.4.0", "@babel/generator@^7.5.0", "@babel/generator@^7.7.2", "@babel/generator@^7.9.0":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.2.tgz#87b75813bec87916210e5e01939a4c823d6bb74f"
+  integrity sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==
   dependencies:
-    "@babel/types" "^7.22.5"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    "@jridgewell/trace-mapping" "^0.3.17"
-    jsesc "^2.5.1"
+    "@babel/parser" "^7.26.2"
+    "@babel/types" "^7.26.0"
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^3.0.2"
 
 "@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.22.5":
   version "7.22.5"
@@ -436,7 +439,7 @@
     "@babel/template" "^7.22.5"
     "@babel/types" "^7.22.5"
 
-"@babel/helper-hoist-variables@^7.18.6", "@babel/helper-hoist-variables@^7.22.5":
+"@babel/helper-hoist-variables@^7.18.6":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz#c01a007dac05c085914e8fb652b339db50d823bb"
   integrity sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==
@@ -520,15 +523,15 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
-"@babel/helper-string-parser@^7.22.5":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
-  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
+"@babel/helper-string-parser@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
+  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
 
-"@babel/helper-validator-identifier@^7.19.1", "@babel/helper-validator-identifier@^7.22.5":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
-  integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
+"@babel/helper-validator-identifier@^7.19.1", "@babel/helper-validator-identifier@^7.22.5", "@babel/helper-validator-identifier@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
+  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
 "@babel/helper-validator-option@^7.14.5", "@babel/helper-validator-option@^7.18.6", "@babel/helper-validator-option@^7.22.5":
   version "7.22.5"
@@ -554,7 +557,7 @@
     "@babel/traverse" "^7.22.6"
     "@babel/types" "^7.22.5"
 
-"@babel/highlight@^7.0.0", "@babel/highlight@^7.10.4", "@babel/highlight@^7.22.5":
+"@babel/highlight@^7.0.0", "@babel/highlight@^7.10.4":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.5.tgz#aa6c05c5407a67ebce408162b7ede789b4d22031"
   integrity sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==
@@ -563,10 +566,12 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.15.5", "@babel/parser@^7.16.4", "@babel/parser@^7.18.4", "@babel/parser@^7.20.15", "@babel/parser@^7.22.5", "@babel/parser@^7.22.7", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0":
-  version "7.22.7"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.7.tgz#df8cf085ce92ddbdbf668a7f186ce848c9036cae"
-  integrity sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.15.5", "@babel/parser@^7.16.4", "@babel/parser@^7.18.4", "@babel/parser@^7.20.15", "@babel/parser@^7.22.7", "@babel/parser@^7.25.9", "@babel/parser@^7.26.2", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0", "@babel/parser@^7.9.0":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.2.tgz#fd7b6f487cfea09889557ef5d4eeb9ff9a5abd11"
+  integrity sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==
+  dependencies:
+    "@babel/types" "^7.26.0"
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1637,39 +1642,35 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/template@^7.0.0", "@babel/template@^7.15.4", "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.22.5", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.5.tgz#0c8c4d944509875849bd0344ff0050756eefc6ec"
-  integrity sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==
+"@babel/template@^7.0.0", "@babel/template@^7.15.4", "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.22.5", "@babel/template@^7.25.9", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.9.tgz#ecb62d81a8a6f5dc5fe8abfc3901fc52ddf15016"
+  integrity sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==
   dependencies:
-    "@babel/code-frame" "^7.22.5"
-    "@babel/parser" "^7.22.5"
-    "@babel/types" "^7.22.5"
+    "@babel/code-frame" "^7.25.9"
+    "@babel/parser" "^7.25.9"
+    "@babel/types" "^7.25.9"
 
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.11.5", "@babel/traverse@^7.13.0", "@babel/traverse@^7.15.4", "@babel/traverse@^7.18.2", "@babel/traverse@^7.20.5", "@babel/traverse@^7.22.6", "@babel/traverse@^7.22.8", "@babel/traverse@^7.4.3", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2", "@babel/traverse@^7.9.0":
-  version "7.22.8"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.8.tgz#4d4451d31bc34efeae01eac222b514a77aa4000e"
-  integrity sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
+  integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
   dependencies:
-    "@babel/code-frame" "^7.22.5"
-    "@babel/generator" "^7.22.7"
-    "@babel/helper-environment-visitor" "^7.22.5"
-    "@babel/helper-function-name" "^7.22.5"
-    "@babel/helper-hoist-variables" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/parser" "^7.22.7"
-    "@babel/types" "^7.22.5"
-    debug "^4.1.0"
+    "@babel/code-frame" "^7.25.9"
+    "@babel/generator" "^7.25.9"
+    "@babel/parser" "^7.25.9"
+    "@babel/template" "^7.25.9"
+    "@babel/types" "^7.25.9"
+    debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.15.4", "@babel/types@^7.15.6", "@babel/types@^7.18.4", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.22.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.5.tgz#cd93eeaab025880a3a47ec881f4b096a5b786fbe"
-  integrity sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==
+"@babel/types@^7.0.0", "@babel/types@^7.15.4", "@babel/types@^7.15.6", "@babel/types@^7.18.4", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.22.5", "@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.9.0":
+  version "7.26.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.0.tgz#deabd08d6b753bc8e0f198f8709fb575e31774ff"
+  integrity sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==
   dependencies:
-    "@babel/helper-string-parser" "^7.22.5"
-    "@babel/helper-validator-identifier" "^7.22.5"
-    to-fast-properties "^2.0.0"
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -2779,29 +2780,24 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
-  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
+"@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
+  integrity sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==
   dependencies:
-    "@jridgewell/set-array" "^1.0.1"
+    "@jridgewell/set-array" "^1.2.1"
     "@jridgewell/sourcemap-codec" "^1.4.10"
-    "@jridgewell/trace-mapping" "^0.3.9"
+    "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/resolve-uri@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
-  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/resolve-uri@^3.0.3":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
-  integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
-
-"@jridgewell/set-array@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
-  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+"@jridgewell/set-array@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
+  integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
 
 "@jridgewell/source-map@^0.3.2":
   version "0.3.2"
@@ -2811,10 +2807,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
-  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
+  integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
@@ -2824,13 +2820,13 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
-  integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
   dependencies:
-    "@jridgewell/resolve-uri" "3.1.0"
-    "@jridgewell/sourcemap-codec" "1.4.14"
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@jsdoc/salty@^0.2.1":
   version "0.2.5"
@@ -19609,10 +19605,10 @@ jsesc@^1.3.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
   integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
-jsesc@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
-  integrity sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=
+jsesc@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
+  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -30369,11 +30365,6 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
   integrity sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==
-
-to-fast-properties@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
-  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
 to-object-path@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION

- in insights middleware: ensure we read from the _initialResults (as insights starts before index is init'ed and the parameters aren't in the index, but in the main index)
- in getInitialResults: add the parameters to every index explicitly (it's not ui state so was missing otherwise)

other changes in this PR:
- something in the dependencies to prevent https://github.com/babel/babel/issues/16689
- use a cache in the server side react examples
- type `userToken` in SearchParameters

related to [CR-6992]

[CR-6992]: https://algolia.atlassian.net/browse/CR-6992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ