### PR TITLE
fix(insights): detect appId and apiKey from client directly in v5

### DIFF
--- a/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
@@ -28,4 +28,14 @@ describe('getAppIdAndApiKey', () => {
     expect(appId).toEqual(APP_ID);
     expect(apiKey).toEqual(API_KEY);
   });
+
+  it('gets manually set applicationID and apiKey', () => {
+    const searchClient = algoliasearchV4(APP_ID, API_KEY);
+    (searchClient.transporter as any).queryParameters = {};
+    (searchClient as any).applicationID = 'anotherAppId';
+    (searchClient as any).apiKey = 'anotherApiKey';
+    const [appId, apiKey] = getAppIdAndApiKey(searchClient);
+    expect(appId).toEqual('anotherAppId');
+    expect(apiKey).toEqual('anotherApiKey');
+  });
 });

--- a/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/getAppIdAndApiKey-test.ts
@@ -28,14 +28,4 @@ describe('getAppIdAndApiKey', () => {
     expect(appId).toEqual(APP_ID);
     expect(apiKey).toEqual(API_KEY);
   });
-
-  it('gets manually set applicationID and apiKey', () => {
-    const searchClient = algoliasearchV4(APP_ID, API_KEY);
-    (searchClient.transporter as any).queryParameters = {};
-    (searchClient as any).applicationID = 'anotherAppId';
-    (searchClient as any).apiKey = 'anotherApiKey';
-    const [appId, apiKey] = getAppIdAndApiKey(searchClient);
-    expect(appId).toEqual('anotherAppId');
-    expect(apiKey).toEqual('anotherApiKey');
-  });
 });

--- a/packages/instantsearch.js/src/lib/utils/getAppIdAndApiKey.ts
+++ b/packages/instantsearch.js/src/lib/utils/getAppIdAndApiKey.ts
@@ -1,6 +1,11 @@
 // typed as any, since it accepts the _real_ js clients, not the interface we otherwise expect
-export function getAppIdAndApiKey(searchClient: any): [string, string] {
-  if (searchClient.transporter) {
+export function getAppIdAndApiKey(
+  searchClient: any
+): [appId: string, apiKey: string] | [appId: undefined, apiKey: undefined] {
+  if (searchClient.applicationID && searchClient.apiKey) {
+    // searchClient v3
+    return [searchClient.applicationID, searchClient.apiKey];
+  } else if (searchClient.transporter) {
     // searchClient v4 or v5
     const transporter = searchClient.transporter;
     const headers = transporter.headers || transporter.baseHeaders;
@@ -11,8 +16,6 @@ export function getAppIdAndApiKey(searchClient: any): [string, string] {
     const appId = headers[APP_ID] || queryParameters[APP_ID];
     const apiKey = headers[API_KEY] || queryParameters[API_KEY];
     return [appId, apiKey];
-  } else {
-    // searchClient v3
-    return [searchClient.applicationID, searchClient.apiKey];
   }
+  return [undefined, undefined];
 }

--- a/packages/instantsearch.js/src/lib/utils/getAppIdAndApiKey.ts
+++ b/packages/instantsearch.js/src/lib/utils/getAppIdAndApiKey.ts
@@ -2,9 +2,9 @@
 export function getAppIdAndApiKey(
   searchClient: any
 ): [appId: string, apiKey: string] | [appId: undefined, apiKey: undefined] {
-  if (searchClient.applicationID && searchClient.apiKey) {
-    // searchClient v3
-    return [searchClient.applicationID, searchClient.apiKey];
+  if (searchClient.appId && searchClient.apiKey) {
+    // searchClient v5
+    return [searchClient.appId, searchClient.apiKey];
   } else if (searchClient.transporter) {
     // searchClient v4 or v5
     const transporter = searchClient.transporter;
@@ -16,6 +16,8 @@ export function getAppIdAndApiKey(
     const appId = headers[APP_ID] || queryParameters[APP_ID];
     const apiKey = headers[API_KEY] || queryParameters[API_KEY];
     return [appId, apiKey];
+  } else {
+    // searchClient v3
+    return [searchClient.applicationID, searchClient.apiKey];
   }
-  return [undefined, undefined];
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

In the insights middleware / getAppIdAndApiKey function we quickly fall back to the brittle logic with transporter. I've made a PR to the client (https://github.com/algolia/api-clients-automation/pull/4285) to expose appId and apiKey directly on the object, so newer v5 will mostly use this logic. 

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

in v5 we use `appId` and `apiKey` from the client, which can also be a good way to be documented for custom clients

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
