### PR TITLE
feat(recommend): filter out input objectIDs [RECO-2436]

### DIFF
--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -1922,6 +1922,7 @@ AlgoliaSearchHelper.prototype._dispatchRecommendResponse = function (
     }
     cache[id] = Object.assign({}, firstResult, {
       hits: sortAndMergeRecommendations(
+        ids,
         indices.map(function (idx) {
           return content.results[idx].hits;
         })

--- a/packages/algoliasearch-helper/src/utils/sortAndMergeRecommendations.js
+++ b/packages/algoliasearch-helper/src/utils/sortAndMergeRecommendations.js
@@ -21,11 +21,14 @@ function getAverageIndices(indexTracker, nrOfObjs) {
   });
 }
 
-function sortAndMergeRecommendations(results) {
+function sortAndMergeRecommendations(objectIDs, results) {
   var indexTracker = {};
 
   results.forEach(function (hits) {
     hits.forEach(function (hit, index) {
+      // filter out hits that match the source objectIDs
+      if (objectIDs.include(hit.objectID)) return;
+
       if (!indexTracker[hit.objectID]) {
         indexTracker[hit.objectID] = { indexSum: index, count: 1 };
       } else {

--- a/packages/algoliasearch-helper/src/utils/sortAndMergeRecommendations.js
+++ b/packages/algoliasearch-helper/src/utils/sortAndMergeRecommendations.js
@@ -25,20 +25,18 @@ function sortAndMergeRecommendations(objectIDs, results) {
   var indexTracker = {};
 
   results.forEach(function (hits) {
-    hits
-      .filter(function (hit) {
-        return !objectIDs.includes(hit.objectID);
-      })
-      .forEach(function (hit, index) {
-        if (!indexTracker[hit.objectID]) {
-          indexTracker[hit.objectID] = { indexSum: index, count: 1 };
-        } else {
-          indexTracker[hit.objectID] = {
-            indexSum: indexTracker[hit.objectID].indexSum + index,
-            count: indexTracker[hit.objectID].count + 1,
-          };
-        }
-      });
+    hits.forEach(function (hit, index) {
+      if (objectIDs.includes(hit.objectID)) return;
+
+      if (!indexTracker[hit.objectID]) {
+        indexTracker[hit.objectID] = { indexSum: index, count: 1 };
+      } else {
+        indexTracker[hit.objectID] = {
+          indexSum: indexTracker[hit.objectID].indexSum + index,
+          count: indexTracker[hit.objectID].count + 1,
+        };
+      }
+    });
   });
 
   var sortedAverageIndices = getAverageIndices(indexTracker, results.length);

--- a/packages/algoliasearch-helper/src/utils/sortAndMergeRecommendations.js
+++ b/packages/algoliasearch-helper/src/utils/sortAndMergeRecommendations.js
@@ -25,19 +25,20 @@ function sortAndMergeRecommendations(objectIDs, results) {
   var indexTracker = {};
 
   results.forEach(function (hits) {
-    hits.forEach(function (hit, index) {
-      // filter out hits that match the source objectIDs
-      if (objectIDs.include(hit.objectID)) return;
-
-      if (!indexTracker[hit.objectID]) {
-        indexTracker[hit.objectID] = { indexSum: index, count: 1 };
-      } else {
-        indexTracker[hit.objectID] = {
-          indexSum: indexTracker[hit.objectID].indexSum + index,
-          count: indexTracker[hit.objectID].count + 1,
-        };
-      }
-    });
+    hits
+      .filter(function (hit) {
+        return !objectIDs.includes(hit.objectID);
+      })
+      .forEach(function (hit, index) {
+        if (!indexTracker[hit.objectID]) {
+          indexTracker[hit.objectID] = { indexSum: index, count: 1 };
+        } else {
+          indexTracker[hit.objectID] = {
+            indexSum: indexTracker[hit.objectID].indexSum + index,
+            count: indexTracker[hit.objectID].count + 1,
+          };
+        }
+      });
   });
 
   var sortedAverageIndices = getAverageIndices(indexTracker, results.length);

--- a/packages/algoliasearch-helper/test/spec/utils/sortAndMergeRecommendations.js
+++ b/packages/algoliasearch-helper/test/spec/utils/sortAndMergeRecommendations.js
@@ -147,14 +147,14 @@ test('filters out input objectIDs', () => {
           "objectID": "F",
         },
         Object {
-          "_score": 89,
-          "name": "Product D",
-          "objectID": "D",
-        },
-        Object {
           "_score": 96,
           "name": "Product G",
           "objectID": "G",
+        },
+        Object {
+          "_score": 89,
+          "name": "Product D",
+          "objectID": "D",
         },
       ]
     `);

--- a/packages/algoliasearch-helper/test/spec/utils/sortAndMergeRecommendations.js
+++ b/packages/algoliasearch-helper/test/spec/utils/sortAndMergeRecommendations.js
@@ -125,3 +125,37 @@ test('sorts the items based on their average index thus preserving applied rules
       ]
     `);
 });
+
+test('filters out input objectIDs', () => {
+  const result = sortAndMergeRecommendations(
+    ['A', 'B', 'C'],
+    response.results.map(function (res) {
+      return res.hits;
+    })
+  );
+
+  expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "_score": 76,
+          "name": "Product E",
+          "objectID": "E",
+        },
+        Object {
+          "_score": 100,
+          "name": "Product F",
+          "objectID": "F",
+        },
+        Object {
+          "_score": 89,
+          "name": "Product D",
+          "objectID": "D",
+        },
+        Object {
+          "_score": 96,
+          "name": "Product G",
+          "objectID": "G",
+        },
+      ]
+    `);
+});

--- a/packages/algoliasearch-helper/test/spec/utils/sortAndMergeRecommendations.js
+++ b/packages/algoliasearch-helper/test/spec/utils/sortAndMergeRecommendations.js
@@ -79,6 +79,7 @@ var response = {
 
 test('sorts the items based on their average index thus preserving applied rules', () => {
   const result = sortAndMergeRecommendations(
+    [],
     response.results.map(function (res) {
       return res.hits;
     })
@@ -110,6 +111,40 @@ test('sorts the items based on their average index thus preserving applied rules
           "_score": 100,
           "name": "Product A",
           "objectID": "A",
+        },
+        Object {
+          "_score": 96,
+          "name": "Product G",
+          "objectID": "G",
+        },
+        Object {
+          "_score": 89,
+          "name": "Product D",
+          "objectID": "D",
+        },
+      ]
+    `);
+});
+
+test('filters out input objectIDs', () => {
+  const result = sortAndMergeRecommendations(
+    ['A', 'B', 'C'],
+    response.results.map(function (res) {
+      return res.hits;
+    })
+  );
+
+  expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "_score": 76,
+          "name": "Product E",
+          "objectID": "E",
+        },
+        Object {
+          "_score": 100,
+          "name": "Product F",
+          "objectID": "F",
         },
         Object {
           "_score": 96,

--- a/packages/algoliasearch-helper/test/spec/utils/sortAndMergeRecommendations.js
+++ b/packages/algoliasearch-helper/test/spec/utils/sortAndMergeRecommendations.js
@@ -79,7 +79,7 @@ var response = {
 
 test('sorts the items based on their average index thus preserving applied rules', () => {
   const result = sortAndMergeRecommendations(
-    [],
+    ['X', 'Y', 'Z'],
     response.results.map(function (res) {
       return res.hits;
     })
@@ -111,40 +111,6 @@ test('sorts the items based on their average index thus preserving applied rules
           "_score": 100,
           "name": "Product A",
           "objectID": "A",
-        },
-        Object {
-          "_score": 96,
-          "name": "Product G",
-          "objectID": "G",
-        },
-        Object {
-          "_score": 89,
-          "name": "Product D",
-          "objectID": "D",
-        },
-      ]
-    `);
-});
-
-test('filters out input objectIDs', () => {
-  const result = sortAndMergeRecommendations(
-    ['A', 'B', 'C'],
-    response.results.map(function (res) {
-      return res.hits;
-    })
-  );
-
-  expect(result).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "_score": 76,
-          "name": "Product E",
-          "objectID": "E",
-        },
-        Object {
-          "_score": 100,
-          "name": "Product F",
-          "objectID": "F",
         },
         Object {
           "_score": 96,


### PR DESCRIPTION
**Summary**

When requesting multiple objectIDs, there is a chance that the merged results contains some of the input items.

We can filter those out for a more consistent output.
