### PR TITLE
fix(umd): remove ai components from react umd bundle

### DIFF
--- a/packages/react-instantsearch-core/rollup.config.js
+++ b/packages/react-instantsearch-core/rollup.config.js
@@ -45,8 +45,8 @@ const plugins = [
 ];
 
 const createConfiguration = ({ name, minify = false } = {}) => ({
-  input: 'src/index.ts',
-  external: ['react', 'ai', 'zod'],
+  input: 'src/index.umd.ts',
+  external: ['react'],
   output: {
     file: `dist/umd/ReactInstantSearch${name}${minify ? '.min' : ''}.js`,
     name: `ReactInstantSearch${name}`,

--- a/packages/react-instantsearch-core/src/index.umd.ts
+++ b/packages/react-instantsearch-core/src/index.umd.ts
@@ -1,0 +1,50 @@
+export { default as version } from './version';
+export * from './components/Configure';
+export * from './components/DynamicWidgets';
+export * from './components/Index';
+export * from './components/InstantSearch';
+export * from './components/InstantSearchServerContext';
+export * from './components/InstantSearchSSRProvider';
+export * from './connectors/useBreadcrumb';
+
+export const useChat = () => {
+  throw new Error(
+    `"useChat()" is not available from the UMD build.
+
+Please use React InstantSearch with a packaging system:
+https://www.algolia.com/doc/guides/building-search-ui/installation/react/#install-react-instantsearch-as-an-npm-package`
+  );
+};
+
+export * from './connectors/useClearRefinements';
+export * from './connectors/useConfigure';
+export * from './connectors/useCurrentRefinements';
+export * from './connectors/useDynamicWidgets';
+export * from './connectors/useFrequentlyBoughtTogether';
+export * from './connectors/useGeoSearch';
+export * from './connectors/useHierarchicalMenu';
+export * from './connectors/useHits';
+export * from './connectors/useHitsPerPage';
+export * from './connectors/useInfiniteHits';
+export * from './connectors/useMenu';
+export * from './connectors/useNumericMenu';
+export * from './connectors/usePagination';
+export * from './connectors/usePoweredBy';
+export * from './connectors/useQueryRules';
+export * from './connectors/useRange';
+export * from './connectors/useRefinementList';
+export * from './connectors/useRelatedProducts';
+export * from './connectors/useSearchBox';
+export * from './connectors/useSortBy';
+export * from './connectors/useStats';
+export * from './connectors/useToggleRefinement';
+export * from './connectors/useTrendingItems';
+export * from './connectors/useLookingSimilar';
+export * from './hooks/useConnector';
+export * from './hooks/useInstantSearch';
+export * from './lib/wrapPromiseWithState';
+export * from './lib/useInstantSearchContext';
+export * from './lib/useRSCContext';
+export * from './lib/InstantSearchRSCContext';
+export * from './lib/InstantSearchSSRContext';
+export * from './server';

--- a/packages/react-instantsearch/rollup.config.js
+++ b/packages/react-instantsearch/rollup.config.js
@@ -45,7 +45,7 @@ const plugins = [
 ];
 
 const createConfiguration = ({ name, minify = false } = {}) => ({
-  input: 'src/index.ts',
+  input: 'src/index.umd.ts',
   external: ['react', 'ai'],
   output: {
     file: `dist/umd/ReactInstantSearch${name}${minify ? '.min' : ''}.js`,

--- a/packages/react-instantsearch/src/index.umd.ts
+++ b/packages/react-instantsearch/src/index.umd.ts
@@ -1,0 +1,3 @@
+export * from 'react-instantsearch-core/src/index.umd';
+export * from './widgets/index.umd';
+export * from './components';

--- a/packages/react-instantsearch/src/widgets/index.umd.ts
+++ b/packages/react-instantsearch/src/widgets/index.umd.ts
@@ -1,0 +1,32 @@
+export * from './Breadcrumb';
+
+export const Chat = () => {
+  throw new Error(
+    `"<Chat>" is not available from the UMD build.
+
+Please use React InstantSearch with a packaging system:
+https://www.algolia.com/doc/guides/building-search-ui/installation/react/#install-react-instantsearch-as-an-npm-package`
+  );
+};
+
+export * from './ClearRefinements';
+export * from './CurrentRefinements';
+export * from './FrequentlyBoughtTogether';
+export * from './HierarchicalMenu';
+export * from './Highlight';
+export * from './Hits';
+export * from './HitsPerPage';
+export * from './InfiniteHits';
+export * from './LookingSimilar';
+export * from './Menu';
+export * from './Pagination';
+export * from './PoweredBy';
+export * from './RangeInput';
+export * from './RefinementList';
+export * from './RelatedProducts';
+export * from './SearchBox';
+export * from './Snippet';
+export * from './SortBy';
+export * from './Stats';
+export * from './ToggleRefinement';
+export * from './TrendingItems';

--- a/tests/umd.test.ts
+++ b/tests/umd.test.ts
@@ -1,23 +1,10 @@
 import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { resolve as resolvePath } from 'path';
 
 import { JSDOM } from 'jsdom';
 
-/**
- * Adds a UMD script to the JSDOM window
- * @param window A reference to the window provided by JSDOM
- * @param path The path to the bundle relative to the root of the project
- */
-function addScript(window: JSDOM['window'], path: string) {
-  const bundle = readFileSync(resolve(process.cwd(), path), 'utf8');
-
-  const script = window.document.createElement('script');
-  script.textContent = bundle;
-  window.document.body.appendChild(script);
-}
-
 describe('UMD bundle', () => {
-  test.each([
+  describe.each([
     {
       name: 'algoliasearch-helper',
       bundle: 'dist/algoliasearch.helper.min.js',
@@ -27,26 +14,128 @@ describe('UMD bundle', () => {
       name: 'instantsearch.js',
       bundle: 'dist/instantsearch.production.min.js',
       globalName: 'instantsearch',
+      unavailable: ['connectors.connectChat', 'widgets.chat'],
+    },
+    {
+      name: 'react-instantsearch-core',
+      bundle: 'dist/umd/ReactInstantSearchCore.js',
+      globalName: 'ReactInstantSearchCore',
+      dependencies: [
+        'https://cdn.jsdelivr.net/npm/react@17/umd/react.production.min.js',
+      ],
+      unavailable: ['useChat'],
+    },
+    {
+      name: 'react-instantsearch',
+      bundle: 'dist/umd/ReactInstantSearch.js',
+      globalName: 'ReactInstantSearch',
+      dependencies: [
+        'https://cdn.jsdelivr.net/npm/react@17/umd/react.production.min.js',
+      ],
+      unavailable: ['useChat', 'Chat'],
     },
     {
       name: 'vue-instantsearch',
       bundle: 'vue2/umd/index.js',
       globalName: 'VueInstantSearch',
-      dependency: 'node_modules/vue/dist/vue.min.js',
+      dependencies: ['https://cdn.jsdelivr.net/npm/vue@2/dist/vue.min.js'],
     },
-  ])('$name loads successfully', ({ name, bundle, globalName, dependency }) => {
-    const { window } = new JSDOM('', { runScripts: 'dangerously' });
+    {
+      name: 'vue-instantsearch',
+      bundle: 'vue3/umd/index.js',
+      globalName: 'VueInstantSearch',
+      dependencies: [
+        'https://cdn.jsdelivr.net/npm/vue@3/dist/vue.global.prod.js',
+      ],
+    },
+  ])('$bundle', ({ name, bundle, globalName, dependencies, unavailable }) => {
+    test('loads successfully', async () => {
+      const { window, error } = await createEnvironment(
+        `packages/${name}/${bundle}`,
+        dependencies
+      );
 
-    const errorFn = jest.fn();
-    window.addEventListener('error', errorFn);
+      expect(error).not.toHaveBeenCalled();
+      expect(window[globalName]).toBeDefined();
+    });
 
-    if (dependency) {
-      addScript(window, dependency);
+    if (unavailable) {
+      test.each(unavailable)(
+        'throws when calling %s',
+        async (componentPath) => {
+          const { window } = await createEnvironment(
+            `packages/${name}/${bundle}`,
+            dependencies
+          );
+
+          const component = componentPath
+            .split('.')
+            .reduce((acc, path) => acc[path], window[globalName]);
+
+          expect(() => component()).toThrow(
+            /is not available from the UMD build/
+          );
+        }
+      );
     }
-
-    addScript(window, `packages/${name}/${bundle}`);
-
-    expect(errorFn).not.toHaveBeenCalled();
-    expect(window[globalName]).toBeDefined();
   });
 });
+
+/**
+ * Adds a UMD script to the JSDOM window
+ * @param window Reference to the window provided by JSDOM
+ * @param pathOrUrl Path to the bundle relative to the project's root or URL
+ */
+function addScript(
+  window: JSDOM['window'],
+  pathOrUrl: string
+): Promise<void> | void {
+  const script = window.document.createElement('script');
+
+  if (pathOrUrl.startsWith('https')) {
+    return new Promise((resolve, reject) => {
+      script.src = pathOrUrl;
+      script.onload = () => resolve();
+      script.onerror = () =>
+        reject(new Error(`Failed to load script: ${pathOrUrl}`));
+
+      window.document.head.appendChild(script);
+    });
+  }
+
+  const bundle = readFileSync(resolvePath(process.cwd(), pathOrUrl), 'utf8');
+  script.textContent = bundle;
+
+  window.document.body.appendChild(script);
+  return Promise.resolve();
+}
+
+/**
+ * Creates a JSDOM environment with the given bundle and dependencies
+ * @param bundle Path to the bundle relative to the project's root
+ * @param dependencies Array of dependencies
+ */
+async function createEnvironment(
+  bundle: string,
+  dependencies?: string[]
+): Promise<{ window: JSDOM['window']; error: jest.Mock }> {
+  const { window } = new JSDOM('', {
+    runScripts: 'dangerously',
+    resources: 'usable',
+  });
+
+  const error = jest.fn();
+  window.addEventListener('error', error);
+
+  if (dependencies) {
+    for (const dependency of dependencies) {
+      await addScript(window, dependency);
+    }
+  }
+
+  await addScript(window, bundle);
+
+  return new Promise((resolve) => {
+    window.addEventListener('load', () => resolve({ window, error }));
+  });
+}


### PR DESCRIPTION
**Summary**

This PR updates react-instantsearch to not export `useChat` and `Chat` on the UMD bundle, since we're not bundling ai. There are also changes to the UMD test file in order to add more in-depths assertions and additionally cover react-instantsearch-core + vue-instantsearch (vue3).

FX-3530