### PR TITLE
FIX : in come cases, this.nodes[0] is undefined

### DIFF
--- a/packages/instantsearch.js/src/components/Template/Template.tsx
+++ b/packages/instantsearch.js/src/components/Template/Template.tsx
@@ -33,7 +33,7 @@ class RawHtml extends Component<{ content: string }> {
     });
     // if there is one TextNode first and one TextNode last, the
     // last one's nodeValue will be assigned to the first.
-    if (this.nodes[0].nodeValue) {
+    if (this.nodes[0] && this.nodes[0].nodeValue) {
       this.nodes[0].nodeValue = '';
     }
   }

--- a/packages/instantsearch.js/src/components/Template/__tests__/Template-test.tsx
+++ b/packages/instantsearch.js/src/components/Template/__tests__/Template-test.tsx
@@ -114,6 +114,28 @@ describe('Template', () => {
     expect(wrapper.container).toMatchSnapshot();
   });
 
+  it('correctly unmounts empty', () => {
+    const props = getProps({
+      rootTagName: 'fragment',
+      templates: { test: '' },
+    });
+    const wrapper = render(
+      <div>
+        <Template {...props} />
+      </div>
+    );
+
+    expect(wrapper.container).toMatchInlineSnapshot(`
+      <div>
+        <div />
+      </div>
+    `);
+
+    wrapper.unmount();
+
+    expect(wrapper.container).toMatchInlineSnapshot(`<div />`);
+  });
+
   it('forward rootProps to the first node', () => {
     function onClick() {}
 


### PR DESCRIPTION
**Summary**

"Playing" with facets can result to this error : 

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'nodeValue')
    at a.value (algolia-instantsearch.min.js:2:229597)

    at e (algolia-instantsearch.min.js:2:98166)

    at e (algolia-instantsearch.min.js:2:98280)

    at e (algolia-instantsearch.min.js:2:98280)

    at $n (algolia-instantsearch.min.js:2:98366)

    at algolia-instantsearch.min.js:2:102651

    at Kn (algolia-instantsearch.min.js:2:103009)

    at $n (algolia-instantsearch.min.js:2:97461)

    at Kn (algolia-instantsearch.min.js:2:101481)

    at $n (algolia-instantsearch.min.js:2:97461)

```

**Result**

Error is gone :) 