### PR TITLE
feat(routing): change default of cleanUrlOnDispose to false

### DIFF
--- a/examples/js/e-commerce-umd/src/routing.ts
+++ b/examples/js/e-commerce-umd/src/routing.ts
@@ -80,7 +80,6 @@ function getCategoryName(slug: string): string {
 const originalWindowTitle = document.title;
 
 const router = window.instantsearch.routers.history<RouteState>({
-  cleanUrlOnDispose: false,
   windowTitle({ category, query }) {
     const queryTitle = query ? `Results for "${query}"` : '';
 

--- a/examples/js/e-commerce/src/routing.ts
+++ b/examples/js/e-commerce/src/routing.ts
@@ -82,7 +82,6 @@ function getCategoryName(slug: string): string {
 const originalWindowTitle = document.title;
 
 const router = historyRouter<RouteState>({
-  cleanUrlOnDispose: false,
   windowTitle({ category, query }) {
     const queryTitle = query ? `Results for "${query}"` : '';
 

--- a/examples/react/e-commerce/routing.ts
+++ b/examples/react/e-commerce/routing.ts
@@ -76,7 +76,6 @@ function getCategoryName(slug: string): string {
 const originalWindowTitle = document.title;
 
 const router = historyRouter<RouteState>({
-  cleanUrlOnDispose: false,
   windowTitle({ category, query }) {
     const queryTitle = query ? `Results for "${query}"` : '';
 

--- a/examples/react/next-routing/pages/index.tsx
+++ b/examples/react/next-routing/pages/index.tsx
@@ -67,9 +67,6 @@ export default function HomePage({ serverState, url }: HomePageProps) {
           router: createInstantSearchRouterNext({
             singletonRouter,
             serverUrl: url,
-            routerOptions: {
-              cleanUrlOnDispose: false,
-            },
           }),
         }}
         insights={true}

--- a/examples/react/next-routing/pages/test.tsx
+++ b/examples/react/next-routing/pages/test.tsx
@@ -46,9 +46,6 @@ export default function HomePage({ serverState, url }: HomePageProps) {
           router: createInstantSearchRouterNext({
             singletonRouter,
             serverUrl: url,
-            routerOptions: {
-              cleanUrlOnDispose: false,
-            },
           }),
         }}
         insights={true}

--- a/examples/react/next/pages/index.tsx
+++ b/examples/react/next/pages/index.tsx
@@ -61,9 +61,6 @@ export default function HomePage({ serverState, url }: HomePageProps) {
           router: createInstantSearchRouterNext({
             serverUrl: url,
             singletonRouter,
-            routerOptions: {
-              cleanUrlOnDispose: false,
-            },
           }),
         }}
         insights={true}

--- a/examples/react/ssr/src/App.js
+++ b/examples/react/ssr/src/App.js
@@ -30,7 +30,6 @@ function App({ serverState, currentURL }) {
         routing={{
           stateMapping: simple(),
           router: history({
-            cleanUrlOnDispose: false,
             getCurrentURL() {
               if (typeof window === 'undefined') {
                 return currentURL;

--- a/examples/vue/default-theme/src/App.vue
+++ b/examples/vue/default-theme/src/App.vue
@@ -136,9 +136,7 @@ export default {
         '6be0576ff61c053d5f9a3225e2a90f76'
       ),
       routing: {
-        router: historyRouter({
-          cleanUrlOnDispose: false,
-        }),
+        router: historyRouter(),
         stateMapping: simpleStateMapping(),
       },
     };

--- a/examples/vue/e-commerce/src/routing.js
+++ b/examples/vue/e-commerce/src/routing.js
@@ -87,7 +87,6 @@ function getCategoryName(slug) {
 const originalWindowTitle = document.title;
 
 const router = historyRouter({
-  cleanUrlOnDispose: false,
   windowTitle({ category, query }) {
     const queryTitle = query ? `Results for "${query}"` : '';
 

--- a/examples/vue/media/src/App.vue
+++ b/examples/vue/media/src/App.vue
@@ -125,9 +125,7 @@ export default {
         '6be0576ff61c053d5f9a3225e2a90f76'
       ),
       routing: {
-        router: historyRouter({
-          cleanUrlOnDispose: false,
-        }),
+        router: historyRouter(),
         stateMapping: simpleStateMapping(),
       },
     };

--- a/packages/instantsearch-core/src/routing/__tests__/dispose-start.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/dispose-start.test.ts
@@ -24,10 +24,10 @@ describe('routing back and forth to an InstantSearch instance', () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: '/'
-    // 4. Refine: '/'
-    // 5. Start: '/'
-    // 6. Refine: '/?indexName[query]=Apple'
+    // 3. Dispose: '/?indexName[query]=Apple'
+    // 4. Refine: '/?indexName[query]=Apple'
+    // 5. Start: '/?indexName[query]=Apple'
+    // 6. Refine: '/?indexName[query]=Samsung'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -61,34 +61,40 @@ describe('routing back and forth to an InstantSearch instance', () => {
       expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 3. Dispose: '/'
+    // 3. Dispose: '/?indexName[query]=Apple'
     {
       search.dispose();
 
       await wait(writeWait);
-      expect(window.location.search).toEqual('');
-      expect(pushState).toHaveBeenCalledTimes(2);
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+      expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 4. Refine: '/'
+    // 4. Refine: '/?indexName[query]=Apple'
     {
-      search.renderState.indexName.searchBox!.refine('Apple');
+      search.renderState.indexName.searchBox!.refine('Samsung');
 
       await wait(writeWait);
-      expect(window.location.search).toEqual('');
-      expect(pushState).toHaveBeenCalledTimes(2);
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+      expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 5. Start: '/'
+    // 5. Start: '/?indexName[query]=Apple'
     {
       addWidgetsAndStart(search);
 
       await wait(writeWait);
-      expect(window.location.search).toEqual('');
-      expect(pushState).toHaveBeenCalledTimes(2);
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+      expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 6. Refine: '/?indexName[query]=Apple'
+    // 6. Refine: '/?indexName[query]=Samsung'
     {
       search.renderState.indexName.searchBox!.refine('Samsung');
 
@@ -96,7 +102,7 @@ describe('routing back and forth to an InstantSearch instance', () => {
       expect(window.location.search).toEqual(
         `?${encodeURI('indexName[query]=Samsung')}`
       );
-      expect(pushState).toHaveBeenCalledTimes(3);
+      expect(pushState).toHaveBeenCalledTimes(2);
     }
   });
 });

--- a/packages/instantsearch-core/src/routing/__tests__/historyRouter-integration.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/historyRouter-integration.test.ts
@@ -99,7 +99,7 @@ test('clears url with cleanUrlOnDispose: true', async () => {
   expect(window.location.search).toBe('');
 });
 
-test('clears url with cleanUrlOnDispose: undefined', async () => {
+test('does not clear url with cleanUrlOnDispose: undefined', async () => {
   const router = historyRouter({ writeDelay });
 
   const indexName = 'indexName';
@@ -135,6 +135,8 @@ test('clears url with cleanUrlOnDispose: undefined', async () => {
 
   await wait(writeWait);
 
-  // URL has been cleaned
-  expect(window.location.search).toBe('');
+  // URL has not been cleaned
+  expect(window.location.search).toBe(
+    `?${encodeURI('indexName[page]=40&indexName[query]=test')}`
+  );
 });

--- a/packages/instantsearch-core/src/routing/__tests__/historyRouter.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/historyRouter.test.ts
@@ -276,17 +276,9 @@ describe('life cycle', () => {
         consoleSpy.mockReset();
       });
 
-      test('cleans refinements from URL if not defined', () => {
+      test('does not clean refinements from URL if not defined', () => {
         const windowPushState = jest.spyOn(window.history, 'pushState');
         const router = historyRouter<UiState>();
-
-        expect(consoleSpy)
-          .toHaveBeenCalledWith(`Starting from the next major version, InstantSearch will not clean up the URL from active refinements when it is disposed.
-
-We recommend setting \`cleanUrlOnDispose\` to false to adopt this change today.
-To stay with the current behaviour and remove this warning, set the option to true.
-
-See documentation: https://www.algolia.com/doc/api-reference/widgets/history-router/js/#widget-param-cleanurlondispose`);
 
         router.write({ indexName: { query: 'query1' } });
         jest.runAllTimers();
@@ -303,12 +295,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/history-rou
         router.dispose();
         jest.runAllTimers();
 
-        expect(windowPushState).toHaveBeenCalledTimes(2);
-        expect(windowPushState).toHaveBeenLastCalledWith(
-          {},
-          '',
-          'http://localhost/'
-        );
+        expect(windowPushState).toHaveBeenCalledTimes(1);
       });
 
       test('cleans refinements from URL if `true`', () => {

--- a/packages/instantsearch-core/src/routing/__tests__/modal-clean.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/modal-clean.test.ts
@@ -12,17 +12,12 @@ import { instantsearch, historyRouter, connectSearchBox } from '../..';
 const writeDelay = 10;
 const writeWait = 10 * writeDelay;
 
-describe('routing using `replaceState`', () => {
-  // We can't assert whether another router did update the URL
-  // So there's no way to prevent `write` after `dispose`
-  test('does not clean the URL after navigating', async () => {
+describe('routing with no navigation', () => {
+  test('cleans the URL when InstantSearch is disposed within the same page', async () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: does not yet write
-    // 4. Route change (with `replaceState`): '/about?external=true', replaces state 2
-    // 5. Dispose: does not write
-    // 6. Back: '/'
+    // 3. Dispose: '/'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -32,6 +27,7 @@ describe('routing using `replaceState`', () => {
       routing: {
         router: historyRouter({
           writeDelay,
+          cleanUrlOnDispose: true,
         }),
       },
     });
@@ -51,37 +47,21 @@ describe('routing using `replaceState`', () => {
       search.renderState.indexName.searchBox!.refine('Apple');
 
       await wait(writeWait);
+      expect(window.location.pathname).toEqual('/');
       expect(window.location.search).toEqual(
         `?${encodeURI('indexName[query]=Apple')}`
       );
       expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 3. Dispose: '/about'
-    // 4. Route change (with `replaceState`): '/about'
+    // 3. Dispose: '/'
     {
       search.dispose();
-      window.history.replaceState({}, '', '/about?external=true');
-
-      // Asserting `replaceState` call
-      expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('?external=true');
-      expect(pushState).toHaveBeenCalledTimes(1);
-
-      // Asserting `dispose` calling `pushState`
-      await wait(writeWait);
-      expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('?external=true');
-      expect(pushState).toHaveBeenCalledTimes(1);
-    }
-
-    // 5. Back: '/about'
-    {
-      window.history.back();
 
       await wait(writeWait);
       expect(window.location.pathname).toEqual('/');
       expect(window.location.search).toEqual('');
+      expect(pushState).toHaveBeenCalledTimes(2);
     }
   });
 });

--- a/packages/instantsearch-core/src/routing/__tests__/modal.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/modal.test.ts
@@ -13,11 +13,11 @@ const writeDelay = 10;
 const writeWait = 10 * writeDelay;
 
 describe('routing with no navigation', () => {
-  test('cleans the URL when InstantSearch is disposed within the same page', async () => {
+  test('does not clean the URL when InstantSearch is disposed within the same page', async () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: '/'
+    // 3. Dispose: '/?indexName[query]=Apple'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -59,8 +59,10 @@ describe('routing with no navigation', () => {
 
       await wait(writeWait);
       expect(window.location.pathname).toEqual('/');
-      expect(window.location.search).toEqual('');
-      expect(pushState).toHaveBeenCalledTimes(2);
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+      expect(pushState).toHaveBeenCalledTimes(1);
     }
   });
 });

--- a/packages/instantsearch-core/src/routing/__tests__/spa-clean.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/spa-clean.test.ts
@@ -12,17 +12,15 @@ import { instantsearch, historyRouter, connectSearchBox } from '../..';
 const writeDelay = 10;
 const writeWait = 10 * writeDelay;
 
-describe('routing using `replaceState`', () => {
-  // We can't assert whether another router did update the URL
-  // So there's no way to prevent `write` after `dispose`
+describe('routing with third-party client-side router', () => {
   test('does not clean the URL after navigating', async () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: does not yet write
-    // 4. Route change (with `replaceState`): '/about?external=true', replaces state 2
-    // 5. Dispose: does not write
-    // 6. Back: '/'
+    // 3. Navigate: '/about'
+    // 4. Back: '/?indexName[query]=Apple'
+    // 5. Restart: '/?indexName[query]=Apple'
+    // 6. Refine: '/?indexName[query]=Samsung'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -32,6 +30,7 @@ describe('routing using `replaceState`', () => {
       routing: {
         router: historyRouter({
           writeDelay,
+          cleanUrlOnDispose: true,
         }),
       },
     });
@@ -57,31 +56,49 @@ describe('routing using `replaceState`', () => {
       expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 3. Dispose: '/about'
-    // 4. Route change (with `replaceState`): '/about'
+    // 3. Navigate: '/about'
     {
       search.dispose();
-      window.history.replaceState({}, '', '/about?external=true');
+      window.history.pushState({}, '', '/about');
 
-      // Asserting `replaceState` call
-      expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('?external=true');
-      expect(pushState).toHaveBeenCalledTimes(1);
-
-      // Asserting `dispose` calling `pushState`
       await wait(writeWait);
       expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('?external=true');
-      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(window.location.search).toEqual('');
+      expect(pushState).toHaveBeenCalledTimes(2);
     }
 
-    // 5. Back: '/about'
+    // 4. Back to previous page
     {
       window.history.back();
 
       await wait(writeWait);
       expect(window.location.pathname).toEqual('/');
-      expect(window.location.search).toEqual('');
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    }
+
+    // 5. Restart InstantSearch
+    {
+      search.addWidgets([connectSearchBox(() => {})({})]);
+      search.start();
+
+      await wait(writeWait);
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+    }
+
+    // 6. Refine: '/?indexName[query]=Samsung'
+    {
+      search.renderState.indexName.searchBox!.refine('Samsung');
+
+      await wait(writeWait);
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Samsung')}`
+      );
+      expect(pushState).toHaveBeenCalledTimes(3);
     }
   });
 });

--- a/packages/instantsearch-core/src/routing/__tests__/spa-debounced-clean.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/spa-debounced-clean.test.ts
@@ -12,17 +12,15 @@ import { instantsearch, historyRouter, connectSearchBox } from '../..';
 const writeDelay = 10;
 const writeWait = 10 * writeDelay;
 
-describe('routing using `replaceState`', () => {
-  // We can't assert whether another router did update the URL
-  // So there's no way to prevent `write` after `dispose`
+describe('routing with debounced third-party client-side router', () => {
   test('does not clean the URL after navigating', async () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: does not yet write
-    // 4. Route change (with `replaceState`): '/about?external=true', replaces state 2
-    // 5. Dispose: does not write
-    // 6. Back: '/'
+    // 3. Dispose: '/'
+    // 4. Route change: '/about'
+    // 5. Back: '/'
+    // 6. Back: '/?indexName[query]=Apple'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -32,6 +30,7 @@ describe('routing using `replaceState`', () => {
       routing: {
         router: historyRouter({
           writeDelay,
+          cleanUrlOnDispose: true,
         }),
       },
     });
@@ -57,31 +56,45 @@ describe('routing using `replaceState`', () => {
       expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 3. Dispose: '/about'
-    // 4. Route change (with `replaceState`): '/about'
+    // 3. Dispose: '/'
     {
       search.dispose();
-      window.history.replaceState({}, '', '/about?external=true');
 
-      // Asserting `replaceState` call
-      expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('?external=true');
-      expect(pushState).toHaveBeenCalledTimes(1);
-
-      // Asserting `dispose` calling `pushState`
       await wait(writeWait);
-      expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('?external=true');
-      expect(pushState).toHaveBeenCalledTimes(1);
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual('');
+      expect(pushState).toHaveBeenCalledTimes(2);
     }
 
-    // 5. Back: '/about'
+    // 4. Route change: '/about'
+    {
+      window.history.pushState({}, '', '/about');
+
+      await wait(writeWait);
+      expect(window.location.pathname).toEqual('/about');
+      expect(window.location.search).toEqual('');
+      expect(pushState).toHaveBeenCalledTimes(3);
+    }
+
+    // 5. Back: '/'
     {
       window.history.back();
 
       await wait(writeWait);
       expect(window.location.pathname).toEqual('/');
       expect(window.location.search).toEqual('');
+    }
+
+    // 6. Back: '/?indexName[query]=Apple'
+    {
+      window.history.back();
+
+      await wait(writeWait);
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+      expect(pushState).toHaveBeenCalledTimes(3);
     }
   });
 });

--- a/packages/instantsearch-core/src/routing/__tests__/spa-debounced.test.ts
+++ b/packages/instantsearch-core/src/routing/__tests__/spa-debounced.test.ts
@@ -17,10 +17,10 @@ describe('routing with debounced third-party client-side router', () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: '/'
+    // 3. Dispose: '/?indexName[query]=Apple'
     // 4. Route change: '/about'
-    // 5. Back: '/'
-    // 6. Back: '/?indexName[query]=Apple'
+    // 5. Back: '/?indexName[query]=Apple'
+    // 6. Back: '/'
 
     const pushState = jest.spyOn(window.history, 'pushState');
 
@@ -55,14 +55,16 @@ describe('routing with debounced third-party client-side router', () => {
       expect(pushState).toHaveBeenCalledTimes(1);
     }
 
-    // 3. Dispose: '/'
+    // 3. Dispose: '/?indexName[query]=Apple'
     {
       search.dispose();
 
       await wait(writeWait);
       expect(window.location.pathname).toEqual('/');
-      expect(window.location.search).toEqual('');
-      expect(pushState).toHaveBeenCalledTimes(2);
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
+      expect(pushState).toHaveBeenCalledTimes(1);
     }
 
     // 4. Route change: '/about'
@@ -72,19 +74,10 @@ describe('routing with debounced third-party client-side router', () => {
       await wait(writeWait);
       expect(window.location.pathname).toEqual('/about');
       expect(window.location.search).toEqual('');
-      expect(pushState).toHaveBeenCalledTimes(3);
+      expect(pushState).toHaveBeenCalledTimes(2);
     }
 
-    // 5. Back: '/'
-    {
-      window.history.back();
-
-      await wait(writeWait);
-      expect(window.location.pathname).toEqual('/');
-      expect(window.location.search).toEqual('');
-    }
-
-    // 6. Back: '/?indexName[query]=Apple'
+    // 5. Back: '/?indexName[query]=Apple'
     {
       window.history.back();
 
@@ -93,7 +86,16 @@ describe('routing with debounced third-party client-side router', () => {
       expect(window.location.search).toEqual(
         `?${encodeURI('indexName[query]=Apple')}`
       );
-      expect(pushState).toHaveBeenCalledTimes(3);
+    }
+
+    // 6. Back: '/'
+    {
+      window.history.back();
+
+      await wait(writeWait);
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual('');
+      expect(pushState).toHaveBeenCalledTimes(2);
     }
   });
 });

--- a/packages/instantsearch-core/src/routing/historyRouter.ts
+++ b/packages/instantsearch-core/src/routing/historyRouter.ts
@@ -1,10 +1,6 @@
 import qs from 'qs';
 
-import {
-  createDocumentationLink,
-  safelyRunOnBrowser,
-  warning,
-} from '../lib/public';
+import { safelyRunOnBrowser, warning } from '../lib/public';
 
 import type { Router, UiState } from '../types';
 
@@ -34,7 +30,6 @@ export type BrowserHistoryArgs<TRouteState> = {
    * remove active refinements from the URL.
    * @default true
    */
-  // @MAJOR: Switch the default to `false` and remove the console info in the next major version.
   cleanUrlOnDispose?: boolean;
 };
 
@@ -134,20 +129,7 @@ class BrowserHistory<TRouteState> implements Router<TRouteState> {
     this._start = start;
     this._dispose = dispose;
     this._push = push;
-    this._cleanUrlOnDispose =
-      typeof cleanUrlOnDispose === 'undefined' ? true : cleanUrlOnDispose;
-
-    if (__DEV__ && typeof cleanUrlOnDispose === 'undefined') {
-      // eslint-disable-next-line no-console
-      console.info(`Starting from the next major version, InstantSearch will not clean up the URL from active refinements when it is disposed.
-
-We recommend setting \`cleanUrlOnDispose\` to false to adopt this change today.
-To stay with the current behaviour and remove this warning, set the option to true.
-
-See documentation: ${createDocumentationLink({
-        name: 'history-router',
-      })}#widget-param-cleanurlondispose`);
-    }
+    this._cleanUrlOnDispose = Boolean(cleanUrlOnDispose);
 
     safelyRunOnBrowser(({ window }) => {
       const title = this.windowTitle && this.windowTitle(this.read());

--- a/packages/instantsearch-core/src/routing/historyRouter.ts
+++ b/packages/instantsearch-core/src/routing/historyRouter.ts
@@ -28,7 +28,7 @@ export type BrowserHistoryArgs<TRouteState> = {
    * Whether the URL should be cleaned up when the router is disposed.
    * This can be useful when closing a modal containing InstantSearch, to
    * remove active refinements from the URL.
-   * @default true
+   * @default false
    */
   cleanUrlOnDispose?: boolean;
 };

--- a/packages/react-instantsearch-core/src/components/__tests__/routing-clean/dispose-start.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/routing-clean/dispose-start.test.tsx
@@ -13,10 +13,10 @@ describe('routing back and forth to an InstantSearch instance', () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: '/?indexName[query]=Apple'
-    // 4. Refine: '/?indexName[query]=Apple'
-    // 5. Start: '/?indexName[query]=Apple'
-    // 6. Refine: '/?indexName[query]=Samsung'
+    // 3. Dispose: '/'
+    // 4. Refine: '/'
+    // 5. Start: '/'
+    // 6. Refine: '/?indexName[query]=Apple'
 
     const pushState = jest.spyOn(window.history, 'pushState');
     const searchClient = createSearchClient({});
@@ -37,7 +37,9 @@ describe('routing back and forth to an InstantSearch instance', () => {
         <InstantSearch
           searchClient={searchClient}
           indexName="indexName"
-          routing={{ router: historyRouter({ writeDelay: 0 }) }}
+          routing={{
+            router: historyRouter({ writeDelay: 0, cleanUrlOnDispose: true }),
+          }}
         >
           <QueryController />
           <SearchBox />
@@ -67,31 +69,25 @@ describe('routing back and forth to an InstantSearch instance', () => {
     unmount();
 
     await waitFor(() => {
-      expect(window.location.search).toEqual(
-        `?${encodeURI('indexName[query]=Apple')}`
-      );
+      expect(window.location.search).toEqual('');
     });
-    expect(pushState).toHaveBeenCalledTimes(1);
+    expect(pushState).toHaveBeenCalledTimes(2);
 
     // 4. Refine: '/'
-    setQuery('Samsung');
+    setQuery('Apple');
 
     await waitFor(() => {
-      expect(window.location.search).toEqual(
-        `?${encodeURI('indexName[query]=Apple')}`
-      );
+      expect(window.location.search).toEqual('');
     });
-    expect(pushState).toHaveBeenCalledTimes(1);
+    expect(pushState).toHaveBeenCalledTimes(2);
 
     // 5. Start: '/'
     render(<App />);
 
     await waitFor(() => {
-      expect(window.location.search).toEqual(
-        `?${encodeURI('indexName[query]=Apple')}`
-      );
+      expect(window.location.search).toEqual('');
     });
-    expect(pushState).toHaveBeenCalledTimes(1);
+    expect(pushState).toHaveBeenCalledTimes(2);
 
     // 6. Refine: '/?indexName[query]=Samsung'
     setQuery('Samsung');
@@ -101,6 +97,6 @@ describe('routing back and forth to an InstantSearch instance', () => {
         `?${encodeURI('indexName[query]=Samsung')}`
       );
     });
-    expect(pushState).toHaveBeenCalledTimes(2);
+    expect(pushState).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/react-instantsearch-core/src/components/__tests__/routing/modal.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/routing/modal.test.tsx
@@ -14,7 +14,7 @@ describe('routing with no navigation', () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: '/'
+    // 3. Dispose: '/?indexName[query]=Apple'
 
     const pushState = jest.spyOn(window.history, 'pushState');
     const searchClient = createSearchClient({});
@@ -50,13 +50,15 @@ describe('routing with no navigation', () => {
     });
     expect(pushState).toHaveBeenCalledTimes(1);
 
-    // 3. Dispose: '/'
+    // 3. Dispose: '/?indexName[query]=Apple'
     unmount();
 
     await waitFor(() => {
       expect(window.location.pathname).toEqual('/');
-      expect(window.location.search).toEqual('');
+      expect(window.location.search).toEqual(
+        `?${encodeURI('indexName[query]=Apple')}`
+      );
     });
-    expect(pushState).toHaveBeenCalledTimes(2);
+    expect(pushState).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-instantsearch-core/src/components/__tests__/routing/spa-replace-state.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/routing/spa-replace-state.test.tsx
@@ -16,9 +16,9 @@ describe('routing using `replaceState`', () => {
     // -- Flow
     // 1. Initial: '/'
     // 2. Refine: '/?indexName[query]=Apple'
-    // 3. Dispose: does not yet write
+    // 3. Dispose: does not write
     // 4. Route change (with `replaceState`): '/about?external=true', replaces state 2
-    // 5. Dispose: writes '/about' (this is a bug, and should be fixed when we have a way to prevent it)
+    // 5. Dispose: does not write
     // 6. Back: '/about?external=true'
 
     const pushState = jest.spyOn(window.history, 'pushState');
@@ -65,19 +65,19 @@ describe('routing using `replaceState`', () => {
     expect(window.location.search).toEqual('?external=true');
     expect(pushState).toHaveBeenCalledTimes(1);
 
-    // Asserting `dispose` calling `pushState`
-    await waitFor(() => {
-      expect(window.location.pathname).toEqual('/about');
-      expect(window.location.search).toEqual('');
-    });
-    expect(pushState).toHaveBeenCalledTimes(2);
-
-    // 5. Back: '/about'
-    window.history.back();
-
+    // Asserting `dispose` not calling `pushState`
     await waitFor(() => {
       expect(window.location.pathname).toEqual('/about');
       expect(window.location.search).toEqual('?external=true');
+    });
+    expect(pushState).toHaveBeenCalledTimes(1);
+
+    // 5. Back: '/'
+    window.history.back();
+
+    await waitFor(() => {
+      expect(window.location.pathname).toEqual('/');
+      expect(window.location.search).toEqual('');
     });
   });
 });


### PR DESCRIPTION
In the vast majority of cases you're either never disposing InstantSearch, or the URL already gets cleared some other way (eg. through SPA navigation). This is why the new default for cleanUrlOnDispose is `false`.

You'd still want to set this option to `true` if you're rendering instantsearch in a modal that should have the url cleared when that modal is closed.

BREAKING CHANGE: default of cleanUrlOnDispose is false

[FX-3213]

[FX-3213]: https://algolia.atlassian.net/browse/FX-3213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ