### PR TITLE
feat: make composition work server-side + some typing

### DIFF
--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -17,6 +17,7 @@ import type {
   TrendingFacetsQuery,
   TrendingItemsQuery,
   PlainRecommendParameters as ClientPlainRecommendParameters,
+  CompositionClient,
 } from './types/algoliasearch';
 
 /**
@@ -30,7 +31,7 @@ import type {
  * @param searchResultsOptions
  */
 declare function algoliasearchHelper(
-  client: SearchClient,
+  client: SearchClient | CompositionClient,
   index: string,
   opts?: algoliasearchHelper.PlainSearchParameters,
   searchResultsOptions?: algoliasearchHelper.SearchResultsOptions
@@ -404,8 +405,8 @@ declare namespace algoliasearchHelper {
      */
     containsRefinement(...any: any[]): any;
     clearCache(): this;
-    setClient(client: SearchClient): this;
-    getClient(): SearchClient;
+    setClient(client: SearchClient | CompositionClient): this;
+    getClient(): SearchClient | CompositionClient;
     derive(
       deriveFn: (oldParams: SearchParameters) => SearchParameters,
       deriveRecommendFn?: (

--- a/packages/algoliasearch-helper/types/algoliasearch.d.ts
+++ b/packages/algoliasearch-helper/types/algoliasearch.d.ts
@@ -334,3 +334,19 @@ export interface SearchClient {
     : never;
   addAlgoliaAgent?: DefaultSearchClient['addAlgoliaAgent'];
 }
+
+export interface CompositionClient {
+  search: <T>(request: {
+    compositionID: string;
+    requestBody: { params: SearchOptions };
+  }) => Promise<{
+    results: Array<
+      // AlgoliaSearch.SearchResponse<T>
+      AlgoliaSearch.BaseSearchResponse &
+        Pick<AlgoliaSearch.SearchHits<T>, 'hits'> &
+        AlgoliaSearch.SearchPagination
+    >;
+  }>;
+  initIndex?: never;
+  addAlgoliaAgent?: DefaultSearchClient['addAlgoliaAgent'];
+}

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -39,6 +39,7 @@ import type {
   MiddlewareDefinition,
   RenderState,
   InitialResults,
+  CompositionClient,
 } from '../types';
 import type { AlgoliaSearchHelper } from 'algoliasearch-helper';
 
@@ -101,7 +102,7 @@ export type InstantSearchOptions<
    * });
    * ```
    */
-  searchClient: SearchClient;
+  searchClient: SearchClient | CompositionClient;
 
   /**
    * The locale used to display numbers. This will be passed

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -24,12 +24,20 @@ export function waitForResults(
   helper.setClient({
     ...client,
     search(queries) {
-      requestParamsList = queries.map(({ params }) => params);
+      requestParamsList = search.compositionID
+        ? [(queries as any).requestBody.params]
+        : queries.map(({ params }) => params);
       return client.search(queries);
     },
   });
 
-  search._hasSearchWidget && helper.searchOnlyWithDerivedHelpers();
+  if (search._hasSearchWidget) {
+    if (search.compositionID) {
+      helper.searchWithComposition();
+    } else {
+      helper.searchOnlyWithDerivedHelpers();
+    }
+  }
   !skipRecommend && search._hasRecommendWidget && helper.recommend();
 
   return new Promise((resolve, reject) => {

--- a/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
+++ b/packages/instantsearch.js/src/lib/utils/hydrateSearchClient.ts
@@ -91,10 +91,14 @@ export function hydrateSearchClient(
     ) => any;
     // @ts-ignore wanting type checks for v3 on this would make this too complex
     client.search = (requests, ...methodArgs) => {
-      const requestsWithSerializedParams = requests.map((request) => ({
-        ...request,
-        params: serializeQueryParameters(request.params),
-      }));
+      const requestsWithSerializedParams =
+        'requestBody' in requests
+          ? // for composition client
+            serializeQueryParameters(requests.requestBody as any)
+          : requests.map((request) => ({
+              ...request,
+              params: serializeQueryParameters(request.params),
+            }));
 
       return (client as ClientWithTransporter).transporter.responsesCache.get(
         {

--- a/packages/react-instantsearch-core/src/lib/useInstantSearchApi.ts
+++ b/packages/react-instantsearch-core/src/lib/useInstantSearchApi.ts
@@ -14,6 +14,7 @@ import { useRSCContext } from './useRSCContext';
 import { warn } from './warn';
 
 import type {
+  CompositionClient,
   InstantSearchOptions,
   SearchClient,
   UiState,
@@ -243,7 +244,7 @@ export function useInstantSearchApi<TUiState extends UiState, TRouteState>(
 }
 
 function addAlgoliaAgents(
-  searchClient: SearchClient,
+  searchClient: SearchClient | CompositionClient,
   userAgents: Array<string | null>
 ) {
   if (typeof searchClient.addAlgoliaAgent !== 'function') {

--- a/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.tsx
@@ -10,7 +10,12 @@ import {
 
 import { htmlEscapeJsonString } from './htmlEscape';
 
-import type { InitialResults, SearchOptions } from 'instantsearch.js';
+import type {
+  InitialResults,
+  SearchOptions,
+  CompositionClient,
+  SearchClient,
+} from 'instantsearch.js';
 
 type InitializePromiseProps = {
   /**
@@ -60,13 +65,24 @@ export function InitializePromise({ nonce }: InitializePromiseProps) {
   // Extract search parameters from the search client to use them
   // later during hydration.
   let requestParamsList: SearchOptions[];
-  search.mainHelper!.setClient({
-    ...search.mainHelper!.getClient(),
-    search(queries) {
-      requestParamsList = queries.map(({ params }) => params);
-      return search.client.search(queries);
-    },
-  });
+
+  if (search.compositionID) {
+    search.mainHelper!.setClient({
+      ...search.mainHelper!.getClient(),
+      search(query) {
+        requestParamsList = [query.requestBody.params];
+        return (search.client as CompositionClient).search(query);
+      },
+    } as CompositionClient);
+  } else {
+    search.mainHelper!.setClient({
+      ...search.mainHelper!.getClient(),
+      search(queries) {
+        requestParamsList = queries.map(({ params }) => params);
+        return (search.client as SearchClient).search(queries);
+      },
+    } as SearchClient);
+  }
 
   resetWidgetId();
 

--- a/packages/react-instantsearch-nextjs/src/TriggerSearch.ts
+++ b/packages/react-instantsearch-nextjs/src/TriggerSearch.ts
@@ -8,8 +8,13 @@ export function TriggerSearch() {
   const waitForResultsRef = useRSCContext();
 
   if (waitForResultsRef?.current?.status === 'pending') {
-    instantsearch._hasSearchWidget &&
-      instantsearch.mainHelper?.searchOnlyWithDerivedHelpers();
+    if (instantsearch._hasSearchWidget) {
+      if (instantsearch.compositionID) {
+        instantsearch.mainHelper?.searchWithComposition();
+      } else {
+        instantsearch.mainHelper?.searchOnlyWithDerivedHelpers();
+      }
+    }
     instantsearch._hasRecommendWidget && instantsearch.mainHelper?.recommend();
   }
 


### PR DESCRIPTION
**Summary**
- added minimal typing for `CompositionClient` and used it where necessary → it makes our life easier (and helped me catch a case I wouldn't have catched otherwise)
- `hydrateSearchClient` method adapted to work with Composition Client → not satisfactory but I don't have a better option :/
- `TriggerSearch` adapted to work with Composition (same as in instantsearch.ts)
- `server.ts > waitForResult`
  - adapted search to work with Composition (same as in instantsearch.ts)
  - get `requestParamsList` from the correct place when using Composition Client
- `react-instantsearch-nextjs > InitializePromise.tsx` method adapted to work with Composition Client

[EMERCH-1746](https://algolia.atlassian.net/browse/EMERCH-1746) + at least some of [EMERCH-1749](https://algolia.atlassian.net/browse/EMERCH-1749)

[EMERCH-1746]: https://algolia.atlassian.net/browse/EMERCH-1746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMERCH-1749]: https://algolia.atlassian.net/browse/EMERCH-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ