### PR TITLE
feat(helper): persistHierarchicalRootCount: true

### DIFF
--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -1114,7 +1114,6 @@ declare namespace algoliasearchHelper {
      * This is for internal use, e.g., avoiding caching in infinite hits, or delaying the display of these results.
      */
     __isArtificial?: boolean | undefined;
-    persistHierarchicalRootCount?: boolean;
   }
 
   type ISearchResponse<T> = Omit<SearchResponse<T>, 'facets' | 'params'> &

--- a/packages/algoliasearch-helper/src/SearchResults/index.js
+++ b/packages/algoliasearch-helper/src/SearchResults/index.js
@@ -241,7 +241,7 @@ function SearchResults(state, results, options) {
 
   // Make every key of the result options reachable from the instance
   var opts = defaultsPure(options, {
-    persistHierarchicalRootCount: false,
+    persistHierarchicalRootCount: true,
   });
   Object.keys(opts).forEach(function (key) {
     self[key] = opts[key];

--- a/packages/algoliasearch-helper/src/SearchResults/index.js
+++ b/packages/algoliasearch-helper/src/SearchResults/index.js
@@ -240,11 +240,8 @@ function SearchResults(state, results, options) {
   });
 
   // Make every key of the result options reachable from the instance
-  var opts = defaultsPure(options, {
-    persistHierarchicalRootCount: true,
-  });
-  Object.keys(opts).forEach(function (key) {
-    self[key] = opts[key];
+  Object.keys(options || {}).forEach(function (key) {
+    self[key] = options[key];
   });
 
   /**
@@ -508,16 +505,10 @@ function SearchResults(state, results, options) {
           return;
         }
 
-        self.hierarchicalFacets[position][attributeIndex].data =
-          self.persistHierarchicalRootCount
-            ? defaultsPure(
-                self.hierarchicalFacets[position][attributeIndex].data,
-                facetResults
-              )
-            : defaultsPure(
-                facetResults,
-                self.hierarchicalFacets[position][attributeIndex].data
-              );
+        self.hierarchicalFacets[position][attributeIndex].data = defaultsPure(
+          self.hierarchicalFacets[position][attributeIndex].data,
+          facetResults
+        );
       } else {
         position = disjunctiveFacetsIndices[dfacet];
 
@@ -589,28 +580,7 @@ function SearchResults(state, results, options) {
           return;
         }
 
-        // when we always get root levels, if the hits refinement is `beers > IPA` (count: 5),
-        // then the disjunctive values will be `beers` (count: 100),
-        // but we do not want to display
-        //   | beers (100)
-        //     > IPA (5)
-        // We want
-        //   | beers (5)
-        //     > IPA (5)
-        // @MAJOR: remove this legacy behaviour in next major version
-        var defaultData = {};
-
-        if (
-          currentRefinement.length > 0 &&
-          !self.persistHierarchicalRootCount
-        ) {
-          var root = currentRefinement[0].split(separator)[0];
-          defaultData[root] =
-            self.hierarchicalFacets[position][attributeIndex].data[root];
-        }
-
         self.hierarchicalFacets[position][attributeIndex].data = defaultsPure(
-          defaultData,
           facetResults,
           self.hierarchicalFacets[position][attributeIndex].data
         );

--- a/packages/algoliasearch-helper/test/datasets/SearchParameters/search.dataset.js
+++ b/packages/algoliasearch-helper/test/datasets/SearchParameters/search.dataset.js
@@ -336,7 +336,6 @@ function getData() {
     index: 'test_hotels-node',
     hitsPerPage: 20,
     nbHits: 4,
-    persistHierarchicalRootCount: true,
     nbPages: 1,
     page: 0,
     params:

--- a/packages/algoliasearch-helper/test/datasets/SearchParameters/search.dataset.js
+++ b/packages/algoliasearch-helper/test/datasets/SearchParameters/search.dataset.js
@@ -336,7 +336,7 @@ function getData() {
     index: 'test_hotels-node',
     hitsPerPage: 20,
     nbHits: 4,
-    persistHierarchicalRootCount: false,
+    persistHierarchicalRootCount: true,
     nbPages: 1,
     page: 0,
     params:

--- a/packages/algoliasearch-helper/test/spec/SearchResults/getFacetValues.js
+++ b/packages/algoliasearch-helper/test/spec/SearchResults/getFacetValues.js
@@ -751,60 +751,16 @@ test('getFacetValues(facetName) prefers the "main" facet result (disjunctive)', 
   expect(facetValues).toEqual(expected);
 });
 
-test('getFacetValues(facetName) prefers the "main" facet result (hierarchical) (persistHierarchicalRootCount: true)', function () {
+test('getFacetValues(facetName) prefers the "main" facet result (hierarchical)', function () {
   var data = require('./getFacetValues/hierarchical-non-exhaustive.json');
   var searchParams = new SearchParameters(data.state);
-  var result = new SearchResults(searchParams, data.content.results, {
-    persistHierarchicalRootCount: true,
-  });
+  var result = new SearchResults(searchParams, data.content.results);
 
   var facetValues = result.getFacetValues('brand').data;
 
   var expected = [
     {
       count: 1000,
-      data: null,
-      isRefined: true,
-      name: 'Apple',
-      escapedValue: 'Apple',
-      path: 'Apple',
-      exhaustive: true,
-    },
-    {
-      count: 551,
-      data: null,
-      isRefined: false,
-      name: 'Insignia™',
-      escapedValue: 'Insignia™',
-      path: 'Insignia™',
-      exhaustive: true,
-    },
-    {
-      count: 551,
-      data: null,
-      isRefined: false,
-      name: 'Samsung',
-      escapedValue: 'Samsung',
-      path: 'Samsung',
-      exhaustive: true,
-    },
-  ];
-
-  expect(facetValues).toEqual(expected);
-});
-
-test('getFacetValues(facetName) prefers the "main" facet result (hierarchical) (persistHierarchicalRootCount: false)', function () {
-  var data = require('./getFacetValues/hierarchical-non-exhaustive.json');
-  var searchParams = new SearchParameters(data.state);
-  var result = new SearchResults(searchParams, data.content.results, {
-    persistHierarchicalRootCount: false,
-  });
-
-  var facetValues = result.getFacetValues('brand').data;
-
-  var expected = [
-    {
-      count: 50,
       data: null,
       isRefined: true,
       name: 'Apple',

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/searchOnce.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/searchOnce.js
@@ -3,7 +3,7 @@
 var algoliasearchHelper = require('../../../index');
 var SearchParameters = require('../../../src/SearchParameters');
 
-test('searchOnce should call the algolia client according to the number of refinements and call callback with no error and with results when no error', function (done) {
+test('searchOnce should call the algolia client according to the number of refinements and call callback with no error and with results when no error', async function () {
   var testData = require('../../datasets/SearchParameters/search.dataset')();
 
   var client = {
@@ -21,76 +21,72 @@ test('searchOnce should call the algolia client according to the number of refin
     .addDisjunctiveFacetRefinement('city', 'Paris')
     .addDisjunctiveFacetRefinement('city', 'New York');
 
-  helper.searchOnce(parameters, function (err, data) {
-    expect(err).toBe(null);
+  const { content } = await helper.searchOnce(parameters);
 
-    // shame deepclone, to remove any associated methods coming from the results
-    expect(JSON.parse(JSON.stringify(data))).toEqual(
-      JSON.parse(JSON.stringify(testData.responseHelper))
-    );
+  // shame deepclone, to remove any associated methods coming from the results
+  expect(JSON.parse(JSON.stringify(content))).toEqual(
+    JSON.parse(JSON.stringify(testData.responseHelper))
+  );
 
-    var cityValues = data.getFacetValues('city');
-    var expectedCityValues = [
-      { name: 'Paris', escapedValue: 'Paris', count: 3, isRefined: true },
-      { name: 'New York', escapedValue: 'New York', count: 1, isRefined: true },
-      {
-        name: 'San Francisco',
-        escapedValue: 'San Francisco',
-        count: 1,
-        isRefined: false,
-      },
-    ];
+  var cityValues = content.getFacetValues('city');
+  var expectedCityValues = [
+    { name: 'Paris', escapedValue: 'Paris', count: 3, isRefined: true },
+    { name: 'New York', escapedValue: 'New York', count: 1, isRefined: true },
+    {
+      name: 'San Francisco',
+      escapedValue: 'San Francisco',
+      count: 1,
+      isRefined: false,
+    },
+  ];
 
-    expect(cityValues).toEqual(expectedCityValues);
+  expect(cityValues).toEqual(expectedCityValues);
 
-    var cityValuesCustom = data.getFacetValues('city', {
-      sortBy: ['count:asc', 'name:asc'],
-    });
-    var expectedCityValuesCustom = [
-      { name: 'New York', escapedValue: 'New York', count: 1, isRefined: true },
-      {
-        name: 'San Francisco',
-        escapedValue: 'San Francisco',
-        count: 1,
-        isRefined: false,
-      },
-      { name: 'Paris', escapedValue: 'Paris', count: 3, isRefined: true },
-    ];
-
-    expect(cityValuesCustom).toEqual(expectedCityValuesCustom);
-
-    var cityValuesFn = data.getFacetValues('city', {
-      sortBy: function (a, b) {
-        return a.count - b.count;
-      },
-    });
-    var expectedCityValuesFn = [
-      { name: 'New York', escapedValue: 'New York', count: 1, isRefined: true },
-      {
-        name: 'San Francisco',
-        escapedValue: 'San Francisco',
-        count: 1,
-        isRefined: false,
-      },
-      { name: 'Paris', escapedValue: 'Paris', count: 3, isRefined: true },
-    ];
-
-    expect(cityValuesFn).toEqual(expectedCityValuesFn);
-
-    expect(client.search).toHaveBeenCalledTimes(1);
-
-    var queries = client.search.mock.calls[0][0];
-    for (var i = 0; i < queries.length; i++) {
-      var query = queries[i];
-      expect(query.query).toBeUndefined();
-      expect(query.params.query).toBeUndefined();
-    }
-
-    done();
+  var cityValuesCustom = content.getFacetValues('city', {
+    sortBy: ['count:asc', 'name:asc'],
   });
+  var expectedCityValuesCustom = [
+    { name: 'New York', escapedValue: 'New York', count: 1, isRefined: true },
+    {
+      name: 'San Francisco',
+      escapedValue: 'San Francisco',
+      count: 1,
+      isRefined: false,
+    },
+    { name: 'Paris', escapedValue: 'Paris', count: 3, isRefined: true },
+  ];
+
+  expect(cityValuesCustom).toEqual(expectedCityValuesCustom);
+
+  var cityValuesFn = content.getFacetValues('city', {
+    sortBy: function (a, b) {
+      return a.count - b.count;
+    },
+  });
+  var expectedCityValuesFn = [
+    { name: 'New York', escapedValue: 'New York', count: 1, isRefined: true },
+    {
+      name: 'San Francisco',
+      escapedValue: 'San Francisco',
+      count: 1,
+      isRefined: false,
+    },
+    { name: 'Paris', escapedValue: 'Paris', count: 3, isRefined: true },
+  ];
+
+  expect(cityValuesFn).toEqual(expectedCityValuesFn);
+
+  expect(client.search).toHaveBeenCalledTimes(1);
+
+  var queries = client.search.mock.calls[0][0];
+  for (var i = 0; i < queries.length; i++) {
+    var query = queries[i];
+    expect(query.query).toBeUndefined();
+    expect(query.params.query).toBeUndefined();
+  }
 });
 
-test('searchOnce should call the algolia client according to the number of refinements and call callback with error and no results when error', function (done) {
+test('searchOnce should call the algolia client according to the number of refinements and call callback with error and no results when error', async function () {
   var error = { message: 'error' };
   var client = {
     search: jest.fn().mockImplementationOnce(function () {
@@ -107,19 +103,14 @@ test('searchOnce should call the algolia client according to the number of refin
     .addDisjunctiveFacetRefinement('city', 'Paris')
     .addDisjunctiveFacetRefinement('city', 'New York');
 
-  helper.searchOnce(parameters, function (err, data) {
-    expect(err).toBe(error);
-    expect(data).toBe(null);
+  await expect(() => helper.searchOnce(parameters)).rejects.toEqual(error);
 
-    expect(client.search).toHaveBeenCalledTimes(1);
+  expect(client.search).toHaveBeenCalledTimes(1);
 
-    var queries = client.search.mock.calls[0][0];
-    for (var i = 0; i < queries.length; i++) {
-      var query = queries[i];
-      expect(query.query).toBeUndefined();
-      expect(query.params.query).toBeUndefined();
-    }
-
-    done();
-  });
+  var queries = client.search.mock.calls[0][0];
+  for (var i = 0; i < queries.length; i++) {
+    var query = queries[i];
+    expect(query.query).toBeUndefined();
+    expect(query.params.query).toBeUndefined();
+  }
 });

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/simple-usage.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/simple-usage.js
@@ -87,19 +87,26 @@ describe('hierarchical facets: simple usage', function () {
   });
 
   test('persistHierarchicalRootCount: false', function (done) {
-    var helper = algoliasearchHelper(client, indexName, {
-      hierarchicalFacets: [
-        {
-          name: 'categories',
-          attributes: [
-            'categories.lvl0',
-            'categories.lvl1',
-            'categories.lvl2',
-            'categories.lvl3',
-          ],
-        },
-      ],
-    });
+    var helper = algoliasearchHelper(
+      client,
+      indexName,
+      {
+        hierarchicalFacets: [
+          {
+            name: 'categories',
+            attributes: [
+              'categories.lvl0',
+              'categories.lvl1',
+              'categories.lvl2',
+              'categories.lvl3',
+            ],
+          },
+        ],
+      },
+      {
+        persistHierarchicalRootCount: false,
+      }
+    );
 
     helper.toggleFacetRefinement('categories', 'beers > IPA > Flying dog');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/simple-usage.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/simple-usage.js
@@ -86,196 +86,20 @@ describe('hierarchical facets: simple usage', function () {
     client.search.mockClear();
   });
 
-  test('persistHierarchicalRootCount: false', function (done) {
-    var helper = algoliasearchHelper(
-      client,
-      indexName,
-      {
-        hierarchicalFacets: [
-          {
-            name: 'categories',
-            attributes: [
-              'categories.lvl0',
-              'categories.lvl1',
-              'categories.lvl2',
-              'categories.lvl3',
-            ],
-          },
-        ],
-      },
-      {
-        persistHierarchicalRootCount: false,
-      }
-    );
-
-    helper.toggleFacetRefinement('categories', 'beers > IPA > Flying dog');
-
-    var expectedHelperResponse = [
-      {
-        name: 'categories',
-        count: null,
-        isRefined: true,
-        path: null,
-        escapedValue: null,
-        exhaustive: true,
-        data: [
-          {
-            name: 'beers',
-            path: 'beers',
-            escapedValue: 'beers',
-            count: 9,
-            isRefined: true,
-            exhaustive: true,
-            data: [
-              {
-                name: 'IPA',
-                path: 'beers > IPA',
-                escapedValue: 'beers > IPA',
-                count: 9,
-                isRefined: true,
-                exhaustive: true,
-                data: [
-                  {
-                    name: 'Flying dog',
-                    path: 'beers > IPA > Flying dog',
-                    escapedValue: 'beers > IPA > Flying dog',
-                    count: 3,
-                    isRefined: true,
-                    exhaustive: true,
-                    data: null,
-                  },
-                  {
-                    name: 'Brewdog punk IPA',
-                    path: 'beers > IPA > Brewdog punk IPA',
-                    escapedValue: 'beers > IPA > Brewdog punk IPA',
-                    count: 6,
-                    isRefined: false,
-                    exhaustive: true,
-                    data: null,
-                  },
-                ],
-              },
-              {
-                name: 'Pale Ale',
-                path: 'beers > Pale Ale',
-                escapedValue: 'beers > Pale Ale',
-                count: 10,
-                isRefined: false,
-                exhaustive: true,
-                data: null,
-              },
-              {
-                name: 'Stout',
-                path: 'beers > Stout',
-                escapedValue: 'beers > Stout',
-                count: 1,
-                isRefined: false,
-                exhaustive: true,
-                data: null,
-              },
-            ],
-          },
-          {
-            name: 'fruits',
-            path: 'fruits',
-            escapedValue: 'fruits',
-            count: 5,
-            isRefined: false,
-            exhaustive: true,
-            data: null,
-          },
-          {
-            name: 'sales',
-            path: 'sales',
-            escapedValue: 'sales',
-            count: 20,
-            isRefined: false,
-            exhaustive: true,
-            data: null,
-          },
-        ],
-      },
-    ];
-
-    helper.setQuery('a').search();
-
-    helper.once('result', function (event) {
-      var queries = client.search.mock.calls[0][0];
-      var hitsQuery = queries[0];
-      var parentValuesQuery = queries[1];
-      var fullParentsValuesQueries = queries.slice(2);
-
-      expect(queries.length).toBe(4);
-
-      expect(hitsQuery.params.facets).toEqual([
-        'categories.lvl0',
-        'categories.lvl1',
-        'categories.lvl2',
-        'categories.lvl3',
-      ]);
-      expect(hitsQuery.params.facetFilters).toEqual([
-        ['categories.lvl2:beers > IPA > Flying dog'],
-      ]);
-
-      expect(parentValuesQuery.params.facets).toEqual([
-        'categories.lvl0',
-        'categories.lvl1',
-        'categories.lvl2',
-      ]);
-      expect(parentValuesQuery.params.facetFilters).toEqual([
-        ['categories.lvl1:beers > IPA'],
-      ]);
-
-      // Root
-      expect(fullParentsValuesQueries[0].params.facets).toEqual(
-        'categories.lvl0'
-      );
-      expect(fullParentsValuesQueries[0].params.facetFilters).toBe(undefined);
-
-      // Level 1
-      expect(fullParentsValuesQueries[1].params.facets).toEqual(
-        'categories.lvl1'
-      );
-      expect(fullParentsValuesQueries[1].params.facetFilters).toEqual([
-        'categories.lvl0:beers',
-      ]);
-
-      expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
-      expect(
-        event.results.hierarchicalFacets.find((f) => f.name === 'categories')
-      ).toEqual(expectedHelperResponse[0]);
-
-      // we do not yet support multiple values for hierarchicalFacetsRefinements
-      // but at some point we may want to open multiple leafs of a hierarchical menu
-      // So we set this as an array so that we do not have to bump major to handle it
-      expect(
-        Array.isArray(helper.state.hierarchicalFacetsRefinements.categories)
-      ).toBeTruthy();
-      done();
+  test('simple usage', function (done) {
+    var helper = algoliasearchHelper(client, indexName, {
+      hierarchicalFacets: [
+        {
+          name: 'categories',
+          attributes: [
+            'categories.lvl0',
+            'categories.lvl1',
+            'categories.lvl2',
+            'categories.lvl3',
+          ],
+        },
+      ],
     });
-  });
-
-  test('persistHierarchicalRootCount: true', function (done) {
-    var helper = algoliasearchHelper(
-      client,
-      indexName,
-      {
-        hierarchicalFacets: [
-          {
-            name: 'categories',
-            attributes: [
-              'categories.lvl0',
-              'categories.lvl1',
-              'categories.lvl2',
-              'categories.lvl3',
-            ],
-          },
-        ],
-      },
-      {
-        persistHierarchicalRootCount: true,
-      }
-    );
 
     helper.toggleFacetRefinement('categories', 'beers > IPA > Flying dog');
 

--- a/packages/algoliasearch-helper/test/spec/hierarchical-facets/sort-by.js
+++ b/packages/algoliasearch-helper/test/spec/hierarchical-facets/sort-by.js
@@ -1,6 +1,6 @@
 'use strict';
 
-test('hierarchical facets: using sortBy', function (done) {
+test('hierarchical facets: using sortBy', async function () {
   var algoliasearch = require('algoliasearch');
   algoliasearch = algoliasearch.algoliasearch || algoliasearch;
 
@@ -30,6 +30,7 @@ test('hierarchical facets: using sortBy', function (done) {
 
   var algoliaResponse = {
     results: [
+      // for hits
       {
         query: 'a',
         index: indexName,
@@ -45,6 +46,7 @@ test('hierarchical facets: using sortBy', function (done) {
           'categories.lvl2': { 'beers > IPA > Flying dog': 1 },
         },
       },
+      // deepest level
       {
         query: 'a',
         index: indexName,
@@ -54,8 +56,8 @@ test('hierarchical facets: using sortBy', function (done) {
         nbPages: 1,
         hitsPerPage: 1,
         facets: {
-          'categories.lvl0': { beers: 5 },
-          'categories.lvl1': { 'beers > IPA': 5 },
+          'categories.lvl0': { beers: 1 },
+          'categories.lvl1': { 'beers > IPA': 1 },
           'categories.lvl2': {
             'beers > IPA > Flying dog': 1,
             'beers > IPA > Anchor steam': 1,
@@ -63,6 +65,7 @@ test('hierarchical facets: using sortBy', function (done) {
           },
         },
       },
+      // root level
       {
         query: 'a',
         index: indexName,
@@ -73,6 +76,19 @@ test('hierarchical facets: using sortBy', function (done) {
         hitsPerPage: 1,
         facets: {
           'categories.lvl0': { beers: 5 },
+        },
+      },
+      // other levels
+      {
+        query: 'a',
+        index: indexName,
+        hits: [{ objectID: 'one' }],
+        nbHits: 1,
+        page: 0,
+        nbPages: 1,
+        hitsPerPage: 1,
+        facets: {
+          'categories.lvl1': { 'beers > IPA': 5 },
         },
       },
     ],
@@ -143,8 +159,10 @@ test('hierarchical facets: using sortBy', function (done) {
   });
 
   helper.setQuery('a').search();
-  helper.once('result', function (event) {
-    expect(event.results.hierarchicalFacets).toEqual(expectedHelperResponse);
-    done();
+
+  const { results } = await new Promise(function (resolve) {
+    helper.once('result', resolve);
   });
+
+  expect(results.hierarchicalFacets).toEqual(expectedHelperResponse);
 });

--- a/packages/instantsearch-core/src/__tests__/instantsearch.test.tsx
+++ b/packages/instantsearch-core/src/__tests__/instantsearch.test.tsx
@@ -865,7 +865,7 @@ describe('start', () => {
       searchClient,
       indexName,
       undefined,
-      { persistHierarchicalRootCount: false }
+      { persistHierarchicalRootCount: true }
     );
   });
 
@@ -887,7 +887,7 @@ describe('start', () => {
       searchClient,
       indexName,
       undefined,
-      future
+      { persistHierarchicalRootCount: true }
     );
   });
 

--- a/packages/instantsearch-core/src/__tests__/instantsearch.test.tsx
+++ b/packages/instantsearch-core/src/__tests__/instantsearch.test.tsx
@@ -864,30 +864,7 @@ describe('start', () => {
     expect(algoliasearchHelper).toHaveBeenCalledWith(
       searchClient,
       indexName,
-      undefined,
-      { persistHierarchicalRootCount: true }
-    );
-  });
-
-  it('creates a Helper with `persistHierarchicalRootCount` set to true when specified with a future flag', () => {
-    const searchClient = createSearchClient();
-    const indexName = 'indexName';
-    const future = {
-      persistHierarchicalRootCount: true,
-    };
-    const search = new InstantSearch({
-      indexName,
-      searchClient,
-      future,
-    });
-
-    search.start();
-
-    expect(algoliasearchHelper).toHaveBeenCalledWith(
-      searchClient,
-      indexName,
-      undefined,
-      { persistHierarchicalRootCount: true }
+      undefined
     );
   });
 

--- a/packages/instantsearch-core/src/instantsearch.ts
+++ b/packages/instantsearch-core/src/instantsearch.ts
@@ -52,7 +52,7 @@ export const INSTANTSEARCH_FUTURE_DEFAULTS: Required<
   InstantSearchOptions['future']
 > = {
   preserveSharedStateOnUnmount: false,
-  persistHierarchicalRootCount: false,
+  persistHierarchicalRootCount: true,
 };
 
 /**

--- a/packages/instantsearch-core/src/instantsearch.ts
+++ b/packages/instantsearch-core/src/instantsearch.ts
@@ -52,7 +52,6 @@ export const INSTANTSEARCH_FUTURE_DEFAULTS: Required<
   InstantSearchOptions['future']
 > = {
   preserveSharedStateOnUnmount: false,
-  persistHierarchicalRootCount: true,
 };
 
 /**
@@ -343,9 +342,7 @@ See documentation: ${createDocumentationLink({
     // we need to respect this helper as a way to keep all listeners correct.
     const mainHelper =
       this.mainHelper ||
-      algoliasearchHelper(this.client, this.indexName, undefined, {
-        persistHierarchicalRootCount: this.future.persistHierarchicalRootCount,
-      });
+      algoliasearchHelper(this.client, this.indexName, undefined);
 
     mainHelper.search = () => {
       this.status = 'loading';

--- a/packages/instantsearch-core/src/types/instantsearch.ts
+++ b/packages/instantsearch-core/src/types/instantsearch.ts
@@ -108,9 +108,9 @@ export type InstantSearchOptions<
      *
      * If `true`, the count of the root level stays the same as the count of all children levels.
      *
-     * @default false
+     * @default true
      */
-    persistHierarchicalRootCount?: boolean; // @MAJOR change the default to true
+    persistHierarchicalRootCount?: boolean; // @MAJOR remove the option
   };
 };
 

--- a/packages/instantsearch-core/src/types/instantsearch.ts
+++ b/packages/instantsearch-core/src/types/instantsearch.ts
@@ -101,16 +101,6 @@ export type InstantSearchOptions<
      * @default false
      */
     preserveSharedStateOnUnmount?: boolean; // @MAJOR remove option, only keep the "true" behaviour
-    /**
-     * Changes the way root levels of hierarchical facets have their count displayed.
-     *
-     * If `false` (by default), the count of the refined root level is updated to match the count of the actively refined parent level.
-     *
-     * If `true`, the count of the root level stays the same as the count of all children levels.
-     *
-     * @default true
-     */
-    persistHierarchicalRootCount?: boolean; // @MAJOR remove the option
   };
 };
 

--- a/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
+++ b/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
@@ -3346,7 +3346,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         nbPages: 1,
         page: 0,
         params: '',
-        persistHierarchicalRootCount: false,
+        persistHierarchicalRootCount: true,
         processingTimeMS: 0,
         query: 'iphone',
       };

--- a/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
+++ b/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
@@ -3346,7 +3346,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
         nbPages: 1,
         page: 0,
         params: '',
-        persistHierarchicalRootCount: true,
         processingTimeMS: 0,
         query: 'iphone',
       };


### PR DESCRIPTION
BREAKING CHANGE: the option persistHierarchicalRootCount no longer exists. The default behaviour is now the same as used to be with persistHierarchicalRootCount: true

[FX-3185]

[FX-3185]: https://algolia.atlassian.net/browse/FX-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ