### PR TITLE
fix(connectors): don't expose duplicates of canRefine

### DIFF
--- a/examples/react/default-theme/src/components/NumericMenu.tsx
+++ b/examples/react/default-theme/src/components/NumericMenu.tsx
@@ -7,13 +7,13 @@ export type NumericMenuProps = React.ComponentProps<'div'> &
   UseNumericMenuProps;
 
 export function NumericMenu(props: NumericMenuProps) {
-  const { hasNoResults, items, refine } = useNumericMenu(props);
+  const { canRefine, items, refine } = useNumericMenu(props);
 
   return (
     <div
       className={cx(
         'ais-NumericMenu',
-        hasNoResults && 'ais-NumericMenu--noRefinement',
+        !canRefine && 'ais-NumericMenu--noRefinement',
         props.className
       )}
     >

--- a/packages/instantsearch-core/src/connectors/__tests__/connectClearRefinements.test.ts
+++ b/packages/instantsearch-core/src/connectors/__tests__/connectClearRefinements.test.ts
@@ -97,7 +97,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
       expect(firstRenderingOptions.createURL).toBeInstanceOf(Function);
       expect(firstRenderingOptions.refine).toBeInstanceOf(Function);
       expect(firstRenderingOptions.canRefine).toBe(false);
-      expect(firstRenderingOptions.hasRefinements).toBe(false);
       expect(firstRenderingOptions.widgetParams).toEqual({
         foo: 'bar', // dummy param to test `widgetParams`
       });
@@ -121,7 +120,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
       expect(isFirstRenderAtRender).toBe(false);
       expect(secondRenderingOptions.createURL).toBeInstanceOf(Function);
       expect(secondRenderingOptions.refine).toBeInstanceOf(Function);
-      expect(secondRenderingOptions.hasRefinements).toBe(false);
       expect(secondRenderingOptions.canRefine).toBe(false);
     });
 
@@ -162,7 +160,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         );
 
         expect(renderState1.clearRefinements).toEqual({
-          hasRefinements: false,
           canRefine: false,
           createURL: expect.any(Function),
           refine: expect.any(Function),
@@ -209,7 +206,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         );
 
         expect(renderState2.clearRefinements).toEqual({
-          hasRefinements: true,
           canRefine: true,
           createURL: expect.any(Function),
           refine: expect.any(Function),
@@ -243,7 +239,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         );
 
         expect(renderState1).toEqual({
-          hasRefinements: false,
           canRefine: false,
           createURL: expect.any(Function),
           refine: expect.any(Function),
@@ -289,7 +284,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         );
 
         expect(renderState2).toEqual({
-          hasRefinements: true,
           canRefine: true,
           createURL: expect.any(Function),
           refine: expect.any(Function),
@@ -449,7 +443,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         })
       );
 
-      expect(rendering.mock.calls[0][0].hasRefinements).toBe(false);
       expect(rendering.mock.calls[0][0].canRefine).toBe(false);
 
       widget.render!(
@@ -462,7 +455,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         })
       );
 
-      expect(rendering.mock.calls[1][0].hasRefinements).toBe(true);
       expect(rendering.mock.calls[1][0].canRefine).toBe(true);
     });
 
@@ -488,7 +480,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         })
       );
 
-      expect(rendering.mock.calls[0][0].hasRefinements).toBe(false);
       expect(rendering.mock.calls[0][0].canRefine).toBe(false);
 
       widget.render!(
@@ -501,7 +492,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         })
       );
 
-      expect(rendering.mock.calls[1][0].hasRefinements).toBe(true);
       expect(rendering.mock.calls[1][0].canRefine).toBe(true);
     });
 
@@ -524,7 +514,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         })
       );
 
-      expect(rendering.mock.calls[0][0].hasRefinements).toBe(false);
       expect(rendering.mock.calls[0][0].canRefine).toBe(false);
 
       widget.render!(
@@ -537,7 +526,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         })
       );
 
-      expect(rendering.mock.calls[1][0].hasRefinements).toBe(false);
       expect(rendering.mock.calls[1][0].canRefine).toBe(false);
     });
 
@@ -557,7 +545,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         })
       );
 
-      expect(rendering.mock.calls[0][0].hasRefinements).toBe(false);
       expect(rendering.mock.calls[0][0].canRefine).toBe(false);
 
       widget.render!(
@@ -570,7 +557,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         })
       );
 
-      expect(rendering.mock.calls[1][0].hasRefinements).toBe(false);
       expect(rendering.mock.calls[1][0].canRefine).toBe(false);
     });
 
@@ -624,7 +610,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
 
       expect(helper.hasRefinements('facet1')).toBe(false);
       expect(helper.hasRefinements('facet2')).toBe(true);
-      expect(rendering.mock.calls[2][0].hasRefinements).toBe(false);
       expect(rendering.mock.calls[2][0].canRefine).toBe(false);
     });
 
@@ -675,7 +660,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
 
       expect(helper.hasRefinements('facet1')).toBe(false);
       expect(helper.state.query).toBe('');
-      expect(rendering.mock.calls[2][0].hasRefinements).toBe(false);
       expect(rendering.mock.calls[2][0].canRefine).toBe(false);
     });
 
@@ -723,8 +707,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
 
         expect(helper.hasRefinements('facet1')).toBe(false);
         expect(helper.hasRefinements('facet2')).toBe(true);
-
-        expect(rendering.mock.calls[1][0].hasRefinements).toBe(true);
         expect(rendering.mock.calls[1][0].canRefine).toBe(true);
       }
 
@@ -824,7 +806,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
       expect(helper.hasRefinements('facet2')).toBe(true);
       expect(helper.hasRefinements('facet3')).toBe(false);
       expect(helper.state.query).toBe('');
-      expect(rendering.mock.calls[2][0].hasRefinements).toBe(false);
       expect(rendering.mock.calls[2][0].canRefine).toBe(false);
     });
 

--- a/packages/instantsearch-core/src/connectors/__tests__/connectHitsPerPage.test.ts
+++ b/packages/instantsearch-core/src/connectors/__tests__/connectHitsPerPage.test.ts
@@ -769,7 +769,6 @@ You may want to add another entry to the \`items\` option with this value.`);
             ],
             createURL: expect.any(Function),
             refine: expect.any(Function),
-            hasNoResults: false,
             canRefine: true,
             widgetParams: {
               items: [
@@ -804,7 +803,6 @@ You may want to add another entry to the \`items\` option with this value.`);
           },
         ],
         createURL: expect.any(Function),
-        hasNoResults: true,
         canRefine: false,
         refine: expect.any(Function),
         widgetParams: {
@@ -841,7 +839,6 @@ You may want to add another entry to the \`items\` option with this value.`);
             ],
             createURL: () => '',
             refine: () => {},
-            hasNoResults: true,
             canRefine: false,
             widgetParams: {
               items: [
@@ -889,7 +886,6 @@ You may want to add another entry to the \`items\` option with this value.`);
           },
         ],
         createURL: expect.any(Function),
-        hasNoResults: true,
         canRefine: false,
         refine: expect.any(Function),
         widgetParams: {
@@ -944,7 +940,6 @@ You may want to add another entry to the \`items\` option with this value.`);
         ],
         refine: expect.any(Function),
         createURL: expect.any(Function),
-        hasNoResults: true,
         canRefine: false,
         widgetParams: {
           items: [
@@ -995,7 +990,6 @@ You may want to add another entry to the \`items\` option with this value.`);
           },
         ],
         createURL: expect.any(Function),
-        hasNoResults: true,
         canRefine: false,
         refine: expect.any(Function),
         widgetParams: {

--- a/packages/instantsearch-core/src/connectors/__tests__/connectNumericMenu.test.ts
+++ b/packages/instantsearch-core/src/connectors/__tests__/connectNumericMenu.test.ts
@@ -1172,7 +1172,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
       expect(renderState1.numericMenu).toEqual({
         numerics: {
           createURL: expect.any(Function),
-          hasNoResults: true,
           canRefine: false,
           items: [
             {
@@ -1232,7 +1231,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
           createURL: expect.any(Function),
           refine: renderState1.numericMenu.numerics.refine,
           sendEvent: renderState1.numericMenu.numerics.sendEvent,
-          hasNoResults: true,
           canRefine: false,
           items: [
             {
@@ -1314,7 +1312,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
         createURL: expect.any(Function),
         refine: expect.any(Function),
         sendEvent: expect.any(Function),
-        hasNoResults: true,
         canRefine: false,
         widgetParams: {
           attribute: 'numerics',
@@ -1365,7 +1362,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
         createURL: expect.any(Function),
         refine: expect.any(Function),
         sendEvent: expect.any(Function),
-        hasNoResults: true,
         canRefine: false,
         widgetParams: {
           attribute: 'numerics',
@@ -1401,7 +1397,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/numeric-men
 
       expect(renderState2).toEqual({
         createURL: expect.any(Function),
-        hasNoResults: true,
         canRefine: false,
         items: [
           {

--- a/packages/instantsearch-core/src/connectors/__tests__/connectRatingMenu.test.ts
+++ b/packages/instantsearch-core/src/connectors/__tests__/connectRatingMenu.test.ts
@@ -493,7 +493,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
           canRefine: false,
           refine: expect.any(Function),
           sendEvent: expect.any(Function),
-          hasNoResults: true,
           widgetParams: {
             attribute: 'grade',
           },
@@ -577,7 +576,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
           canRefine: true,
           refine: expect.any(Function),
           sendEvent: renderState1.ratingMenu.grade.sendEvent,
-          hasNoResults: true,
           widgetParams: {
             attribute: 'grade',
           },
@@ -613,7 +611,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         canRefine: false,
         refine: expect.any(Function),
         sendEvent: expect.any(Function),
-        hasNoResults: true,
         widgetParams: {
           attribute: 'grade',
         },
@@ -695,7 +692,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         canRefine: true,
         refine: expect.any(Function),
         sendEvent: renderState1.sendEvent,
-        hasNoResults: true,
         widgetParams: {
           attribute: 'grade',
         },
@@ -735,7 +731,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/rating-menu
         canRefine: false,
         refine: expect.any(Function),
         sendEvent: renderState1.sendEvent,
-        hasNoResults: true,
         widgetParams: {
           attribute: 'grade',
         },

--- a/packages/instantsearch-core/src/connectors/__tests__/connectSortBy.test.ts
+++ b/packages/instantsearch-core/src/connectors/__tests__/connectSortBy.test.ts
@@ -329,7 +329,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       expect(renderState1.sortBy).toEqual({
         currentRefinement: 'index_default',
         refine: expect.any(Function),
-        hasNoResults: true,
         canRefine: false,
         options: [
           { label: 'default', value: 'index_default' },
@@ -371,7 +370,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       expect(renderState2.sortBy).toEqual({
         currentRefinement: 'index_desc',
         refine: expect.any(Function),
-        hasNoResults: false,
         canRefine: true,
         options: [
           { label: 'default', value: 'index_default' },
@@ -412,7 +410,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       expect(renderState1).toEqual({
         currentRefinement: 'index_desc',
         refine: expect.any(Function),
-        hasNoResults: true,
         canRefine: false,
         options: [
           { label: 'default', value: 'index_default' },
@@ -452,7 +449,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/sort-by/js/
       expect(renderState2).toEqual({
         currentRefinement: 'index_default',
         refine: expect.any(Function),
-        hasNoResults: false,
         canRefine: true,
         options: [
           { label: 'default', value: 'index_default' },

--- a/packages/instantsearch-core/src/connectors/connectClearRefinements.ts
+++ b/packages/instantsearch-core/src/connectors/connectClearRefinements.ts
@@ -44,12 +44,6 @@ export type ClearRefinementsRenderState = {
   refine: () => void;
 
   /**
-   * Indicates if search state is refined.
-   * @deprecated prefer reading canRefine
-   */
-  hasRefinements: boolean;
-
-  /**
    * Indicates if search state can be refined.
    */
   canRefine: boolean;
@@ -210,7 +204,6 @@ export const connectClearRefinements: ClearRefinementsConnector =
 
           return {
             canRefine,
-            hasRefinements: canRefine,
             refine: cachedRefine,
             createURL: cachedCreateURL,
             widgetParams,

--- a/packages/instantsearch-core/src/connectors/connectHitsPerPage.ts
+++ b/packages/instantsearch-core/src/connectors/connectHitsPerPage.ts
@@ -89,12 +89,6 @@ export type HitsPerPageRenderState = {
   refine: (value: number) => void;
 
   /**
-   * Indicates whether or not the search has results.
-   * @deprecated Use `canRefine` instead.
-   */
-  hasNoResults: boolean;
-
-  /**
    * Indicates if search state can be refined.
    */
   canRefine: boolean;
@@ -278,7 +272,6 @@ You may want to add another entry to the \`items\` option with this value.`
               getWidgetUiState: this.getWidgetUiState,
               helper,
             }),
-            hasNoResults: !canRefine,
             canRefine,
             widgetParams,
           };

--- a/packages/instantsearch-core/src/connectors/connectNumericMenu.ts
+++ b/packages/instantsearch-core/src/connectors/connectNumericMenu.ts
@@ -83,12 +83,6 @@ export type NumericMenuRenderState = {
   createURL: CreateURL<NumericMenuRenderStateItem['value']>;
 
   /**
-   * `true` if the last search contains no result
-   * @deprecated Use `canRefine` instead.
-   */
-  hasNoResults: boolean;
-
-  /**
    * Indicates if search state can be refined.
    *
    * This is `true` if the last search contains no result and
@@ -340,7 +334,6 @@ export const connectNumericMenu: NumericMenuConnector =
           return {
             createURL: connectorState.createURL(state),
             items: transformItems(preparedItems, { results }),
-            hasNoResults,
             canRefine: !(hasNoResults && allIsSelected),
             refine: connectorState.refine,
             sendEvent: connectorState.sendEvent,

--- a/packages/instantsearch-core/src/connectors/connectRatingMenu.ts
+++ b/packages/instantsearch-core/src/connectors/connectRatingMenu.ts
@@ -132,13 +132,6 @@ export type RatingMenuRenderState = {
   refine: (value: string) => void;
 
   /**
-   * `true` if the last search contains no result.
-   *
-   * @deprecated Use `canRefine` instead.
-   */
-  hasNoResults: boolean;
-
-  /**
    * Send event to insights middleware
    */
   sendEvent: SendEvent;
@@ -415,7 +408,6 @@ export const connectRatingMenu: RatingMenuConnector =
 
           return {
             items: facetValues,
-            hasNoResults,
             canRefine: (!hasNoResults || refinementIsApplied) && totalCount > 0,
             refine: connectorState.toggleRefinementFactory(helper),
             sendEvent,

--- a/packages/instantsearch-core/src/connectors/connectSortBy.ts
+++ b/packages/instantsearch-core/src/connectors/connectSortBy.ts
@@ -58,11 +58,6 @@ export type SortByRenderState = {
    */
   refine: (value: string) => void;
   /**
-   * `true` if the last search contains no result.
-   * @deprecated Use `canRefine` instead.
-   */
-  hasNoResults: boolean;
-  /**
    * `true` if we can refine.
    */
   canRefine: boolean;
@@ -179,7 +174,6 @@ export const connectSortBy: SortByConnector = function connectSortBy(
           currentRefinement: state.index,
           options: transformItems(items, { results }),
           refine: connectorState.setIndex,
-          hasNoResults,
           canRefine: !hasNoResults && items.length > 0,
           widgetParams,
         };

--- a/packages/instantsearch.js/src/components/ClearRefinements/ClearRefinements.tsx
+++ b/packages/instantsearch.js/src/components/ClearRefinements/ClearRefinements.tsx
@@ -22,12 +22,12 @@ export type ClearRefinementsComponentTemplates =
 export type ClearRefinementsProps = {
   refine: ClearRefinementsRenderState['refine'];
   cssClasses: ClearRefinementsComponentCSSClasses;
-  hasRefinements: ClearRefinementsRenderState['hasRefinements'];
+  canRefine: ClearRefinementsRenderState['canRefine'];
   templateProps: PreparedTemplateProps<ClearRefinementsComponentTemplates>;
 };
 
 const ClearRefinements = ({
-  hasRefinements,
+  canRefine,
   refine,
   cssClasses,
   templateProps,
@@ -40,12 +40,12 @@ const ClearRefinements = ({
       rootProps={{
         className: cx(
           cssClasses.button,
-          !hasRefinements && cssClasses.disabledButton
+          !canRefine && cssClasses.disabledButton
         ),
         onClick: refine,
-        disabled: !hasRefinements,
+        disabled: !canRefine,
       }}
-      data={{ hasRefinements }}
+      data={{ canRefine }}
     />
   </div>
 );

--- a/packages/instantsearch.js/src/widgets/clear-refinements/__tests__/clear-refinements.test.tsx
+++ b/packages/instantsearch.js/src/widgets/clear-refinements/__tests__/clear-refinements.test.tsx
@@ -158,11 +158,9 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         clearRefinements({
           container,
           templates: {
-            resetLabel({ hasRefinements }, { html }) {
+            resetLabel({ canRefine }, { html }) {
               return html`<span
-                >${hasRefinements
-                  ? 'Clear refinements'
-                  : 'No refinements'}</span
+                >${canRefine ? 'Clear refinements' : 'No refinements'}</span
               >`;
             },
           },
@@ -235,10 +233,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/clear-refin
         clearRefinements({
           container,
           templates: {
-            resetLabel({ hasRefinements }) {
+            resetLabel({ canRefine }) {
               return (
                 <span>
-                  {hasRefinements ? 'Clear refinements' : 'No refinements'}
+                  {canRefine ? 'Clear refinements' : 'No refinements'}
                 </span>
               );
             },

--- a/packages/instantsearch.js/src/widgets/clear-refinements/clear-refinements.tsx
+++ b/packages/instantsearch.js/src/widgets/clear-refinements/clear-refinements.tsx
@@ -61,7 +61,7 @@ const renderer =
       <ClearRefinements
         refine={refine}
         cssClasses={cssClasses}
-        hasRefinements={canRefine}
+        canRefine={canRefine}
         templateProps={renderState.templateProps!}
       />,
       containerNode
@@ -89,7 +89,7 @@ export type ClearRefinementsTemplates = Partial<{
   /**
    * Template for the content of the button
    */
-  resetLabel: Template<{ hasRefinements: boolean }>;
+  resetLabel: Template<{ canRefine: boolean }>;
 }>;
 
 export type ClearRefinementsWidgetParams = {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useClearRefinements.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useClearRefinements.test.tsx
@@ -19,7 +19,6 @@ describe('useClearRefinements', () => {
 
     // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
-      hasRefinements: false,
       canRefine: false,
       refine: expect.any(Function),
       createURL: expect.any(Function),
@@ -29,7 +28,6 @@ describe('useClearRefinements', () => {
 
     // InstantSearch.js state from the `render` lifecycle step
     expect(result.current).toEqual({
-      hasRefinements: false,
       canRefine: false,
       refine: expect.any(Function),
       createURL: expect.any(Function),
@@ -64,7 +62,6 @@ describe('useClearRefinements', () => {
 
     // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
-      hasRefinements: true,
       canRefine: true,
       refine: expect.any(Function),
       createURL: expect.any(Function),
@@ -74,7 +71,6 @@ describe('useClearRefinements', () => {
 
     // InstantSearch.js state from the `render` lifecycle step
     expect(result.current).toEqual({
-      hasRefinements: true,
       canRefine: true,
       refine: expect.any(Function),
       createURL: expect.any(Function),

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useHitsPerPage.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useHitsPerPage.test.tsx
@@ -23,7 +23,6 @@ describe('useHitsPerPage', () => {
     expect(result.current).toEqual({
       refine: expect.any(Function),
       createURL: expect.any(Function),
-      hasNoResults: true,
       canRefine: false,
       items: [
         {
@@ -46,7 +45,6 @@ describe('useHitsPerPage', () => {
     expect(result.current).toEqual({
       refine: expect.any(Function),
       createURL: expect.any(Function),
-      hasNoResults: true,
       canRefine: false,
       items: [
         {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useNumericMenu.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useNumericMenu.test.tsx
@@ -25,7 +25,6 @@ describe('useNumericMenu', () => {
     // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
       createURL: expect.any(Function),
-      hasNoResults: true,
       canRefine: false,
       items: [
         {
@@ -58,7 +57,6 @@ describe('useNumericMenu', () => {
     // InstantSearch.js state from the `render` lifecycle step
     expect(result.current).toEqual({
       createURL: expect.any(Function),
-      hasNoResults: true,
       canRefine: false,
       items: [
         {

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useSortBy.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useSortBy.test.tsx
@@ -21,7 +21,6 @@ describe('useSortBy', () => {
       currentRefinement: 'indexName',
       options: items,
       refine: expect.any(Function),
-      hasNoResults: expect.any(Boolean),
       canRefine: expect.any(Boolean),
     });
 
@@ -31,7 +30,6 @@ describe('useSortBy', () => {
       currentRefinement: 'indexName',
       options: items,
       refine: expect.any(Function),
-      hasNoResults: expect.any(Boolean),
       canRefine: expect.any(Boolean),
     });
   });

--- a/packages/react-instantsearch/src/ui/CurrentRefinements.tsx
+++ b/packages/react-instantsearch/src/ui/CurrentRefinements.tsx
@@ -14,7 +14,7 @@ export type CurrentRefinementsProps = React.ComponentProps<'div'> & {
     > &
       Record<string, unknown>
   >;
-  hasRefinements?: boolean;
+  canRefine?: boolean;
 };
 
 export type CurrentRefinementsClassNames = {
@@ -59,7 +59,7 @@ export type CurrentRefinementsClassNames = {
 export function CurrentRefinements({
   classNames = {},
   items = [],
-  hasRefinements = false,
+  canRefine = false,
   ...props
 }: CurrentRefinementsProps) {
   return (
@@ -68,7 +68,7 @@ export function CurrentRefinements({
       className={cx(
         'ais-CurrentRefinements',
         classNames.root,
-        !hasRefinements &&
+        !canRefine &&
           cx(
             'ais-CurrentRefinements--noRefinement',
             classNames.noRefinementRoot
@@ -81,7 +81,7 @@ export function CurrentRefinements({
           'ais-CurrentRefinements-list',
           classNames.list,
           /* @MAJOR remove to ensure conformity with InstantSearch.css specs */
-          !hasRefinements &&
+          !canRefine &&
             cx(
               'ais-CurrentRefinements-list--noRefinement',
               classNames.noRefinementList

--- a/packages/react-instantsearch/src/ui/__tests__/CurrentRefinements.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/CurrentRefinements.test.tsx
@@ -52,7 +52,7 @@ describe('CurrentRefinements', () => {
             ],
           },
         ]}
-        hasRefinements={true}
+        canRefine={true}
       />
     );
 

--- a/packages/react-instantsearch/src/widgets/CurrentRefinements.tsx
+++ b/packages/react-instantsearch/src/widgets/CurrentRefinements.tsx
@@ -6,10 +6,7 @@ import { CurrentRefinements as CurrentRefinementsUiComponent } from '../ui/Curre
 import type { CurrentRefinementsProps as CurrentRefinementsUiComponentProps } from '../ui/CurrentRefinements';
 import type { UseCurrentRefinementsProps } from 'react-instantsearch-core';
 
-type UiProps = Pick<
-  CurrentRefinementsUiComponentProps,
-  'items' | 'hasRefinements'
->;
+type UiProps = Pick<CurrentRefinementsUiComponentProps, 'items' | 'canRefine'>;
 
 export type CurrentRefinementsProps = Omit<
   CurrentRefinementsUiComponentProps,
@@ -36,7 +33,7 @@ export function CurrentRefinements({
 
   const uiProps: UiProps = {
     items,
-    hasRefinements: canRefine,
+    canRefine,
   };
 
   return <CurrentRefinementsUiComponent {...props} {...uiProps} />;

--- a/packages/vue-instantsearch/src/components/ClearRefinements.vue
+++ b/packages/vue-instantsearch/src/components/ClearRefinements.vue
@@ -2,14 +2,17 @@
 <template>
   <div v-if="state" :class="suit()">
     <slot
-      :can-refine="canRefine"
+      :can-refine="state.canRefine"
       :refine="state.refine"
       :createURL="state.createURL"
     >
       <button
         type="reset"
-        :class="[suit('button'), !canRefine && suit('button', 'disabled')]"
-        :disabled="!canRefine"
+        :class="[
+          suit('button'),
+          !state.canRefine && suit('button', 'disabled'),
+        ]"
+        :disabled="!state.canRefine"
         @click.prevent="state.refine"
       >
         <slot name="resetLabel"> Clear refinements </slot>
@@ -60,9 +63,6 @@ export default {
         excludedAttributes: this.excludedAttributes,
         transformItems: this.transformItems,
       };
-    },
-    canRefine() {
-      return this.state.hasRefinements;
     },
   },
 };

--- a/packages/vue-instantsearch/src/components/__tests__/ClearRefinements.js
+++ b/packages/vue-instantsearch/src/components/__tests__/ClearRefinements.js
@@ -11,7 +11,7 @@ jest.mock('../../mixins/widget');
 jest.mock('../../mixins/panel');
 
 const defaultState = {
-  hasRefinements: true,
+  canRefine: true,
   refine: () => {},
   createURL: () => {},
 };
@@ -59,7 +59,7 @@ describe('default render', () => {
   it('renders correctly without refinements', () => {
     __setState({
       ...defaultState,
-      hasRefinements: false,
+      canRefine: false,
     });
 
     const wrapper = mount(ClearRefinements);
@@ -118,7 +118,7 @@ describe('custom default render', () => {
   it('renders correctly without refinement', () => {
     __setState({
       ...defaultState,
-      hasRefinements: false,
+      canRefine: false,
     });
 
     const wrapper = mount({


### PR DESCRIPTION
In the past, `canRefine` has been introduced as a consistent way to check if any widget can be refined. There were previous largely overlapping pieces of information exposed which were deprecated. These are now removed.

[FX-3195]

BREAKING CHANGE: clearRefinements: replace `hasRefinements` with `canRefine`
BREAKING CHANGE: hitsPerPage: replace `hasNoResults` with `!canRefine`
BREAKING CHANGE: numericMenu: replace `hasNoResults` with `!canRefine`
BREAKING CHANGE: ratingMenu: replace `hasNoResults` with `!canRefine`
BREAKING CHANGE: sortBy: replace `hasNoResults` with `!canRefine`

[FX-3195]: https://algolia.atlassian.net/browse/FX-3195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ