### PR TITLE
feat: expose raw request content under _rawContent

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "65.55 kB"
+      "maxSize": "65.75 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -1844,7 +1844,7 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function (
   if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
 
   var results = content.results.slice();
-  var rawContent = content;
+  var rawContent = Object.create(content);
   delete rawContent.results;
 
   states.forEach(function (s) {
@@ -1867,7 +1867,9 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function (
       self._searchResultsOptions
     );
 
-    helper.lastResults._rawContent = rawContent;
+    if (Object.keys(rawContent).length > 0) {
+      helper.lastResults._rawContent = rawContent;
+    }
 
     helper.emit('result', {
       results: helper.lastResults,

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -1844,6 +1844,8 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function (
   if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
 
   var results = content.results.slice();
+  var rawContent = content;
+  delete rawContent.results;
 
   states.forEach(function (s) {
     var state = s.state;
@@ -1864,6 +1866,8 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function (
       specificResults,
       self._searchResultsOptions
     );
+
+    helper.lastResults._rawContent = rawContent;
 
     helper.emit('result', {
       results: helper.lastResults,

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -1846,6 +1846,9 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function (
   var results = content.results.slice();
   var rawContent = Object.create(content);
   delete rawContent.results;
+  if (Object.keys(rawContent).length <= 0) {
+    rawContent = undefined;
+  }
 
   states.forEach(function (s) {
     var state = s.state;
@@ -1866,14 +1869,12 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function (
       specificResults,
       self._searchResultsOptions
     );
-
-    if (Object.keys(rawContent).length > 0) {
-      helper.lastResults._rawContent = rawContent;
-    }
+    helper.lastResults._rawContent = rawContent;
 
     helper.emit('result', {
       results: helper.lastResults,
       state: state,
+      _rawContent: rawContent,
     });
   });
 };

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -652,12 +652,6 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
           new algoliasearchHelper.SearchParameters(indexInitialResults.state),
           indexInitialResults.results
         );
-        if (
-          '_rawContent' in indexInitialResults &&
-          indexInitialResults._rawContent
-        ) {
-          results._rawResults = indexInitialResults?._rawContent as any;
-        }
 
         derivedHelper.lastResults = results;
         helper.lastResults = results;

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -652,6 +652,12 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
           new algoliasearchHelper.SearchParameters(indexInitialResults.state),
           indexInitialResults.results
         );
+        if (
+          '_rawContent' in indexInitialResults &&
+          indexInitialResults._rawContent
+        ) {
+          results._rawResults = indexInitialResults?._rawContent as any;
+        }
 
         derivedHelper.lastResults = results;
         helper.lastResults = results;


### PR DESCRIPTION
**Summary**

In order to access some composition-related data (when `getRankingInfo` is requested), we need to access the root content of the API response, not just `results` (cf. [last example on this doc](https://algolia.atlassian.net/wiki/spaces/CMP/pages/5556273184/DD+-+Composition+API+updates)).

**Result**

exposing the root content of the API response (excluding `results` that is already exposed) through a `_rawContent` non-documented & non-typed property on search results.

it can therefor be accessed like this:
```ts
const { results: { _rawContent } } = useInstantSearch();
```