### PR TITLE
feat(facetOrdering): implement hidden facets in SFFV

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "packages/algoliasearch-helper/dist/algoliasearch.helper.js",
-      "maxSize": "42 kB"
+      "maxSize": "42.25 kB"
     },
     {
       "path": "packages/algoliasearch-helper/dist/algoliasearch.helper.min.js",
@@ -18,19 +18,19 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "51.75 kB"
+      "maxSize": "52 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "65.75 kB"
+      "maxSize": "66 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "69.25 kB"
+      "maxSize": "70 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "69.75 kB"
+      "maxSize": "70 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -437,6 +437,15 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function (
     query: query,
   });
 
+  var hide =
+    (this.lastResults &&
+      this.lastResults.renderingContent &&
+      this.lastResults.renderingContent.facetOrdering &&
+      this.lastResults.renderingContent.facetOrdering.values &&
+      this.lastResults.renderingContent.facetOrdering.values[facet] &&
+      this.lastResults.renderingContent.facetOrdering.values[facet].hide) ||
+    [];
+
   return searchForFacetValuesPromise.then(
     function addIsRefined(content) {
       self._currentNbQueries--;
@@ -444,7 +453,11 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function (
 
       content = Array.isArray(content) ? content[0] : content;
 
-      content.facetHits.forEach(function (f) {
+      content.facetHits.forEach(function (f, i) {
+        if (hide.indexOf(f.value) > -1) {
+          content.facetHits.splice(i, 1);
+          return;
+        }
         f.escapedValue = escapeFacetValue(f.value);
         f.isRefined = isDisjunctive
           ? state.isDisjunctiveFacetRefined(facet, f.escapedValue)

--- a/packages/algoliasearch-helper/src/algoliasearch.helper.js
+++ b/packages/algoliasearch-helper/src/algoliasearch.helper.js
@@ -439,6 +439,7 @@ AlgoliaSearchHelper.prototype.searchForFacetValues = function (
 
   var hide =
     (this.lastResults &&
+      this.lastResults.index === state.index &&
       this.lastResults.renderingContent &&
       this.lastResults.renderingContent.facetOrdering &&
       this.lastResults.renderingContent.facetOrdering.values &&

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -580,7 +580,7 @@ test('does not hide if last results are for another index', function () {
       return Promise.resolve({
         results: [
           {
-            index: 'index1',
+            index: 'index',
             renderingContent: {
               facetOrdering: {
                 values: {
@@ -616,7 +616,7 @@ test('does not hide if last results are for another index', function () {
     },
   };
 
-  var helper = algoliasearchHelper(fakeClient, 'index1', {
+  var helper = algoliasearchHelper(fakeClient, 'index', {
     disjunctiveFacets: ['facet'],
     renderingContent: {
       facetValues: [

--- a/packages/algoliasearch-helper/test/spec/algoliasearch.helper/searchForFacetValues.js
+++ b/packages/algoliasearch-helper/test/spec/algoliasearch.helper/searchForFacetValues.js
@@ -493,3 +493,81 @@ test('escaped value is marked as refined', function () {
     });
   });
 });
+
+test('hides a facet value that is hidden according to `renderingContent`', function () {
+  var fakeClient = {
+    addAlgoliaAgent: function () {},
+    search: function () {
+      return Promise.resolve({
+        results: [
+          {
+            renderingContent: {
+              facetOrdering: {
+                values: {
+                  facet: {
+                    hide: ['hidden'],
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+    },
+    searchForFacetValues: function () {
+      return Promise.resolve([
+        {
+          exhaustiveFacetsCount: true,
+          facetHits: [
+            {
+              count: 318,
+              highlighted: 'something',
+              value: 'something',
+            },
+            {
+              count: 1,
+              highlighted: 'hidden',
+              value: 'hidden',
+            },
+          ],
+          processingTimeMS: 3,
+        },
+      ]);
+    },
+  };
+
+  var helper = algoliasearchHelper(fakeClient, 'index', {
+    disjunctiveFacets: ['facet'],
+    renderingContent: {
+      facetValues: [
+        {
+          name: 'something',
+          isRefined: true,
+        },
+      ],
+    },
+  });
+
+  return new Promise(function (res) {
+    helper.search();
+    helper.once('result', res);
+  })
+    .then(function () {
+      return helper.searchForFacetValues('facet', 'k', 1);
+    })
+    .then(function (content) {
+      expect(content).toEqual({
+        exhaustiveFacetsCount: true,
+        processingTimeMS: 3,
+        facetHits: [
+          {
+            count: 318,
+            highlighted: 'something',
+            isRefined: false,
+            escapedValue: 'something',
+            value: 'something',
+          },
+        ],
+      });
+    });
+});


### PR DESCRIPTION


**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

We read the last results' facet ordering and apply hidden facets (not facet ordering) to the results array.

nbHits does not need to be changed as search for facet values doesn't return that key.

[CR-8645]

**Result**

hidden facets according to facetOrdering of the previous "full search" response are taken in account in search for facet values.

the lastResponse is always the most correct one if the index matches, if the previous search was for another index we do nothing

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->


[CR-8645]: https://algolia.atlassian.net/browse/CR-8645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ