### PR TITLE
test(date): set static date

### DIFF
--- a/packages/create-instantsearch-app/e2e/__snapshots__/templates.test.js.snap
+++ b/packages/create-instantsearch-app/e2e/__snapshots__/templates.test.js.snap
@@ -2125,7 +2125,7 @@ If you want to publish it as a public scoped package, run \`npm publish --access
 exports[`Templates InstantSearch.js widget File content: LICENSE.md 1`] = `
 "The MIT License (MIT)
 
-Copyright (c) 2025-present algolia.
+Copyright (c) 2020-present algolia.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the \\"Software\\"), to deal

--- a/packages/create-instantsearch-app/e2e/templates.test.js
+++ b/packages/create-instantsearch-app/e2e/templates.test.js
@@ -57,6 +57,7 @@ describe('Templates', () => {
           attributesForFaceting: ['ais.dynamicWidgets', 'facet1', 'facet2'],
           organization: 'algolia',
           enableInsights: true,
+          currentYear: '2020',
         };
 
         configFilePath = `${temporaryDirectory}/${templateConfig.appName}.config.json`;

--- a/packages/create-instantsearch-app/src/cli/postProcessAnswers.js
+++ b/packages/create-instantsearch-app/src/cli/postProcessAnswers.js
@@ -59,12 +59,12 @@ async function postProcessAnswers({
   );
 
   return {
+    currentYear: new Date().getFullYear(),
     ...combinedAnswers,
     ...alternativeNames,
     libraryVersion,
     template: templatePath,
     installation: optionsFromArguments.installation,
-    currentYear: new Date().getFullYear(),
     attributesToDisplay:
       Array.isArray(combinedAnswers.attributesToDisplay) &&
       combinedAnswers.attributesToDisplay.filter(


### PR DESCRIPTION
this way it doesn't need to be updated yearly. Follow up on #6511.

I checked and can't find a way to pass the current date for just one command and the `date` command requires sudo. Only other similar option I saw would be using jest directly, but then we're no longer testing the CLI.