### PR TITLE
fix: rawContent was not correctly cloned (hence undefined)

### DIFF
--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -1844,7 +1844,7 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function (
   if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
 
   var results = content.results.slice();
-  var rawContent = Object.create(content);
+  var rawContent = Object.assign({}, content);
   delete rawContent.results;
   if (Object.keys(rawContent).length <= 0) {
     rawContent = undefined;

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -1844,8 +1844,11 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function (
   if (this._currentNbQueries === 0) this.emit('searchQueueEmpty');
 
   var results = content.results.slice();
-  var rawContent = Object.assign({}, content);
-  delete rawContent.results;
+  var rawContent = Object.keys(content).reduce(function (value, key) {
+    if (key !== 'results') value[key] = content[key];
+    return value;
+  }, {});
+
   if (Object.keys(rawContent).length <= 0) {
     rawContent = undefined;
   }
@@ -1869,12 +1872,11 @@ AlgoliaSearchHelper.prototype._dispatchAlgoliaResponse = function (
       specificResults,
       self._searchResultsOptions
     );
-    helper.lastResults._rawContent = rawContent;
+    if (rawContent !== undefined) helper.lastResults._rawContent = rawContent;
 
     helper.emit('result', {
       results: helper.lastResults,
       state: state,
-      _rawContent: rawContent,
     });
   });
 };


### PR DESCRIPTION
**Summary**

Fixing an error made in #6544, where using `Object.create(content)` resulted in `rawContent` always being an empty object and the final `_rawContent` property always being `undefined`.
Now using a custom method to smartly clone `content` without the `results` property, which behaves correctly.

This approach avoids the need to delete the `results` property as it "just" creates a new object without it in the first place.
This result in a more performant approach than using the existing `merge` util + deleting the `results` property afterward.

**Result**

`_rawContent` as retrieved in the below example is now not always `undefined` anymore.

```ts
const { results: { _rawContent } } = useInstantSearch();
```

