### PR TITLE
refactor(range): make range connector more consistent and simpler to use

### DIFF
--- a/examples/react/e-commerce/components/PriceSlider.tsx
+++ b/examples/react/e-commerce/components/PriceSlider.tsx
@@ -1,4 +1,4 @@
-import { Range, RangeBoundaries } from 'instantsearch-core';
+import { Range } from 'instantsearch-core';
 import React, { useState } from 'react';
 import {
   Slider,
@@ -56,15 +56,15 @@ function Handle({
   );
 }
 
-function convertToTicks(start: RangeBoundaries, range: Range): number[] {
+function convertToTicks({ min, max }: Range, range: Range): number[] {
   const domain =
     range.min === 0 && range.max === 0
       ? { min: undefined, max: undefined }
       : range;
 
   return [
-    start[0] === -Infinity ? domain.min! : start[0]!,
-    start[1] === Infinity ? domain.max! : start[1]!,
+    min === -Infinity ? domain.min! : min!,
+    max === Infinity ? domain.max! : max!,
   ];
 }
 
@@ -77,7 +77,7 @@ export function PriceSlider({
   min?: number;
   max?: number;
 }) {
-  const { range, start, refine, canRefine } = useRange(
+  const { range, currentRefinement, refine, canRefine } = useRange(
     {
       attribute,
       min,
@@ -85,16 +85,18 @@ export function PriceSlider({
     },
     { $$widgetType: 'e-commerce.rangeSlider' }
   );
-  const [ticksValues, setTicksValues] = useState(convertToTicks(start, range));
-  const [prevStart, setPrevStart] = useState(start);
+  const [ticksValues, setTicksValues] = useState(
+    convertToTicks(currentRefinement, range)
+  );
+  const [prevRefinement, setPrevRefinement] = useState(currentRefinement);
 
-  if (start !== prevStart) {
-    setTicksValues(convertToTicks(start, range));
-    setPrevStart(start);
+  if (currentRefinement !== prevRefinement) {
+    setTicksValues(convertToTicks(currentRefinement, range));
+    setPrevRefinement(currentRefinement);
   }
 
-  const onChange = (values: readonly number[]) => {
-    refine(values as [number, number]);
+  const onChange = ([newMin, newMax]: readonly number[]) => {
+    refine({ min: newMin, max: newMax });
   };
 
   const onUpdate = (values: readonly number[]) => {
@@ -114,7 +116,9 @@ export function PriceSlider({
       mode={2}
       step={1}
       domain={[range.min!, range.max!]}
-      values={start as number[]}
+      values={
+        [currentRefinement.min, currentRefinement.max] as [number, number]
+      }
       disabled={!canRefine}
       onChange={onChange}
       onUpdate={onUpdate}

--- a/packages/instantsearch.js/src/components/RangeInput/RangeInput.tsx
+++ b/packages/instantsearch.js/src/components/RangeInput/RangeInput.tsx
@@ -5,7 +5,7 @@ import { h, Component } from 'preact';
 
 import Template from '../Template/Template';
 
-import type { Range, RangeBoundaries } from '../../connectors';
+import type { Range } from '../../connectors';
 import type { ComponentCSSClasses } from '../../types';
 import type {
   RangeInputCSSClasses,
@@ -26,7 +26,7 @@ export type RangeInputProps = {
   templateProps: {
     templates: RangeInputComponentTemplates;
   };
-  refine: (rangeValue: RangeBoundaries) => void;
+  refine: (rangeValue: Range) => void;
 };
 
 // Strips leading `0` from a positive number value
@@ -62,10 +62,10 @@ class RangeInput extends Component<
     event.preventDefault();
 
     const { min, max } = this.state;
-    this.props.refine([
-      min ? Number(min) : undefined,
-      max ? Number(max) : undefined,
-    ]);
+    this.props.refine({
+      min: min ? Number(min) : undefined,
+      max: max ? Number(max) : undefined,
+    });
   };
 
   public render() {

--- a/packages/instantsearch.js/src/components/Slider/Slider.tsx
+++ b/packages/instantsearch.js/src/components/Slider/Slider.tsx
@@ -8,7 +8,7 @@ import { range } from '../../lib/utils';
 import Pit from './Pit';
 import Rheostat from './Rheostat';
 
-import type { RangeBoundaries } from '../../connectors';
+import type { Range } from '../../connectors';
 import type { ComponentCSSClasses } from '../../types';
 import type {
   RangeSliderCssClasses,
@@ -20,10 +20,10 @@ export type RangeSliderComponentCSSClasses =
   ComponentCSSClasses<RangeSliderCssClasses>;
 
 export type SliderProps = {
-  refine: (values: RangeBoundaries) => void;
+  refine: (values: Range) => void;
   min?: number;
   max?: number;
-  values: RangeBoundaries;
+  values: Range;
   pips?: boolean;
   step?: number;
   tooltips?: RangeSliderWidgetParams['tooltips'];
@@ -35,9 +35,11 @@ class Slider extends Component<SliderProps> {
     return this.props.min! >= this.props.max!;
   }
 
-  private handleChange = ({ values }: { values: RangeBoundaries }) => {
+  private handleChange = ({
+    values: [min, max],
+  }: Parameters<NonNullable<Rheostat['props']['onChange']>>[0]) => {
     if (!this.isDisabled) {
-      this.props.refine(values);
+      this.props.refine({ min, max });
     }
   };
 
@@ -132,7 +134,12 @@ class Slider extends Component<SliderProps> {
           pitPoints={pitPoints}
           snap={true}
           snapPoints={snapPoints}
-          values={(this.isDisabled ? [min, max] : values) as [number, number]}
+          values={
+            (this.isDisabled ? [min, max] : [values.min, values.max]) as [
+              number,
+              number
+            ]
+          }
           disabled={this.isDisabled}
         />
       </div>

--- a/packages/instantsearch.js/src/connectors/index.ts
+++ b/packages/instantsearch.js/src/connectors/index.ts
@@ -160,7 +160,6 @@ export type {
   RangeWidgetDescription,
   RangeConnectorParams,
   Range,
-  RangeBoundaries,
 } from 'instantsearch-core';
 
 export { connectRatingMenu } from 'instantsearch-core';

--- a/packages/instantsearch.js/src/widgets/range-input/range-input.tsx
+++ b/packages/instantsearch.js/src/widgets/range-input/range-input.tsx
@@ -134,7 +134,7 @@ const renderer =
     };
     templates: RangeInputTemplates;
   }): Renderer<RangeRenderState, Partial<RangeInputWidgetParams>> =>
-  ({ refine, range, start, widgetParams }, isFirstRendering) => {
+  ({ refine, range, currentRefinement, widgetParams }, isFirstRendering) => {
     if (isFirstRendering) {
       renderState.templateProps = prepareTemplateProps({
         defaultTemplates,
@@ -144,7 +144,7 @@ const renderer =
     }
 
     const { min: rangeMin, max: rangeMax } = range;
-    const [minValue, maxValue] = start;
+    const { min: minValue, max: maxValue } = currentRefinement;
 
     const step = 1 / Math.pow(10, widgetParams.precision || 0);
 

--- a/packages/instantsearch.js/src/widgets/range-slider/range-slider.tsx
+++ b/packages/instantsearch.js/src/widgets/range-slider/range-slider.tsx
@@ -13,7 +13,7 @@ import {
 
 import type { RangeSliderComponentCSSClasses } from '../../components/Slider/Slider';
 import type {
-  RangeBoundaries,
+  Range,
   RangeConnectorParams,
   RangeRenderState,
   RangeWidgetDescription,
@@ -37,7 +37,7 @@ const renderer =
     step?: number;
     tooltips: RangeSliderWidgetParams['tooltips'];
   }): Renderer<RangeRenderState, Partial<RangeSliderWidgetParams>> =>
-  ({ refine, range, start }, isFirstRendering) => {
+  ({ refine, range, currentRefinement }, isFirstRendering) => {
     if (isFirstRendering) {
       // There's no information at this point, let's render nothing.
       return;
@@ -45,17 +45,17 @@ const renderer =
 
     const { min: minRange, max: maxRange } = range;
 
-    const [minStart, maxStart] = start;
-    const minFinite = minStart === -Infinity ? minRange : minStart;
-    const maxFinite = maxStart === Infinity ? maxRange : maxStart;
+    const { min: minValue, max: maxValue } = currentRefinement;
+    const minFinite = minValue === -Infinity ? minRange : minValue;
+    const maxFinite = maxValue === Infinity ? maxRange : maxValue;
 
     // Clamp values to the range for avoid extra rendering & refinement
     // Should probably be done on the connector side, but we need to stay
     // backward compatible so we still need to pass [-Infinity, Infinity]
-    const values: RangeBoundaries = [
-      minFinite! > maxRange! ? maxRange : minFinite,
-      maxFinite! < minRange! ? minRange : maxFinite,
-    ];
+    const values: Range = {
+      min: minFinite! > maxRange! ? maxRange : minFinite,
+      max: maxFinite! < minRange! ? minRange : maxFinite,
+    };
 
     render(
       <Slider

--- a/packages/react-instantsearch/src/ui/RangeInput.tsx
+++ b/packages/react-instantsearch/src/ui/RangeInput.tsx
@@ -6,7 +6,7 @@ import type { useRange } from 'react-instantsearch-core';
 type RangeRenderState = ReturnType<typeof useRange>;
 
 export type RangeInputProps = Omit<React.ComponentProps<'div'>, 'onSubmit'> &
-  Pick<RangeRenderState, 'range' | 'start'> & {
+  Pick<RangeRenderState, 'range' | 'currentRefinement'> & {
     classNames?: Partial<RangeInputClassNames>;
     disabled: boolean;
     onSubmit: RangeRenderState['refine'];
@@ -75,7 +75,7 @@ function stripLeadingZeroFromInput(value: string): string {
 export function RangeInput({
   classNames = {},
   range: { min, max },
-  start: [minValue, maxValue],
+  currentRefinement: { min: minValue, max: maxValue },
   step = 1,
   disabled,
   onSubmit,
@@ -118,10 +118,10 @@ export function RangeInput({
         className={cx('ais-RangeInput-form', classNames.form)}
         onSubmit={(event) => {
           event.preventDefault();
-          onSubmit([
-            from ? Number(from) : undefined,
-            to ? Number(to) : undefined,
-          ]);
+          onSubmit({
+            min: from ? Number(from) : undefined,
+            max: to ? Number(to) : undefined,
+          });
         }}
       >
         <label className={cx('ais-RangeInput-label', classNames.label)}>

--- a/packages/react-instantsearch/src/widgets/RangeInput.tsx
+++ b/packages/react-instantsearch/src/widgets/RangeInput.tsx
@@ -8,7 +8,12 @@ import type { UseRangeProps } from 'react-instantsearch-core';
 
 type UiProps = Pick<
   RangeInputUiProps,
-  'disabled' | 'onSubmit' | 'range' | 'start' | 'step' | 'translations'
+  | 'disabled'
+  | 'onSubmit'
+  | 'range'
+  | 'currentRefinement'
+  | 'step'
+  | 'translations'
 >;
 
 export type RangeInputProps = Omit<RangeInputUiProps, keyof UiProps> &
@@ -22,7 +27,7 @@ export function RangeInput({
   translations,
   ...props
 }: RangeInputProps) {
-  const { range, start, canRefine, refine } = useRange(
+  const { range, currentRefinement, canRefine, refine } = useRange(
     { attribute, min, max, precision },
     { $$widgetType: 'ais.rangeInput' }
   );
@@ -31,7 +36,7 @@ export function RangeInput({
 
   const uiProps: UiProps = {
     range,
-    start,
+    currentRefinement,
     step,
     disabled: !canRefine,
     onSubmit: refine,

--- a/packages/vue-instantsearch/src/components/RangeInput.vue
+++ b/packages/vue-instantsearch/src/components/RangeInput.vue
@@ -121,7 +121,7 @@ export default {
       return 1 / Math.pow(10, this.precision);
     },
     values() {
-      const [minValue, maxValue] = this.state.start;
+      const { min: minValue, max: maxValue } = this.state.currentRefinement;
       const { min: minRange, max: maxRange } = this.state.range;
 
       return {
@@ -143,7 +143,7 @@ export default {
       }
     },
     refine({ min, max }) {
-      this.state.refine([min, max]);
+      this.state.refine({ min, max });
     },
   },
 };


### PR DESCRIPTION
**Summary**

This PR reworks `connectRange` and its widgets to provide a simpler and more consistent experience.

BREAKING:
- `start` is now called `currentRefinement` and has the same type as `range` (`{ min: number, max: number }`)
