### PR TITLE
ci: run e2e tests on next branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ workflows:
             branches:
               only:
                 - master
+                - next
       - helper docs:
           requires:
             - build
@@ -85,6 +86,7 @@ workflows:
             branches:
               only:
                 - master
+                - next
       - e2e tests router nextjs:
           context: fx-libraries
           requires:
@@ -93,6 +95,7 @@ workflows:
             branches:
               only:
                 - master
+                - next
       - release if needed:
           context: fx-libraries
           requires:


### PR DESCRIPTION
**Summary**

This PR enables running e2e tests on the next branch, to ensure large codebase changes result in predicable behaviors when interacting with our test app.