### PR TITLE
fix(recommend): omit fallbackParameters from query when not passed as params

### DIFF
--- a/packages/instantsearch.js/src/connectors/looking-similar/__tests__/connectLookingSimilar-test.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/__tests__/connectLookingSimilar-test.ts
@@ -118,7 +118,6 @@ describe('connectLookingSimilar', () => {
             maxRecommendations: 10,
             threshold: 95,
             queryParameters: { userToken: 'token' },
-            fallbackParameters: {},
           })
           .addLookingSimilar({
             // @ts-expect-error
@@ -127,7 +126,62 @@ describe('connectLookingSimilar', () => {
             maxRecommendations: 10,
             threshold: 95,
             queryParameters: { userToken: 'token' },
-            fallbackParameters: {},
+          })
+      );
+    });
+
+    it('adds escapeHTML tags', () => {
+      const render = () => {};
+      const makeWidget = connectLookingSimilar(render);
+      const widget = makeWidget({
+        objectIDs: ['1', '2'],
+        limit: 10,
+        threshold: 95,
+        queryParameters: { userToken: 'token' },
+        fallbackParameters: { query: 'query' },
+        escapeHTML: true,
+      });
+
+      // @ts-expect-error
+      const actual = widget.getWidgetParameters(new RecommendParameters(), {
+        uiState: {},
+      });
+
+      expect(actual).toEqual(
+        new RecommendParameters()
+          .addLookingSimilar({
+            // @ts-expect-error
+            $$id: widget.$$id,
+            objectID: '1',
+            maxRecommendations: 10,
+            threshold: 95,
+            queryParameters: {
+              userToken: 'token',
+              highlightPostTag: '__/ais-highlight__',
+              highlightPreTag: '__ais-highlight__',
+            },
+            fallbackParameters: {
+              query: 'query',
+              highlightPostTag: '__/ais-highlight__',
+              highlightPreTag: '__ais-highlight__',
+            },
+          })
+          .addLookingSimilar({
+            // @ts-expect-error
+            $$id: widget.$$id,
+            objectID: '2',
+            maxRecommendations: 10,
+            threshold: 95,
+            queryParameters: {
+              userToken: 'token',
+              highlightPostTag: '__/ais-highlight__',
+              highlightPreTag: '__ais-highlight__',
+            },
+            fallbackParameters: {
+              query: 'query',
+              highlightPostTag: '__/ais-highlight__',
+              highlightPreTag: '__ais-highlight__',
+            },
           })
       );
     });

--- a/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
+++ b/packages/instantsearch.js/src/connectors/looking-similar/connectLookingSimilar.ts
@@ -215,10 +215,12 @@ export default (function connectLookingSimilar<
               objectID,
               maxRecommendations: limit,
               threshold,
-              fallbackParameters: {
-                ...fallbackParameters,
-                ...(escapeHTML ? TAG_PLACEHOLDER : {}),
-              },
+              fallbackParameters: fallbackParameters
+                ? {
+                    ...fallbackParameters,
+                    ...(escapeHTML ? TAG_PLACEHOLDER : {}),
+                  }
+                : undefined,
               queryParameters: {
                 ...queryParameters,
                 ...(escapeHTML ? TAG_PLACEHOLDER : {}),

--- a/packages/instantsearch.js/src/connectors/related-products/__tests__/connectRelatedProducts-test.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/__tests__/connectRelatedProducts-test.ts
@@ -118,7 +118,6 @@ describe('connectRelatedProducts', () => {
             maxRecommendations: 10,
             threshold: 95,
             queryParameters: { userToken: 'token' },
-            fallbackParameters: {},
           })
           .addRelatedProducts({
             // @ts-expect-error
@@ -127,7 +126,62 @@ describe('connectRelatedProducts', () => {
             maxRecommendations: 10,
             threshold: 95,
             queryParameters: { userToken: 'token' },
-            fallbackParameters: {},
+          })
+      );
+    });
+
+    it('adds escapeHTML tags', () => {
+      const render = () => {};
+      const makeWidget = connectRelatedProducts(render);
+      const widget = makeWidget({
+        objectIDs: ['1', '2'],
+        limit: 10,
+        threshold: 95,
+        queryParameters: { userToken: 'token' },
+        fallbackParameters: { query: 'query' },
+        escapeHTML: true,
+      });
+
+      // @ts-expect-error
+      const actual = widget.getWidgetParameters(new RecommendParameters(), {
+        uiState: {},
+      });
+
+      expect(actual).toEqual(
+        new RecommendParameters()
+          .addRelatedProducts({
+            // @ts-expect-error
+            $$id: widget.$$id,
+            objectID: '1',
+            maxRecommendations: 10,
+            threshold: 95,
+            queryParameters: {
+              userToken: 'token',
+              highlightPostTag: '__/ais-highlight__',
+              highlightPreTag: '__ais-highlight__',
+            },
+            fallbackParameters: {
+              highlightPostTag: '__/ais-highlight__',
+              highlightPreTag: '__ais-highlight__',
+              query: 'query',
+            },
+          })
+          .addRelatedProducts({
+            // @ts-expect-error
+            $$id: widget.$$id,
+            objectID: '2',
+            maxRecommendations: 10,
+            threshold: 95,
+            queryParameters: {
+              userToken: 'token',
+              highlightPostTag: '__/ais-highlight__',
+              highlightPreTag: '__ais-highlight__',
+            },
+            fallbackParameters: {
+              highlightPostTag: '__/ais-highlight__',
+              highlightPreTag: '__ais-highlight__',
+              query: 'query',
+            },
           })
       );
     });

--- a/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
+++ b/packages/instantsearch.js/src/connectors/related-products/connectRelatedProducts.ts
@@ -216,10 +216,12 @@ export default (function connectRelatedProducts<
               objectID,
               maxRecommendations: limit,
               threshold,
-              fallbackParameters: {
-                ...fallbackParameters,
-                ...(escapeHTML ? TAG_PLACEHOLDER : {}),
-              },
+              fallbackParameters: fallbackParameters
+                ? {
+                    ...fallbackParameters,
+                    ...(escapeHTML ? TAG_PLACEHOLDER : {}),
+                  }
+                : undefined,
               queryParameters: {
                 ...queryParameters,
                 ...(escapeHTML ? TAG_PLACEHOLDER : {}),

--- a/packages/instantsearch.js/src/connectors/trending-items/__tests__/connectTrendingItems-test.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/__tests__/connectTrendingItems-test.ts
@@ -134,7 +134,6 @@ describe('connectTrendingItems', () => {
           maxRecommendations: 10,
           threshold: 95,
           queryParameters: { userToken: 'token' },
-          fallbackParameters: {},
         })
       );
     });
@@ -165,7 +164,46 @@ describe('connectTrendingItems', () => {
           maxRecommendations: 10,
           threshold: 95,
           queryParameters: { userToken: 'token' },
-          fallbackParameters: {},
+        })
+      );
+    });
+
+    it('adds escapeHTML tags', () => {
+      const render = () => {};
+      const makeWidget = connectTrendingItems(render);
+      const widget = makeWidget({
+        facetName: 'key',
+        facetValue: 'value',
+        limit: 10,
+        threshold: 95,
+        queryParameters: { userToken: 'token' },
+        escapeHTML: true,
+        fallbackParameters: { query: 'query' },
+      });
+
+      // @ts-expect-error
+      const actual = widget.getWidgetParameters(new RecommendParameters(), {
+        uiState: {},
+      });
+
+      expect(actual).toEqual(
+        new RecommendParameters().addTrendingItems({
+          // @ts-expect-error
+          $$id: widget.$$id,
+          facetName: 'key',
+          facetValue: 'value',
+          maxRecommendations: 10,
+          threshold: 95,
+          queryParameters: {
+            userToken: 'token',
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+          },
+          fallbackParameters: {
+            highlightPostTag: '__/ais-highlight__',
+            highlightPreTag: '__ais-highlight__',
+            query: 'query',
+          },
         })
       );
     });

--- a/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
+++ b/packages/instantsearch.js/src/connectors/trending-items/connectTrendingItems.ts
@@ -235,10 +235,12 @@ export default (function connectTrendingItems<
           facetValue: facetValue as string,
           maxRecommendations: limit,
           threshold,
-          fallbackParameters: {
-            ...fallbackParameters,
-            ...(escapeHTML ? TAG_PLACEHOLDER : {}),
-          },
+          fallbackParameters: fallbackParameters
+            ? {
+                ...fallbackParameters,
+                ...(escapeHTML ? TAG_PLACEHOLDER : {}),
+              }
+            : undefined,
           queryParameters: {
             ...queryParameters,
             ...(escapeHTML ? TAG_PLACEHOLDER : {}),


### PR DESCRIPTION
**Summary**

`fallbackParameters` shouldn't be passed to the query unless the user specifically provides a value. Otherwise this could trigger an unexpected fallback query.  
