### PR TITLE
feat(autocomplete): implement suggestions for React

### DIFF
--- a/examples/react/getting-started/src/App.tsx
+++ b/examples/react/getting-started/src/App.tsx
@@ -11,6 +11,7 @@ import {
   SearchBox,
   TrendingItems,
   Carousel,
+  EXPERIMENTAL_Autocomplete,
 } from 'react-instantsearch';
 
 import { Panel } from './Panel';
@@ -45,6 +46,13 @@ export function App() {
           indexName="instant_search"
           insights={true}
         >
+          <EXPERIMENTAL_Autocomplete
+            indices={[]}
+            showSuggestions={{
+              indexName: 'instant_search_demo_query_suggestions',
+            }}
+          />
+
           <Configure hitsPerPage={8} />
           <div className="search-panel">
             <div className="search-panel__filters">

--- a/packages/instantsearch-ui-components/src/components/autocomplete/AutocompleteIndex.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/AutocompleteIndex.tsx
@@ -8,7 +8,8 @@ export type AutocompleteIndexProps<
   T = { objectID: string } & Record<string, unknown>
 > = {
   items: T[];
-  ItemComponent: (item: T) => JSX.Element;
+  onSelect: (item: T) => void;
+  ItemComponent: (props: { item: T; onSelect: () => void }) => JSX.Element;
   classNames?: Partial<AutocompleteIndexClassNames>;
 };
 
@@ -29,7 +30,7 @@ export type AutocompleteIndexClassNames = {
 
 export function createAutocompleteIndexComponent({ createElement }: Renderer) {
   return function AutocompleteIndex(userProps: AutocompleteIndexProps) {
-    const { items, ItemComponent, classNames = {} } = userProps;
+    const { items, ItemComponent, onSelect, classNames = {} } = userProps;
 
     return (
       <div className={cx('ais-AutocompleteIndex', classNames.root)}>
@@ -39,7 +40,7 @@ export function createAutocompleteIndexComponent({ createElement }: Renderer) {
               key={item.objectID}
               className={cx('ais-AutocompleteIndexItem', classNames.item)}
             >
-              <ItemComponent {...item} />
+              <ItemComponent item={item} onSelect={() => onSelect(item)} />
             </li>
           ))}
         </ol>

--- a/packages/instantsearch-ui-components/src/components/autocomplete/AutocompleteSuggestion.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/AutocompleteSuggestion.tsx
@@ -1,0 +1,39 @@
+/** @jsx createElement */
+
+import { cx } from '../../lib';
+
+import type { Renderer } from '../../types';
+
+export type AutocompleteSuggestionProps<
+  T = { query: string } & Record<string, unknown>
+> = {
+  item: T;
+  onSelect: () => void;
+  classNames?: Partial<AutocompleteSuggestionClassNames>;
+};
+
+export type AutocompleteSuggestionClassNames = {
+  /**
+   * Class names to apply to the root element
+   **/
+  root: string | string[];
+};
+
+export function createAutocompleteSuggestionComponent({
+  createElement,
+}: Renderer) {
+  return function AutocompleteSuggestion({
+    item,
+    onSelect,
+    classNames,
+  }: AutocompleteSuggestionProps) {
+    return (
+      <div
+        onClick={onSelect}
+        className={cx('ais-AutocompleteSuggestion', classNames?.root)}
+      >
+        {item.query}
+      </div>
+    );
+  };
+}

--- a/packages/instantsearch-ui-components/src/components/autocomplete/index.ts
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/index.ts
@@ -1,3 +1,4 @@
 export * from './Autocomplete';
 export * from './AutocompleteIndex';
 export * from './AutocompletePanel';
+export * from './AutocompleteSuggestion';

--- a/packages/react-instantsearch/src/components/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/components/Autocomplete.tsx
@@ -2,13 +2,18 @@ import {
   createAutocompleteComponent,
   createAutocompleteIndexComponent,
   createAutocompletePanelComponent,
+  createAutocompleteSuggestionComponent,
+  cx,
 } from 'instantsearch-ui-components';
 import React, { createElement, useState, Fragment } from 'react';
-import { Index, useHits } from 'react-instantsearch-core';
+import { Index, useHits, useInstantSearch } from 'react-instantsearch-core';
 
 import { SearchBox } from '../widgets/SearchBox';
 
-import type { Pragma } from 'instantsearch-ui-components';
+import type {
+  AutocompleteIndexClassNames,
+  Pragma,
+} from 'instantsearch-ui-components';
 import type { BaseHit, Hit } from 'instantsearch.js';
 
 const Autocomplete = createAutocompleteComponent({
@@ -26,19 +31,72 @@ const AutocompleteIndex = createAutocompleteIndexComponent({
   Fragment,
 });
 
-type IndexConfig<TItem extends Hit<BaseHit> = Hit<BaseHit>> = {
+const AutocompleteSuggestion = createAutocompleteSuggestionComponent({
+  createElement: createElement as Pragma,
+  Fragment,
+});
+
+type ItemComponentProps<TItem> = React.ComponentType<{
+  item: TItem;
+  onSelect: () => void;
+}>;
+
+type IndexConfig<TItem extends Hit<BaseHit> = Hit<BaseHit> | any> = {
   indexName: string;
   getQuery?: (item: TItem) => string;
   getURL?: (item: TItem) => string;
-  itemComponent: React.ComponentType<TItem> | React.ComponentType<any>;
+  itemComponent: ItemComponentProps<TItem>;
+  onSelect?: (params: {
+    item: TItem;
+    getQuery: () => string;
+    getURL: () => string;
+    setQuery: (query: string) => void;
+  }) => void;
+  classNames?: Partial<AutocompleteIndexClassNames>;
 };
 
 export type AutocompleteProps = {
-  indices: IndexConfig[];
+  indices?: IndexConfig[];
+  showSuggestions?: {
+    itemComponent?: ItemComponentProps<Hit<{ query: string }>>;
+    indexName?: string;
+    classNames?: Partial<AutocompleteIndexClassNames>;
+  };
 };
 
-export function EXPERIMENTAL_Autocomplete({ indices }: AutocompleteProps) {
+export function EXPERIMENTAL_Autocomplete({
+  indices: userIndices = [],
+  showSuggestions,
+}: AutocompleteProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const { setIndexUiState } = useInstantSearch();
+
+  const indices = [...userIndices];
+
+  if (showSuggestions?.indexName) {
+    indices.unshift({
+      indexName: showSuggestions.indexName,
+      itemComponent: showSuggestions.itemComponent || AutocompleteSuggestion,
+      classNames: {
+        root: cx(
+          'ais-AutocompleteSuggestions',
+          showSuggestions?.classNames?.root
+        ),
+        list: cx(
+          'ais-AutocompleteSuggestionsList',
+          showSuggestions?.classNames?.list
+        ),
+        item: cx(
+          'ais-AutocompleteSuggestionsItem',
+          showSuggestions?.classNames?.item
+        ),
+      },
+      getQuery: (item) => item.query,
+      onSelect: ({ getQuery, setQuery }) => {
+        setQuery(getQuery());
+      },
+    });
+  }
 
   return (
     <Index EXPERIMENTAL_isolated>
@@ -47,7 +105,12 @@ export function EXPERIMENTAL_Autocomplete({ indices }: AutocompleteProps) {
         <AutocompletePanel isOpen={isOpen}>
           {indices.map((index) => (
             <Index key={index.indexName} indexName={index.indexName}>
-              <AutocompleteIndexComponent itemComponent={index.itemComponent} />
+              <AutocompleteIndexComponent
+                {...index}
+                setQuery={(query) => {
+                  setIndexUiState((state) => ({ ...state, query }));
+                }}
+              />
             </Index>
           ))}
         </AutocompletePanel>
@@ -56,13 +119,14 @@ export function EXPERIMENTAL_Autocomplete({ indices }: AutocompleteProps) {
   );
 }
 
-type AutocompleteIndexProps = {
-  itemComponent: IndexConfig['itemComponent'];
-};
-
 function AutocompleteIndexComponent({
   itemComponent: ItemComponent,
-}: AutocompleteIndexProps) {
+  onSelect,
+  getQuery,
+  getURL,
+  setQuery,
+  classNames,
+}: IndexConfig & { setQuery: (query: string) => void }) {
   const { items } = useHits();
 
   return (
@@ -70,6 +134,15 @@ function AutocompleteIndexComponent({
       // @ts-expect-error - there seems to be problems with React.ComponentType and this, but it's actually correct
       ItemComponent={ItemComponent}
       items={items}
+      onSelect={(item) => {
+        onSelect?.({
+          item,
+          getQuery: () => getQuery?.(item) || '',
+          getURL: () => getURL?.(item) || '',
+          setQuery,
+        });
+      }}
+      classNames={classNames}
     />
   );
 }


### PR DESCRIPTION
**Summary**

[FX-3503](https://algolia.atlassian.net/browse/FX-3503)

**Result**

Had to implement something like `onSelect` options, and pass `setQuery`.
Not sure if `getQuery` and `getURL` are really relevant with this, as they can just do anything with `onSelect` + whatever is on their record
