### PR TITLE
fix(recommend): use Hit type instead of AlgoliaHit

### DIFF
--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
@@ -19,6 +19,7 @@ import type {
   UnknownWidgetParams,
   RecommendResponse,
   Hit,
+  AlgoliaHit,
 } from '../../types';
 import type { PlainSearchParameters } from 'algoliasearch-helper';
 
@@ -79,7 +80,7 @@ export type FrequentlyBoughtTogetherConnectorParams<
    */
   transformItems?: TransformItems<
     Hit<THit>,
-    { results: RecommendResponse<Hit<THit>> }
+    { results: RecommendResponse<AlgoliaHit<THit>> }
   >;
 };
 
@@ -189,7 +190,7 @@ export default (function connectFrequentlyBoughtTogether<
         const transformedItems = transformItems(
           itemsWithAbsolutePositionAndQueryID,
           {
-            results: results as RecommendResponse<Hit<THit>>,
+            results: results as RecommendResponse<AlgoliaHit<THit>>,
           }
         );
 

--- a/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
+++ b/packages/instantsearch.js/src/connectors/frequently-bought-together/connectFrequentlyBoughtTogether.ts
@@ -18,7 +18,7 @@ import type {
   Unmounter,
   UnknownWidgetParams,
   RecommendResponse,
-  AlgoliaHit,
+  Hit,
 } from '../../types';
 import type { PlainSearchParameters } from 'algoliasearch-helper';
 
@@ -33,7 +33,7 @@ export type FrequentlyBoughtTogetherRenderState<
   /**
    * The matched recommendations from Algolia API.
    */
-  items: Array<AlgoliaHit<THit>>;
+  items: Array<Hit<THit>>;
 
   /**
    * Sends an event to the Insights middleware.
@@ -78,8 +78,8 @@ export type FrequentlyBoughtTogetherConnectorParams<
    * Function to transform the items passed to the templates.
    */
   transformItems?: TransformItems<
-    AlgoliaHit<THit>,
-    { results: RecommendResponse<AlgoliaHit<THit>> }
+    Hit<THit>,
+    { results: RecommendResponse<Hit<THit>> }
   >;
 };
 
@@ -189,7 +189,7 @@ export default (function connectFrequentlyBoughtTogether<
         const transformedItems = transformItems(
           itemsWithAbsolutePositionAndQueryID,
           {
-            results: results as RecommendResponse<AlgoliaHit<THit>>,
+            results: results as RecommendResponse<Hit<THit>>,
           }
         );
 

--- a/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
@@ -18,7 +18,7 @@ import type {
   Unmounter,
   UnknownWidgetParams,
   RecommendResponse,
-  AlgoliaHit,
+  Hit,
 } from '../../types';
 import type { PlainSearchParameters } from 'algoliasearch-helper';
 
@@ -33,7 +33,7 @@ export type LookingSimilarRenderState<
   /**
    * The matched recommendations from the Algolia API.
    */
-  items: Array<AlgoliaHit<THit>>;
+  items: Array<Hit<THit>>;
   /**
    * Sends an event to the Insights middleware.
    */
@@ -79,8 +79,8 @@ export type LookingSimilarConnectorParams<
    * Function to transform the items passed to the templates.
    */
   transformItems?: TransformItems<
-    AlgoliaHit<THit>,
-    { results: RecommendResponse<AlgoliaHit<THit>> }
+    Hit<THit>,
+    { results: RecommendResponse<Hit<THit>> }
   >;
 };
 
@@ -191,7 +191,7 @@ export default (function connectLookingSimilar<
         const transformedItems = transformItems(
           itemsWithAbsolutePositionAndQueryID,
           {
-            results: results as RecommendResponse<AlgoliaHit<THit>>,
+            results: results as RecommendResponse<Hit<THit>>,
           }
         );
 

--- a/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
@@ -19,6 +19,7 @@ import type {
   UnknownWidgetParams,
   RecommendResponse,
   Hit,
+  AlgoliaHit,
 } from '../../types';
 import type { PlainSearchParameters } from 'algoliasearch-helper';
 
@@ -80,7 +81,7 @@ export type LookingSimilarConnectorParams<
    */
   transformItems?: TransformItems<
     Hit<THit>,
-    { results: RecommendResponse<Hit<THit>> }
+    { results: RecommendResponse<AlgoliaHit<THit>> }
   >;
 };
 
@@ -191,7 +192,7 @@ export default (function connectLookingSimilar<
         const transformedItems = transformItems(
           itemsWithAbsolutePositionAndQueryID,
           {
-            results: results as RecommendResponse<Hit<THit>>,
+            results: results as RecommendResponse<AlgoliaHit<THit>>,
           }
         );
 

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -19,6 +19,7 @@ import type {
   UnknownWidgetParams,
   RecommendResponse,
   Hit,
+  AlgoliaHit,
 } from '../../types';
 import type { PlainSearchParameters } from 'algoliasearch-helper';
 
@@ -81,7 +82,7 @@ export type RelatedProductsConnectorParams<
    */
   transformItems?: TransformItems<
     Hit<THit>,
-    { results: RecommendResponse<Hit<THit>> }
+    { results: RecommendResponse<AlgoliaHit<THit>> }
   >;
 };
 
@@ -192,7 +193,7 @@ export default (function connectRelatedProducts<
         const transformedItems = transformItems(
           itemsWithAbsolutePositionAndQueryID,
           {
-            results: results as RecommendResponse<Hit<THit>>,
+            results: results as RecommendResponse<AlgoliaHit<THit>>,
           }
         );
 

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -18,7 +18,7 @@ import type {
   Unmounter,
   UnknownWidgetParams,
   RecommendResponse,
-  AlgoliaHit,
+  Hit,
 } from '../../types';
 import type { PlainSearchParameters } from 'algoliasearch-helper';
 
@@ -33,7 +33,7 @@ export type RelatedProductsRenderState<
   /**
    * The matched recommendations from the Algolia API.
    */
-  items: Array<AlgoliaHit<THit>>;
+  items: Array<Hit<THit>>;
 
   /**
    * Sends an event to the Insights middleware.
@@ -80,8 +80,8 @@ export type RelatedProductsConnectorParams<
    * Function to transform the items passed to the templates.
    */
   transformItems?: TransformItems<
-    AlgoliaHit<THit>,
-    { results: RecommendResponse<AlgoliaHit<THit>> }
+    Hit<THit>,
+    { results: RecommendResponse<Hit<THit>> }
   >;
 };
 
@@ -192,7 +192,7 @@ export default (function connectRelatedProducts<
         const transformedItems = transformItems(
           itemsWithAbsolutePositionAndQueryID,
           {
-            results: results as RecommendResponse<AlgoliaHit<THit>>,
+            results: results as RecommendResponse<Hit<THit>>,
           }
         );
 

--- a/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
@@ -20,6 +20,7 @@ import type {
   UnknownWidgetParams,
   RecommendResponse,
   Hit,
+  AlgoliaHit,
 } from '../../types';
 import type { PlainSearchParameters } from 'algoliasearch-helper';
 
@@ -93,7 +94,7 @@ export type TrendingItemsConnectorParams<
    */
   transformItems?: TransformItems<
     Hit<THit>,
-    { results: RecommendResponse<Hit<THit>> }
+    { results: RecommendResponse<AlgoliaHit<THit>> }
   >;
 };
 
@@ -212,7 +213,7 @@ export default (function connectTrendingItems<
         const transformedItems = transformItems(
           itemsWithAbsolutePositionAndQueryID,
           {
-            results: results as RecommendResponse<Hit<THit>>,
+            results: results as RecommendResponse<AlgoliaHit<THit>>,
           }
         );
 

--- a/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
@@ -19,7 +19,7 @@ import type {
   Unmounter,
   UnknownWidgetParams,
   RecommendResponse,
-  AlgoliaHit,
+  Hit,
 } from '../../types';
 import type { PlainSearchParameters } from 'algoliasearch-helper';
 
@@ -34,7 +34,7 @@ export type TrendingItemsRenderState<
   /**
    * The matched recommendations from the Algolia API.
    */
-  items: Array<AlgoliaHit<THit>>;
+  items: Array<Hit<THit>>;
 
   /**
    * Sends an event to the Insights middleware.
@@ -92,8 +92,8 @@ export type TrendingItemsConnectorParams<
    * Function to transform the items passed to the templates.
    */
   transformItems?: TransformItems<
-    AlgoliaHit<THit>,
-    { results: RecommendResponse<AlgoliaHit<THit>> }
+    Hit<THit>,
+    { results: RecommendResponse<Hit<THit>> }
   >;
 };
 
@@ -212,7 +212,7 @@ export default (function connectTrendingItems<
         const transformedItems = transformItems(
           itemsWithAbsolutePositionAndQueryID,
           {
-            results: results as RecommendResponse<AlgoliaHit<THit>>,
+            results: results as RecommendResponse<Hit<THit>>,
           }
         );
 

--- a/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
+++ b/packages/instantsearch.js/src/widgets/frequently-bought-together/frequently-bought-together.tsx
@@ -20,7 +20,6 @@ import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   Template,
   WidgetFactory,
-  AlgoliaHit,
   Renderer,
   BaseHit,
   RecommendResponse,
@@ -83,9 +82,9 @@ const renderer =
             />
           )
         : undefined
-    ) as FrequentlyBoughtTogetherUiProps<AlgoliaHit>['headerComponent'];
+    ) as FrequentlyBoughtTogetherUiProps<Hit>['headerComponent'];
 
-    const itemComponent: FrequentlyBoughtTogetherUiProps<AlgoliaHit>['itemComponent'] =
+    const itemComponent: FrequentlyBoughtTogetherUiProps<Hit>['itemComponent'] =
       templates.item
         ? ({ item, sendEvent: _sendEvent, ...rootProps }) => {
             return (
@@ -112,7 +111,7 @@ const renderer =
             />
           )
         : undefined
-    ) as FrequentlyBoughtTogetherUiProps<AlgoliaHit>['emptyComponent'];
+    ) as FrequentlyBoughtTogetherUiProps<Hit>['emptyComponent'];
 
     const layoutComponent = (
       templates.layout
@@ -126,7 +125,7 @@ const renderer =
                 items: data.items,
                 templates: {
                   item: templates.item
-                    ? ({ item }: { item: AlgoliaHit<THit> }) => (
+                    ? ({ item }: { item: Hit<THit> }) => (
                         <TemplateComponent
                           {...renderState.templateProps}
                           templateKey="item"
@@ -146,7 +145,7 @@ const renderer =
             />
           )
         : undefined
-    ) as FrequentlyBoughtTogetherUiProps<AlgoliaHit<THit>>['layout'];
+    ) as FrequentlyBoughtTogetherUiProps<Hit<THit>>['layout'];
 
     render(
       <FrequentlyBoughtTogether
@@ -171,7 +170,7 @@ export type FrequentlyBoughtTogetherTemplates<
   /**
    * Template to use when there are no results.
    */
-  empty: Template<RecommendResponse<AlgoliaHit<THit>>>;
+  empty: Template<RecommendResponse<Hit<THit>>>;
 
   /**
    * Template to use for the header of the widget.
@@ -180,7 +179,7 @@ export type FrequentlyBoughtTogetherTemplates<
     Pick<
       Parameters<
         NonNullable<
-          FrequentlyBoughtTogetherUiProps<AlgoliaHit<THit>>['headerComponent']
+          FrequentlyBoughtTogetherUiProps<Hit<THit>>['headerComponent']
         >
       >[0],
       'items'
@@ -190,7 +189,7 @@ export type FrequentlyBoughtTogetherTemplates<
   /**
    * Template to use for each result. This template will receive an object containing a single record.
    */
-  item: TemplateWithBindEvent<AlgoliaHit<THit>>;
+  item: TemplateWithBindEvent<Hit<THit>>;
 
   /**
    * Template to use to wrap all items.
@@ -198,14 +197,12 @@ export type FrequentlyBoughtTogetherTemplates<
   layout: Template<
     Pick<
       Parameters<
-        NonNullable<FrequentlyBoughtTogetherUiProps<AlgoliaHit<THit>>['layout']>
+        NonNullable<FrequentlyBoughtTogetherUiProps<Hit<THit>>['layout']>
       >[0],
       'items'
     > & {
       templates: {
-        item: FrequentlyBoughtTogetherUiProps<
-          AlgoliaHit<THit>
-        >['itemComponent'];
+        item: FrequentlyBoughtTogetherUiProps<Hit<THit>>['itemComponent'];
       };
       cssClasses: Pick<FrequentlyBoughtTogetherCSSClasses, 'list' | 'item'>;
     }

--- a/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
+++ b/packages/instantsearch.js/src/widgets/looking-similar/looking-similar.tsx
@@ -20,7 +20,6 @@ import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   Template,
   WidgetFactory,
-  AlgoliaHit,
   Renderer,
   BaseHit,
   RecommendResponse,
@@ -82,9 +81,9 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as LookingSimilarUiProps<AlgoliaHit>['headerComponent'];
+    ) as LookingSimilarUiProps<Hit>['headerComponent'];
 
-    const itemComponent: LookingSimilarUiProps<AlgoliaHit>['itemComponent'] =
+    const itemComponent: LookingSimilarUiProps<Hit>['itemComponent'] =
       templates.item
         ? ({ item, sendEvent: _sendEvent, ...rootProps }) => {
             return (
@@ -111,7 +110,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as LookingSimilarUiProps<AlgoliaHit>['emptyComponent'];
+    ) as LookingSimilarUiProps<Hit>['emptyComponent'];
 
     const layoutComponent = (
       templates.layout
@@ -125,7 +124,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
                 items: data.items,
                 templates: {
                   item: templates.item
-                    ? ({ item }: { item: AlgoliaHit<THit> }) => (
+                    ? ({ item }: { item: Hit<THit> }) => (
                         <TemplateComponent
                           {...renderState.templateProps}
                           templateKey="item"
@@ -145,7 +144,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as LookingSimilarUiProps<AlgoliaHit<THit>>['layout'];
+    ) as LookingSimilarUiProps<Hit<THit>>['layout'];
 
     render(
       <LookingSimilar
@@ -171,7 +170,7 @@ export type LookingSimilarTemplates<
   /**
    * Template to use when there are no results.
    */
-  empty: Template<RecommendResponse<AlgoliaHit<THit>>>;
+  empty: Template<RecommendResponse<Hit<THit>>>;
 
   /**
    * Template to use for the header of the widget.
@@ -179,7 +178,7 @@ export type LookingSimilarTemplates<
   header: Template<
     Pick<
       Parameters<
-        NonNullable<LookingSimilarUiProps<AlgoliaHit<THit>>['headerComponent']>
+        NonNullable<LookingSimilarUiProps<Hit<THit>>['headerComponent']>
       >[0],
       'items'
     > & { cssClasses: RecommendClassNames }
@@ -188,20 +187,18 @@ export type LookingSimilarTemplates<
   /**
    * Template to use for each result. This template will receive an object containing a single record.
    */
-  item: TemplateWithBindEvent<AlgoliaHit<THit>>;
+  item: TemplateWithBindEvent<Hit<THit>>;
 
   /**
    * Template to use to wrap all items.
    */
   layout: Template<
     Pick<
-      Parameters<
-        NonNullable<LookingSimilarUiProps<AlgoliaHit<THit>>['layout']>
-      >[0],
+      Parameters<NonNullable<LookingSimilarUiProps<Hit<THit>>['layout']>>[0],
       'items'
     > & {
       templates: {
-        item: LookingSimilarUiProps<AlgoliaHit<THit>>['itemComponent'];
+        item: LookingSimilarUiProps<Hit<THit>>['itemComponent'];
       };
       cssClasses: Pick<LookingSimilarCSSClasses, 'list' | 'item'>;
     }

--- a/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
+++ b/packages/instantsearch.js/src/widgets/related-products/related-products.tsx
@@ -20,11 +20,10 @@ import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   Template,
   WidgetFactory,
-  AlgoliaHit,
+  Hit,
   Renderer,
   BaseHit,
   RecommendResponse,
-  Hit,
   TemplateWithBindEvent,
 } from '../../types';
 import type {
@@ -89,9 +88,9 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as RelatedProductsUiProps<AlgoliaHit>['headerComponent'];
+    ) as RelatedProductsUiProps<Hit>['headerComponent'];
 
-    const itemComponent: RelatedProductsUiProps<AlgoliaHit>['itemComponent'] =
+    const itemComponent: RelatedProductsUiProps<Hit>['itemComponent'] =
       templates.item
         ? ({ item, sendEvent: _sendEvent, ...rootProps }) => {
             return (
@@ -118,7 +117,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as RelatedProductsUiProps<AlgoliaHit>['emptyComponent'];
+    ) as RelatedProductsUiProps<Hit>['emptyComponent'];
 
     const layoutComponent = (
       templates.layout
@@ -132,7 +131,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
                 items: data.items,
                 templates: {
                   item: templates.item
-                    ? ({ item }: { item: AlgoliaHit<THit> }) => (
+                    ? ({ item }: { item: Hit<THit> }) => (
                         <TemplateComponent
                           {...renderState.templateProps}
                           templateKey="item"
@@ -152,7 +151,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as RelatedProductsUiProps<AlgoliaHit<THit>>['layout'];
+    ) as RelatedProductsUiProps<Hit<THit>>['layout'];
 
     render(
       <RelatedProducts
@@ -178,7 +177,7 @@ export type RelatedProductsTemplates<
   /**
    * Template to use when there are no results.
    */
-  empty: Template<RecommendResponse<AlgoliaHit<THit>>>;
+  empty: Template<RecommendResponse<Hit<THit>>>;
 
   /**
    * Template to use for the header of the widget.
@@ -186,7 +185,7 @@ export type RelatedProductsTemplates<
   header: Template<
     Pick<
       Parameters<
-        NonNullable<RelatedProductsUiProps<AlgoliaHit<THit>>['headerComponent']>
+        NonNullable<RelatedProductsUiProps<Hit<THit>>['headerComponent']>
       >[0],
       'items'
     > & { cssClasses: RecommendClassNames }
@@ -195,20 +194,18 @@ export type RelatedProductsTemplates<
   /**
    * Template to use for each result. This template will receive an object containing a single record.
    */
-  item: TemplateWithBindEvent<AlgoliaHit<THit>>;
+  item: TemplateWithBindEvent<Hit<THit>>;
 
   /**
    * Template to use to wrap all items.
    */
   layout: Template<
     Pick<
-      Parameters<
-        NonNullable<RelatedProductsUiProps<AlgoliaHit<THit>>['layout']>
-      >[0],
+      Parameters<NonNullable<RelatedProductsUiProps<Hit<THit>>['layout']>>[0],
       'items'
     > & {
       templates: {
-        item: RelatedProductsUiProps<AlgoliaHit<THit>>['itemComponent'];
+        item: RelatedProductsUiProps<Hit<THit>>['itemComponent'];
       };
       cssClasses: Pick<RelatedProductsCSSClasses, 'list' | 'item'>;
     }

--- a/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-items/trending-items.tsx
@@ -20,7 +20,6 @@ import type { PreparedTemplateProps } from '../../lib/templating';
 import type {
   Template,
   WidgetFactory,
-  AlgoliaHit,
   Renderer,
   BaseHit,
   RecommendResponse,
@@ -89,9 +88,9 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as TrendingItemsUiProps<AlgoliaHit>['headerComponent'];
+    ) as TrendingItemsUiProps<Hit>['headerComponent'];
 
-    const itemComponent: TrendingItemsUiProps<AlgoliaHit>['itemComponent'] =
+    const itemComponent: TrendingItemsUiProps<Hit>['itemComponent'] =
       templates.item
         ? ({ item, sendEvent: _sendEvent, ...rootProps }) => {
             return (
@@ -118,7 +117,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as TrendingItemsUiProps<AlgoliaHit>['emptyComponent'];
+    ) as TrendingItemsUiProps<Hit>['emptyComponent'];
 
     const layoutComponent = (
       templates.layout
@@ -132,7 +131,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
                 items: data.items,
                 templates: {
                   item: templates.item
-                    ? ({ item }: { item: AlgoliaHit<THit> }) => (
+                    ? ({ item }: { item: Hit<THit> }) => (
                         <TemplateComponent
                           {...renderState.templateProps}
                           templateKey="item"
@@ -152,7 +151,7 @@ function createRenderer<THit extends NonNullable<object> = BaseHit>({
             />
           )
         : undefined
-    ) as TrendingItemsUiProps<AlgoliaHit<THit>>['layout'];
+    ) as TrendingItemsUiProps<Hit<THit>>['layout'];
 
     render(
       <TrendingItems
@@ -177,7 +176,7 @@ export type TrendingItemsTemplates<THit extends NonNullable<object> = BaseHit> =
     /**
      * Template to use when there are no results.
      */
-    empty: Template<RecommendResponse<AlgoliaHit<THit>>>;
+    empty: Template<RecommendResponse<Hit<THit>>>;
 
     /**
      * Template to use for the header of the widget.
@@ -185,7 +184,7 @@ export type TrendingItemsTemplates<THit extends NonNullable<object> = BaseHit> =
     header: Template<
       Pick<
         Parameters<
-          NonNullable<TrendingItemsUiProps<AlgoliaHit<THit>>['headerComponent']>
+          NonNullable<TrendingItemsUiProps<Hit<THit>>['headerComponent']>
         >[0],
         'items'
       > & { cssClasses: RecommendClassNames }
@@ -194,20 +193,18 @@ export type TrendingItemsTemplates<THit extends NonNullable<object> = BaseHit> =
     /**
      * Template to use for each result. This template will receive an object containing a single record.
      */
-    item: TemplateWithBindEvent<AlgoliaHit<THit>>;
+    item: TemplateWithBindEvent<Hit<THit>>;
 
     /**
      * Template to use to wrap all items.
      */
     layout: Template<
       Pick<
-        Parameters<
-          NonNullable<TrendingItemsUiProps<AlgoliaHit<THit>>['layout']>
-        >[0],
+        Parameters<NonNullable<TrendingItemsUiProps<Hit<THit>>['layout']>>[0],
         'items'
       > & {
         templates: {
-          item: TrendingItemsUiProps<AlgoliaHit<THit>>['itemComponent'];
+          item: TrendingItemsUiProps<Hit<THit>>['itemComponent'];
         };
         cssClasses: Pick<TrendingItemsCSSClasses, 'list' | 'item'>;
       }

--- a/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
+++ b/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
@@ -9,11 +9,11 @@ import type {
   FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherPropsUiComponentProps,
   Pragma,
 } from 'instantsearch-ui-components';
-import type { AlgoliaHit, BaseHit } from 'instantsearch.js';
+import type { Hit, BaseHit } from 'instantsearch.js';
 import type { UseFrequentlyBoughtTogetherProps } from 'react-instantsearch-core';
 
 type UiProps<THit extends BaseHit> = Pick<
-  FrequentlyBoughtTogetherPropsUiComponentProps<AlgoliaHit<THit>>,
+  FrequentlyBoughtTogetherPropsUiComponentProps<Hit<THit>>,
   | 'items'
   | 'itemComponent'
   | 'headerComponent'
@@ -24,7 +24,7 @@ type UiProps<THit extends BaseHit> = Pick<
 >;
 
 export type FrequentlyBoughtTogetherProps<THit extends BaseHit> = Omit<
-  FrequentlyBoughtTogetherPropsUiComponentProps<AlgoliaHit<THit>>,
+  FrequentlyBoughtTogetherPropsUiComponentProps<Hit<THit>>,
   keyof UiProps<THit>
 > &
   UseFrequentlyBoughtTogetherProps<THit> & {

--- a/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
+++ b/packages/react-instantsearch/src/widgets/FrequentlyBoughtTogether.tsx
@@ -9,7 +9,7 @@ import type {
   FrequentlyBoughtTogetherProps as FrequentlyBoughtTogetherPropsUiComponentProps,
   Pragma,
 } from 'instantsearch-ui-components';
-import type { AlgoliaHit, BaseHit, Hit } from 'instantsearch.js';
+import type { AlgoliaHit, BaseHit } from 'instantsearch.js';
 import type { UseFrequentlyBoughtTogetherProps } from 'react-instantsearch-core';
 
 type UiProps<THit extends BaseHit> = Pick<
@@ -86,7 +86,7 @@ export function FrequentlyBoughtTogether<THit extends BaseHit = BaseHit>({
   );
 
   const uiProps: UiProps<THit> = {
-    items: items as Array<Hit<THit>>,
+    items,
     itemComponent: _itemComponent,
     headerComponent,
     emptyComponent,

--- a/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
+++ b/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
@@ -6,11 +6,11 @@ import type {
   LookingSimilarProps as LookingSimilarPropsUiComponentProps,
   Pragma,
 } from 'instantsearch-ui-components';
-import type { AlgoliaHit, BaseHit } from 'instantsearch.js';
+import type { Hit, BaseHit } from 'instantsearch.js';
 import type { UseLookingSimilarProps } from 'react-instantsearch-core';
 
 type UiProps<THit extends BaseHit> = Pick<
-  LookingSimilarPropsUiComponentProps<AlgoliaHit<THit>>,
+  LookingSimilarPropsUiComponentProps<Hit<THit>>,
   | 'items'
   | 'itemComponent'
   | 'headerComponent'
@@ -21,7 +21,7 @@ type UiProps<THit extends BaseHit> = Pick<
 >;
 
 export type LookingSimilarProps<THit extends BaseHit> = Omit<
-  LookingSimilarPropsUiComponentProps<AlgoliaHit<THit>>,
+  LookingSimilarPropsUiComponentProps<Hit<THit>>,
   keyof UiProps<THit>
 > &
   UseLookingSimilarProps<THit> & {

--- a/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
+++ b/packages/react-instantsearch/src/widgets/LookingSimilar.tsx
@@ -6,7 +6,7 @@ import type {
   LookingSimilarProps as LookingSimilarPropsUiComponentProps,
   Pragma,
 } from 'instantsearch-ui-components';
-import type { AlgoliaHit, BaseHit, Hit } from 'instantsearch.js';
+import type { AlgoliaHit, BaseHit } from 'instantsearch.js';
 import type { UseLookingSimilarProps } from 'react-instantsearch-core';
 
 type UiProps<THit extends BaseHit> = Pick<
@@ -84,7 +84,7 @@ export function LookingSimilar<THit extends BaseHit = BaseHit>({
   );
 
   const uiProps: UiProps<THit> = {
-    items: items as Array<Hit<THit>>,
+    items,
     itemComponent: _itemComponent,
     headerComponent,
     emptyComponent,


### PR DESCRIPTION
**Summary**

Follow-up on #6533

When using `sendEvent` with Recommend in InstantSearch.js we encounter a typing issue

```
Type 'AlgoliaHit<Record<string, any>>' is not assignable to type 'Hit'.
  Property '__position' is missing in type 'AlgoliaHit<Record<string, any>>' but required in type '{ __position: number; __queryID?: string | undefined; }'
```

codesandbox to demonstrate the type issue https://codesandbox.io/p/sandbox/nzkfh7

This is because `AlgoliaHit` is only meant for hits that don't first go through `addAbsolutePosition` and `addQueryId`. This means that the type we actually mean to use is Hit in most cases.


**Result**

The issue was not caught by `yarn type-check` initially, I'm not sure how we could have done better to automatically catch it.
