### PR TITLE
Add Aria labels to hitsPerPage

### DIFF
--- a/packages/instantsearch.js/src/widgets/hits-per-page/hits-per-page.tsx
+++ b/packages/instantsearch.js/src/widgets/hits-per-page/hits-per-page.tsx
@@ -42,6 +42,7 @@ const renderer =
       <div className={cssClasses.root}>
         <Selector
           cssClasses={cssClasses}
+          ariaLabel='Items per page'
           currentValue={currentValue}
           options={items}
           // @ts-expect-error: the refine function expects a number, but setValue will call it with a string. We don't want to change the type of the refine function because it's part of the connector API.

--- a/packages/react-instantsearch/src/ui/HitsPerPage.tsx
+++ b/packages/react-instantsearch/src/ui/HitsPerPage.tsx
@@ -39,6 +39,7 @@ export function HitsPerPage({
     >
       <select
         className={cx('ais-HitsPerPage-select', classNames.select)}
+        aria-label="Items per page"
         onChange={(event) => {
           onChange(Number(event.target.value));
         }}

--- a/packages/react-instantsearch/src/ui/__tests__/HitsPerPage.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/HitsPerPage.test.tsx
@@ -38,6 +38,7 @@ describe('HitsPerPage', () => {
         >
           <select
             class="ais-HitsPerPage-select"
+            aria-label="Items per page"
           >
             <option
               class="ais-HitsPerPage-option"
@@ -112,7 +113,7 @@ describe('HitsPerPage', () => {
           class="ais-HitsPerPage ROOT MyCustomHitsPerPage"
         >
           <select
-            class="ais-HitsPerPage-select SELECT"
+            class="ais-HitsPerPage-select aria-label="Items per page" SELECT"
           >
             <option
               class="ais-HitsPerPage-option OPTION"

--- a/packages/react-instantsearch/src/ui/__tests__/HitsPerPage.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/HitsPerPage.test.tsx
@@ -37,8 +37,8 @@ describe('HitsPerPage', () => {
           class="ais-HitsPerPage"
         >
           <select
-            class="ais-HitsPerPage-select"
             aria-label="Items per page"
+            class="ais-HitsPerPage-select"
           >
             <option
               class="ais-HitsPerPage-option"
@@ -113,7 +113,8 @@ describe('HitsPerPage', () => {
           class="ais-HitsPerPage ROOT MyCustomHitsPerPage"
         >
           <select
-            class="ais-HitsPerPage-select aria-label="Items per page" SELECT"
+            aria-label="Items per page"
+            class="ais-HitsPerPage-select SELECT"
           >
             <option
               class="ais-HitsPerPage-option OPTION"

--- a/packages/vue-instantsearch/src/components/HitsPerPage.vue
+++ b/packages/vue-instantsearch/src/components/HitsPerPage.vue
@@ -9,6 +9,7 @@
     >
       <select
         :class="suit('select')"
+        aria-label="Items per page"
         @change="state.refine(Number($event.currentTarget.value))"
       >
         <option

--- a/tests/common/widgets/hits-per-page/options.ts
+++ b/tests/common/widgets/hits-per-page/options.ts
@@ -41,6 +41,7 @@ export function createOptionsTests(
           class="ais-HitsPerPage"
         >
           <select
+            aria-label="Items per page"
             class="ais-HitsPerPage-select"
           >
             <option
@@ -94,6 +95,7 @@ export function createOptionsTests(
           class="ais-HitsPerPage"
         >
           <select
+            aria-label="Items per page"
             class="ais-HitsPerPage-select"
           >
             <option


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

I was working on improving the accessibility of a project using Instantsearch and noticed that the hits per page widget has no aria label, so I've added it to all three flavors of instantsearch and updated relevant tests

**Result**

![Screenshot 2024-12-11 140606](https://github.com/user-attachments/assets/cfe83b6e-62b3-44d0-b7c9-643f929f6748)

Here's a screenshot of my version with an Aria label present on the hits per page selector.
