### PR TITLE
feat(routing): replace getLocation with getCurrentURL

### DIFF
--- a/examples/js/e-commerce-umd/src/routing.ts
+++ b/examples/js/e-commerce-umd/src/routing.ts
@@ -89,10 +89,10 @@ const router = window.instantsearch.routers.history<RouteState>({
       .join(' | ');
   },
 
-  createURL({ qsModule, routeState, location }): string {
-    const { protocol, hostname, port = '', pathname, hash } = location;
+  createURL({ qsModule, routeState, currentURL }): string {
+    const { protocol, hostname, port = '', pathname, hash } = currentURL;
     const portWithPrefix = port === '' ? '' : `:${port}`;
-    const urlParts = location.href.match(/^(.*?)\/search/);
+    const urlParts = currentURL.href.match(/^(.*?)\/search/);
     const baseUrl =
       (urlParts && urlParts[0]) ||
       `${protocol}//${hostname}${portWithPrefix}${pathname}search`;
@@ -156,12 +156,14 @@ const router = window.instantsearch.routers.history<RouteState>({
     return `${baseUrl}/${categoryPath}${queryString}${hash}`;
   },
 
-  parseURL({ qsModule, location }): RouteState {
-    const pathnameMatches = location.pathname.match(/search\/(.*?)\/?$/);
+  parseURL({ qsModule, currentURL }): RouteState {
+    const pathnameMatches = currentURL.pathname.match(/search\/(.*?)\/?$/);
     const category = getCategoryName(
       (pathnameMatches && pathnameMatches[1]) || ''
     );
-    const queryParameters = qsModule.parse(location.search.slice(1));
+    const queryParameters = qsModule.parse(currentURL.search, {
+      ignoreQueryPrefix: true,
+    });
     const {
       query = '',
       page = 1,

--- a/examples/js/e-commerce/src/routing.ts
+++ b/examples/js/e-commerce/src/routing.ts
@@ -91,10 +91,10 @@ const router = historyRouter<RouteState>({
       .join(' | ');
   },
 
-  createURL({ qsModule, routeState, location }): string {
-    const { protocol, hostname, port = '', pathname, hash } = location;
+  createURL({ qsModule, routeState, currentURL }): string {
+    const { protocol, hostname, port = '', pathname, hash } = currentURL;
     const portWithPrefix = port === '' ? '' : `:${port}`;
-    const urlParts = location.href.match(/^(.*?)\/search/);
+    const urlParts = currentURL.href.match(/^(.*?)\/search/);
     const baseUrl =
       (urlParts && urlParts[0]) ||
       `${protocol}//${hostname}${portWithPrefix}${pathname}search`;
@@ -158,12 +158,14 @@ const router = historyRouter<RouteState>({
     return `${baseUrl}/${categoryPath}${queryString}${hash}`;
   },
 
-  parseURL({ qsModule, location }): RouteState {
-    const pathnameMatches = location.pathname.match(/search\/(.*?)\/?$/);
+  parseURL({ qsModule, currentURL }): RouteState {
+    const pathnameMatches = currentURL.pathname.match(/search\/(.*?)\/?$/);
     const category = getCategoryName(
       (pathnameMatches && pathnameMatches[1]) || ''
     );
-    const queryParameters = qsModule.parse(location.search.slice(1));
+    const queryParameters = qsModule.parse(currentURL.search, {
+      ignoreQueryPrefix: true,
+    });
     const {
       query = '',
       page = 1,

--- a/examples/react/e-commerce/routing.ts
+++ b/examples/react/e-commerce/routing.ts
@@ -85,10 +85,10 @@ const router = historyRouter<RouteState>({
       .join(' | ');
   },
 
-  createURL({ qsModule, routeState, location }): string {
-    const { protocol, hostname, port = '', pathname, hash } = location;
+  createURL({ qsModule, routeState, currentURL }): string {
+    const { protocol, hostname, port = '', pathname, hash } = currentURL;
     const portWithPrefix = port === '' ? '' : `:${port}`;
-    const urlParts = location.href.match(/^(.*?)\/search/);
+    const urlParts = currentURL.href.match(/^(.*?)\/search/);
     const baseUrl =
       (urlParts && urlParts[0]) ||
       `${protocol}//${hostname}${portWithPrefix}${pathname}search`;
@@ -152,13 +152,15 @@ const router = historyRouter<RouteState>({
     return `${baseUrl}/${categoryPath}${queryString}${hash}`;
   },
 
-  parseURL({ qsModule, location }): RouteState {
-    const pathnameMatches = location.pathname.match(/search\/(.*?)\/?$/);
+  parseURL({ qsModule, currentURL }): RouteState {
+    const pathnameMatches = currentURL.pathname.match(/search\/(.*?)\/?$/);
     const category = getCategoryName(
       (pathnameMatches && pathnameMatches[1]) || ''
     );
 
-    const queryParameters = qsModule.parse(location.search.slice(1));
+    const queryParameters = qsModule.parse(currentURL.search, {
+      ignoreQueryPrefix: true,
+    });
     const {
       query = '',
       page = 1,

--- a/examples/react/ssr/src/App.js
+++ b/examples/react/ssr/src/App.js
@@ -21,7 +21,7 @@ function Hit({ hit }) {
   return <Highlight hit={hit} attribute="name" />;
 }
 
-function App({ serverState, location }) {
+function App({ serverState, currentURL }) {
   return (
     <InstantSearchSSRProvider {...serverState}>
       <InstantSearch
@@ -31,12 +31,12 @@ function App({ serverState, location }) {
           stateMapping: simple(),
           router: history({
             cleanUrlOnDispose: false,
-            getLocation() {
+            getCurrentURL() {
               if (typeof window === 'undefined') {
-                return location;
+                return currentURL;
               }
 
-              return window.location;
+              return new URL(window.location.href);
             },
           }),
         }}

--- a/examples/react/ssr/src/server.js
+++ b/examples/react/ssr/src/server.js
@@ -13,15 +13,15 @@ const app = express();
 app.use('/assets', express.static(join(__dirname, 'assets')));
 
 app.get('/', async (req, res) => {
-  const location = new URL(
+  const currentURL = new URL(
     `${req.protocol}://${req.get('host')}${req.originalUrl}`
   );
-  const serverState = await getServerState(<App location={location} />, {
+  const serverState = await getServerState(<App currentURL={currentURL} />, {
     renderToString,
   });
   requestsCache.clear();
   const html = renderToString(
-    <App serverState={serverState} location={location} />
+    <App serverState={serverState} currentURL={currentURL} />
   );
 
   res.send(

--- a/examples/vue/e-commerce/src/routing.js
+++ b/examples/vue/e-commerce/src/routing.js
@@ -96,10 +96,10 @@ const router = historyRouter({
       .join(' | ');
   },
 
-  createURL({ qsModule, routeState, location }) {
-    const { protocol, hostname, port = '', pathname, hash } = location;
+  createURL({ qsModule, routeState, currentURL }) {
+    const { protocol, hostname, port = '', pathname, hash } = currentURL;
     const portWithPrefix = port === '' ? '' : `:${port}`;
-    const urlParts = location.href.match(/^(.*?)\/search/);
+    const urlParts = currentURL.href.match(/^(.*?)\/search/);
     const baseUrl =
       (urlParts && urlParts[0]) ||
       `${protocol}//${hostname}${portWithPrefix}${pathname}search`;
@@ -163,12 +163,14 @@ const router = historyRouter({
     return `${baseUrl}/${categoryPath}${queryString}${hash}`;
   },
 
-  parseURL({ qsModule, location }) {
-    const pathnameMatches = location.pathname.match(/search\/(.*?)\/?$/);
+  parseURL({ qsModule, currentURL }) {
+    const pathnameMatches = currentURL.pathname.match(/search\/(.*?)\/?$/);
     const category = getCategoryName(
       (pathnameMatches && pathnameMatches[1]) || ''
     );
-    const queryParameters = qsModule.parse(location.search.slice(1));
+    const queryParameters = qsModule.parse(currentURL.search, {
+      ignoreQueryPrefix: true,
+    });
     const {
       query = '',
       page = 1,

--- a/packages/instantsearch-core/src/__tests__/RoutingManager.test.ts
+++ b/packages/instantsearch-core/src/__tests__/RoutingManager.test.ts
@@ -580,7 +580,7 @@ describe('RoutingManager', () => {
       // In a next refactor, we can consider changing this test implementation.
       const parsedUrl = router.parseURL({
         qsModule: qs,
-        location: window.location,
+        currentURL: new URL(window.location.href),
       });
 
       expect(parsedUrl.refinementList!.brand).toBeInstanceOf(Array);
@@ -627,7 +627,7 @@ describe('RoutingManager', () => {
       // In a next refactor, we can consider changing this test implementation.
       const parsedUrl = router.parseURL({
         qsModule: qs,
-        location: window.location,
+        currentURL: new URL(window.location.href),
       });
 
       expect(parsedUrl.refinementList!.brand).toBeInstanceOf(Array);

--- a/packages/instantsearch-core/src/routing/__tests__/historyRouter.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/historyRouter.test.ts
@@ -80,50 +80,50 @@ describe('life cycle', () => {
     });
   });
 
-  describe('getLocation', () => {
-    test('calls getLocation on windowTitle', () => {
-      const getLocation = jest.fn(() => window.location);
+  describe('getCurrentURL', () => {
+    test('calls getCurrentURL on windowTitle', () => {
+      const getCurrentURL = jest.fn(() => new URL(window.location.href));
 
       historyRouter<UiState>({
         windowTitle() {
           return 'Search';
         },
-        getLocation,
+        getCurrentURL,
         cleanUrlOnDispose: true,
       });
 
-      expect(getLocation).toHaveBeenCalledTimes(1);
+      expect(getCurrentURL).toHaveBeenCalledTimes(1);
     });
 
-    test('calls getLocation on read', () => {
-      const getLocation = jest.fn(() => window.location);
+    test('calls getCurrentURL on read', () => {
+      const getCurrentURL = jest.fn(() => new URL(window.location.href));
       const router = historyRouter<UiState>({
-        getLocation,
+        getCurrentURL,
         cleanUrlOnDispose: true,
       });
 
-      expect(getLocation).toHaveBeenCalledTimes(0);
+      expect(getCurrentURL).toHaveBeenCalledTimes(0);
 
       router.write({ indexName: { query: 'query1' } });
       jest.runAllTimers();
 
-      expect(getLocation).toHaveBeenCalledTimes(1);
+      expect(getCurrentURL).toHaveBeenCalledTimes(1);
 
       router.read();
 
-      expect(getLocation).toHaveBeenCalledTimes(2);
+      expect(getCurrentURL).toHaveBeenCalledTimes(2);
     });
 
-    test('calls getLocation on createURL', () => {
-      const getLocation = jest.fn(() => window.location);
+    test('calls getCurrentURL on createURL', () => {
+      const getCurrentURL = jest.fn(() => new URL(window.location.href));
       const router = historyRouter<UiState>({
-        getLocation,
+        getCurrentURL,
         cleanUrlOnDispose: true,
       });
 
       router.createURL({ indexName: { query: 'query1' } });
 
-      expect(getLocation).toHaveBeenCalledTimes(1);
+      expect(getCurrentURL).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -188,25 +188,18 @@ describe('life cycle', () => {
         search.start();
         jest.runAllTimers();
       }).toThrowErrorMatchingInlineSnapshot(
-        `"You need to provide \`getLocation\` to the \`history\` router in environments where \`window\` does not exist."`
+        `"You need to provide \`getCurrentURL\` to the \`history\` router in environments where \`window\` does not exist."`
       );
     });
 
-    test('does not fail on environments without window with provided getLocation', () => {
+    test('does not fail on environments without window with provided getCurrentURL', () => {
       // @ts-expect-error
       delete global.window;
 
       expect(() => {
         const router = historyRouter<UiState>({
-          getLocation() {
-            return {
-              protocol: '',
-              hostname: '',
-              port: '',
-              pathname: '',
-              hash: '',
-              search: '',
-            } as unknown as Location;
+          getCurrentURL() {
+            return new URL('http://localhost/');
           },
           cleanUrlOnDispose: true,
         });
@@ -224,21 +217,14 @@ describe('life cycle', () => {
       }).not.toThrow();
     });
 
-    test('does not fail when running the whole router lifecycle with getLocation', () => {
+    test('does not fail when running the whole router lifecycle with getCurrentURL', () => {
       // @ts-expect-error
       delete global.window;
 
       expect(() => {
         const router = historyRouter<UiState>({
-          getLocation() {
-            return {
-              protocol: '',
-              hostname: '',
-              port: '',
-              pathname: '',
-              hash: '',
-              search: '',
-            } as unknown as Location;
+          getCurrentURL() {
+            return new URL('http://localhost/');
           },
           cleanUrlOnDispose: true,
         });

--- a/packages/react-instantsearch-core/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/InstantSearch.test.tsx
@@ -244,10 +244,8 @@ describe('InstantSearch', () => {
     const routing = {
       stateMapping: simple(),
       router: history({
-        getLocation() {
-          return new URL(
-            `http://localhost/?indexName[query]=iphone`
-          ) as unknown as Location;
+        getCurrentURL() {
+          return new URL(`http://localhost/?indexName[query]=iphone`);
         },
       }),
     };
@@ -306,8 +304,8 @@ describe('InstantSearch', () => {
       const routing = {
         stateMapping: simple(),
         router: history({
-          getLocation() {
-            return new URL(url) as unknown as Location;
+          getCurrentURL() {
+            return new URL(url);
           },
         }),
       };

--- a/packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/InstantSearchSSRProvider.test.tsx
@@ -166,10 +166,8 @@ describe('InstantSearchSSRProvider', () => {
     const routing = {
       stateMapping: simple(),
       router: history({
-        getLocation() {
-          return new URL(
-            `http://localhost/?indexName[query]=iphone`
-          ) as unknown as Location;
+        getCurrentURL() {
+          return new URL(`http://localhost/?indexName[query]=iphone`);
         },
       }),
     };

--- a/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
+++ b/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
@@ -28,21 +28,21 @@ export function useInstantSearchRouting<
   if (passedRouting && !routingRef.current) {
     let browserHistoryOptions: Partial<BrowserHistoryArgs<TRouteState>> = {};
 
-    browserHistoryOptions.getLocation = () => {
+    browserHistoryOptions.getCurrentURL = () => {
       if (typeof window === 'undefined') {
         const url = `${
           headers().get('x-forwarded-proto') || 'http'
         }://${headers().get('host')}${pathname}?${searchParams}`;
-        return new URL(url) as unknown as Location;
+        return new URL(url);
       }
 
       if (isMounting.current) {
         return new URL(
           `${window.location.protocol}//${window.location.host}${pathname}?${searchParams}`
-        ) as unknown as Location;
+        );
       }
 
-      return window.location;
+      return new URL(window.location.href);
     };
     browserHistoryOptions.push = function push(
       this: ReturnType<typeof historyRouter>,

--- a/packages/react-instantsearch-router-nextjs/src/index.ts
+++ b/packages/react-instantsearch-router-nextjs/src/index.ts
@@ -85,8 +85,8 @@ export function createInstantSearchRouterNext<TRouteState = UiState>(
   // If we're rendering on the server, we create a simpler router
   if (typeof window === 'undefined') {
     return history({
-      getLocation() {
-        return new URL(serverUrl!) as unknown as Location;
+      getCurrentURL() {
+        return new URL(serverUrl!);
       },
       ...routerOptions,
     });


### PR DESCRIPTION
getCurrentURL is the alternative of getLocation in the history router. This is changed as it's possible to create a URL out of a string, but not a location. We also don't use any properties of the location that aren't also present in a URL.

[FX-3193]

BREAKING CHANGE: change from `getLocation` to `getCurrentURL`, and return a URL object.
BREAKING CHANGE: createURL createURL now receives `currentURL` instead of `location`
BREAKING CHANGE: parseURL createURL now receives `currentURL` instead of `location`

[FX-3193]: https://algolia.atlassian.net/browse/FX-3193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ