### PR TITLE
fix(storybook): update algoliasearch import statement in vue stories

### DIFF
--- a/packages/vue-instantsearch/.storybook/webpack.config.js
+++ b/packages/vue-instantsearch/.storybook/webpack.config.js
@@ -14,5 +14,11 @@ module.exports = ({ config, mode }) => {
     ],
   });
 
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      __DEV__: JSON.stringify(mode === 'DEVELOPMENT'),
+    })
+  );
+
   return config;
 };

--- a/packages/vue-instantsearch/stories/ConfigureRelatedItems.stories.js
+++ b/packages/vue-instantsearch/stories/ConfigureRelatedItems.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import algoliasearch from 'algoliasearch';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 
 storiesOf('ais-configure-related-items', module).add('default', () => ({
   template: `

--- a/packages/vue-instantsearch/stories/Index.stories.js
+++ b/packages/vue-instantsearch/stories/Index.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import algoliasearch from 'algoliasearch';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 
 storiesOf('ais-index', module)
   .add('default', () => ({

--- a/packages/vue-instantsearch/stories/InstantSearch.stories.js
+++ b/packages/vue-instantsearch/stories/InstantSearch.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 
 class FakeClient {
   // eslint-disable-next-line require-await

--- a/packages/vue-instantsearch/stories/RelevantSort.stories.js
+++ b/packages/vue-instantsearch/stories/RelevantSort.stories.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 
 import { previewWrapper } from './utils';
 

--- a/packages/vue-instantsearch/stories/utils.js
+++ b/packages/vue-instantsearch/stories/utils.js
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite';
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
 
 export const previewWrapper =
   ({


### PR DESCRIPTION
**Summary**

This PR fixes a few issues that prevented [the deployed Vue Storybook](https://instantsearchjs.netlify.app/stories/vue/) from being properly available.
