### PR TITLE
fix(create-instantsearch-app): fix corejs version in vue-is template 

### DIFF
--- a/packages/create-instantsearch-app/src/templates/Vue InstantSearch/package.json
+++ b/packages/create-instantsearch-app/src/templates/Vue InstantSearch/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "algoliasearch": "4",
-    "core-js": "3.6.5",
+    "core-js": "3.40.0",
     "vue": "2.6.11",
     "vue-instantsearch": "{{libraryVersion}}"
   },


### PR DESCRIPTION
**Summary**
Using the vue instantsearch template with the `create-instantsearch-app` results in a dependency error when running `yarn start`. This fixes the `core-js` version to prevent that.

TODO:
- Check if other templates have the same error
