### PR TITLE
fix(perf): don't render loading icon if not visible

### DIFF
--- a/packages/instantsearch.js/src/components/SearchBox/SearchBox.tsx
+++ b/packages/instantsearch.js/src/components/SearchBox/SearchBox.tsx
@@ -231,13 +231,12 @@ class SearchBox extends Component<
             data={{ cssClasses }}
           />
 
-          {showLoadingIndicator && (
+          {showLoadingIndicator && isSearchStalled && (
             <Template
               templateKey="loadingIndicator"
               rootTagName="span"
               rootProps={{
                 className: cssClasses.loadingIndicator,
-                hidden: !isSearchStalled,
               }}
               templates={templates}
               data={{ cssClasses }}

--- a/packages/react-instantsearch/src/ui/SearchBox.tsx
+++ b/packages/react-instantsearch/src/ui/SearchBox.tsx
@@ -229,7 +229,7 @@ export function SearchBox({
           )}
           hidden={!isSearchStalled}
         >
-          <LoadingIcon classNames={classNames} />
+          {isSearchStalled && <LoadingIcon classNames={classNames} />}
         </span>
       </form>
     </div>


### PR DESCRIPTION
In Safari, an animation with animateTransform being in the dom (even if hidden) will cause a style recalculation on every frame. This also causes needless processor usage, and slowdown on old devices.

This PR solves this issue in instantsearch by preventing rendering of the loading icon if it shouldn't be displayed.

- react: remove rendering
- js: remove rendering
- vue: already not rendering

ref: https://bugs.webkit.org/show_bug.cgi?id=298217
ref: https://github.com/algolia/autocomplete/issues/1322
ref: https://github.com/algolia/autocomplete/pull/1323