### PR TITLE
chore(examples): update react ssr webpack config

### DIFF
--- a/examples/react/ssr/package.json
+++ b/examples/react/ssr/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "webpack && nodemon dist/server.js",
     "watch": "webpack --watch",
-    "build": "webpack --mode=production"
+    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --mode=production"
   },
   "devDependencies": {
     "@babel/core": "7.15.5",

--- a/examples/react/ssr/webpack.config.js
+++ b/examples/react/ssr/webpack.config.js
@@ -1,64 +1,62 @@
 const path = require('path');
 
+const webpack = require('webpack');
 const nodeExternals = require('webpack-node-externals');
 
-module.exports = [
-  {
+module.exports = (_, { mode }) => {
+  const common = {
     mode: 'development',
-    entry: ['@babel/polyfill', './src/server.js'],
-    output: {
-      path: path.join(__dirname, 'dist'),
-      filename: 'server.js',
-      libraryTarget: 'commonjs2',
-      publicPath: '/',
-    },
-    target: 'node',
-    node: {
-      console: false,
-      global: false,
-      process: false,
-      Buffer: false,
-      __filename: false,
-      __dirname: false,
-    },
-    externals: nodeExternals(),
+    plugins: [new webpack.DefinePlugin({ __DEV__: mode !== 'production' })],
     module: {
       rules: [
         {
           test: /\.js$/,
-          exclude: /node_modules\/(?!(algoliasearch)\/).*/,
+          exclude: /node_modules\/(?!(algoliasearch|@algolia)\/).*/,
           use: [
             {
               loader: 'babel-loader',
+              options: {
+                rootMode: 'upward',
+              },
             },
           ],
         },
       ],
     },
-  },
-  {
-    mode: 'development',
-    entry: ['@babel/polyfill', './src/browser.js'],
-    output: {
-      path: path.join(__dirname, 'dist/assets'),
-      publicPath: '/',
-      filename: 'bundle.js',
+  };
+
+  return [
+    {
+      ...common,
+      entry: ['@babel/polyfill', './src/server.js'],
+      output: {
+        path: path.join(__dirname, 'dist'),
+        filename: 'server.js',
+        libraryTarget: 'commonjs2',
+        publicPath: '/',
+      },
+      target: 'node',
+      node: {
+        console: false,
+        global: false,
+        process: false,
+        Buffer: false,
+        __filename: false,
+        __dirname: false,
+      },
+      externals: nodeExternals(),
     },
-    module: {
-      rules: [
-        {
-          test: /\.js$/,
-          exclude: /node_modules\/(?!(algoliasearch)\/).*/,
-          use: [
-            {
-              loader: 'babel-loader',
-            },
-          ],
-        },
-      ],
+    {
+      ...common,
+      entry: ['@babel/polyfill', './src/browser.js'],
+      output: {
+        path: path.join(__dirname, 'dist/assets'),
+        publicPath: '/',
+        filename: 'bundle.js',
+      },
+      resolve: {
+        extensions: ['.js', '.jsx'],
+      },
     },
-    resolve: {
-      extensions: ['.js', '.jsx'],
-    },
-  },
-];
+  ];
+};


### PR DESCRIPTION
**Summary**

This PR updates the webpack config for the **examples/react/ssr** to fix an issue between babel and algoliasearch's transitive dependencies.

It also adds a node option to fix an issue during production build generation.
