### PR TITLE
fix(insights): use latest appId and apiKey

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "69.50 kB"
+      "maxSize": "69.75 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -38,15 +38,20 @@ declare global {
 }
 
 describe('insights', () => {
-  const searchClientWithCredentials = createSearchClient({
-    // @ts-expect-error only available in search client v4
-    transporter: {
-      headers: {
-        'x-algolia-application-id': 'myAppId',
-        'x-algolia-api-key': 'myApiKey',
+  let searchClientWithCredentials: SearchClient;
+
+  beforeEach(() => {
+    searchClientWithCredentials = createSearchClient({
+      // @ts-expect-error only available in search client v4
+      transporter: {
+        headers: {
+          'x-algolia-application-id': 'myAppId',
+          'x-algolia-api-key': 'myApiKey',
+        },
       },
-    },
+    });
   });
+
   const createTestEnvironment = ({
     searchClient = searchClientWithCredentials,
     started = true,
@@ -1213,6 +1218,76 @@ describe('insights', () => {
           headers: {
             'X-Algolia-Application-Id': 'myAppId',
             'X-Algolia-API-Key': 'myApiKey',
+          },
+        }
+      );
+    });
+
+    it('uses latest appId and apiKey from client', () => {
+      const { insightsClient, instantSearchInstance, analytics } =
+        createTestEnvironment();
+
+      instantSearchInstance.use(
+        createInsightsMiddleware({
+          insightsClient,
+        })
+      );
+      insightsClient('setUserToken', 'token');
+
+      instantSearchInstance.sendEventToInsights({
+        insightsMethod: 'viewedObjectIDs',
+        widgetType: 'ais.customWidget',
+        eventType: 'view',
+        payload: {
+          index: 'my-index',
+          eventName: 'My Hits Viewed',
+          objectIDs: ['obj1'],
+        },
+      });
+
+      expect(analytics.viewedObjectIDs).toHaveBeenCalledTimes(1);
+      expect(analytics.viewedObjectIDs).toHaveBeenCalledWith(
+        {
+          index: 'my-index',
+          eventName: 'My Hits Viewed',
+          objectIDs: ['obj1'],
+          algoliaSource: ['instantsearch'],
+        },
+        {
+          headers: {
+            'X-Algolia-Application-Id': 'myAppId',
+            'X-Algolia-API-Key': 'myApiKey',
+          },
+        }
+      );
+
+      // @ts-expect-error - only works for v4+
+      instantSearchInstance.client.transporter.headers['x-algolia-api-key'] =
+        'myApiKey2';
+
+      instantSearchInstance.sendEventToInsights({
+        insightsMethod: 'viewedObjectIDs',
+        widgetType: 'ais.customWidget',
+        eventType: 'view',
+        payload: {
+          index: 'my-index',
+          eventName: 'My Hits Viewed',
+          objectIDs: ['obj2'],
+        },
+      });
+
+      expect(analytics.viewedObjectIDs).toHaveBeenCalledTimes(2);
+      expect(analytics.viewedObjectIDs).toHaveBeenCalledWith(
+        {
+          index: 'my-index',
+          eventName: 'My Hits Viewed',
+          objectIDs: ['obj2'],
+          algoliaSource: ['instantsearch'],
+        },
+        {
+          headers: {
+            'X-Algolia-Application-Id': 'myAppId',
+            'X-Algolia-API-Key': 'myApiKey2',
           },
         }
       );

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -332,10 +332,13 @@ export function createInsightsMiddleware<
 
         if (isModernInsightsClient(insightsClient)) {
           insightsClientWithLocalCredentials = (method, payload) => {
+            const [latestAppId, latestApiKey] = getAppIdAndApiKey(
+              instantSearchInstance.client
+            );
             const extraParams = {
               headers: {
-                'X-Algolia-Application-Id': appId,
-                'X-Algolia-API-Key': apiKey,
+                'X-Algolia-Application-Id': latestAppId,
+                'X-Algolia-API-Key': latestApiKey,
               },
             };
 


### PR DESCRIPTION
**Summary**

[FX-3372](https://algolia.atlassian.net/browse/FX-3372)

Fixes #6623 

**Result**

We should use the latest `appId` and `apiKey` as the latter can be rotated

[FX-3372]: https://algolia.atlassian.net/browse/FX-3372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ