### PR TITLE
fix(instantsearch): remove searchFunction

### DIFF
--- a/packages/instantsearch-core/src/__tests__/instantsearch.test.tsx
+++ b/packages/instantsearch-core/src/__tests__/instantsearch.test.tsx
@@ -824,52 +824,6 @@ describe('start', () => {
     ).toHaveBeenCalledTimes(1);
   });
 
-  it('calls the provided `searchFunction` with a single request', async () => {
-    const searchFunction = jest.fn((helper) =>
-      helper.setQuery('test').search()
-    );
-    const searchClient = createSearchClient();
-    const search = new InstantSearch({
-      indexName: 'indexName',
-      searchFunction,
-      searchClient,
-    });
-
-    search.addWidgets([virtualSearchBox({})]);
-
-    expect(searchFunction).toHaveBeenCalledTimes(0);
-    expect(searchClient.search).toHaveBeenCalledTimes(0);
-
-    search.start();
-
-    await wait(0);
-
-    expect(searchFunction).toHaveBeenCalledTimes(1);
-    expect(searchClient.search).toHaveBeenCalledTimes(1);
-    expect(search.mainIndex.getHelper()!.state.query).toBe('test');
-  });
-
-  it('calls the provided `searchFunction` with multiple requests', () => {
-    const searchClient = createSearchClient();
-    const search = new InstantSearch({
-      indexName: 'indexName',
-      searchClient,
-      searchFunction(helper) {
-        const nextState = helper.state
-          .addDisjunctiveFacet('brand')
-          .addDisjunctiveFacetRefinement('brand', 'Apple');
-
-        helper.setState(nextState).search();
-      },
-    });
-
-    search.addWidgets([virtualSearchBox({})]);
-
-    expect(() => {
-      search.start();
-    }).not.toThrow();
-  });
-
   it('forwards the `initialUiState` to the main index', () => {
     const search = new InstantSearch({
       indexName: 'indexName',

--- a/packages/instantsearch-core/src/types/instantsearch.ts
+++ b/packages/instantsearch-core/src/types/instantsearch.ts
@@ -2,7 +2,6 @@ import type { SearchClient } from './algoliasearch';
 import type { InsightsProps } from './insights';
 import type { RouterProps } from './router';
 import type { UiState } from './ui-state';
-import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
 export type InstantSearchOptions<
   TUiState extends UiState = UiState,
@@ -45,13 +44,6 @@ export type InstantSearchOptions<
    * to `Number.prototype.toLocaleString()`
    */
   numberLocale?: string;
-  /**
-   * A hook that will be called each time a search needs to be done, with the
-   * helper as a parameter. It's your responsibility to call `helper.search()`.
-   * This option allows you to avoid doing searches at page load for example.
-   * @deprecated use onStateChange instead
-   */
-  searchFunction?: (helper: AlgoliaSearchHelper) => void;
   /**
    * Function called when the state changes.
    *

--- a/packages/instantsearch.js/stories/instantsearch.stories.ts
+++ b/packages/instantsearch.js/stories/instantsearch.stories.ts
@@ -4,16 +4,16 @@ import { withHits } from '../.storybook/decorators';
 
 storiesOf('Basics/InstantSearch', module)
   .add(
-    'with searchFunction to prevent search',
+    'with onStateChange to prevent search',
     withHits(() => {}, {
-      searchFunction: (helper) => {
-        const query = helper.state.query;
+      onStateChange({ uiState, setUiState }) {
+        const query = uiState.instant_search?.query ?? '';
 
         if (query === '') {
           return;
         }
 
-        helper.search();
+        setUiState(uiState);
       },
     })
   )

--- a/packages/react-instantsearch-core/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/InstantSearch.test.tsx
@@ -775,55 +775,6 @@ describe('InstantSearch', () => {
     });
   });
 
-  test('updates searchFunction on searchFunction prop change', async () => {
-    const searchClient = createAlgoliaSearchClient({});
-    const searchFunction1 = jest.fn((helper) => {
-      helper.search();
-    });
-    const searchFunction2 = jest.fn((helper) => {
-      helper.search();
-    });
-
-    function App({
-      searchFunction,
-    }: Pick<InstantSearchProps, 'searchFunction'>) {
-      return (
-        <StrictMode>
-          <InstantSearch
-            searchClient={searchClient}
-            indexName="indexName"
-            searchFunction={searchFunction}
-          >
-            <SearchBox />
-          </InstantSearch>
-        </StrictMode>
-      );
-    }
-
-    const { rerender } = render(<App searchFunction={searchFunction1} />);
-
-    await waitFor(() => {
-      expect(searchFunction1).toHaveBeenCalledTimes(1);
-    });
-
-    userEvent.type(screen.getByRole('searchbox'), 'iphone');
-
-    await waitFor(() => {
-      expect(searchFunction1).toHaveBeenCalledTimes(7);
-    });
-
-    rerender(<App searchFunction={searchFunction2} />);
-
-    userEvent.type(screen.getByRole('searchbox'), ' case', {
-      initialSelectionStart: 6,
-    });
-
-    await waitFor(() => {
-      expect(searchFunction1).toHaveBeenCalledTimes(7);
-      expect(searchFunction2).toHaveBeenCalledTimes(5);
-    });
-  });
-
   test('triggers no search on unmount', async () => {
     const searchClient = createAlgoliaSearchClient({});
 

--- a/packages/react-instantsearch-core/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-core/src/lib/useInstantSearchApi.ts
@@ -163,14 +163,6 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
       prevPropsRef.current = props;
     }
 
-    if (prevProps.searchFunction !== props.searchFunction) {
-      // Updating the `searchFunction` to `undefined` is not supported by
-      // InstantSearch.js, so it will throw an error.
-      // This is a fair behavior until we add an update API in InstantSearch.js.
-      search._searchFunction = props.searchFunction;
-      prevPropsRef.current = props;
-    }
-
     if (prevProps.stalledSearchDelay !== props.stalledSearchDelay) {
       // The default `stalledSearchDelay` in InstantSearch.js is 200ms.
       // We need to reset it when it's undefined to get back to the original value.

--- a/packages/vue-instantsearch/src/components/InstantSearch.js
+++ b/packages/vue-instantsearch/src/components/InstantSearch.js
@@ -49,10 +49,6 @@ export default createInstantSearchComponent({
       type: Number,
       default: undefined,
     },
-    searchFunction: {
-      type: Function,
-      default: undefined,
-    },
     onStateChange: {
       type: Function,
       default: undefined,
@@ -98,7 +94,6 @@ export default createInstantSearchComponent({
         indexName: this.indexName,
         routing: this.routing,
         stalledSearchDelay: this.stalledSearchDelay,
-        searchFunction: this.searchFunction,
         onStateChange: this.onStateChange,
         initialUiState: this.initialUiState,
         future: this.future,

--- a/packages/vue-instantsearch/src/components/__tests__/InstantSearch.js
+++ b/packages/vue-instantsearch/src/components/__tests__/InstantSearch.js
@@ -42,7 +42,6 @@ beforeEach(() => {
 
 it('passes props to InstantSearch.js', () => {
   const searchClient = createSearchClient();
-  const searchFunction = (helper) => helper.search();
   const routing = {
     router: historyRouter(),
     stateMapping: simpleStateMapping(),
@@ -54,7 +53,6 @@ it('passes props to InstantSearch.js', () => {
       indexName: 'something',
       routing,
       stalledSearchDelay: 250,
-      searchFunction,
     },
   });
 
@@ -62,7 +60,6 @@ it('passes props to InstantSearch.js', () => {
     indexName: 'something',
     routing,
     searchClient,
-    searchFunction,
     stalledSearchDelay: 250,
   });
 });
@@ -247,33 +244,11 @@ it('does not warn when the `search-client` does not change', async () => {
   expect(warn).not.toHaveBeenCalled();
 });
 
-it('Allows a change in `search-function`', async () => {
-  const oldValue = () => {};
-  const newValue = () => {};
-
-  const wrapper = mount(InstantSearch, {
-    propsData: {
-      searchClient: createSearchClient(),
-      indexName: 'bla',
-      searchFunction: oldValue,
-    },
-  });
-
-  expect(wrapper.vm.instantSearchInstance._searchFunction).toEqual(oldValue);
-
-  await wrapper.setProps({
-    searchFunction: newValue,
-  });
-
-  expect(wrapper.vm.instantSearchInstance._searchFunction).toEqual(newValue);
-});
-
 it('Allows a change in `stalled-search-delay`', async () => {
   const wrapper = mount(InstantSearch, {
     propsData: {
       searchClient: createSearchClient(),
       indexName: 'bla',
-      searchFunction: () => {},
       stalledSearchDelay: 200,
     },
   });

--- a/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
+++ b/packages/vue-instantsearch/src/util/createInstantSearchComponent.js
@@ -54,10 +54,6 @@ export const createInstantSearchComponent = (component) => ({
           'Please open a new issue: https://github.com/algolia/instantsearch/discussions/new?category=ideas&labels=triage%2cLibrary%3A+Vue+InstantSearch&title=Feature%20request%3A%20dynamic%20props'
       );
     },
-    searchFunction(searchFunction) {
-      // private InstantSearch.js API:
-      this.instantSearchInstance._searchFunction = searchFunction;
-    },
     middlewares: {
       immediate: true,
       handler(next, prev) {

--- a/packages/vue-instantsearch/stories/InstantSearch.stories.js
+++ b/packages/vue-instantsearch/stories/InstantSearch.stories.js
@@ -29,13 +29,6 @@ const clients = {
   fake: new FakeClient(),
 };
 
-const searchFunctions = {
-  working: undefined,
-  broken(helper) {
-    helper.setQuery('bingo').search();
-  },
-};
-
 storiesOf('ais-instant-search', module)
   .add('simple usage', () => ({
     template: `
@@ -74,7 +67,6 @@ storiesOf('ais-instant-search', module)
         <ais-instant-search
           :index-name="indexName"
           :search-client="searchClient"
-          :search-function="searchFunction"
           :stalled-search-delay="stalledSearchDelay"
         >
           <p>This is inside a <code>ais-instant-search</code>: <code>{{indexName}}</code></p>
@@ -91,8 +83,6 @@ storiesOf('ais-instant-search', module)
       return {
         searchClientName: 'working',
         searchClient: clients.working,
-        searchFunctionName: 'working',
-        searchFunction: searchFunctions.working,
         stalledSearchDelay: undefined,
         indexName: 'instant_search',
       };
@@ -101,10 +91,6 @@ storiesOf('ais-instant-search', module)
       searchClientName(newName) {
         this.searchClientName = newName;
         this.searchClient = clients[newName];
-      },
-      searchFunctionName(newName) {
-        this.searchFunctionName = newName;
-        this.searchFunction = searchFunctions[newName];
       },
     },
   }));


### PR DESCRIPTION
This option is deprecated and all use cases are possible with onStateChange or other methods too

[FX-3216]

BREAKING CHANGE: replace searchFunction usage with onStateChange


[FX-3216]: https://algolia.atlassian.net/browse/FX-3216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ