### PR TITLE
fix(infiniteHits): always return valid showPrevious and showMore functions

### DIFF
--- a/packages/instantsearch.js/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -1510,6 +1510,51 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
         widgetParams: {},
       });
     });
+
+    it('returns the widget render state with artificial results', () => {
+      const renderFn = jest.fn();
+      const unmountFn = jest.fn();
+      const createInfiniteHits = connectInfiniteHits(renderFn, unmountFn);
+      const infiniteHitsWidget = createInfiniteHits({});
+      const helper = algoliasearchHelper(createSearchClient(), 'indexName', {
+        index: 'indexName',
+      });
+
+      const results = new SearchResults(
+        helper.state,
+        [
+          createSingleSearchResponse({
+            hits: [],
+            queryID: 'theQueryID',
+          }),
+        ],
+        { __isArtificial: true }
+      );
+
+      const renderOptions = createRenderOptions({
+        helper,
+        state: helper.state,
+        results,
+      });
+
+      const renderState =
+        infiniteHitsWidget.getWidgetRenderState(renderOptions);
+
+      expect(renderState).toEqual({
+        hits: [],
+        items: [],
+        currentPageHits: [],
+        sendEvent: expect.any(Function),
+        bindEvent: expect.any(Function),
+        isFirstPage: true,
+        isLastPage: true,
+        banner: undefined,
+        results,
+        showMore: expect.any(Function),
+        showPrevious: expect.any(Function),
+        widgetParams: {},
+      });
+    });
   });
 
   describe('getWidgetSearchParameters', () => {

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -350,9 +350,12 @@ export default (function connectInfiniteHits<
 
         const banner = results?.renderingContent?.widgets?.banners?.[0];
 
-        if (!results) {
+        if (!showPrevious) {
           showPrevious = getShowPrevious(helper);
           showMore = getShowMore(helper);
+        }
+
+        if (!sendEvent) {
           sendEvent = createSendEventForHits({
             instantSearchInstance,
             helper,
@@ -363,6 +366,9 @@ export default (function connectInfiniteHits<
             widgetType: this.$$type,
             instantSearchInstance,
           });
+        }
+
+        if (!results) {
           isFirstPage =
             state.page === undefined ||
             getFirstReceivedPage(state, cachedHits) === 0;

--- a/packages/react-instantsearch-core/src/connectors/__tests__/useInfiniteHits.test.tsx
+++ b/packages/react-instantsearch-core/src/connectors/__tests__/useInfiniteHits.test.tsx
@@ -16,16 +16,16 @@ describe('useInfiniteHits', () => {
 
     // Initial render state from manual `getWidgetRenderState`
     expect(result.current).toEqual({
-      bindEvent: undefined,
+      bindEvent: expect.any(Function),
+      sendEvent: expect.any(Function),
       hits: [],
       items: [],
       results: expect.objectContaining({ nbHits: 0 }),
-      sendEvent: undefined,
       currentPageHits: [],
       isFirstPage: true,
       isLastPage: true,
-      showMore: undefined,
-      showPrevious: undefined,
+      showMore: expect.any(Function),
+      showPrevious: expect.any(Function),
     });
 
     await waitFor(() => {

--- a/packages/react-instantsearch/src/widgets/InfiniteHits.tsx
+++ b/packages/react-instantsearch/src/widgets/InfiniteHits.tsx
@@ -44,14 +44,13 @@ export function InfiniteHits<THit extends BaseHit = BaseHit>({
   showPrevious: shouldShowPrevious = true,
   cache,
   escapeHTML,
-  showPrevious: userShowPrevious,
   transformItems,
   translations,
   bannerComponent: BannerComponent,
   ...props
 }: InfiniteHitsProps<THit>) {
   const {
-    hits,
+    items,
     banner,
     sendEvent,
     showPrevious,
@@ -59,7 +58,7 @@ export function InfiniteHits<THit extends BaseHit = BaseHit>({
     isFirstPage,
     isLastPage,
   } = useInfiniteHits<THit>(
-    { cache, escapeHTML, showPrevious: userShowPrevious, transformItems },
+    { cache, escapeHTML, showPrevious: shouldShowPrevious, transformItems },
     { $$widgetType: 'ais.infiniteHits' }
   );
 
@@ -68,7 +67,7 @@ export function InfiniteHits<THit extends BaseHit = BaseHit>({
   ) as InfiniteHitsUiComponentProps<THit>['bannerComponent'];
 
   const uiProps: UiProps<THit> = {
-    hits,
+    hits: items,
     banner,
     bannerComponent,
     sendEvent,

--- a/packages/react-instantsearch/src/widgets/__tests__/InfiniteHits.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/InfiniteHits.test.tsx
@@ -229,6 +229,12 @@ describe('InfiniteHits', () => {
           <div
             class="ais-InfiniteHits ais-InfiniteHits--empty"
           >
+            <button
+              class="ais-InfiniteHits-loadPrevious ais-InfiniteHits-loadPrevious--disabled"
+              disabled=""
+            >
+              Show previous results
+            </button>
             <ol
               class="ais-InfiniteHits-list"
             />


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

We default the infinite hits showPrevious to true, but in the initial render the functions `showPrevious` and `showMore` are not yet present in the sate. This fixes that and ensures the functions are always returned.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- show more button always shows up by default (and doesn't flash)
- ensure that showMore and showPrevious functions are always defined, even if the first render is _with_ results (artificial for example)