### PR TITLE
fix(next-app-router): do not use SSR context for CSR

### DIFF
--- a/packages/react-instantsearch-nextjs/src/__tests__/InstantSearchNext.test.tsx
+++ b/packages/react-instantsearch-nextjs/src/__tests__/InstantSearchNext.test.tsx
@@ -4,9 +4,9 @@
 
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils';
-import { act, render } from '@testing-library/react';
-import React from 'react';
-import { SearchBox } from 'react-instantsearch';
+import { act, render, screen } from '@testing-library/react';
+import React, { useContext } from 'react';
+import { InstantSearchRSCContext, SearchBox } from 'react-instantsearch';
 
 import { InstantSearchNext } from '../InstantSearchNext';
 
@@ -80,6 +80,42 @@ describe('rerendering', () => {
     });
 
     expect(client.search).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not have server-side rendering context when not needed', async () => {
+    function TestContext() {
+      const rscContext = useContext(InstantSearchRSCContext);
+
+      return <div data-testid="rsc">{rscContext ? 'rsc' : 'no-rsc'}</div>;
+    }
+
+    const { unmount } = render(
+      <InstantSearchNext searchClient={client} indexName="indexName">
+        <SearchBox />
+        <TestContext />
+      </InstantSearchNext>
+    );
+
+    expect(screen.getByTestId('rsc')).toHaveTextContent('rsc');
+
+    await act(async () => {
+      await wait(0);
+      unmount();
+      await wait(0);
+    });
+
+    render(
+      <InstantSearchNext searchClient={client} indexName="indexName">
+        <SearchBox />
+        <TestContext />
+      </InstantSearchNext>
+    );
+
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(screen.getByTestId('rsc')).toHaveTextContent('no-rsc');
   });
 });
 


### PR DESCRIPTION
**Summary**

Fix looks simple but it took time as it was really difficult to debug.

Basically, when navigating with category pages, `InstantSearchNext` remounts and recreates a whole new InstantSearch instance (this is a root problem we may want to deal with later by ensuring we always use a single instance).
It does so too with back and forward buttons, **BUT**, this particular piece of code behaves differently (was really hard to find) : 
https://github.com/algolia/instantsearch/blob/772189605029e8bbb61413737824c096f16269da/packages/instantsearch.js/src/lib/InstantSearch.ts#L698-L710

`defer` is really unreliable on Next.js and Remix IIRC, here when we navigate it did properly remove the `noop`, but with back and forward buttons it didn't which is why we had the initial issue where it would display empty results.

The fix that was made for that worked but it caused issue #6479, as now CSR ran the hydration logic which is to add widgets during render, causing a lot of duplicate `addWidgets` in CSR.

**Result**

Now if we're doing CSR (on the browser, no hydration), we just remove the server contexts to make sure it behaves the same way as regular `react-instantsearch` would.
