### PR TITLE
feat(helper): remove previousPage and nextPage

### DIFF
--- a/packages/algoliasearch-helper/index.d.ts
+++ b/packages/algoliasearch-helper/index.d.ts
@@ -305,8 +305,6 @@ declare namespace algoliasearchHelper {
     toggleFacetExclusion(facet: string, value: string): this;
     toggleFacetRefinement(facet: string, value: string): this;
     toggleTag(tag: string): this;
-    nextPage(): this;
-    previousPage(): this;
     setPage(page: number): this;
     setQueryParameter<SearchParameter extends keyof PlainSearchParameters>(
       parameter: SearchParameter,

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -1021,34 +1021,6 @@ AlgoliaSearchHelper.prototype.toggleTag = function (tag) {
 };
 
 /**
- * Increments the page number by one.
- * @return {AlgoliaSearchHelper} Method is chainable, it returns itself
- * @fires change
- * @chainable
- * @example
- * helper.setPage(0).nextPage().getPage();
- * // returns 1
- */
-AlgoliaSearchHelper.prototype.nextPage = function () {
-  var page = this.state.page || 0;
-  return this.setPage(page + 1);
-};
-
-/**
- * Decrements the page number by one.
- * @fires change
- * @return {AlgoliaSearchHelper} Method is chainable, it returns itself
- * @chainable
- * @example
- * helper.setPage(1).previousPage().getPage();
- * // returns 0
- */
-AlgoliaSearchHelper.prototype.previousPage = function () {
-  var page = this.state.page || 0;
-  return this.setPage(page - 1);
-};
-
-/**
  * Updates the current page.
  * @function
  * @param  {number} page The page number

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/pages.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/pages.js
@@ -4,7 +4,7 @@ var algoliasearchHelper = require('../../../index');
 
 var fakeClient = {};
 
-test('setChange should change the current page', function () {
+test('setPage should change the current page', function () {
   var helper = algoliasearchHelper(fakeClient, null, null);
 
   expect(helper.getPage()).toBeUndefined();
@@ -12,40 +12,6 @@ test('setChange should change the current page', function () {
   helper.setPage(3);
 
   expect(helper.getPage()).toBe(3);
-});
-
-test('nextPage should increment the page by one', function () {
-  var helper = algoliasearchHelper(fakeClient, null, null);
-
-  expect(helper.getPage()).toBeUndefined();
-
-  helper.nextPage();
-  helper.nextPage();
-  helper.nextPage();
-
-  expect(helper.getPage()).toBe(3);
-});
-
-test('previousPage should decrement the current page by one', function () {
-  var helper = algoliasearchHelper(fakeClient, null, null);
-
-  expect(helper.getPage()).toBeUndefined();
-
-  helper.setPage(3);
-
-  expect(helper.getPage()).toBe(3);
-
-  helper.previousPage();
-
-  expect(helper.getPage()).toBe(2);
-});
-
-test('previousPage should throw an error without a current page', function () {
-  var helper = algoliasearchHelper(fakeClient, null, null);
-
-  expect(function () {
-    helper.previousPage();
-  }).toThrow('Page requested below 0.');
 });
 
 test('pages should be reset if the mutation might change the number of pages', function () {


### PR DESCRIPTION
These functions are redundant with the setPage and setQueryParameter/s/setState functions and aren't used in InstantSearch

BREAKING CHANGE: remove usage of helper.previousPage, helper.nextPage and use setPage, setState or setQueryParameter instead
