### PR TITLE
fix(searchForFacetValues): only call client.search

### DIFF
--- a/packages/algoliasearch-helper/src/requestBuilder.js
+++ b/packages/algoliasearch-helper/src/requestBuilder.js
@@ -434,7 +434,6 @@ var requestBuilder = {
       : state;
     var searchForFacetSearchParameters = {
       facetQuery: query,
-      facetName: facetName,
     };
     if (typeof maxFacetHits === 'number') {
       searchForFacetSearchParameters.maxFacetHits = maxFacetHits;

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/events.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/events.js
@@ -7,9 +7,6 @@ function makeFakeClient() {
     search: jest.fn(function () {
       return new Promise(function () {});
     }),
-    searchForFacetValues: jest.fn(function () {
-      return new Promise(function () {});
-    }),
   };
 }
 
@@ -297,7 +294,7 @@ test(
     helper.on('searchForFacetValues', searchedForFacetValues);
 
     expect(searchedForFacetValues).toHaveBeenCalledTimes(0);
-    expect(fakeClient.searchForFacetValues).toHaveBeenCalledTimes(0);
+    expect(fakeClient.search).toHaveBeenCalledTimes(0);
 
     helper.searchForFacetValues('city', 'NYC');
     expect(searchedForFacetValues).toHaveBeenCalledTimes(1);
@@ -306,7 +303,7 @@ test(
       facet: 'city',
       query: 'NYC',
     });
-    expect(fakeClient.searchForFacetValues).toHaveBeenCalledTimes(1);
+    expect(fakeClient.search).toHaveBeenCalledTimes(1);
   }
 );
 

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -10,77 +10,36 @@ function makeFakeSearchForFacetValuesResponse() {
   };
 }
 
-test('searchForFacetValues calls the client method over the index method', function () {
-  var clientSearchForFacetValues = jest.fn(function () {
-    return Promise.resolve([makeFakeSearchForFacetValuesResponse()]);
-  });
-
-  var indexSearchForFacetValues = jest.fn(function () {
-    return Promise.resolve(makeFakeSearchForFacetValuesResponse());
-  });
-
-  var fakeClient = {
-    searchForFacetValues: clientSearchForFacetValues,
-    initIndex: function () {
-      return {
-        searchForFacetValues: indexSearchForFacetValues,
-      };
-    },
-  };
-
-  var helper = algoliasearchHelper(fakeClient, 'index');
-
-  return helper.searchForFacetValues('facet', 'query', 1).then(function () {
-    expect(clientSearchForFacetValues).toHaveBeenCalledTimes(1);
-    expect(indexSearchForFacetValues).toHaveBeenCalledTimes(0);
-  });
-});
-
-test('searchForFacetValues calls the index method if no client method', function () {
-  var indexSearchForFacetValues = jest.fn(function () {
-    return Promise.resolve(makeFakeSearchForFacetValuesResponse());
-  });
-
-  var fakeClient = {
-    initIndex: function () {
-      return {
-        searchForFacetValues: indexSearchForFacetValues,
-      };
-    },
-  };
-
-  var helper = algoliasearchHelper(fakeClient, 'index');
-
-  return helper.searchForFacetValues('facet', 'query', 1).then(function () {
-    expect(indexSearchForFacetValues).toHaveBeenCalledTimes(1);
-  });
-});
-
 test('searchForFacetValues calls client.search if client.searchForFacets exists', function () {
-  var clientSearch = jest.fn(function () {
-    return Promise.resolve({
-      results: [makeFakeSearchForFacetValuesResponse()],
-    });
-  });
-
   var fakeClient = {
+    initIndex: function () {
+      return {
+        searchForFacetValues: jest.fn(function () {}),
+      };
+    },
     searchForFacets: jest.fn(),
     searchForFacetValues: jest.fn(),
-    search: clientSearch,
+    search: jest.fn(function () {
+      return Promise.resolve({
+        results: [makeFakeSearchForFacetValuesResponse()],
+      });
+    }),
   };
 
   var helper = algoliasearchHelper(fakeClient, 'index');
 
   return helper.searchForFacetValues('facet', 'query', 1).then(function () {
-    expect(clientSearch).toHaveBeenCalledTimes(1);
+    expect(fakeClient.search).toHaveBeenCalledTimes(1);
   });
 });
 
 test('searchForFacetValues resolve with the correct response from client', function () {
   var fakeClient = {
     addAlgoliaAgent: function () {},
-    searchForFacetValues: function () {
-      return Promise.resolve([makeFakeSearchForFacetValuesResponse()]);
+    search: function () {
+      return Promise.resolve({
+        results: [makeFakeSearchForFacetValuesResponse()],
+      });
     },
   };
 
@@ -95,40 +54,14 @@ test('searchForFacetValues resolve with the correct response from client', funct
     });
 });
 
-test('searchForFacetValues resolve with the correct response from initIndex', function () {
+test('searchForFacetValues should search for facetValues with the current state', function () {
   var fakeClient = {
     addAlgoliaAgent: function () {},
-    initIndex: function () {
-      return {
-        searchForFacetValues: function () {
-          return Promise.resolve(makeFakeSearchForFacetValuesResponse());
-        },
-      };
-    },
-  };
-
-  var helper = algoliasearchHelper(fakeClient, 'index');
-
-  return helper
-    .searchForFacetValues('facet', 'query', 1)
-    .then(function (content) {
-      expect(content.exhaustiveFacetsCount).toBe(true);
-      expect(content.facetHits.length).toBe(0);
-      expect(content.processingTimeMS).toBe(3);
-    });
-});
-
-test('index.searchForFacetValues should search for facetValues with the current state', function () {
-  var indexSearchForFacetValues = jest.fn(function () {
-    return Promise.resolve(makeFakeSearchForFacetValuesResponse());
-  });
-
-  var fakeClient = {
-    initIndex: function () {
-      return {
-        searchForFacetValues: indexSearchForFacetValues,
-      };
-    },
+    search: jest.fn(function () {
+      return Promise.resolve({
+        results: [makeFakeSearchForFacetValuesResponse()],
+      });
+    }),
   };
 
   var helper = algoliasearchHelper(fakeClient, 'index', {
@@ -139,144 +72,22 @@ test('index.searchForFacetValues should search for facetValues with the current 
 
   helper.searchForFacetValues('facet', 'query', 75);
 
-  var lastArguments = indexSearchForFacetValues.mock.calls[0][0];
+  var lastArguments = fakeClient.search.mock.calls[0][0][0];
 
-  expect(lastArguments.query).toBe('iphone');
-  expect(lastArguments.facetQuery).toBe('query');
-  expect(lastArguments.facetName).toBe('facet');
-  expect(lastArguments.highlightPreTag).toBe('HIGHLIGHT>');
-  expect(lastArguments.highlightPostTag).toBe('<HIGHLIGHT');
-});
-
-test('index.searchForFacetValues can override the current search state', function () {
-  var indexSearchForFacetValues = jest.fn(function () {
-    return Promise.resolve(makeFakeSearchForFacetValuesResponse());
-  });
-
-  var fakeClient = {
-    initIndex: function () {
-      return {
-        searchForFacetValues: indexSearchForFacetValues,
-      };
-    },
-  };
-
-  var helper = algoliasearchHelper(fakeClient, 'index', {
-    highlightPreTag: 'HIGHLIGHT>',
-    highlightPostTag: '<HIGHLIGHT',
-    query: 'iphone',
-  });
-
-  helper.searchForFacetValues('facet', 'query', 75, {
-    query: undefined,
-    highlightPreTag: 'highlightTag',
-  });
-
-  var lastArguments = indexSearchForFacetValues.mock.calls[0][0];
-
-  expect(lastArguments.hasOwnProperty('query')).toBeFalsy();
-  expect(lastArguments.facetQuery).toBe('query');
-  expect(lastArguments.facetName).toBe('facet');
-  expect(lastArguments.highlightPreTag).toBe('highlightTag');
-  expect(lastArguments.highlightPostTag).toBe('<HIGHLIGHT');
-});
-
-test('client.searchForFacetValues should search for facetValues with the current state', function () {
-  var clientSearchForFacetValues = jest.fn(function () {
-    return Promise.resolve([makeFakeSearchForFacetValuesResponse()]);
-  });
-
-  var fakeClient = {
-    searchForFacetValues: clientSearchForFacetValues,
-  };
-
-  var helper = algoliasearchHelper(fakeClient, 'index', {
-    highlightPreTag: 'HIGHLIGHT>',
-    highlightPostTag: '<HIGHLIGHT',
-    query: 'iphone',
-  });
-
-  helper.searchForFacetValues('facet', 'query', 75);
-
-  var lastArguments = clientSearchForFacetValues.mock.calls[0][0][0];
-
-  expect(lastArguments.indexName).toBe('index');
   expect(lastArguments.params.query).toBe('iphone');
   expect(lastArguments.params.facetQuery).toBe('query');
-  expect(lastArguments.params.facetName).toBe('facet');
-  expect(lastArguments.params.highlightPreTag).toBe('HIGHLIGHT>');
-  expect(lastArguments.params.highlightPostTag).toBe('<HIGHLIGHT');
-});
-
-test('client.searchForFacetValues can override the current search state', function () {
-  var clientSearchForFacetValues = jest.fn(function () {
-    return Promise.resolve([makeFakeSearchForFacetValuesResponse()]);
-  });
-
-  var fakeClient = {
-    searchForFacetValues: clientSearchForFacetValues,
-  };
-
-  var helper = algoliasearchHelper(fakeClient, 'index', {
-    highlightPreTag: 'HIGHLIGHT>',
-    highlightPostTag: '<HIGHLIGHT',
-    query: 'iphone',
-  });
-
-  helper.searchForFacetValues('facet', 'query', 75, {
-    query: undefined,
-    highlightPreTag: 'highlightTag',
-  });
-
-  var lastArguments = clientSearchForFacetValues.mock.calls[0][0][0];
-
-  expect(lastArguments.indexName).toBe('index');
-  expect(lastArguments.params.hasOwnProperty('query')).toBeFalsy();
-  expect(lastArguments.params.facetQuery).toBe('query');
-  expect(lastArguments.params.facetName).toBe('facet');
-  expect(lastArguments.params.highlightPreTag).toBe('highlightTag');
-  expect(lastArguments.params.highlightPostTag).toBe('<HIGHLIGHT');
-});
-
-test('client.search should search for facetValues with the current state', function () {
-  var clientSearch = jest.fn(function () {
-    return Promise.resolve({
-      results: [makeFakeSearchForFacetValuesResponse()],
-    });
-  });
-
-  var fakeClient = {
-    search: clientSearch,
-  };
-
-  var helper = algoliasearchHelper(fakeClient, 'index', {
-    highlightPreTag: 'HIGHLIGHT>',
-    highlightPostTag: '<HIGHLIGHT',
-    query: 'iphone',
-  });
-
-  helper.searchForFacetValues('facet', 'query', 75);
-
-  var lastArguments = clientSearch.mock.calls[0][0][0];
-
-  expect(lastArguments.indexName).toBe('index');
-  expect(lastArguments.params.query).toBe('iphone');
-  expect(lastArguments.params.facetQuery).toBe('query');
-  expect(lastArguments.params.hasOwnProperty('facetName')).toBeFalsy();
   expect(lastArguments.facet).toBe('facet');
   expect(lastArguments.params.highlightPreTag).toBe('HIGHLIGHT>');
   expect(lastArguments.params.highlightPostTag).toBe('<HIGHLIGHT');
 });
 
-test('client.search can override the current search state', function () {
-  var clientSearch = jest.fn(function () {
-    return Promise.resolve({
-      results: [makeFakeSearchForFacetValuesResponse()],
-    });
-  });
-
+test('searchForFacetValues can override the current search state', function () {
   var fakeClient = {
-    search: clientSearch,
+    search: jest.fn(function () {
+      return Promise.resolve({
+        results: [makeFakeSearchForFacetValuesResponse()],
+      });
+    }),
   };
 
   var helper = algoliasearchHelper(fakeClient, 'index', {
@@ -290,52 +101,39 @@ test('client.search can override the current search state', function () {
     highlightPreTag: 'highlightTag',
   });
 
-  var lastArguments = clientSearch.mock.calls[0][0][0];
+  var lastArguments = fakeClient.search.mock.calls[0][0][0];
 
-  expect(lastArguments.indexName).toBe('index');
   expect(lastArguments.params.hasOwnProperty('query')).toBeFalsy();
   expect(lastArguments.params.facetQuery).toBe('query');
-  expect(lastArguments.params.hasOwnProperty('facetName')).toBeFalsy();
   expect(lastArguments.facet).toBe('facet');
   expect(lastArguments.params.highlightPreTag).toBe('highlightTag');
   expect(lastArguments.params.highlightPostTag).toBe('<HIGHLIGHT');
-});
-
-test('an error will be thrown if the client does not contain .searchForFacetValues', function () {
-  var fakeClient = {};
-  var helper = algoliasearchHelper(fakeClient, 'index');
-
-  try {
-    helper.searchForFacetValues('facet', 'query');
-  } catch (e) {
-    expect(e.message).toBe(
-      'search for facet values (searchable) was called, but this client does not have a function client.searchForFacetValues or client.initIndex(index).searchForFacetValues'
-    );
-  }
 });
 
 test('isRefined is set for disjunctive facets', function () {
   var fakeClient = {
     addAlgoliaAgent: function () {},
-    searchForFacetValues: function () {
-      return Promise.resolve([
-        {
-          exhaustiveFacetsCount: true,
-          facetHits: [
-            {
-              count: 318,
-              highlighted: '__ais-highlight__K__/ais-highlight__itchenAid',
-              value: 'KitchenAid',
-            },
-            {
-              count: 1,
-              highlighted: 'something',
-              value: 'something',
-            },
-          ],
-          processingTimeMS: 3,
-        },
-      ]);
+    search: function () {
+      return Promise.resolve({
+        results: [
+          {
+            exhaustiveFacetsCount: true,
+            facetHits: [
+              {
+                count: 318,
+                highlighted: '__ais-highlight__K__/ais-highlight__itchenAid',
+                value: 'KitchenAid',
+              },
+              {
+                count: 1,
+                highlighted: 'something',
+                value: 'something',
+              },
+            ],
+            processingTimeMS: 3,
+          },
+        ],
+      });
     },
   };
 
@@ -360,25 +158,27 @@ test('isRefined is set for disjunctive facets', function () {
 test('isRefined is set for conjunctive facets', function () {
   var fakeClient = {
     addAlgoliaAgent: function () {},
-    searchForFacetValues: function () {
-      return Promise.resolve([
-        {
-          exhaustiveFacetsCount: true,
-          facetHits: [
-            {
-              count: 318,
-              highlighted: '__ais-highlight__K__/ais-highlight__itchenAid',
-              value: 'KitchenAid',
-            },
-            {
-              count: 1,
-              highlighted: 'something',
-              value: 'something',
-            },
-          ],
-          processingTimeMS: 3,
-        },
-      ]);
+    search: function () {
+      return Promise.resolve({
+        results: [
+          {
+            exhaustiveFacetsCount: true,
+            facetHits: [
+              {
+                count: 318,
+                highlighted: '__ais-highlight__K__/ais-highlight__itchenAid',
+                value: 'KitchenAid',
+              },
+              {
+                count: 1,
+                highlighted: 'something',
+                value: 'something',
+              },
+            ],
+            processingTimeMS: 3,
+          },
+        ],
+      });
     },
   };
 
@@ -403,25 +203,27 @@ test('isRefined is set for conjunctive facets', function () {
 test('value is escaped when it starts with `-`', function () {
   var fakeClient = {
     addAlgoliaAgent: function () {},
-    searchForFacetValues: function () {
-      return Promise.resolve([
-        {
-          exhaustiveFacetsCount: true,
-          facetHits: [
-            {
-              count: 318,
-              highlighted: 'something',
-              value: 'something',
-            },
-            {
-              count: 1,
-              highlighted: '-20%',
-              value: '-20%',
-            },
-          ],
-          processingTimeMS: 3,
-        },
-      ]);
+    search: function () {
+      return Promise.resolve({
+        results: [
+          {
+            exhaustiveFacetsCount: true,
+            facetHits: [
+              {
+                count: 318,
+                highlighted: 'something',
+                value: 'something',
+              },
+              {
+                count: 1,
+                highlighted: '-20%',
+                value: '-20%',
+              },
+            ],
+            processingTimeMS: 3,
+          },
+        ],
+      });
     },
   };
 
@@ -441,25 +243,27 @@ test('value is escaped when it starts with `-`', function () {
 test('escaped value is marked as refined', function () {
   var fakeClient = {
     addAlgoliaAgent: function () {},
-    searchForFacetValues: function () {
-      return Promise.resolve([
-        {
-          exhaustiveFacetsCount: true,
-          facetHits: [
-            {
-              count: 318,
-              highlighted: 'something',
-              value: 'something',
-            },
-            {
-              count: 1,
-              highlighted: '-20%',
-              value: '-20%',
-            },
-          ],
-          processingTimeMS: 3,
-        },
-      ]);
+    search: function () {
+      return Promise.resolve({
+        results: [
+          {
+            exhaustiveFacetsCount: true,
+            facetHits: [
+              {
+                count: 318,
+                highlighted: 'something',
+                value: 'something',
+              },
+              {
+                count: 1,
+                highlighted: '-20%',
+                value: '-20%',
+              },
+            ],
+            processingTimeMS: 3,
+          },
+        ],
+      });
     },
   };
 

--- a/packages/algoliasearch-helper/types/algoliasearch.d.ts
+++ b/packages/algoliasearch-helper/types/algoliasearch.d.ts
@@ -287,31 +287,27 @@ export type SupportedLanguage = PickForClient<{
   v5: AlgoliaSearch.SupportedLanguage;
 }>;
 
-// v5 only has the `searchForFacetValues` method in the `search` client, not in `lite`.
-// We need to check both clients to get the correct type.
-// (this is not actually used in the codebase, but it's here for completeness)
-type SearchForFacetValuesV5 = ClientSearchV5 | ClientFullV5 extends {
-  searchForFacetValues: unknown;
-}
-  ?
-      | ClientSearchV5['searchForFacetValues']
-      | ClientFullV5['searchForFacetValues']
-  : never;
-
 export interface SearchClient {
   search: <T>(
-    requests: Array<{ indexName: string; params: SearchOptions }>
+    requests: Array<
+      | {
+          type?: 'default';
+          indexName: string;
+          params: SearchOptions;
+        }
+      | {
+          type: 'facet';
+          indexName: string;
+          facet: string;
+          params: SearchOptions & {
+            maxFacetHits?: number;
+            facetQuery?: string;
+          };
+        }
+    >
   ) => Promise<SearchResponses<T>>;
   getRecommendations?: <T>(
     requests: RecommendOptions[]
   ) => Promise<RecommendResponses<T>>;
-  searchForFacetValues?: DefaultSearchClient extends {
-    searchForFacetValues: unknown;
-  }
-    ? DefaultSearchClient['searchForFacetValues']
-    : SearchForFacetValuesV5;
-  initIndex?: DefaultSearchClient extends { initIndex: unknown }
-    ? DefaultSearchClient['initIndex']
-    : never;
   addAlgoliaAgent?: DefaultSearchClient['addAlgoliaAgent'];
 }

--- a/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
@@ -1157,89 +1157,83 @@ describe('refinementList', () => {
 });
 
 function createMockedSearchClient() {
+  const facetHits = [
+    {
+      value: 'Apple',
+      highlighted: '__ais-highlight__App__/ais-highlight__le',
+      count: 442,
+    },
+    {
+      value: 'Alpine',
+      highlighted: '__ais-highlight__Alp__/ais-highlight__ine',
+      count: 30,
+    },
+    {
+      value: 'APC',
+      highlighted: '__ais-highlight__AP__/ais-highlight__C',
+      count: 24,
+    },
+    {
+      value: 'Amped Wireless',
+      highlighted: '__ais-highlight__Amp__/ais-highlight__ed Wireless',
+      count: 4,
+    },
+    {
+      value: "Applebee's",
+      highlighted: "__ais-highlight__App__/ais-highlight__lebee's",
+      count: 2,
+    },
+    {
+      value: 'Amplicom',
+      highlighted: '__ais-highlight__Amp__/ais-highlight__licom',
+      count: 1,
+    },
+    {
+      value: 'Apollo Enclosures',
+      highlighted: '__ais-highlight__Ap__/ais-highlight__ollo Enclosures',
+      count: 1,
+    },
+    {
+      value: 'Apple®',
+      highlighted: '__ais-highlight__App__/ais-highlight__le®',
+      count: 1,
+    },
+    {
+      value: 'Applica',
+      highlighted: '__ais-highlight__App__/ais-highlight__lica',
+      count: 1,
+    },
+    {
+      value: 'Apricorn',
+      highlighted: '__ais-highlight__Ap__/ais-highlight__ricorn',
+      count: 1,
+    },
+  ];
+
   return createSearchClient({
     search: jest.fn((requests) => {
       return Promise.resolve(
         createMultiSearchResponse(
-          ...requests.map(() =>
-            createSingleSearchResponse({
-              facets: {
-                brand: {
-                  Apple: 746,
-                  Samsung: 633,
-                  Metra: 591,
-                },
-              },
-            })
+          ...requests.map((request) =>
+            request.type === 'facet'
+              ? createSFFVResponse({
+                  facetHits:
+                    request.params.facetQuery === 'query with no results'
+                      ? []
+                      : facetHits,
+                })
+              : createSingleSearchResponse({
+                  facets: {
+                    brand: {
+                      Apple: 746,
+                      Samsung: 633,
+                      Metra: 591,
+                    },
+                  },
+                })
           )
         )
       );
-    }),
-    // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can replace this method and its usages with search({ type: 'facet })
-    searchForFacetValues: jest.fn((requests) => {
-      return Promise.resolve([
-        createSFFVResponse({
-          facetHits:
-            // @ts-ignore for v5, which has a different definition of `searchForFacetValues`
-            requests[0].params.facetQuery === 'query with no results'
-              ? []
-              : [
-                  {
-                    value: 'Apple',
-                    highlighted: '__ais-highlight__App__/ais-highlight__le',
-                    count: 442,
-                  },
-                  {
-                    value: 'Alpine',
-                    highlighted: '__ais-highlight__Alp__/ais-highlight__ine',
-                    count: 30,
-                  },
-                  {
-                    value: 'APC',
-                    highlighted: '__ais-highlight__AP__/ais-highlight__C',
-                    count: 24,
-                  },
-                  {
-                    value: 'Amped Wireless',
-                    highlighted:
-                      '__ais-highlight__Amp__/ais-highlight__ed Wireless',
-                    count: 4,
-                  },
-                  {
-                    value: "Applebee's",
-                    highlighted:
-                      "__ais-highlight__App__/ais-highlight__lebee's",
-                    count: 2,
-                  },
-                  {
-                    value: 'Amplicom',
-                    highlighted: '__ais-highlight__Amp__/ais-highlight__licom',
-                    count: 1,
-                  },
-                  {
-                    value: 'Apollo Enclosures',
-                    highlighted:
-                      '__ais-highlight__Ap__/ais-highlight__ollo Enclosures',
-                    count: 1,
-                  },
-                  {
-                    value: 'Apple®',
-                    highlighted: '__ais-highlight__App__/ais-highlight__le®',
-                    count: 1,
-                  },
-                  {
-                    value: 'Applica',
-                    highlighted: '__ais-highlight__App__/ais-highlight__lica',
-                    count: 1,
-                  },
-                  {
-                    value: 'Apricorn',
-                    highlighted: '__ais-highlight__Ap__/ais-highlight__ricorn',
-                    count: 1,
-                  },
-                ],
-        }),
-      ]);
     }),
   });
 }

--- a/tests/mocks/createSearchClient.ts
+++ b/tests/mocks/createSearchClient.ts
@@ -16,12 +16,14 @@ export const createSearchClient = (
   search: jest.fn((requests) =>
     Promise.resolve(
       createMultiSearchResponse(
-        ...requests.map(() => createSingleSearchResponse())
+        ...requests.map((request) =>
+          request.type === 'facet'
+            ? createSFFVResponse()
+            : createSingleSearchResponse()
+        )
       )
     )
   ),
-  // @ts-ignore v5 does not have this method, but it's easier to have it here. In a future version we can replace this method and its usages with search({ type: 'facet })
-  searchForFacetValues: jest.fn(() => Promise.resolve([createSFFVResponse()])),
   // @ts-ignore this allows us to test insights initialization without warning
   applicationID: 'appId',
   apiKey: 'apiKey',


### PR DESCRIPTION
This signature is the easiest to detect and makes the required signature of the searchClient simpler (only `search`, `getRecommendations` and `addAlgoliaAgent` are now used).

In this PR I also fix the signature of `search` in `SearchClient` type to make this usage fit reality

BREAKING CHANGE: in `helper.searchForFacetFalues` only the method `client.search` is used, none of the previous fallbacks.
