### PR TITLE
fix(build): prevent destructure with reuse of same symbol.

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "rollup-plugin-node-globals": "1.4.0",
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-replace": "2.2.0",
-    "rollup-plugin-uglify": "6.0.4",
+    "@rollup/plugin-terser": "0.4.4",
     "shelljs": "0.8.5",
     "shipjs": "0.26.0",
     "ts-jest": "27",

--- a/packages/algolia-experiences/rollup.config.js
+++ b/packages/algolia-experiences/rollup.config.js
@@ -1,10 +1,10 @@
 import path from 'path';
 
+import terser from '@rollup/plugin-terser';
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import resolve from 'rollup-plugin-node-resolve';
 import replace from 'rollup-plugin-replace';
-import { uglify } from 'rollup-plugin-uglify';
 
 import packageJson from '../../package.json';
 
@@ -68,12 +68,7 @@ const createConfiguration = ({ mode, filename }) => ({
       __DEV__: mode === 'development',
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
-    mode === 'production' &&
-      uglify({
-        output: {
-          preamble: license,
-        },
-      }),
+    mode === 'production' && terser(),
   ].filter(Boolean),
 });
 

--- a/packages/instantsearch.js/scripts/rollup/rollup.config.js
+++ b/packages/instantsearch.js/scripts/rollup/rollup.config.js
@@ -1,9 +1,9 @@
+import terser from '@rollup/plugin-terser';
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import filesize from 'rollup-plugin-filesize';
 import resolve from 'rollup-plugin-node-resolve';
 import replace from 'rollup-plugin-replace';
-import { uglify } from 'rollup-plugin-uglify';
 
 import packageJson from '../../package.json';
 
@@ -55,12 +55,7 @@ const createConfiguration = ({ mode, filename }) => ({
       __DEV__: mode === 'development',
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
-    mode === 'production' &&
-      uglify({
-        output: {
-          preamble: license,
-        },
-      }),
+    mode === 'production' && terser(),
   ].filter(Boolean),
 });
 

--- a/packages/react-instantsearch-core/rollup.config.js
+++ b/packages/react-instantsearch-core/rollup.config.js
@@ -1,10 +1,10 @@
+import terser from '@rollup/plugin-terser';
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import filesize from 'rollup-plugin-filesize';
 import globals from 'rollup-plugin-node-globals';
 import resolve from 'rollup-plugin-node-resolve';
 import replace from 'rollup-plugin-replace';
-import { uglify } from 'rollup-plugin-uglify';
 
 const clear = (x) => x.filter(Boolean);
 
@@ -63,16 +63,7 @@ const createConfiguration = ({ name, minify = false } = {}) => ({
 
     warn(warning);
   },
-  plugins: plugins.concat(
-    clear([
-      minify &&
-        uglify({
-          output: {
-            preamble: createBanner(name),
-          },
-        }),
-    ])
-  ),
+  plugins: plugins.concat(clear([minify && terser()])),
 });
 
 export default [

--- a/packages/react-instantsearch/rollup.config.js
+++ b/packages/react-instantsearch/rollup.config.js
@@ -1,10 +1,10 @@
+import terser from '@rollup/plugin-terser';
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import filesize from 'rollup-plugin-filesize';
 import globals from 'rollup-plugin-node-globals';
 import resolve from 'rollup-plugin-node-resolve';
 import replace from 'rollup-plugin-replace';
-import { uglify } from 'rollup-plugin-uglify';
 
 const clear = (x) => x.filter(Boolean);
 
@@ -63,16 +63,7 @@ const createConfiguration = ({ name, minify = false } = {}) => ({
 
     warn(warning);
   },
-  plugins: plugins.concat(
-    clear([
-      minify &&
-        uglify({
-          output: {
-            preamble: createBanner(name),
-          },
-        }),
-    ])
-  ),
+  plugins: plugins.concat(clear([minify && terser()])),
 });
 
 export default [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5368,6 +5368,15 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-1.0.0.tgz#05bb0031533598f9458cf65a502b8df0eecae780"
   integrity sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w==
 
+"@rollup/plugin-terser@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz#15dffdb3f73f121aa4fbb37e7ca6be9aeea91962"
+  integrity sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==
+  dependencies:
+    serialize-javascript "^6.0.1"
+    smob "^1.0.0"
+    terser "^5.17.4"
+
 "@rollup/rollup-android-arm-eabi@4.24.0":
   version "4.24.0"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz#1661ff5ea9beb362795304cb916049aba7ac9c54"
@@ -27898,16 +27907,6 @@ rollup-plugin-terser@4.0.4:
     serialize-javascript "^1.6.1"
     terser "^3.14.1"
 
-rollup-plugin-uglify@6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.4.tgz#65a0959d91586627f1e46a7db966fd504ec6c4e6"
-  integrity sha512-ddgqkH02klveu34TF0JqygPwZnsbhHVI6t8+hGTcYHngPkQb5MIHI0XiztXIN/d6V9j+efwHAqEL7LspSxQXGw==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    jest-worker "^24.0.0"
-    serialize-javascript "^2.1.2"
-    uglify-js "^3.4.9"
-
 "rollup-plugin-vue2@npm:rollup-plugin-vue@4.3.2":
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-vue/-/rollup-plugin-vue-4.3.2.tgz#0bdf0cf677565b0ac2358d590f177b6b4ded8cce"
@@ -28458,10 +28457,10 @@ serialize-javascript@^5.0.1:
   dependencies:
     randombytes "^2.1.0"
 
-serialize-javascript@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
-  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
+serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
+  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
 
@@ -28878,6 +28877,11 @@ smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
+smob@^1.0.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/smob/-/smob-1.5.0.tgz#85d79a1403abf128d24d3ebc1cdc5e1a9548d3ab"
+  integrity sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==
 
 snake-case@^2.1.0:
   version "2.1.0"
@@ -30457,10 +30461,10 @@ terser@^4.1.2, terser@^4.4.3, terser@^4.6.12, terser@^4.6.3, terser@^4.8.0:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.3.4, terser@^5.6.0:
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.36.0.tgz#8b0dbed459ac40ff7b4c9fd5a3a2029de105180e"
-  integrity sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==
+terser@^5.17.4, terser@^5.3.4, terser@^5.6.0:
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.37.0.tgz#38aa66d1cfc43d0638fab54e43ff8a4f72a21ba3"
+  integrity sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"
@@ -31231,7 +31235,7 @@ uglify-js@3.4.x:
     commander "~2.17.1"
     source-map "~0.6.1"
 
-uglify-js@^3.1.4, uglify-js@^3.4.9, uglify-js@^3.5.1:
+uglify-js@^3.1.4, uglify-js@^3.5.1:
   version "3.17.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
   integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==


### PR DESCRIPTION
This is the cause of the UMD e2e failure in `next`.

Basically the flow is:

1. source code that destructures something in arguments:

```js
function fn({ one, two }) {}
```

2. esm output of source code

```js
function fn(_ref) {
  let {
    one,
    two,
  } = _ref
```

3. umd production output (using uglify)

```js
function fn(e) {
  var { one: e, two: t } = e
```

note the reused variable name

4. output after import through parcel of the prod umd import

```js
function fn(e) {
  var e = e.one,
    t = e.two;
```

This fixes it by changing step 3 by using terser to:

```js
function fn(e) {
  let { one: t, two: n } = e;
}
```

note that it doesn't reuse the `e` variable and thus no longer bugs and has this output in parcel:

```js
function fn(e) {
  var t = e.one,
    n = e.two;
}
```

This issue started showing up once we changed the browser output of the js umd build to keep destructuring, which had this "rename-bug". Updating to terser is the right solution for the future as it's actually kept updated unlike uglify.
