### PR TITLE
fix(refinementList): canRefine is calculated for searchable

### DIFF
--- a/packages/instantsearch-core/src/connectors/__tests__/connectRefinementList.test.ts
+++ b/packages/instantsearch-core/src/connectors/__tests__/connectRefinementList.test.ts
@@ -1122,7 +1122,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/refinement-
       refine: expect.any(Function),
       searchForItems: expect.any(Function),
       isFromSearch: true,
-      canRefine: true,
+      canRefine: false,
       widgetParams: {
         attribute: 'category',
         limit: 1,

--- a/packages/instantsearch-core/src/connectors/connectRefinementList.ts
+++ b/packages/instantsearch-core/src/connectors/connectRefinementList.ts
@@ -125,8 +125,6 @@ export type RefinementListRenderState = {
   isFromSearch: boolean;
   /**
    * `true` if a refinement can be applied.
-   * @MAJOR: reconsider how `canRefine` is computed so it both accounts for the
-   * items returned in the main search and in SFFV.
    */
   canRefine: boolean;
   /**
@@ -324,7 +322,7 @@ export const connectRefinementList: RefinementListConnector =
                       }),
                       items: normalizedFacetValues,
                       canToggleShowMore: false,
-                      canRefine: true,
+                      canRefine: normalizedFacetValues.length > 0,
                       isFromSearch: true,
                       instantSearchInstance,
                     },


### PR DESCRIPTION
Before this PR `canRefine` was always true for searchable.

[FX-3190]

BREAKING CHANGE: `canRefine` is false if there are no results from searchable if there's a query.


[FX-3190]: https://algolia.atlassian.net/browse/FX-3190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ