### PR TITLE
fix(ssr-example): responsesCache instead of requestsCache

### DIFF
--- a/examples/react/ssr/src/searchClient.js
+++ b/examples/react/ssr/src/searchClient.js
@@ -1,11 +1,11 @@
 import { createMemoryCache } from '@algolia/client-common';
 import { liteClient as algoliasearch } from 'algoliasearch/lite';
 
-export const requestsCache = createMemoryCache();
+export const responsesCache = createMemoryCache();
 export const searchClient = algoliasearch(
   'latency',
   '6be0576ff61c053d5f9a3225e2a90f76',
   {
-    requestsCache,
+    responsesCache,
   }
 );

--- a/examples/react/ssr/src/server.js
+++ b/examples/react/ssr/src/server.js
@@ -6,7 +6,7 @@ import { renderToString } from 'react-dom/server';
 import { getServerState } from 'react-instantsearch';
 
 import App from './App';
-import { requestsCache } from './searchClient';
+import { responsesCache } from './searchClient';
 
 const app = express();
 
@@ -19,7 +19,7 @@ app.get('/', async (req, res) => {
   const serverState = await getServerState(<App location={location} />, {
     renderToString,
   });
-  requestsCache.clear();
+  responsesCache.clear();
   const html = renderToString(
     <App serverState={serverState} location={location} />
   );


### PR DESCRIPTION
**Summary**

[CR-6992](https://algolia.atlassian.net/browse/CR-6992)

Next.js examples does this with `responsesCache` not `requestsCache`, user had tried with `requestsCache` but it didn't fix anything as it was the wrong key, so I've updated the example too.



[CR-6992]: https://algolia.atlassian.net/browse/CR-6992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ