### PR TITLE
fix(memory): cache key includes agent id

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -158,6 +158,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           ? options
           : {
               ...options,
+              id: options.agentId,
               transport,
             };
 

--- a/packages/instantsearch.js/src/lib/chat/chat.ts
+++ b/packages/instantsearch.js/src/lib/chat/chat.ts
@@ -11,12 +11,12 @@ export type { UIMessage };
 export { AbstractChat };
 export { ChatInit };
 
-export const CACHE_KEY = 'instantsearch-chat-initial-messages';
+export const CACHE_KEY = 'instantsearch-chat-initial-messages-';
 
-function getDefaultInitialMessages<
-  TUIMessage extends UIMessage
->(): TUIMessage[] {
-  const initialMessages = sessionStorage.getItem(CACHE_KEY);
+function getDefaultInitialMessages<TUIMessage extends UIMessage>(
+  id?: string
+): TUIMessage[] {
+  const initialMessages = sessionStorage.getItem(CACHE_KEY + id);
   return initialMessages ? JSON.parse(initialMessages) : [];
 }
 
@@ -32,13 +32,14 @@ export class ChatState<TUiMessage extends UIMessage>
   _errorCallbacks = new Set<() => void>();
 
   constructor(
-    initialMessages: TUiMessage[] = getDefaultInitialMessages<TUiMessage>()
+    id: string | undefined = undefined,
+    initialMessages: TUiMessage[] = getDefaultInitialMessages<TUiMessage>(id)
   ) {
     this._messages = initialMessages;
     const saveMessagesInLocalStorage = () => {
       if (this.status === 'ready') {
         try {
-          sessionStorage.setItem(CACHE_KEY, JSON.stringify(this.messages));
+          sessionStorage.setItem(CACHE_KEY + id, JSON.stringify(this.messages));
         } catch (e) {
           // Do nothing if sessionStorage is not available or full
         }
@@ -139,8 +140,8 @@ export class Chat<
 > extends AbstractChat<TUiMessage> {
   _state: ChatState<TUiMessage>;
 
-  constructor({ messages, ...init }: ChatInit<TUiMessage>) {
-    const state = new ChatState(messages);
+  constructor({ messages, id, ...init }: ChatInit<TUiMessage>) {
+    const state = new ChatState(id, messages);
     super({ ...init, state });
     this._state = state;
   }

--- a/packages/react-instantsearch-core/src/connectors/useChat.ts
+++ b/packages/react-instantsearch-core/src/connectors/useChat.ts
@@ -111,6 +111,7 @@ export function useChat<TUiMessage extends UIMessage = UIMessage>({
     }
     return {
       ...options,
+      id: options.agentId,
       transport,
     };
   }, [options, transport]);


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This ensures the same chat is restarted, only if the configuration matched.

I think there may also be something possible with chat.id that gets generated after creation of the chat, but i don't think we can reason anything about its identity.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

if you change the agentId, the chat is restarted.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
