### PR TITLE
chore: don't transform facets as disjunctive if they have no value selected

### DIFF
--- a/packages/algoliasearch-helper/src/requestBuilder.js
+++ b/packages/algoliasearch-helper/src/requestBuilder.js
@@ -187,7 +187,16 @@ var requestBuilder = {
     var facets = state.facets
       .concat(
         state.disjunctiveFacets.map(function (value) {
-          return 'disjunctive(' + value + ')';
+          if (
+            state.disjunctiveFacetsRefinements &&
+            state.disjunctiveFacetsRefinements[value] &&
+            state.disjunctiveFacetsRefinements[value].length > 0
+          ) {
+            // only tag a disjunctiveFacet as disjunctive if it has a value selected
+            // this helps avoid hitting the limit of 20 disjunctive facets in the Composition API
+            return 'disjunctive(' + value + ')';
+          }
+          return value;
         })
       )
       .concat(requestBuilder._getHitsHierarchicalFacetsAttributes(state))

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-composition-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-composition-test.tsx
@@ -178,7 +178,8 @@ describe('Composition implementation', () => {
       search.addWidgets([
         configure({
           facets: ['brand'],
-          disjunctiveFacets: ['categories'],
+          disjunctiveFacets: ['categories', 'author'],
+          disjunctiveFacetsRefinements: { author: ['Terry Pratchett'] },
         }),
         virtualSearchBox({}),
       ]);
@@ -190,7 +191,11 @@ describe('Composition implementation', () => {
       expect(searchClient.search).toHaveBeenNthCalledWith(1, {
         compositionID: 'my-composition',
         requestBody: {
-          params: { query: '', facets: ['brand', 'disjunctive(categories)'] },
+          params: {
+            query: '',
+            facets: ['brand', 'categories', 'disjunctive(author)'],
+            facetFilters: [['author:Terry Pratchett']],
+          },
         },
       });
     });


### PR DESCRIPTION
**Summary**

[EMERCH-1942](https://algolia.atlassian.net/browse/EMERCH-1942)

- the Composition API has a limit of 20 facets annotated as `disjunctive`
- to limit the risk of reaching that limit, this PR does not annotated as `disjunctive` facets who do not have value selected

The reasoning is that when a facet has no value selected, the list of facet values will be the same with or without a disjunctive request.

**Result**

Less facets are annotated as disjunctive.
Notably, the `RefinementList` widget now does not annotate them by default anymore.

[EMERCH-1942]: https://algolia.atlassian.net/browse/EMERCH-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ