### PR TITLE
feat(index): accept "composed" widgets in add/removeWidgets

### DIFF
--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -492,7 +492,7 @@ See documentation: ${createDocumentationLink({
    * Widgets can be added either before or after InstantSearch has started.
    * @param widgets The array of widgets to add to InstantSearch.
    */
-  public addWidgets(widgets: Array<Widget | IndexWidget>) {
+  public addWidgets(widgets: Array<Widget | IndexWidget | Widget[]>) {
     if (!Array.isArray(widgets)) {
       throw new Error(
         withUsage(
@@ -502,22 +502,8 @@ See documentation: ${createDocumentationLink({
     }
 
     if (
-      widgets.some(
-        (widget) =>
-          typeof widget.init !== 'function' &&
-          typeof widget.render !== 'function'
-      )
-    ) {
-      throw new Error(
-        withUsage(
-          'The widget definition expects a `render` and/or an `init` method.'
-        )
-      );
-    }
-
-    if (
       this.compositionID &&
-      widgets.some((w) => isIndexWidget(w) && !w._isolated)
+      widgets.some((w) => !Array.isArray(w) && isIndexWidget(w) && !w._isolated)
     ) {
       throw new Error(
         withUsage(
@@ -553,18 +539,12 @@ See documentation: ${createDocumentationLink({
    *
    * The widgets must implement a `dispose()` method to clear their states.
    */
-  public removeWidgets(widgets: Array<Widget | IndexWidget>) {
+  public removeWidgets(widgets: Array<Widget | IndexWidget | Widget[]>) {
     if (!Array.isArray(widgets)) {
       throw new Error(
         withUsage(
           'The `removeWidgets` method expects an array of widgets. Please use `removeWidget`.'
         )
-      );
-    }
-
-    if (widgets.some((widget) => typeof widget.dispose !== 'function')) {
-      throw new Error(
-        withUsage('The widget definition expects a `dispose` method.')
       );
     }
 

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -86,10 +86,10 @@ describe('Usage', () => {
       // eslint-disable-next-line no-new
       new InstantSearch({ indexName: 'indexName', searchClient: undefined });
     }).toThrowErrorMatchingInlineSnapshot(`
-"The \`searchClient\` option is required.
+      "The \`searchClient\` option is required.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
+    `);
   });
 
   it('throws if searchClient does not implement a search method', () => {
@@ -98,10 +98,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       // eslint-disable-next-line no-new
       new InstantSearch({ indexName: 'indexName', searchClient: {} });
     }).toThrowErrorMatchingInlineSnapshot(`
-"The \`searchClient\` must implement a \`search\` method.
+      "The \`searchClient\` must implement a \`search\` method.
 
-See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend-search/in-depth/backend-instantsearch/js/"
-`);
+      See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend-search/in-depth/backend-instantsearch/js/"
+    `);
   });
 
   describe('root index warning', () => {
@@ -174,10 +174,10 @@ See: https://www.algolia.com/doc/guides/building-search-ui/going-further/backend
         insightsClient: 'insights',
       });
     }).toThrowErrorMatchingInlineSnapshot(`
-"The \`insightsClient\` option should be a function.
+      "The \`insightsClient\` option should be a function.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
+    `);
   });
 
   it('throws if addWidgets is called with a single widget', () => {
@@ -189,10 +189,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       // @ts-expect-error
       search.addWidgets({});
     }).toThrowErrorMatchingInlineSnapshot(`
-"The \`addWidgets\` method expects an array of widgets. Please use \`addWidget\`.
+      "The \`addWidgets\` method expects an array of widgets. Please use \`addWidget\`.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
+    `);
   });
 
   it('throws if a widget without render or init method is added', () => {
@@ -205,10 +205,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       });
       search.addWidgets(widgets);
     }).toThrowErrorMatchingInlineSnapshot(`
-"The widget definition expects a \`render\` and/or an \`init\` method.
+      "The widget definition expects a \`render\` and/or an \`init\` method.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
+    `);
   });
 
   it('does not throw with a widget having a init method', () => {
@@ -244,10 +244,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       // @ts-expect-error
       search.removeWidgets({});
     }).toThrowErrorMatchingInlineSnapshot(`
-"The \`removeWidgets\` method expects an array of widgets. Please use \`removeWidget\`.
+      "The \`removeWidgets\` method expects an array of widgets. Please use \`removeWidget\`.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
+    `);
   });
 
   it('throws if a widget without dispose method is removed', () => {
@@ -262,10 +262,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       });
       search.removeWidgets(widgets);
     }).toThrowErrorMatchingInlineSnapshot(`
-"The widget definition expects a \`dispose\` method.
+      "The widget definition expects a \`dispose\` method.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
+    `);
   });
 
   it('throws if createURL is called before start', () => {
@@ -275,10 +275,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     });
 
     expect(() => search.createURL()).toThrowErrorMatchingInlineSnapshot(`
-"The \`start\` method needs to be called before \`createURL\`.
+      "The \`start\` method needs to be called before \`createURL\`.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
+    `);
   });
 
   it('throws if refresh is called before start', () => {
@@ -288,10 +288,10 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
     });
 
     expect(() => search.refresh()).toThrowErrorMatchingInlineSnapshot(`
-"The \`start\` method needs to be called before \`refresh\`.
+      "The \`start\` method needs to be called before \`refresh\`.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
+    `);
   });
 
   it('warns dev with EXPERIMENTAL_use', () => {
@@ -1241,10 +1241,10 @@ describe('start', () => {
     expect(() => {
       instance.start();
     }).toThrowErrorMatchingInlineSnapshot(`
-"The \`start\` method has already been called once.
+      "The \`start\` method has already been called once.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
+    `);
   });
 
   it('keeps a mainHelper already set on the instance (Vue SSR)', () => {
@@ -2217,10 +2217,10 @@ describe('setUiState', () => {
     expect(() => {
       search.setUiState({});
     }).toThrowErrorMatchingInlineSnapshot(`
-"The \`start\` method needs to be called before \`setUiState\`.
+      "The \`start\` method needs to be called before \`setUiState\`.
 
-See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
-`);
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsearch/js/"
+    `);
   });
 
   test('triggers a search', async () => {

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -186,6 +186,21 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       expect(instance.getWidgets()).toHaveLength(2);
     });
 
+    it('accepts nested widgets', () => {
+      const instance = index({ indexName: 'indexName' });
+      const searchBox = virtualSearchBox({});
+      const pagination = virtualPagination({});
+      const refinementList = virtualRefinementList({ attribute: 'brand' });
+
+      instance.addWidgets([searchBox, [pagination, refinementList]]);
+      expect(instance.getWidgets()).toHaveLength(3);
+      expect(instance.getWidgets()).toEqual([
+        searchBox,
+        pagination,
+        refinementList,
+      ]);
+    });
+
     it('returns the instance to be able to chain the calls', () => {
       const topLevelInstance = index({ indexName: 'topLevelIndexName' });
       const subLevelInstance = index({ indexName: 'subLevelIndexName' });
@@ -496,6 +511,20 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
 
       instance.removeWidgets([searchBox, pagination]);
 
+      expect(instance.getWidgets()).toHaveLength(0);
+    });
+
+    it('accepts nested widgets', () => {
+      const instance = index({ indexName: 'indexName' });
+      const searchBox = virtualSearchBox({});
+      const pagination = virtualPagination({});
+      const refinementList = virtualRefinementList({ attribute: 'brand' });
+
+      instance.addWidgets([searchBox, pagination, refinementList]);
+
+      expect(instance.getWidgets()).toHaveLength(3);
+
+      instance.removeWidgets([searchBox, [pagination, refinementList]]);
       expect(instance.getWidgets()).toHaveLength(0);
     });
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Accept composed widgets - a composed widget is a widget that itself is an array of widgets - as an argument to addWidgets and removeWidgets.

This will be useful for InstantSearch.js autocomplete widget that will have multiple widgets composing the single widget.

This enables the "pseudo-widget" signature of `function myWidget(params): Widget[]` instead of just `function myWidget(params): Widget`

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

addWidgets and removeWidgets accept a widget that itself is a list, by flattening the list before using it.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

[FX-3501]


[FX-3501]: https://algolia.atlassian.net/browse/FX-3501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ