### PR TITLE
feat: use vanilla css reset

### DIFF
--- a/examples/react/css/src/App.tsx
+++ b/examples/react/css/src/App.tsx
@@ -106,11 +106,11 @@ export function App() {
 }
 
 function HitComponent({ hit }: { hit: Hit }) {
-  return Item({ hit });
+  return <Item hit={hit} />;
 }
 
 function ItemComponent({ item }: { item: Hit }) {
-  return Item({ hit: item });
+  return <Item hit={item} />;
 }
 
 function Item({ hit }: { hit: Hit }) {

--- a/examples/react/css/src/algolia.css
+++ b/examples/react/css/src/algolia.css
@@ -1,0 +1,1 @@
+@import url('reset.css');

--- a/examples/react/css/src/reset.css
+++ b/examples/react/css/src/reset.css
@@ -108,17 +108,17 @@ a[class^='ais-'] {
 
 /* Reset SearchBox input */
 .ais-SearchBox-input {
-  :-ms-clear,
-  ::-ms-reveal {
+  &:-ms-clear,
+  &::-ms-reveal {
     display: none;
     width: 0;
     height: 0;
   }
 
-  ::-webkit-search-decoration,
-  ::-webkit-search-cancel-button,
-  ::-webkit-search-results-button,
-  ::-webkit-search-results-decoration {
+  &::-webkit-search-decoration,
+  &::-webkit-search-cancel-button,
+  &::-webkit-search-results-button,
+  &::-webkit-search-results-decoration {
     display: none;
   }
 }

--- a/examples/react/css/src/reset.css
+++ b/examples/react/css/src/reset.css
@@ -1,3 +1,11 @@
+[class^='ais-'] {
+  box-sizing: border-box;
+}
+
+a[class^='ais-'] {
+  text-decoration: none;
+}
+
 /* Reset all lists */
 .ais-Breadcrumb-list,
 .ais-Carousel-list,
@@ -98,163 +106,19 @@
   overflow-anchor: none;
 }
 
-/* Reset widgets */
-.ais-Breadcrumb-list,
-.ais-Breadcrumb-item,
-.ais-Pagination-list,
-.ais-RangeInput-form,
-.ais-RatingMenu-link,
-.ais-PoweredBy {
-  display: flex;
-  align-items: center;
-}
-
-.ais-GeoSearch,
-.ais-GeoSearch-map {
-  height: 100%;
-}
-
-.ais-HierarchicalMenu-list .ais-HierarchicalMenu-list {
-  margin-left: 1em;
-}
-
-.ais-PoweredBy-logo {
-  display: block;
-  height: 1.2em;
-  width: auto;
-}
-
-.ais-PoweredBy-text {
-  margin-right: 0.3rem;
-}
-
-.ais-RatingMenu-starIcon {
-  display: block;
-  width: 20px;
-  height: 20px;
-}
-
 /* Reset SearchBox input */
-.ais-SearchBox-input::-ms-clear,
-.ais-SearchBox-input::-ms-reveal {
-  display: none;
-  width: 0;
-  height: 0;
-}
-
-.ais-SearchBox-input::-webkit-search-decoration,
-.ais-SearchBox-input::-webkit-search-cancel-button,
-.ais-SearchBox-input::-webkit-search-results-button,
-.ais-SearchBox-input::-webkit-search-results-decoration {
-  display: none;
-}
-
-/* Reset RangeSlider */
-.ais-RangeSlider .rheostat {
-  overflow: visible;
-  margin-top: 40px;
-  margin-bottom: 40px;
-}
-
-.ais-RangeSlider .rheostat-background {
-  height: 6px;
-  top: 0px;
-  width: 100%;
-}
-
-.ais-RangeSlider .rheostat-handle {
-  margin-left: -12px;
-  top: -7px;
-}
-
-.ais-RangeSlider .rheostat-background {
-  position: relative;
-  background-color: #ffffff;
-  border: 1px solid #aaa;
-}
-
-.ais-RangeSlider .rheostat-progress {
-  position: absolute;
-  top: 1px;
-  height: 4px;
-  background-color: #333;
-}
-
-.rheostat-handle {
-  position: relative;
-  z-index: 1;
-  width: 20px;
-  height: 20px;
-  background-color: #fff;
-  border: 1px solid #333;
-  border-radius: 50%;
-  cursor: grab;
-}
-
-.rheostat-marker {
-  margin-left: -1px;
-  position: absolute;
-  width: 1px;
-  height: 5px;
-  background-color: #aaa;
-}
-
-.rheostat-marker--large {
-  height: 9px;
-}
-
-.rheostat-value {
-  margin-left: 50%;
-  padding-top: 15px;
-  position: absolute;
-  text-align: center;
-  transform: translateX(-50%);
-}
-
-.rheostat-tooltip {
-  margin-left: 50%;
-  position: absolute;
-  top: -22px;
-  text-align: center;
-  transform: translateX(-50%);
-}
-
-/* Reset Carousel */
-.ais-Carousel {
-  position: relative;
-}
-
-.ais-Carousel-list {
-  grid-auto-columns: 42%;
-  display: grid;
-  grid-auto-flow: column;
-  overflow-x: auto;
-  scroll-behavior: smooth;
-  scroll-snap-type: x proximity;
-}
-
-@media (min-width: 999px) {
-  .ais-Carousel-list {
-    grid-auto-columns: 20%;
+.ais-SearchBox-input {
+  :-ms-clear,
+  ::-ms-reveal {
+    display: none;
+    width: 0;
+    height: 0;
   }
-}
 
-.ais-Carousel-navigation {
-  position: absolute;
-  top: 35%;
-  z-index: 1;
-}
-
-.ais-Carousel-navigation--previous {
-  left: 0;
-  transform: translateX(-25%);
-}
-
-.ais-Carousel-navigation--next {
-  right: 0;
-  transform: translateX(25%);
-}
-
-.ais-Carousel-item {
-  scroll-snap-align: start;
+  ::-webkit-search-decoration,
+  ::-webkit-search-cancel-button,
+  ::-webkit-search-results-button,
+  ::-webkit-search-results-decoration {
+    display: none;
+  }
 }

--- a/examples/react/css/src/reset.css
+++ b/examples/react/css/src/reset.css
@@ -1,0 +1,260 @@
+/* Reset all lists */
+.ais-Breadcrumb-list,
+.ais-Carousel-list,
+.ais-CurrentRefinements-list,
+.ais-HierarchicalMenu-list,
+.ais-Hits-list,
+.ais-FrequentlyBoughtTogether-list,
+.ais-LookingSimilar-list,
+.ais-RelatedProducts-list,
+.ais-TrendingItems-list,
+.ais-Results-list,
+.ais-InfiniteHits-list,
+.ais-InfiniteResults-list,
+.ais-Menu-list,
+.ais-NumericMenu-list,
+.ais-Pagination-list,
+.ais-RatingMenu-list,
+.ais-RefinementList-list,
+.ais-ToggleRefinement-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Reset all buttons */
+.ais-Carousel-navigation,
+.ais-ClearRefinements-button,
+.ais-CurrentRefinements-delete,
+.ais-CurrentRefinements-reset,
+.ais-GeoSearch-redo,
+.ais-GeoSearch-reset,
+.ais-HierarchicalMenu-showMore,
+.ais-InfiniteHits-loadPrevious,
+.ais-InfiniteHits-loadMore,
+.ais-InfiniteResults-loadMore,
+.ais-Menu-showMore,
+.ais-RangeInput-submit,
+.ais-RefinementList-showMore,
+.ais-SearchBox-submit,
+.ais-SearchBox-reset,
+.ais-VoiceSearch-button {
+  padding: 0;
+  overflow: visible;
+  font: inherit;
+  line-height: normal;
+  color: inherit;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  user-select: none;
+}
+
+.ais-Carousel-navigation::-moz-focus-inner,
+.ais-ClearRefinements-button::-moz-focus-inner,
+.ais-CurrentRefinements-delete::-moz-focus-inner,
+.ais-CurrentRefinements-reset::-moz-focus-inner,
+.ais-GeoSearch-redo::-moz-focus-inner,
+.ais-GeoSearch-reset::-moz-focus-inner,
+.ais-HierarchicalMenu-showMore::-moz-focus-inner,
+.ais-InfiniteHits-loadPrevious::-moz-focus-inner,
+.ais-InfiniteHits-loadMore::-moz-focus-inner,
+.ais-InfiniteResults-loadMore::-moz-focus-inner,
+.ais-Menu-showMore::-moz-focus-inner,
+.ais-RangeInput-submit::-moz-focus-inner,
+.ais-RefinementList-showMore::-moz-focus-inner,
+.ais-SearchBox-submit::-moz-focus-inner,
+.ais-SearchBox-reset::-moz-focus-inner,
+.ais-VoiceSearch-button::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+
+.ais-Carousel-navigation[disabled],
+.ais-ClearRefinements-button[disabled],
+.ais-CurrentRefinements-delete[disabled],
+.ais-CurrentRefinements-reset[disabled],
+.ais-GeoSearch-redo[disabled],
+.ais-GeoSearch-reset[disabled],
+.ais-HierarchicalMenu-showMore[disabled],
+.ais-InfiniteHits-loadPrevious[disabled],
+.ais-InfiniteHits-loadMore[disabled],
+.ais-InfiniteResults-loadMore[disabled],
+.ais-Menu-showMore[disabled],
+.ais-RangeInput-submit[disabled],
+.ais-RefinementList-showMore[disabled],
+.ais-SearchBox-submit[disabled],
+.ais-SearchBox-reset[disabled],
+.ais-VoiceSearch-button[disabled] {
+  cursor: default;
+}
+
+/* Prevent InfiniteHits buttons from moving scroll position */
+.ais-InfiniteHits-loadPrevious,
+.ais-InfiniteHits-loadMore,
+.ais-HierarchicalMenu-showMore,
+.ais-Menu-showMore,
+.ais-RefinementList-showMore {
+  overflow-anchor: none;
+}
+
+/* Reset widgets */
+.ais-Breadcrumb-list,
+.ais-Breadcrumb-item,
+.ais-Pagination-list,
+.ais-RangeInput-form,
+.ais-RatingMenu-link,
+.ais-PoweredBy {
+  display: flex;
+  align-items: center;
+}
+
+.ais-GeoSearch,
+.ais-GeoSearch-map {
+  height: 100%;
+}
+
+.ais-HierarchicalMenu-list .ais-HierarchicalMenu-list {
+  margin-left: 1em;
+}
+
+.ais-PoweredBy-logo {
+  display: block;
+  height: 1.2em;
+  width: auto;
+}
+
+.ais-PoweredBy-text {
+  margin-right: 0.3rem;
+}
+
+.ais-RatingMenu-starIcon {
+  display: block;
+  width: 20px;
+  height: 20px;
+}
+
+/* Reset SearchBox input */
+.ais-SearchBox-input::-ms-clear,
+.ais-SearchBox-input::-ms-reveal {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.ais-SearchBox-input::-webkit-search-decoration,
+.ais-SearchBox-input::-webkit-search-cancel-button,
+.ais-SearchBox-input::-webkit-search-results-button,
+.ais-SearchBox-input::-webkit-search-results-decoration {
+  display: none;
+}
+
+/* Reset RangeSlider */
+.ais-RangeSlider .rheostat {
+  overflow: visible;
+  margin-top: 40px;
+  margin-bottom: 40px;
+}
+
+.ais-RangeSlider .rheostat-background {
+  height: 6px;
+  top: 0px;
+  width: 100%;
+}
+
+.ais-RangeSlider .rheostat-handle {
+  margin-left: -12px;
+  top: -7px;
+}
+
+.ais-RangeSlider .rheostat-background {
+  position: relative;
+  background-color: #ffffff;
+  border: 1px solid #aaa;
+}
+
+.ais-RangeSlider .rheostat-progress {
+  position: absolute;
+  top: 1px;
+  height: 4px;
+  background-color: #333;
+}
+
+.rheostat-handle {
+  position: relative;
+  z-index: 1;
+  width: 20px;
+  height: 20px;
+  background-color: #fff;
+  border: 1px solid #333;
+  border-radius: 50%;
+  cursor: grab;
+}
+
+.rheostat-marker {
+  margin-left: -1px;
+  position: absolute;
+  width: 1px;
+  height: 5px;
+  background-color: #aaa;
+}
+
+.rheostat-marker--large {
+  height: 9px;
+}
+
+.rheostat-value {
+  margin-left: 50%;
+  padding-top: 15px;
+  position: absolute;
+  text-align: center;
+  transform: translateX(-50%);
+}
+
+.rheostat-tooltip {
+  margin-left: 50%;
+  position: absolute;
+  top: -22px;
+  text-align: center;
+  transform: translateX(-50%);
+}
+
+/* Reset Carousel */
+.ais-Carousel {
+  position: relative;
+}
+
+.ais-Carousel-list {
+  grid-auto-columns: 42%;
+  display: grid;
+  grid-auto-flow: column;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  scroll-snap-type: x proximity;
+}
+
+@media (min-width: 999px) {
+  .ais-Carousel-list {
+    grid-auto-columns: 20%;
+  }
+}
+
+.ais-Carousel-navigation {
+  position: absolute;
+  top: 35%;
+  z-index: 1;
+}
+
+.ais-Carousel-navigation--previous {
+  left: 0;
+  transform: translateX(-25%);
+}
+
+.ais-Carousel-navigation--next {
+  right: 0;
+  transform: translateX(25%);
+}
+
+.ais-Carousel-item {
+  scroll-snap-align: start;
+}


### PR DESCRIPTION
Would like to of utilised css nesting but couldn't get Parcel configured correctly.

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

Use Vanilla CSS for the reset instead of Scss

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Move on from Scss and use native CSS

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
