### PR TITLE
chore: don't allow index widget when in composition mode

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -512,6 +512,14 @@ See documentation: ${createDocumentationLink({
       );
     }
 
+    if (this.compositionID && widgets.some(isIndexWidget)) {
+      throw new Error(
+        withUsage(
+          'The `index` widget cannot be used with a composition-based InstantSearch implementation.'
+        )
+      );
+    }
+
     this.mainIndex.addWidgets(widgets);
 
     return this;

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -159,6 +159,31 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
         '[InstantSearch.js]: No indexName provided, nor an explicit index widget in the widgets tree. This is required to be able to display results.'
       );
     });
+
+    it('throws if compositionID & index widget is provided', () => {
+      expect(() => {
+        const search = new InstantSearch({
+          searchClient: createSearchClient(),
+          compositionID: 'my-composition',
+        });
+
+        search.addWidgets([index({ indexName: 'indexName' })]);
+      }).toThrowErrorMatchingInlineSnapshot(`
+        "The \`index\` widget cannot be used with a composition-based InstantSearch implementation.
+
+        See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
+        `);
+    });
+
+    it('does not throw if compositionID is not provided while index widget is provided', () => {
+      expect(() => {
+        const search = new InstantSearch({
+          searchClient: createSearchClient(),
+        });
+
+        search.addWidgets([index({ indexName: 'indexName' })]);
+      }).not.toThrow();
+    });
   });
 
   it('throws if insightsClient is not a function', () => {


### PR DESCRIPTION
**Summary**

prevent explicitely passing an `index` widget while `compositionID` is defined.

[EMERCH-1747](https://algolia.atlassian.net/browse/EMERCH-1747)


[EMERCH-1747]: https://algolia.atlassian.net/browse/EMERCH-1747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ