### PR TITLE
Add a custom label

### DIFF
--- a/packages/instantsearch.js/src/connectors/current-refinements/connectCurrentRefinements.ts
+++ b/packages/instantsearch.js/src/connectors/current-refinements/connectCurrentRefinements.ts
@@ -384,14 +384,15 @@ function getOperatorSymbol(operator: SearchParameters.Operator): string {
 }
 
 function normalizeRefinement(
-  refinement: Refinement
+  refinement: Refinement,
+  customLabel?: string
 ): CurrentRefinementsConnectorParamsRefinement {
   const value = getValue(refinement);
-  const label = (refinement as NumericRefinement).operator
+  const label = customLabel || ((refinement as NumericRefinement).operator
     ? `${getOperatorSymbol(
         (refinement as NumericRefinement).operator as SearchParameters.Operator
       )} ${refinement.name}`
-    : refinement.name;
+    : refinement.name);
 
   const normalizedRefinement: CurrentRefinementsConnectorParamsRefinement = {
     attribute: refinement.attribute,


### PR DESCRIPTION
I am relatively new to working with Algolia and am integrating it with my backend. During this process, I encountered an issue: I often have facets with specific values, but I want to display different names for these values on the frontend. Currently, this functionality is not supported by Algolia.

Proposed Solution:

Extend the existing label functionality to allow setting a custom label for any facet value.
Currently, the label is only used for numeric values. This proposal suggests enabling custom labels for all facet values if provided.
I believe this enhancement would be beneficial for many users who need more flexibility in displaying facet names.
