### PR TITLE
wip: allow disabling storing render state

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -191,6 +191,11 @@ export type InstantSearchOptions<
      */
     // @MAJOR: Remove legacy behaviour here and in algoliasearch-helper
     persistHierarchicalRootCount?: boolean;
+    /**
+     * Experimental option to disable `renderState`
+     * @defualt false
+     */
+    dontStoreRenderState?: boolean;
   };
 };
 
@@ -201,6 +206,7 @@ export const INSTANTSEARCH_FUTURE_DEFAULTS: Required<
 > = {
   preserveSharedStateOnUnmount: false,
   persistHierarchicalRootCount: false,
+  dontStoreRenderState: false,
 };
 
 /**

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -955,6 +955,9 @@ function storeRenderState({
   instantSearchInstance: InstantSearch;
   parent?: IndexWidget;
 }) {
+  if (instantSearchInstance.future.dontStoreRenderState) {
+    return;
+  }
   const parentIndexName = parent
     ? parent.getIndexId()
     : instantSearchInstance.mainIndex.getIndexId();


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

disable storing render state, to avoid a memory leak.


<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

I don't think this is the right long-term solution, but can be a stopgap for @gkunesh.

The option `future.dontStoreRenderState` disables writing to renderState, thus avoiding the class of memory leak described in #6669

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
