### PR TITLE
poc: add `Hits`, `Highlight` and `Snippet` styles

### DIFF
--- a/examples/react/css/src/App.css
+++ b/examples/react/css/src/App.css
@@ -13,13 +13,17 @@ body {
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
   background-color: #fff;
   color: #222;
-}
 
-@media (prefers-color-scheme: dark) {
-  body {
+  @media (prefers-color-scheme: dark) {
     background-color: #222;
     color: #fff;
   }
+}
+
+a:focus-visible {
+  outline: 2px solid
+    rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
+  outline-offset: 2px;
 }
 
 .header {
@@ -30,6 +34,7 @@ body {
   position: fixed;
   top: 0;
   width: 100%;
+  z-index: 10;
   @media (prefers-color-scheme: dark) {
     box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05),
       0 1px 3px 0 rgba(255, 255, 255, 0.15);
@@ -58,4 +63,98 @@ body {
 
 .breadcrumbs-wrapper {
   margin-block: 1rem;
+}
+
+/* Hits */
+.hit {
+  position: relative;
+  height: 100%;
+  line-height: 1.4;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.hit-image-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #fff;
+  aspect-ratio: 1;
+  padding: 1rem;
+  overflow: hidden;
+  position: relative;
+  &:before {
+    transition: opacity var(--ais-transition-duration)
+      var(--ais-transition-timing-function);
+    content: '';
+    opacity: 0;
+    pointer-events: none;
+    display: block;
+    inset: 0;
+    background-color: rgba(255, 255, 255, 0.2);
+    position: absolute;
+    z-index: 1;
+  }
+}
+
+.hit-image {
+  height: auto;
+  max-height: 100%;
+  max-width: 100%;
+  transition: transform var(--ais-transition-duration)
+    var(--ais-transition-timing-function);
+}
+
+.hit-infos {
+  padding: var(--ais-spacing);
+  display: flex;
+  flex-direction: column;
+  row-gap: calc(var(--ais-spacing) / 2);
+  flex: 1;
+}
+
+.hit-category {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgb(var(--ais-muted-color-rgb));
+}
+
+.hit-title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.hit-link {
+  text-decoration: none;
+  color: inherit;
+}
+
+.hit-link-overlay {
+  inset: 0;
+  position: absolute;
+  z-index: 1;
+}
+
+.hit-description {
+  font-size: 0.9rem;
+  opacity: 0.8;
+  margin: 0;
+}
+
+.hit-price {
+  margin-top: auto;
+  font-weight: 500;
+}
+
+@media (hover: hover) {
+  .ais-Hits-item:hover {
+    .hit-image {
+      transform: scale(1.05);
+    }
+
+    .hit-image-container:before {
+      opacity: 1;
+    }
+  }
 }

--- a/examples/react/css/src/App.tsx
+++ b/examples/react/css/src/App.tsx
@@ -39,7 +39,7 @@ export function App() {
       indexName="instant_search"
       insights={true}
     >
-      <Configure hitsPerPage={8} snippetEllipsisText="…" />
+      <Configure hitsPerPage={12} snippetEllipsisText="…" />
       <header className="header">
         <SearchBox placeholder="Search for products…" />
       </header>
@@ -118,19 +118,34 @@ function ItemComponent({ item }: { item: Hit }) {
   return <Item hit={item} />;
 }
 
+function formatToDollar(amount: number, locale = 'en-US', currency = 'USD') {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
 function Item({ hit }: { hit: Hit }) {
   return (
-    <article>
-      <img src={hit.image} />
-      <h2>
-        <a href={`/products.html?pid=${hit.objectID}`}>
-          <Highlight attribute="name" hit={hit} />
-        </a>
-      </h2>
-      <p>
-        <Snippet attribute="description" hit={hit} />
-      </p>
-      <a href={`/products.html?pid=${hit.objectID}`}>See product</a>
+    <article className="hit">
+      <div className="hit-image-container">
+        <img src={hit.image} className="hit-image" />
+      </div>
+      <div className="hit-infos">
+        <p className="hit-category">{hit.categories?.[0]}</p>
+        <h2 className="hit-title">
+          <a href={`/products.html?pid=${hit.objectID}`} className="hit-link">
+            <span aria-hidden className="hit-link-overlay" />
+            <Highlight attribute="name" hit={hit} />
+          </a>
+        </h2>
+        <p className="hit-description">
+          <Snippet attribute="description" hit={hit} />
+        </p>
+        <div className="hit-price">{formatToDollar(hit.price)}</div>
+      </div>
     </article>
   );
 }

--- a/examples/react/css/src/algolia.css
+++ b/examples/react/css/src/algolia.css
@@ -11,3 +11,5 @@
 @import url('panel.css');
 @import url('pagination.css');
 @import url('hits-per-page.css');
+@import url('hits.css');
+@import url('highlight.css');

--- a/examples/react/css/src/highlight.css
+++ b/examples/react/css/src/highlight.css
@@ -1,0 +1,13 @@
+.ais-Highlight-highlighted,
+.ais-Snippet-highlighted {
+  background-color: rgba(
+    var(--ais-primary-color-rgb),
+    var(--ais-primary-color-alpha)
+  );
+  color: rgba(
+    var(--ais-button-text-color-rgb),
+    var(--ais-button-text-color-alpha)
+  );
+  border-radius: var(--ais-radius-xs);
+  padding: calc(var(--ais-spacing) * 0.125);
+}

--- a/examples/react/css/src/highlight.css
+++ b/examples/react/css/src/highlight.css
@@ -1,13 +1,7 @@
 .ais-Highlight-highlighted,
 .ais-Snippet-highlighted {
-  background-color: rgba(
-    var(--ais-primary-color-rgb),
-    var(--ais-primary-color-alpha)
-  );
-  color: rgba(
-    var(--ais-button-text-color-rgb),
-    var(--ais-button-text-color-alpha)
-  );
-  border-radius: var(--ais-radius-xs);
+  background-color: rgba(var(--ais-primary-color-rgb), 0.2);
+  color: rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
+  border-radius: 2px;
   padding: calc(var(--ais-spacing) * 0.125);
 }

--- a/examples/react/css/src/hits.css
+++ b/examples/react/css/src/hits.css
@@ -1,0 +1,31 @@
+.ais-Hits-list {
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(var(--ais-hit-min-width), 1fr)
+  );
+  gap: var(--ais-spacing);
+}
+
+.ais-Hits-item {
+  overflow: hidden;
+  background-color: rgba(
+    var(--ais-background-color-rgb),
+    var(--ais-background-color-alpha)
+  );
+  border-radius: var(--ais-radius-xs);
+  box-shadow: var(--ais-shadow-xs);
+  border: 1px solid
+    rgba(var(--ais-border-color-rgb), var(--ais-border-color-alpha));
+  transition: box-shadow var(--ais-transition-duration)
+      var(--ais-transition-timing-function),
+    background-color var(--ais-transition-duration)
+      var(--ais-transition-timing-function);
+
+  @media (hover: hover) {
+    &:hover {
+      box-shadow: var(--ais-shadow-md);
+      background-color: rgba(var(--ais-primary-color-rgb), 0.05);
+    }
+  }
+}

--- a/examples/react/css/src/variables.css
+++ b/examples/react/css/src/variables.css
@@ -25,6 +25,7 @@
   /* Size and spacing */
   --ais-spacing: 1rem;
   --ais-icon-stroke-width: 1.6;
+  --ais-hit-min-width: 200px;
 
   /* Font */
   --ais-font-family: inherit;
@@ -67,6 +68,9 @@
 
     /* Background color */
     --ais-background-color-rgb: 18, 18, 18;
+
+    /* Shadow color */
+    --ais-shadow-color-rgb: 221, 209, 197;
 
     /* SVG icons */
     /* Use --ais-text-color-rgb: 235, 235, 235; and stroke-width: 1.6; */


### PR DESCRIPTION
**Summary**

This adds the `Hits`, `Highlight` and `Snippet` styles.

<img src="https://github.com/user-attachments/assets/57d87b75-78e7-4440-bf29-43f235e5f58a" alt="Hits in light mode" width="600">
<img src="https://github.com/user-attachments/assets/3138dc60-f75d-4e2c-9a57-1de087c54835" alt="Hits in dark mode" width="600">
