### PR TITLE
feat(autocomplete): draft React component

### DIFF
--- a/packages/react-instantsearch-core/package.json
+++ b/packages/react-instantsearch-core/package.json
@@ -10,6 +10,10 @@
     ".": {
       "import": "./dist/es/index.js",
       "require": "./dist/cjs/index.js"
+    },
+    "./autocomplete": {
+      "import": "./dist/es/autocomplete.js",
+      "require": "./dist/cjs/autocomplete.js"
     }
   },
   "sideEffects": false,

--- a/packages/react-instantsearch-core/src/autocomplete.ts
+++ b/packages/react-instantsearch-core/src/autocomplete.ts
@@ -1,0 +1,2 @@
+export * from './components/AutocompleteWrapper';
+export * from './hooks/useAutocomplete';

--- a/packages/react-instantsearch-core/src/components/AutocompleteWrapper.tsx
+++ b/packages/react-instantsearch-core/src/components/AutocompleteWrapper.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { useIndexContext } from '../lib/useIndexContext';
+
+import { Index } from './Index';
+
+export type AutocompleteWrapperProps = {
+  children: React.ReactNode;
+};
+
+export function AutocompleteWrapper({ children }: AutocompleteWrapperProps) {
+  const parentIndex = useIndexContext();
+
+  const parentIndexName = parentIndex.getIndexName();
+
+  return (
+    <Index
+      indexName={parentIndex.getIndexName()}
+      indexId={`${parentIndexName}-autocomplete`}
+      EXPERIMENTAL_isolated
+    >
+      {children}
+    </Index>
+  );
+}

--- a/packages/react-instantsearch-core/src/hooks/useAutocomplete.ts
+++ b/packages/react-instantsearch-core/src/hooks/useAutocomplete.ts
@@ -1,0 +1,10 @@
+import { useSearchBox } from '../connectors/useSearchBox';
+
+export function useAutocomplete() {
+  const { query, refine } = useSearchBox();
+
+  return {
+    query,
+    refine,
+  };
+}

--- a/packages/react-instantsearch/package.json
+++ b/packages/react-instantsearch/package.json
@@ -10,6 +10,10 @@
     ".": {
       "import": "./dist/es/index.js",
       "require": "./dist/cjs/index.js"
+    },
+    "./autocomplete": {
+      "import": "./dist/es/autocomplete.js",
+      "require": "./dist/cjs/autocomplete.js"
     }
   },
   "sideEffects": false,

--- a/packages/react-instantsearch/src/components/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/components/Autocomplete.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import {
+  AutocompleteWrapper,
+  useAutocomplete,
+} from 'react-instantsearch-core/dist/es/autocomplete';
+
+export function Autocomplete() {
+  return (
+    <AutocompleteWrapper>
+      <AutocompleteInner />
+    </AutocompleteWrapper>
+  );
+}
+
+function AutocompleteInner() {
+  useAutocomplete();
+
+  return null;
+}


### PR DESCRIPTION
**Summary**

[]()

**Result**

Still very much a draft, not too sure about the divide with `react-instantsearch` and core, and whether indices will use `useIndex` hooks or more custom stuff. I think it's good for now until we implement indices.
Also conditional exports doesn't work 100% yet, we'd need to change `moduleResolution`
