### PR TITLE
fix(connectors): replace hits for items

### DIFF
--- a/packages/instantsearch-core/src/connectors/__tests__/connectHits.test.ts
+++ b/packages/instantsearch-core/src/connectors/__tests__/connectHits.test.ts
@@ -122,7 +122,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        hits: [],
+        items: [],
         results: undefined,
       }),
       expect.anything()
@@ -146,7 +146,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        hits,
+        items: hits,
         results,
       }),
       expect.anything()
@@ -170,7 +170,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        hits: [],
+        items: [],
         results: undefined,
       }),
       expect.anything()
@@ -217,7 +217,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        hits: expectedHits,
+        items: expectedHits,
         results,
       }),
       expect.anything()
@@ -244,7 +244,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
 
     expect(renderFn).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ hits: [], results: undefined }),
+      expect.objectContaining({ items: [], results: undefined }),
       expect.anything()
     );
 
@@ -272,7 +272,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        hits: expectedHits,
+        items: expectedHits,
         results,
       }),
       expect.anything()
@@ -345,7 +345,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        hits: expectedHits,
+        items: expectedHits,
       }),
       expect.anything()
     );
@@ -450,7 +450,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
     expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        hits: expectedHits,
+        items: expectedHits,
         results,
       }),
       expect.anything()
@@ -505,7 +505,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       );
 
       expect(renderState1.hits).toEqual({
-        hits: [],
         items: [],
         sendEvent: expect.any(Function),
         results: undefined,
@@ -536,7 +535,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       ];
 
       expect(renderState2.hits).toEqual({
-        hits: expectedHits,
         items: expectedHits,
         sendEvent: renderState1.hits.sendEvent,
         results,
@@ -566,7 +564,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       );
 
       expect(renderState1).toEqual({
-        hits: [],
         items: [],
         banner: undefined,
         sendEvent: expect.any(Function),
@@ -603,7 +600,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hits/js/#co
       ];
 
       expect(renderState2).toEqual({
-        hits: expectedHits,
         items: expectedHits,
         banner,
         sendEvent: renderState1.sendEvent,

--- a/packages/instantsearch-core/src/connectors/__tests__/connectInfiniteHits.test.ts
+++ b/packages/instantsearch-core/src/connectors/__tests__/connectInfiniteHits.test.ts
@@ -105,7 +105,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         instantSearchInstance,
-        hits: [],
+        items: [],
         showPrevious: expect.any(Function),
         showMore: expect.any(Function),
         results: undefined,
@@ -133,7 +133,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
         instantSearchInstance,
-        hits: [],
+        items: [],
         showPrevious: expect.any(Function),
         showMore: expect.any(Function),
         results: expect.any(Object),
@@ -163,7 +163,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
-    expect(firstRenderOptions.hits).toEqual([]);
+    expect(firstRenderOptions.items).toEqual([]);
     expect(firstRenderOptions.results).toBe(undefined);
 
     const hits = [
@@ -184,7 +184,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
     const secondRenderOptions = renderFn.mock.calls[1][0];
     const { showMore } = secondRenderOptions;
-    expect(secondRenderOptions.hits).toEqual(hits);
+    expect(secondRenderOptions.items).toEqual(hits);
     expect(secondRenderOptions.results).toEqual(results);
     showMore();
     expect(helper.search).toHaveBeenCalledTimes(1);
@@ -207,7 +207,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
 
     const thirdRenderOptions = renderFn.mock.calls[2][0];
-    expect(thirdRenderOptions.hits).toEqual([...hits, ...otherHits]);
+    expect(thirdRenderOptions.items).toEqual([...hits, ...otherHits]);
     expect(thirdRenderOptions.results).toEqual(otherResults);
   });
 
@@ -230,7 +230,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
-    expect(firstRenderOptions.hits).toEqual([]);
+    expect(firstRenderOptions.items).toEqual([]);
     expect(firstRenderOptions.results).toBe(undefined);
 
     const hits = [
@@ -251,7 +251,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
 
     const secondRenderOptions = renderFn.mock.calls[1][0];
     const { showPrevious } = secondRenderOptions;
-    expect(secondRenderOptions.hits).toEqual(hits);
+    expect(secondRenderOptions.items).toEqual(hits);
     expect(secondRenderOptions.results).toEqual(results);
     showPrevious();
     expect(helper.state.page).toBe(0);
@@ -279,7 +279,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
 
     const thirdRenderOptions = renderFn.mock.calls[2][0];
-    expect(thirdRenderOptions.hits).toEqual([...previousHits, ...hits]);
+    expect(thirdRenderOptions.items).toEqual([...previousHits, ...hits]);
     expect(thirdRenderOptions.results).toEqual(previousResults);
   });
 
@@ -315,7 +315,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     ).toHaveBeenCalledWith(expect.objectContaining({ page: 3 }));
   });
 
-  it('Provides the hits and flush hists cache on query changes', () => {
+  it('Provides the hits and flush hits cache on query changes', () => {
     const renderFn = jest.fn();
     const makeWidget = connectInfiniteHits(renderFn);
     const widget = makeWidget({});
@@ -331,7 +331,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
-    expect(firstRenderOptions.hits).toEqual([]);
+    expect(firstRenderOptions.items).toEqual([]);
     expect(firstRenderOptions.results).toBe(undefined);
 
     const hits = [
@@ -351,7 +351,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
 
     const secondRenderOptions = renderFn.mock.calls[1][0];
-    expect(secondRenderOptions.hits).toEqual(hits);
+    expect(secondRenderOptions.items).toEqual(hits);
     expect(secondRenderOptions.results).toEqual(results);
 
     helper.setQuery('data');
@@ -374,7 +374,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
 
     const thirdRenderOptions = renderFn.mock.calls[2][0];
-    expect(thirdRenderOptions.hits).toEqual(otherHits);
+    expect(thirdRenderOptions.items).toEqual(otherHits);
     expect(thirdRenderOptions.results).toEqual(otherResults);
   });
 
@@ -480,7 +480,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
-    expect(firstRenderOptions.hits).toEqual([]);
+    expect(firstRenderOptions.items).toEqual([]);
     expect(firstRenderOptions.results).toBe(undefined);
 
     const hits = [
@@ -524,7 +524,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     ];
 
     const secondRenderOptions = renderFn.mock.calls[1][0];
-    expect(secondRenderOptions.hits).toEqual(escapedHits);
+    expect(secondRenderOptions.items).toEqual(escapedHits);
     expect(secondRenderOptions.results).toEqual(results);
   });
 
@@ -548,7 +548,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     );
 
     const firstRenderOptions = renderFn.mock.calls[0][0];
-    expect(firstRenderOptions.hits).toEqual([]);
+    expect(firstRenderOptions.items).toEqual([]);
     expect(firstRenderOptions.results).toBe(undefined);
 
     const hits = [
@@ -586,7 +586,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     ];
 
     const secondRenderOptions = renderFn.mock.calls[1][0];
-    expect(secondRenderOptions.hits).toEqual(transformedHits);
+    expect(secondRenderOptions.items).toEqual(transformedHits);
     expect(secondRenderOptions.results).toEqual(results);
   });
 
@@ -683,7 +683,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        hits: [
+        items: [
           {
             name: 'hello',
             _highlightResult: {
@@ -754,7 +754,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(renderFn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        hits: [
+        items: [
           {
             name: 'name 1',
             objectID: '1',
@@ -819,7 +819,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(renderFn).toHaveBeenCalledTimes(3);
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        hits: [{ objectID: 'a' }, { objectID: 'b' }],
+        items: [{ objectID: 'a' }, { objectID: 'b' }],
       }),
       false
     );
@@ -841,7 +841,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     expect(renderFn).toHaveBeenCalledTimes(4);
     expect(renderFn).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        hits: [{ objectID: 'a' }, { objectID: 'b' }],
+        items: [{ objectID: 'a' }, { objectID: 'b' }],
       }),
       false
     );
@@ -947,7 +947,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       renderWidget({ results: searchResults });
 
       let renderOptions = renderFn.mock.calls[2][0];
-      expect(renderOptions.hits).toEqual(firstPageHits);
+      expect(renderOptions.items).toEqual(firstPageHits);
       expect(renderOptions.results).toEqual(searchResults);
 
       // Search: page 2
@@ -964,7 +964,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       renderWidget({ results: searchResults });
 
       renderOptions = renderFn.mock.calls[3][0];
-      expect(renderOptions.hits).toEqual([...firstPageHits, ...secondPageHits]);
+      expect(renderOptions.items).toEqual([
+        ...firstPageHits,
+        ...secondPageHits,
+      ]);
       expect(renderOptions.results).toEqual(searchResults);
     }
 
@@ -991,7 +994,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       renderWidget({ results: searchResults });
 
       const renderOptions = renderFn.mock.calls[2][0];
-      expect(renderOptions.hits).toEqual([...firstPageHits, ...secondPageHits]);
+      expect(renderOptions.items).toEqual([
+        ...firstPageHits,
+        ...secondPageHits,
+      ]);
       expect(renderOptions.results).toEqual(searchResults);
     }
   });
@@ -1063,7 +1069,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       renderWidget({ results: searchResults });
 
       let renderOptions = renderFn.mock.calls[2][0];
-      expect(renderOptions.hits).toEqual(firstPageHits);
+      expect(renderOptions.items).toEqual(firstPageHits);
       expect(renderOptions.results).toEqual(searchResults);
 
       // Search: page 2
@@ -1081,7 +1087,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       renderWidget({ results: searchResults });
 
       renderOptions = renderFn.mock.calls[3][0];
-      expect(renderOptions.hits).toEqual([...firstPageHits, ...secondPageHits]);
+      expect(renderOptions.items).toEqual([
+        ...firstPageHits,
+        ...secondPageHits,
+      ]);
       expect(renderOptions.results).toEqual(searchResults);
     }
 
@@ -1109,7 +1118,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       renderWidget({ results: searchResults });
 
       const renderOptions = renderFn.mock.calls[2][0];
-      expect(renderOptions.hits).toEqual([...firstPageHits, ...secondPageHits]);
+      expect(renderOptions.items).toEqual([
+        ...firstPageHits,
+        ...secondPageHits,
+      ]);
       expect(renderOptions.results).toEqual(searchResults);
     }
   });
@@ -1323,7 +1335,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       const renderState1 = infiniteHitsWidget.getRenderState({}, initOptions);
 
       expect(renderState1.infiniteHits).toEqual({
-        hits: [],
         items: [],
         currentPageHits: [],
         sendEvent: expect.any(Function),
@@ -1386,7 +1397,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       ];
 
       expect(renderState2.infiniteHits).toEqual({
-        hits: expectedHits,
         items: expectedHits,
         currentPageHits: expectedCurrentPageHits,
         sendEvent: renderState1.infiniteHits.sendEvent,
@@ -1416,7 +1426,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       const renderState1 = infiniteHitsWidget.getWidgetRenderState(initOptions);
 
       expect(renderState1).toEqual({
-        hits: [],
         items: [],
         currentPageHits: [],
         sendEvent: expect.any(Function),
@@ -1492,7 +1501,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
       ];
 
       expect(renderState2).toEqual({
-        hits: expectedHits,
         items: expectedHits,
         currentPageHits: expectedCurrentPageHits,
         sendEvent: renderState1.sendEvent,

--- a/packages/instantsearch-core/src/connectors/connectHits.ts
+++ b/packages/instantsearch-core/src/connectors/connectHits.ts
@@ -32,12 +32,6 @@ const withUsage = createDocumentationMessageGenerator({
 export type HitsRenderState<THit extends NonNullable<object> = BaseHit> = {
   /**
    * The matched hits from Algolia API.
-   * @deprecated use `items` instead
-   */
-  hits: Array<Hit<THit>>;
-
-  /**
-   * The matched hits from Algolia API.
    */
   items: Array<Hit<THit>>;
 
@@ -154,7 +148,6 @@ export const connectHits = function connectHits<TWidgetParams>(
 
         if (!results) {
           return {
-            hits: [],
             items: [],
             results: undefined,
             banner: undefined,
@@ -185,7 +178,6 @@ export const connectHits = function connectHits<TWidgetParams>(
         const banner = results.renderingContent?.widgets?.banners?.[0];
 
         return {
-          hits: items,
           items,
           results,
           banner,

--- a/packages/instantsearch-core/src/lib/infiniteHitsCache/__tests__/sessionStorage-key.test.ts
+++ b/packages/instantsearch-core/src/lib/infiniteHitsCache/__tests__/sessionStorage-key.test.ts
@@ -59,7 +59,7 @@ describe('createInfiniteHitsSessionStorageCache', () => {
     const hits = {
       1: defaultHits,
     };
-    cache.write({ state, hits });
+    cache.write({ state, items: hits });
     expect(cache.read({ state })).toEqual(hits);
   });
 
@@ -68,7 +68,7 @@ describe('createInfiniteHitsSessionStorageCache', () => {
     const state = { query: 'hello' };
     const newState = { query: 'world' };
     const hits = { 1: defaultHits };
-    cache.write({ state, hits });
+    cache.write({ state, items: hits });
     expect(cache.read({ state: newState })).toBeNull();
   });
 
@@ -94,7 +94,7 @@ describe('createInfiniteHitsSessionStorageCache', () => {
     });
     const cache = createInfiniteHitsSessionStorageCache({ key: 'myKey' });
     expect(() => {
-      cache.write({ state: {}, hits: [] });
+      cache.write({ state: {}, items: [] });
     }).not.toThrow();
   });
 });

--- a/packages/instantsearch-core/src/lib/infiniteHitsCache/__tests__/sessionStorage.test.ts
+++ b/packages/instantsearch-core/src/lib/infiniteHitsCache/__tests__/sessionStorage.test.ts
@@ -59,7 +59,7 @@ describe('createInfiniteHitsSessionStorageCache', () => {
     const hits = {
       1: defaultHits,
     };
-    cache.write({ state, hits });
+    cache.write({ state, items: hits });
     expect(cache.read({ state })).toEqual(hits);
   });
 
@@ -68,7 +68,7 @@ describe('createInfiniteHitsSessionStorageCache', () => {
     const state = { query: 'hello' };
     const newState = { query: 'world' };
     const hits = { 1: defaultHits };
-    cache.write({ state, hits });
+    cache.write({ state, items: hits });
     expect(cache.read({ state: newState })).toBeNull();
   });
 
@@ -94,7 +94,7 @@ describe('createInfiniteHitsSessionStorageCache', () => {
     });
     const cache = createInfiniteHitsSessionStorageCache();
     expect(() => {
-      cache.write({ state: {}, hits: [] });
+      cache.write({ state: {}, items: [] });
     }).not.toThrow();
   });
 });

--- a/packages/instantsearch-core/src/lib/infiniteHitsCache/sessionStorage.ts
+++ b/packages/instantsearch-core/src/lib/infiniteHitsCache/sessionStorage.ts
@@ -49,7 +49,7 @@ export function createInfiniteHitsSessionStorageCache({
         return null;
       }
     },
-    write({ state, hits }) {
+    write({ state, items }) {
       const sessionStorage = safelyRunOnBrowser<Storage | undefined>(
         ({ window }) => window.sessionStorage
       );
@@ -63,7 +63,7 @@ export function createInfiniteHitsSessionStorageCache({
           KEY,
           JSON.stringify({
             state: getStateWithoutPage(state),
-            hits,
+            hits: items,
           })
         );
       } catch (error) {

--- a/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
+++ b/packages/instantsearch-core/src/widgets/__tests__/index-widget.test.ts
@@ -3613,7 +3613,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       search.start();
       await wait(0);
 
-      const receivedHits = renderFn.mock.calls[1][0].hits;
+      const receivedHits = renderFn.mock.calls[1][0].items;
       expect(receivedHits).toEqual([
         expect.objectContaining({ objectID: '1' }),
         expect.objectContaining({ objectID: '2' }),

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -5,5 +5,5 @@ export type {
   InfiniteHitsWidgetDescription,
   InfiniteHitsConnectorParams,
   InfiniteHitsCache,
-  InfiniteHitsCachedHits,
+  InfiniteHitsCachedItems,
 } from 'instantsearch-core';

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useHits.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useHits.test.tsx
@@ -13,7 +13,6 @@ describe('useHits', () => {
     // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
       banner: undefined,
-      hits: [],
       items: [],
       results: expect.objectContaining({ nbHits: 0 }),
       sendEvent: expect.any(Function),
@@ -24,7 +23,6 @@ describe('useHits', () => {
     // InstantSearch.js state from the `render` lifecycle step
     expect(result.current).toEqual({
       banner: undefined,
-      hits: [],
       items: [],
       results: expect.objectContaining({ nbHits: 0 }),
       sendEvent: expect.any(Function),

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useInfiniteHits.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useInfiniteHits.test.tsx
@@ -12,7 +12,6 @@ describe('useInfiniteHits', () => {
 
     // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
-      hits: [],
       items: [],
       results: expect.objectContaining({ nbHits: 0 }),
       sendEvent: undefined,
@@ -27,7 +26,6 @@ describe('useInfiniteHits', () => {
 
     // InstantSearch.js state from the `render` lifecycle step
     expect(result.current).toEqual({
-      hits: [],
       items: [],
       results: expect.objectContaining({ nbHits: 0 }),
       sendEvent: expect.any(Function),

--- a/tests/common/widgets/infinite-hits/options.ts
+++ b/tests/common/widgets/infinite-hits/options.ts
@@ -16,7 +16,7 @@ import type { PlainSearchParameters } from 'algoliasearch-helper';
 import type { BaseHit, SearchResponse } from 'instantsearch.js';
 import type {
   InfiniteHitsCache,
-  InfiniteHitsCachedHits,
+  InfiniteHitsCachedItems,
 } from 'instantsearch.js/es/connectors/infinite-hits/connectInfiniteHits';
 
 function normalizeSnapshot(html: string) {
@@ -677,7 +677,7 @@ function createCustomCache() {
 
   let cachedState: PlainSearchParameters | undefined = undefined;
 
-  let cachedHits: InfiniteHitsCachedHits<Record<string, any>> | undefined =
+  let cachedHits: InfiniteHitsCachedItems<Record<string, any>> | undefined =
     undefined;
 
   type Cache = InfiniteHitsCache<Record<string, any>> & { clear: () => void };

--- a/tests/common/widgets/infinite-hits/options.ts
+++ b/tests/common/widgets/infinite-hits/options.ts
@@ -493,7 +493,7 @@ export function createOptionsTests(
       });
 
       expect(cache.write).toHaveBeenCalledTimes(1);
-      expect(cache.write.mock.calls[0][0].hits).toEqual({
+      expect(cache.write.mock.calls[0][0].items).toEqual({
         '0': [
           { __position: 1, objectID: '0' },
           { __position: 2, objectID: '1' },
@@ -514,7 +514,7 @@ export function createOptionsTests(
       });
 
       expect(cache.write).toHaveBeenCalledTimes(2);
-      expect(cache.write.mock.calls[0][0].hits).toEqual({
+      expect(cache.write.mock.calls[0][0].items).toEqual({
         '0': [
           { __position: 1, objectID: '0' },
           { __position: 2, objectID: '1' },
@@ -535,7 +535,7 @@ export function createOptionsTests(
       // We write in cache before instantiating InstantSearch to mimic a
       // pre-filled cache from previous searches (e.g., after a page refresh)
       cache.write({
-        hits: {
+        items: {
           '0': [
             { __position: 1, objectID: 'one' },
             { __position: 2, objectID: 'two' },
@@ -697,9 +697,9 @@ function createCustomCache() {
 
       return null;
     }),
-    write: jest.fn(({ state, hits }) => {
+    write: jest.fn(({ state, items }) => {
       cachedState = getStateWithoutPage(state);
-      cachedHits = hits;
+      cachedHits = items;
     }),
     clear: jest.fn(() => {
       cachedState = undefined;


### PR DESCRIPTION
In the past we have added an `items` alias for the previously added `hits`, so that all widgets are more consistent and the same widget would be usable between hits and relatedItems connectors for example. This is now continued with:
- hits render property removed
- infinite hits cache "write" receives `{ page, items }` instead of hits

[FX-3207]

BREAKING CHANGE: connectHits: `hits` property from render is replaced with `items`
BREAKING CHANGE: connectInfiniteHits: `hits` property from render is replaced with `items`
BREAKING CHANGE: infiniteHits: the cache.write function gets called with `{ page, items }` instead of `{ page, hits }`

[FX-3207]: https://algolia.atlassian.net/browse/FX-3207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ