### PR TITLE
feat(index): remove getWidgetState

### DIFF
--- a/packages/instantsearch-core/src/types/widget.ts
+++ b/packages/instantsearch-core/src/types/widget.ts
@@ -252,17 +252,6 @@ type RequiredUiStateLifeCycle<TWidgetDescription extends WidgetDescription> = {
   ) => Partial<IndexUiState & TWidgetDescription['indexUiState']>;
 
   /**
-   * This function is required for a widget to be taken in account for routing.
-   * It will derive a uiState for this widget based on the existing uiState and
-   * the search parameters applied.
-   *
-   * @deprecated Use `getWidgetUiState` instead.
-   * @param uiState - Current state.
-   * @param widgetStateOptions - Extra information to calculate uiState.
-   */
-  getWidgetState?: RequiredUiStateLifeCycle<TWidgetDescription>['getWidgetUiState'];
-
-  /**
    * This function is required for a widget to behave correctly when a URL is
    * loaded via e.g. Routing. It receives the current UiState and applied search
    * parameters, and is expected to return a new search parameters.
@@ -335,7 +324,7 @@ export type Widget<
 
 export type IndexWidget<TUiState extends UiState = UiState> = Omit<
   Widget<IndexWidgetDescription & { widgetParams: IndexWidgetParams }>,
-  'getWidgetUiState' | 'getWidgetState'
+  'getWidgetUiState'
 > & {
   // public API
   addWidgets: (widgets: Array<Widget | IndexWidget>) => IndexWidget;
@@ -376,10 +365,6 @@ export type IndexWidget<TUiState extends UiState = UiState> = Omit<
   init: (options: IndexInitOptions) => void;
   render: (options: IndexRenderOptions) => void;
   dispose: (options?: DisposeOptions) => void;
-  /**
-   * @deprecated
-   */
-  getWidgetState: (uiState: UiState) => UiState;
   getWidgetUiState: <TSpecificUiState extends UiState = TUiState>(
     uiState: TSpecificUiState
   ) => TSpecificUiState;

--- a/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
+++ b/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
@@ -3246,59 +3246,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
     });
   });
 
-  describe('getWidgetState', () => {
-    test('warns when widget has this method', () => {
-      warnCache.current = {};
-
-      const createDeprecatedSearchBox = (args: Partial<Widget> = {}): Widget =>
-        createWidget({
-          dispose: jest.fn(({ state }) => {
-            return state.setQueryParameter('query', undefined);
-          }),
-          // @ts-expect-error old method
-          getWidgetState: jest.fn((uiState, { searchParameters }) => {
-            if (!searchParameters.query) {
-              return uiState;
-            }
-
-            return {
-              ...uiState,
-              query: searchParameters.query,
-            };
-          }),
-          getWidgetSearchParameters: jest.fn(
-            (searchParameters, { uiState }) => {
-              return searchParameters.setQueryParameter(
-                'query',
-                uiState.query || ''
-              );
-            }
-          ),
-          ...args,
-        });
-
-      const instance = index({ indexName: 'indexName' });
-      const searchClient = createSearchClient();
-      const mainHelper = algoliasearchHelper(searchClient, '', {});
-      const instantSearchInstance = createInstantSearch({
-        mainHelper,
-      });
-
-      instance.addWidgets([createDeprecatedSearchBox()]);
-
-      expect(() => {
-        instance.init(
-          createIndexInitOptions({
-            instantSearchInstance,
-            parent: null,
-          })
-        );
-      }).toWarnDev(
-        '[InstantSearch]: The `getWidgetState` method is renamed `getWidgetUiState` and no longer exists under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
-      );
-    });
-  });
-
   describe('setIndexUiState', () => {
     it('updates main UI state with an object', () => {
       const instance = index({ indexName: 'indexName' });

--- a/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
+++ b/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
@@ -3247,18 +3247,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
   });
 
   describe('getWidgetState', () => {
-    test('warns when index has this method', () => {
-      warnCache.current = {};
-
-      const instance = index({ indexName: 'indexName' });
-
-      expect(() => {
-        instance.getWidgetState({});
-      }).toWarnDev(
-        '[InstantSearch]: The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
-      );
-    });
-
     test('warns when widget has this method', () => {
       warnCache.current = {};
 
@@ -3267,6 +3255,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           dispose: jest.fn(({ state }) => {
             return state.setQueryParameter('query', undefined);
           }),
+          // @ts-expect-error old method
           getWidgetState: jest.fn((uiState, { searchParameters }) => {
             if (!searchParameters.query) {
               return uiState;
@@ -3305,31 +3294,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           })
         );
       }).toWarnDev(
-        '[InstantSearch]: The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
-      );
-    });
-
-    test('does not warn for index itself', () => {
-      warnCache.current = {};
-
-      const instance = index({ indexName: 'indexName' });
-      const searchClient = createSearchClient();
-      const mainHelper = algoliasearchHelper(searchClient, '', {});
-      const instantSearchInstance = createInstantSearch({
-        mainHelper,
-      });
-
-      instance.addWidgets([index({ indexName: 'other' })]);
-
-      expect(() => {
-        instance.init(
-          createIndexInitOptions({
-            instantSearchInstance,
-            parent: null,
-          })
-        );
-      }).not.toWarnDev(
-        '[InstantSearch]: The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
+        '[InstantSearch]: The `getWidgetState` method is renamed `getWidgetUiState` and no longer exists under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
       );
     });
   });

--- a/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
+++ b/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
@@ -29,7 +29,6 @@ import {
   createIndexInitOptions,
   createDisposeOptions,
 } from '../../../test/createWidget';
-import { warnCache } from '../../lib/public';
 
 import type { Widget } from '../../types';
 import type { PlainSearchParameters } from 'algoliasearch-helper';

--- a/packages/instantsearch-core/src/widgets/index-widget.ts
+++ b/packages/instantsearch-core/src/widgets/index-widget.ts
@@ -120,15 +120,11 @@ function getLocalWidgetsUiState(
       return uiState;
     }
 
-    if (!widget.getWidgetUiState && !widget.getWidgetState) {
-      return uiState;
-    }
-
     if (widget.getWidgetUiState) {
       return widget.getWidgetUiState(uiState, widgetStateOptions);
     }
 
-    return widget.getWidgetState!(uiState, widgetStateOptions);
+    return uiState;
   }, initialUiState);
 }
 
@@ -686,10 +682,8 @@ export const index = (widgetParams: IndexWidgetParams): IndexWidget => {
 
       localWidgets.forEach((widget) => {
         warning(
-          // if it has NO getWidgetState or if it has getWidgetUiState, we don't warn
-          // aka we warn if there's _only_ getWidgetState
-          !widget.getWidgetState || Boolean(widget.getWidgetUiState),
-          'The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
+          !(widget as any).getWidgetState,
+          'The `getWidgetState` method is renamed `getWidgetUiState` and no longer exists under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
         );
 
         if (widget.init) {
@@ -845,15 +839,6 @@ export const index = (widgetParams: IndexWidgetParams): IndexWidget => {
             },
           }
         );
-    },
-
-    getWidgetState(uiState: UiState) {
-      warning(
-        false,
-        'The `getWidgetState` method is renamed `getWidgetUiState` and will no longer exist under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
-      );
-
-      return this.getWidgetUiState(uiState);
     },
 
     getWidgetSearchParameters(searchParameters, { uiState }) {

--- a/packages/instantsearch-core/src/widgets/index-widget.ts
+++ b/packages/instantsearch-core/src/widgets/index-widget.ts
@@ -3,7 +3,6 @@ import algoliasearchHelper from 'algoliasearch-helper';
 import {
   addWidgetId,
   createDocumentationMessageGenerator,
-  warning,
   isIndexWidget,
   createInitArgs,
   createRenderArgs,
@@ -681,11 +680,6 @@ export const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       });
 
       localWidgets.forEach((widget) => {
-        warning(
-          !(widget as any).getWidgetState,
-          'The `getWidgetState` method is renamed `getWidgetUiState` and no longer exists under that name in InstantSearch.js 5.x. Please use `getWidgetUiState` instead.'
-        );
-
         if (widget.init) {
           widget.init(createInitArgs(instantSearchInstance, this, uiState));
         }

--- a/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
+++ b/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
@@ -1240,7 +1240,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
         expect(renderArgs.createURL()).toBe('#');
       });
 
-      it('allows for widgets without getWidgetState', () => {
+      it('allows for widgets without getWidgetUiState', () => {
         let instantSearchInstance;
         mount({
           mixins: [
@@ -1258,12 +1258,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
         const widget = {
           init: jest.fn(),
           render: jest.fn(),
-          getWidgetState(uiState) {
+          getWidgetUiState(uiState) {
             return uiState;
           },
         };
 
-        const widgetWithoutGetWidgetState = {
+        const widgetWithoutGetWidgetUiState = {
           init: jest.fn(),
           render: jest.fn(),
         };
@@ -1272,7 +1272,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
           lol: createSerializedState(),
         });
 
-        instantSearchInstance.addWidgets([widget, widgetWithoutGetWidgetState]);
+        instantSearchInstance.addWidgets([
+          widget,
+          widgetWithoutGetWidgetUiState,
+        ]);
 
         instantSearchInstance.__forceRender(
           widget,


### PR DESCRIPTION
The old method has long been deprecated and has no usage inside instantsearch outside of running a warning.

[FX-3197]

BREAKING CHANGE: rename getWidgetState to getWidgetUiState in your custom widgets or connectors.

[FX-3197]: https://algolia.atlassian.net/browse/FX-3197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ