### PR TITLE
fix(chat): add missing props to the IS.js chat widget

### DIFF
--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -164,6 +164,8 @@ const createRenderer = <THit extends NonNullable<object> = BaseHit>({
       setOpen,
       status,
       addToolResult,
+      regenerate,
+      stop,
     } = props;
 
     if (isFirstRendering) {
@@ -209,13 +211,17 @@ const createRenderer = <THit extends NonNullable<object> = BaseHit>({
           classNames={cssClasses}
           open={open}
           maximized={maximized}
+          toggleButtonProps={{ open, onClick: () => setOpen(!open) }}
           headerProps={{
             onClose: () => setOpen(false),
+            maximized,
             onToggleMaximize: () => setMaximized(!maximized),
             onClear,
-            canClear: messages.length > 0 && isClearing !== true,
+            canClear: Boolean(messages?.length) && !isClearing,
           }}
           messagesProps={{
+            status,
+            onReload: (messageId) => regenerate({ messageId }),
             messages,
             indexUiState,
             isClearing,
@@ -235,8 +241,10 @@ const createRenderer = <THit extends NonNullable<object> = BaseHit>({
               sendMessage({ text: input });
               setInput('');
             },
+            onStop: () => {
+              stop();
+            },
           }}
-          toggleButtonProps={{ open, onClick: () => setOpen(!open) }}
         />,
         containerNode
       );

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -188,7 +188,7 @@ export function Chat<
         maximized,
         onToggleMaximize: () => setMaximized(!maximized),
         onClear: handleClear,
-        canClear: messages && messages.length > 0 && !isClearing,
+        canClear: Boolean(messages?.length) && !isClearing,
         ...headerProps,
       }}
       messagesProps={{


### PR DESCRIPTION
**Summary**

This PR fixes the chat widget in InstantSearch.js by adding the missing props to the Chat UI component to achieve parity with the React InstantSearch chat widget.