### PR TITLE
fix(useSearchResults): force setting results

### DIFF
--- a/packages/react-instantsearch-core/src/lib/useSearchResults.ts
+++ b/packages/react-instantsearch-core/src/lib/useSearchResults.ts
@@ -51,6 +51,10 @@ export function useSearchResults(): SearchResultsApi {
 
     search.addListener('render', handleRender);
 
+    // Force setting results to mitigate potential race conditions where
+    // render listener is added after search results have been returned
+    handleRender();
+
     return () => {
       search.removeListener('render', handleRender);
     };

--- a/packages/react-instantsearch-core/src/lib/useSearchResults.ts
+++ b/packages/react-instantsearch-core/src/lib/useSearchResults.ts
@@ -52,7 +52,8 @@ export function useSearchResults(): SearchResultsApi {
     search.addListener('render', handleRender);
 
     // Force setting results to mitigate potential race conditions where
-    // render listener is added after search results have been returned
+    // render listener is added after search results have been returned.
+    // This edge case is currently not covered by the tests.
     handleRender();
 
     return () => {

--- a/packages/react-instantsearch-core/src/lib/useSearchState.ts
+++ b/packages/react-instantsearch-core/src/lib/useSearchState.ts
@@ -48,6 +48,11 @@ export function useSearchState<
 
     search.addListener('render', handleRender);
 
+    // Force setting state to mitigate potential race conditions where
+    // render listener is added after search results have been returned.
+    // This edge case is currently not covered by the tests.
+    handleRender();
+
     return () => {
       search.removeListener('render', handleRender);
     };


### PR DESCRIPTION
**Summary**

This PR updates how `useSearchResults()` sets its results state. Instead of waiting for InstantSearch's `render` event, it immediately sets the state if results are available.

This can help in situations where results are received before the event listener can be set.

CR-8014