### PR TITLE
fix(infiniteHits): fix cache not using proper state

### DIFF
--- a/packages/instantsearch.js/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/__tests__/connectInfiniteHits-test.ts
@@ -327,25 +327,23 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/infinite-hi
     helper.overrideStateWithoutTriggeringChangeEvent = jest.fn(() => helper);
     helper.searchWithoutTriggeringOnStateChange = jest.fn();
 
-    const mainHelper = algoliasearchHelper(createSearchClient(), '', {
+    // we add a query to the parent helper to simulate multi-index where
+    // the parent has a query and the infinite hits index does not
+    const parentHelper = algoliasearchHelper(createSearchClient(), '', {
       page: 4,
-      query: 'test', // arbitrary change to state to force cache mismatch
+      query: 'test',
     });
-    mainHelper.overrideStateWithoutTriggeringChangeEvent = jest.fn(
-      () => mainHelper
-    );
-    mainHelper.searchWithoutTriggeringOnStateChange = jest.fn();
 
     widget.init(
       createInitOptions({
-        state: mainHelper.state,
+        state: parentHelper.state,
         helper,
       })
     );
 
     const { showMore, showPrevious } = widget.getWidgetRenderState(
       createRenderOptions({
-        state: mainHelper.state,
+        state: parentHelper.state,
         helper,
       })
     );

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -263,10 +263,10 @@ export default (function connectInfiniteHits<
     const getShowPrevious =
       (
         helper: Helper,
-        getCachedHitsFn: () => InfiniteHitsCachedHits<THit>
+        getCachedHits: () => InfiniteHitsCachedHits<THit>
       ): (() => void) =>
       () => {
-        const cachedHits = getCachedHitsFn();
+        const cachedHits = getCachedHits();
         // Using the helper's `overrideStateWithoutTriggeringChangeEvent` method
         // avoid updating the browser URL when the user displays the previous page.
         helper
@@ -280,10 +280,10 @@ export default (function connectInfiniteHits<
     const getShowMore =
       (
         helper: Helper,
-        getCachedHitsFn: () => InfiniteHitsCachedHits<THit>
+        getCachedHits: () => InfiniteHitsCachedHits<THit>
       ): (() => void) =>
       () => {
-        const cachedHits = getCachedHitsFn();
+        const cachedHits = getCachedHits();
         helper
           .setPage(getLastReceivedPage(helper.state, cachedHits) + 1)
           .search();

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -261,32 +261,23 @@ export default (function connectInfiniteHits<
     };
 
     const getShowPrevious =
-      (helper: Helper): (() => void) =>
+      (helper: Helper, cachedHits: InfiniteHitsCachedHits<any>): (() => void) =>
       () => {
         // Using the helper's `overrideStateWithoutTriggeringChangeEvent` method
         // avoid updating the browser URL when the user displays the previous page.
         helper
           .overrideStateWithoutTriggeringChangeEvent({
             ...helper.state,
-            page:
-              getFirstReceivedPage(
-                helper.state,
-                cache.read({ state: normalizeState(helper.state) }) || {}
-              ) - 1,
+            page: getFirstReceivedPage(helper.state, cachedHits) - 1,
           })
           .searchWithoutTriggeringOnStateChange();
       };
 
     const getShowMore =
-      (helper: Helper): (() => void) =>
+      (helper: Helper, cachedHits: InfiniteHitsCachedHits<any>): (() => void) =>
       () => {
         helper
-          .setPage(
-            getLastReceivedPage(
-              helper.state,
-              cache.read({ state: normalizeState(helper.state) }) || {}
-            ) + 1
-          )
+          .setPage(getLastReceivedPage(helper.state, cachedHits) + 1)
           .search();
       };
 
@@ -337,6 +328,11 @@ export default (function connectInfiniteHits<
         state: existingState,
         instantSearchInstance,
       }) {
+        const getCacheHits = () => {
+          const state = parent.getPreviousState() || existingState;
+          return cache.read({ state: normalizeState(state) }) || {};
+        };
+
         let isFirstPage: boolean;
         let currentPageHits: Array<Hit<THit>> = [];
         /**
@@ -346,13 +342,13 @@ export default (function connectInfiniteHits<
          */
         const state = parent.getPreviousState() || existingState;
 
-        const cachedHits = cache.read({ state: normalizeState(state) }) || {};
+        const cachedHits = getCacheHits();
 
         const banner = results?.renderingContent?.widgets?.banners?.[0];
 
         if (!showPrevious) {
-          showPrevious = getShowPrevious(helper);
-          showMore = getShowMore(helper);
+          showPrevious = () => getShowPrevious(helper, getCacheHits())();
+          showMore = () => getShowMore(helper, getCacheHits())();
         }
 
         if (!sendEvent) {

--- a/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
+++ b/packages/instantsearch.js/src/connectors/infinite-hits/connectInfiniteHits.ts
@@ -261,8 +261,12 @@ export default (function connectInfiniteHits<
     };
 
     const getShowPrevious =
-      (helper: Helper, cachedHits: InfiniteHitsCachedHits<any>): (() => void) =>
+      (
+        helper: Helper,
+        getCachedHitsFn: () => InfiniteHitsCachedHits<THit>
+      ): (() => void) =>
       () => {
+        const cachedHits = getCachedHitsFn();
         // Using the helper's `overrideStateWithoutTriggeringChangeEvent` method
         // avoid updating the browser URL when the user displays the previous page.
         helper
@@ -274,8 +278,12 @@ export default (function connectInfiniteHits<
       };
 
     const getShowMore =
-      (helper: Helper, cachedHits: InfiniteHitsCachedHits<any>): (() => void) =>
+      (
+        helper: Helper,
+        getCachedHitsFn: () => InfiniteHitsCachedHits<THit>
+      ): (() => void) =>
       () => {
+        const cachedHits = getCachedHitsFn();
         helper
           .setPage(getLastReceivedPage(helper.state, cachedHits) + 1)
           .search();
@@ -347,8 +355,8 @@ export default (function connectInfiniteHits<
         const banner = results?.renderingContent?.widgets?.banners?.[0];
 
         if (!showPrevious) {
-          showPrevious = () => getShowPrevious(helper, getCacheHits())();
-          showMore = () => getShowMore(helper, getCacheHits())();
+          showPrevious = () => getShowPrevious(helper, getCacheHits)();
+          showMore = () => getShowMore(helper, getCacheHits)();
         }
 
         if (!sendEvent) {


### PR DESCRIPTION
**Summary**
Using helper state for getting a page would cause cache miss since infinite hits doesn't have access to base level widgets in a multi index scenario. Using the latest cache directly fixes this.

[CR-8905]
Closes: https://github.com/algolia/instantsearch/issues/6653

**Result**
Get previous page works correctly when preloaded via routing and multi index.


[CR-8905]: https://algolia.atlassian.net/browse/CR-8905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ