### PR TITLE
chore(core): move tests to core

### DIFF
--- a/packages/instantsearch-core/src/__tests__/RoutingManager.test.ts
+++ b/packages/instantsearch-core/src/__tests__/RoutingManager.test.ts
@@ -6,12 +6,15 @@ import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
 import qs from 'qs';
 
-import instantsearch from '../..';
-import { createWidget } from '../../../test/createWidget';
-import { connectHitsPerPage, connectSearchBox } from '../../connectors';
-import historyRouter from '../routers/history';
+import {
+  instantsearch,
+  historyRouter,
+  connectHitsPerPage,
+  connectSearchBox,
+} from '..';
+import { createWidget } from '../../test/createWidget';
 
-import type { Router, UiState, StateMapping, IndexUiState } from '../../types';
+import type { Router, UiState, StateMapping, IndexUiState } from '../types';
 import type { JSDOM } from 'jsdom';
 
 declare const jsdom: JSDOM;

--- a/packages/instantsearch-core/src/__tests__/instantsearch.test.tsx
+++ b/packages/instantsearch-core/src/__tests__/instantsearch.test.tsx
@@ -14,22 +14,23 @@ import { wait } from '@instantsearch/testutils/wait';
 import originalHelper from 'algoliasearch-helper';
 import { h, render, createRef } from 'preact';
 
-import { createRenderOptions, createWidget } from '../../../test/createWidget';
-import { connectSearchBox, connectPagination } from '../../connectors';
-import { createInsightsMiddleware } from '../../middlewares';
-import { index } from '../../widgets';
-import InstantSearch from '../InstantSearch';
+import {
+  InstantSearch,
+  index,
+  createInsightsMiddleware,
+  connectSearchBox,
+  connectPagination,
+} from '..';
+import { createRenderOptions, createWidget } from '../../test/createWidget';
 import version from '../version';
 
 import type {
-  UiState,
-  Widget,
-  IndexWidget,
   PaginationConnectorParams,
   PaginationWidgetDescription,
   SearchBoxWidgetDescription,
   SearchBoxConnectorParams,
-} from '../../types';
+} from '..';
+import type { UiState, Widget, IndexWidget } from '../types';
 import type { RefObject } from 'preact';
 
 type SearchBoxWidgetInstance = Widget<
@@ -318,12 +319,9 @@ describe('InstantSearch', () => {
       searchClient,
     });
 
-    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledTimes(2);
+    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledTimes(1);
     expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
-      expect.stringMatching(/^instantsearch-core \(.*\)$/)
-    );
-    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
-      `instantsearch.js (${version})`
+      `instantsearch-core (${version})`
     );
   });
 

--- a/packages/instantsearch-core/src/__tests__/server.test.ts
+++ b/packages/instantsearch-core/src/__tests__/server.test.ts
@@ -4,13 +4,14 @@ import {
 } from '@instantsearch/mocks';
 
 import {
+  getInitialResults,
+  waitForResults,
+  instantsearch,
+  index,
   connectConfigure,
   connectHierarchicalMenu,
   connectSearchBox,
-} from '../../connectors';
-import instantsearch from '../../index.es';
-import { index } from '../../widgets';
-import { getInitialResults, waitForResults } from '../server';
+} from '..';
 
 describe('waitForResults', () => {
   test('waits for the results from the search instance', async () => {

--- a/packages/instantsearch-core/src/__tests__/status.test.ts
+++ b/packages/instantsearch-core/src/__tests__/status.test.ts
@@ -1,10 +1,10 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
 
-import { connectSearchBox } from '../../connectors';
-import instantsearch from '../../index.es';
+import { connectSearchBox } from '../connectors';
+import { instantsearch } from '../instantsearch';
 
-import type InstantSearch from '../InstantSearch';
+import type { InstantSearch } from '../instantsearch';
 
 function createDelayedSearchClient(timeout: number) {
   const searchClient = createSearchClient();

--- a/packages/instantsearch-core/src/routing/__tests__/correct-urls.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/correct-urls.test.ts
@@ -5,10 +5,13 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
 
-import { connectPagination, connectSearchBox } from '../../../connectors';
-import instantsearch from '../../../index.es';
-import { index } from '../../../widgets';
-import historyRouter from '../../routers/history';
+import {
+  instantsearch,
+  index,
+  historyRouter,
+  connectPagination,
+  connectSearchBox,
+} from '../..';
 
 beforeEach(() => {
   window.history.pushState({}, '', '/');

--- a/packages/instantsearch-core/src/routing/__tests__/duplicate-url.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/duplicate-url.test.ts
@@ -5,9 +5,12 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
 
-import instantsearch from '../../..';
-import { connectPagination, connectSearchBox } from '../../../connectors';
-import historyRouter from '../../routers/history';
+import {
+  instantsearch,
+  historyRouter,
+  connectPagination,
+  connectSearchBox,
+} from '../..';
 
 /* eslint no-lone-blocks: "off" */
 

--- a/packages/instantsearch-core/src/routing/__tests__/modal.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/modal.test.ts
@@ -5,26 +5,19 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
 
-import instantsearch from '../../..';
-import { connectSearchBox } from '../../../connectors';
-import historyRouter from '../../routers/history';
+import { instantsearch, historyRouter, connectSearchBox } from '../..';
 
 /* eslint no-lone-blocks: "off" */
 
 const writeDelay = 10;
 const writeWait = 10 * writeDelay;
 
-describe('routing using `replaceState`', () => {
-  // We can't assert whether another router did update the URL
-  // So there's no way to prevent `write` after `dispose`
-  test('cleans the URL after navigating', async () => {
+describe('routing with no navigation', () => {
+  test('cleans the URL when InstantSearch is disposed within the same page', async () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: does not yet write
-    // 4. Route change (with `replaceState`): '/about?external=true', replaces state 2
-    // 5. Dispose: writes '/about' (this is a bug, and should be fixed when we have a way to prevent it)
-    // 6. Back: '/about?external=true'
+    // 3. Dispose: '/'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -53,37 +46,21 @@ describe('routing using `replaceState`', () => {
       search.renderState.indexName.searchBox!.refine('Apple');
 
       await wait(writeWait);
+      expect(window.location.pathname).toEqual('/');
       expect(window.location.search).toEqual(
         `?${encodeURI('indexName[query]=Apple')}`
       );
       expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 3. Dispose: '/about'
-    // 4. Route change (with `replaceState`): '/about'
+    // 3. Dispose: '/'
     {
       search.dispose();
-      window.history.replaceState({}, '', '/about?external=true');
 
-      // Asserting `replaceState` call
-      expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('?external=true');
-      expect(pushState).toHaveBeenCalledTimes(1);
-
-      // Asserting `dispose` calling `pushState`
       await wait(writeWait);
-      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.pathname).toEqual('/');
       expect(window.location.search).toEqual('');
       expect(pushState).toHaveBeenCalledTimes(2);
-    }
-
-    // 5. Back: '/about'
-    {
-      window.history.back();
-
-      await wait(writeWait);
-      expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('?external=true');
     }
   });
 });

--- a/packages/instantsearch-core/src/routing/__tests__/spa-debounced.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/spa-debounced.test.ts
@@ -5,22 +5,22 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
 
-import instantsearch from '../../..';
-import { connectSearchBox } from '../../../connectors';
-import historyRouter from '../../routers/history';
+import { instantsearch, historyRouter, connectSearchBox } from '../..';
 
 /* eslint no-lone-blocks: "off" */
 
 const writeDelay = 10;
 const writeWait = 10 * writeDelay;
 
-describe('routing with external influence', () => {
-  test('keeps on working when the URL is updated by another program', async () => {
+describe('routing with debounced third-party client-side router', () => {
+  test('does not clean the URL after navigating', async () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. External influence: '/about'
-    // 4. Refine: '/about?indexName[query]=Samsung'
+    // 3. Dispose: '/'
+    // 4. Route change: '/about'
+    // 5. Back: '/'
+    // 6. Back: '/?indexName[query]=Apple'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -55,25 +55,45 @@ describe('routing with external influence', () => {
       expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 3. External influence: '/about'
+    // 3. Dispose: '/'
+    {
+      search.dispose();
+
+      await wait(writeWait);
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual('');
+      expect(pushState).toHaveBeenCalledTimes(2);
+    }
+
+    // 4. Route change: '/about'
     {
       window.history.pushState({}, '', '/about');
 
       await wait(writeWait);
       expect(window.location.pathname).toEqual('/about');
       expect(window.location.search).toEqual('');
-      expect(pushState).toHaveBeenCalledTimes(2);
+      expect(pushState).toHaveBeenCalledTimes(3);
     }
 
-    // 4. Refine: '/about?indexName[query]=Samsung'
+    // 5. Back: '/'
     {
-      search.renderState.indexName.searchBox!.refine('Samsung');
+      window.history.back();
 
       await wait(writeWait);
-      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual('');
+    }
+
+    // 6. Back: '/?indexName[query]=Apple'
+    {
+      window.history.back();
+
+      await wait(writeWait);
+      expect(window.location.pathname).toEqual('/');
       expect(window.location.search).toEqual(
-        `?${encodeURI('indexName[query]=Samsung')}`
+        `?${encodeURI('indexName[query]=Apple')}`
       );
+      expect(pushState).toHaveBeenCalledTimes(3);
     }
   });
 });

--- a/packages/instantsearch-core/src/routing/__tests__/spa-replace-state.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/spa-replace-state.test.ts
@@ -5,24 +5,24 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
 
-import instantsearch from '../../..';
-import { connectSearchBox } from '../../../connectors';
-import historyRouter from '../../routers/history';
+import { instantsearch, historyRouter, connectSearchBox } from '../..';
 
 /* eslint no-lone-blocks: "off" */
 
 const writeDelay = 10;
 const writeWait = 10 * writeDelay;
 
-describe('routing with third-party client-side router', () => {
-  test('does not clean the URL after navigating', async () => {
+describe('routing using `replaceState`', () => {
+  // We can't assert whether another router did update the URL
+  // So there's no way to prevent `write` after `dispose`
+  test('cleans the URL after navigating', async () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Navigate: '/about'
-    // 4. Back: '/?indexName[query]=Apple'
-    // 5. Restart: '/?indexName[query]=Apple'
-    // 6. Refine: '/?indexName[query]=Samsung'
+    // 3. Dispose: does not yet write
+    // 4. Route change (with `replaceState`): '/about?external=true', replaces state 2
+    // 5. Dispose: writes '/about' (this is a bug, and should be fixed when we have a way to prevent it)
+    // 6. Back: '/about?external=true'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -57,49 +57,31 @@ describe('routing with third-party client-side router', () => {
       expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 3. Navigate: '/about'
+    // 3. Dispose: '/about'
+    // 4. Route change (with `replaceState`): '/about'
     {
       search.dispose();
-      window.history.pushState({}, '', '/about');
+      window.history.replaceState({}, '', '/about?external=true');
 
+      // Asserting `replaceState` call
+      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.search).toEqual('?external=true');
+      expect(pushState).toHaveBeenCalledTimes(1);
+
+      // Asserting `dispose` calling `pushState`
       await wait(writeWait);
       expect(window.location.pathname).toEqual('/about');
       expect(window.location.search).toEqual('');
       expect(pushState).toHaveBeenCalledTimes(2);
     }
 
-    // 4. Back to previous page
+    // 5. Back: '/about'
     {
       window.history.back();
 
       await wait(writeWait);
-      expect(window.location.pathname).toEqual('/');
-      expect(window.location.search).toEqual(
-        `?${encodeURI('indexName[query]=Apple')}`
-      );
-    }
-
-    // 5. Restart InstantSearch
-    {
-      search.addWidgets([connectSearchBox(() => {})({})]);
-      search.start();
-
-      await wait(writeWait);
-      expect(window.location.pathname).toEqual('/');
-      expect(window.location.search).toEqual(
-        `?${encodeURI('indexName[query]=Apple')}`
-      );
-    }
-
-    // 6. Refine: '/?indexName[query]=Samsung'
-    {
-      search.renderState.indexName.searchBox!.refine('Samsung');
-
-      await wait(writeWait);
-      expect(window.location.search).toEqual(
-        `?${encodeURI('indexName[query]=Samsung')}`
-      );
-      expect(pushState).toHaveBeenCalledTimes(3);
+      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.search).toEqual('?external=true');
     }
   });
 });

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.ts
@@ -1,0 +1,24 @@
+import { createSearchClient } from '@instantsearch/mocks';
+
+import InstantSearch from '../InstantSearch';
+import version from '../version';
+
+it('calls addAlgoliaAgent', () => {
+  const searchClient = createSearchClient({
+    addAlgoliaAgent: jest.fn(),
+  });
+
+  // eslint-disable-next-line no-new
+  new InstantSearch({
+    indexName: 'indexName',
+    searchClient,
+  });
+
+  expect(searchClient.addAlgoliaAgent).toHaveBeenCalledTimes(2);
+  expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
+    expect.stringMatching(/^instantsearch-core \(.*\)$/)
+  );
+  expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
+    `instantsearch.js (${version})`
+  );
+});


### PR DESCRIPTION
these were still in instantsearch.js but actually are for the "core" domain now.
