### PR TITLE
feat: add searchForFacetValues for composition

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "83.75 kB"
+      "maxSize": "84 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
@@ -18,7 +18,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "51.50 kB"
+      "maxSize": "51.75 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
@@ -26,7 +26,7 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "69.00 kB"
+      "maxSize": "69.25 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",

--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -198,6 +198,26 @@ declare namespace algoliasearchHelper {
     ): Promise<SearchForFacetValues.Result>;
 
     /**
+     * Search for facet values using the Composition API & based on a query and the name of a faceted attribute.
+     * This triggers a search and will return a promise. On top of using the query, it also sends
+     * the parameters from the state so that the search is narrowed down to only the possible values.
+     *
+     * See the description of [FacetSearchResult](reference.html#FacetSearchResult)
+     * @param facet the name of the faceted attribute
+     * @param query the string query for the search
+     * @param [maxFacetHits] the maximum number values returned. Should be > 0 and <= 100
+     * @param [userState] the set of custom parameters to use on top of the current state. Setting a property to `undefined` removes
+     * it in the generated query.
+     * @return the results of the search
+     */
+    searchForCompositionFacetValues(
+      facet: string,
+      query: string,
+      maxFacetHits: number,
+      userState?: PlainSearchParameters
+    ): Promise<SearchForFacetValues.Result>;
+
+    /**
      * Sets the text query used for the search.
      *
      * This method resets the current page to 0.

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -500,8 +500,8 @@ AlgoliaSearchHelper.prototype.searchForCompositionFacetValues = function (
     searchForFacetValuesRequest: {
       params: {
         query: state.query,
-        maxFacetHits,
-        searchQuery: { query },
+        maxFacetHits: maxFacetHits,
+        searchQuery: { query: query },
       },
     },
   });

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -505,10 +505,6 @@ AlgoliaSearchHelper.prototype.searchForCompositionFacetValues = function (
       },
     },
   });
-  // searchForFacetValuesPromise = this.client.searchForFacetValues([
-  //   { indexName: state.index, params: algoliaQuery },
-  // ]);
-  // algoliasearch < 3.27.1
 
   this.emit('searchForFacetValues', {
     state: state,

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -462,6 +462,85 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function (
 };
 
 /**
+ * Search for facet values using the Composition API & based on a query and the name of a faceted attribute.
+ * This triggers a search and will return a promise. On top of using the query, it also sends
+ * the parameters from the state so that the search is narrowed down to only the possible values.
+ *
+ * See the description of [FacetSearchResult](reference.html#FacetSearchResult)
+ * @param {string} facet the name of the faceted attribute
+ * @param {string} query the string query for the search
+ * @param {number} [maxFacetHits] the maximum number values returned. Should be > 0 and <= 100
+ * @param {object} [userState] the set of custom parameters to use on top of the current state. Setting a property to `undefined` removes
+ * it in the generated query.
+ * @return {promise.<FacetSearchResult>} the results of the search
+ */
+AlgoliaSearchHelper.prototype.searchForCompositionFacetValues = function (
+  facet,
+  query,
+  maxFacetHits,
+  userState
+) {
+  if (typeof this.client.searchForFacetValues !== 'function') {
+    throw new Error(
+      'search for facet values (searchable) was called, but this client does not have a function client.searchForFacetValues'
+    );
+  }
+
+  var state = this.state.setQueryParameters(userState || {});
+  var isDisjunctive = state.isDisjunctiveFacet(facet);
+
+  this._currentNbQueries++;
+  // eslint-disable-next-line consistent-this
+  var self = this;
+  var searchForFacetValuesPromise;
+
+  searchForFacetValuesPromise = this.client.searchForFacetValues({
+    compositionID: state.index,
+    facetName: facet,
+    searchForFacetValuesRequest: {
+      params: {
+        query: state.query,
+        maxFacetHits,
+        searchQuery: { query },
+      },
+    },
+  });
+  // searchForFacetValuesPromise = this.client.searchForFacetValues([
+  //   { indexName: state.index, params: algoliaQuery },
+  // ]);
+  // algoliasearch < 3.27.1
+
+  this.emit('searchForFacetValues', {
+    state: state,
+    facet: facet,
+    query: query,
+  });
+
+  return searchForFacetValuesPromise.then(
+    function addIsRefined(content) {
+      self._currentNbQueries--;
+      if (self._currentNbQueries === 0) self.emit('searchQueueEmpty');
+
+      content = content.results[0];
+
+      content.facetHits.forEach(function (f) {
+        f.escapedValue = escapeFacetValue(f.value);
+        f.isRefined = isDisjunctive
+          ? state.isDisjunctiveFacetRefined(facet, f.escapedValue)
+          : state.isFacetRefined(facet, f.escapedValue);
+      });
+
+      return content;
+    },
+    function (e) {
+      self._currentNbQueries--;
+      if (self._currentNbQueries === 0) self.emit('searchQueueEmpty');
+      throw e;
+    }
+  );
+};
+
+/**
  * Sets the text query used for the search.
  *
  * This method resets the current page to 0.

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -589,6 +589,11 @@ See documentation: ${createDocumentationLink({
         persistHierarchicalRootCount: this.future.persistHierarchicalRootCount,
       });
 
+    if (this.compositionID) {
+      mainHelper.searchForFacetValues =
+        mainHelper.searchForCompositionFacetValues.bind(mainHelper);
+    }
+
     mainHelper.search = () => {
       this.status = 'loading';
       this.scheduleRender(false);


### PR DESCRIPTION
**Summary**

adding support for `SearchForFacetValues` when using Composition API
[EMERCH-1745](https://algolia.atlassian.net/browse/EMERCH-1745)

**Result**

there is a small bug on the API side which result in highlighting not working as expecting in the facet values, but that doesn't affect the implementation as the fix should be transparent API-wise

[EMERCH-1745]: https://algolia.atlassian.net/browse/EMERCH-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ