### PR TITLE
refactor(ai-lite): remove unsafe onToolCall any cast

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -461,7 +461,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
 
           return Promise.resolve();
         },
-      });
+      } as ChatInitAi<TUiMessage> & { agentId?: string });
     };
 
     return {

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -12,6 +12,7 @@ import type {
   FileUIPart,
   IdGenerator,
   InferUIMessageMetadata,
+  InferUIMessageToolCall,
   InferUIMessageTools,
   UIMessage,
   UIMessageChunk,
@@ -21,9 +22,9 @@ import type {
   ChatOnDataCallback,
 } from './types';
 
-type ActiveResponse = {
+type ActiveResponse<TChunk extends UIMessageChunk = UIMessageChunk> = {
   abortController: AbortController;
-  stream?: ReadableStream<UIMessageChunk>;
+  stream?: ReadableStream<TChunk>;
 };
 
 /**
@@ -685,7 +686,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                     toolName: chunk.toolName,
                     toolCallId: chunk.toolCallId,
                     input: chunk.input,
-                  } as any,
+                    dynamic: 'dynamic' in chunk ? chunk.dynamic : undefined,
+                  } as InferUIMessageToolCall<TUIMessage>,
                 });
                 if (result && typeof result.then === 'function') {
                   pendingToolCall = pendingToolCall.then(() => result);

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -11,6 +11,7 @@ import type {
   CreateUIMessage,
   FileUIPart,
   IdGenerator,
+  InferUIMessageChunk,
   InferUIMessageMetadata,
   InferUIMessageToolCall,
   InferUIMessageTools,
@@ -44,7 +45,9 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     messages: TUIMessage[];
   }) => boolean | PromiseLike<boolean>;
 
-  private activeResponse: ActiveResponse | null = null;
+  private activeResponse: ActiveResponse<
+    InferUIMessageChunk<TUIMessage>
+  > | null = null;
   private jobExecutor = new SerialJobExecutor();
 
   constructor({
@@ -424,7 +427,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   }
 
   private processStreamWithCallbacks(
-    stream: ReadableStream<UIMessageChunk>
+    stream: ReadableStream<InferUIMessageChunk<TUIMessage>>
   ): Promise<void> {
     this.setStatus({ status: 'streaming' });
 
@@ -444,7 +447,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
     return new Promise((resolve) => {
       processStream<UIMessageChunk>(
-        stream,
+        stream as ReadableStream<UIMessageChunk>,
         // eslint-disable-next-line complexity
         (chunk) => {
           switch (chunk.type) {

--- a/packages/instantsearch.js/src/lib/ai-lite/stream-parser.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/stream-parser.ts
@@ -11,13 +11,13 @@ import type { UIMessageChunk } from './types';
  * @param stream - The input stream of raw bytes
  * @returns A ReadableStream of parsed UIMessageChunk events
  */
-export function parseJsonEventStream(
-  stream: ReadableStream<Uint8Array>
-): ReadableStream<UIMessageChunk> {
+export function parseJsonEventStream<
+  TChunk extends UIMessageChunk = UIMessageChunk
+>(stream: ReadableStream<Uint8Array>): ReadableStream<TChunk> {
   const decoder = new TextDecoder();
   let buffer = '';
 
-  return new ReadableStream<UIMessageChunk>({
+  return new ReadableStream<TChunk>({
     start(controller) {
       const reader = stream.getReader();
 
@@ -30,7 +30,7 @@ export function parseJsonEventStream(
                 const jsonData = extractJsonFromLine(buffer.trim());
                 if (jsonData) {
                   try {
-                    const chunk = JSON.parse(jsonData) as UIMessageChunk;
+                    const chunk = JSON.parse(jsonData) as TChunk;
                     controller.enqueue(chunk);
                   } catch {
                     // Ignore parsing errors for incomplete data at end
@@ -60,7 +60,7 @@ export function parseJsonEventStream(
               if (!jsonData) continue;
 
               try {
-                const chunk = JSON.parse(jsonData) as UIMessageChunk;
+                const chunk = JSON.parse(jsonData) as TChunk;
                 controller.enqueue(chunk);
               } catch {
                 // Skip malformed lines

--- a/packages/instantsearch.js/src/lib/ai-lite/transport.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/transport.ts
@@ -7,8 +7,8 @@ import { resolveValue } from './utils';
 import type {
   ChatTransport,
   HttpChatTransportInitOptions,
+  InferUIMessageChunk,
   UIMessage,
-  UIMessageChunk,
   FetchFunction,
   PrepareSendMessagesRequest,
   PrepareReconnectToStreamRequest,
@@ -57,7 +57,7 @@ export abstract class HttpChatTransport<TUIMessage extends UIMessage>
     headers: requestHeaders,
     body: requestBody,
   }: Parameters<ChatTransport<TUIMessage>['sendMessages']>[0]): Promise<
-    ReadableStream<UIMessageChunk>
+    ReadableStream<InferUIMessageChunk<TUIMessage>>
   > {
     const fetchFn = this.fetch ?? fetch;
 
@@ -151,7 +151,7 @@ export abstract class HttpChatTransport<TUIMessage extends UIMessage>
     body: requestBody,
   }: Parameters<
     ChatTransport<TUIMessage>['reconnectToStream']
-  >[0]): Promise<ReadableStream<UIMessageChunk> | null> {
+  >[0]): Promise<ReadableStream<InferUIMessageChunk<TUIMessage>> | null> {
     const fetchFn = this.fetch ?? fetch;
 
     // Resolve configurable values
@@ -230,7 +230,7 @@ export abstract class HttpChatTransport<TUIMessage extends UIMessage>
 
   protected abstract processResponseStream(
     stream: ReadableStream<Uint8Array>
-  ): ReadableStream<UIMessageChunk>;
+  ): ReadableStream<InferUIMessageChunk<TUIMessage>>;
 }
 
 /**
@@ -245,7 +245,7 @@ export class DefaultChatTransport<
 
   protected processResponseStream(
     stream: ReadableStream<Uint8Array>
-  ): ReadableStream<UIMessageChunk> {
-    return parseJsonEventStream(stream);
+  ): ReadableStream<InferUIMessageChunk<TUIMessage>> {
+    return parseJsonEventStream<InferUIMessageChunk<TUIMessage>>(stream);
   }
 }

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -190,15 +190,13 @@ export type InferUIMessageData<T extends UIMessage> = T extends UIMessage<
   ? DATA_TYPES
   : UIDataTypes;
 
-type _ExtractTools<
-  T extends UIMessage,
-  D extends UIDataTypes
-> = T extends UIMessage<unknown, D, infer TOOLS> ? TOOLS : UITools;
-
-export type InferUIMessageTools<T extends UIMessage> = _ExtractTools<
-  T,
-  InferUIMessageData<T>
->;
+export type InferUIMessageTools<T extends UIMessage> = T extends UIMessage<
+  unknown,
+  any,
+  infer TOOLS
+>
+  ? TOOLS
+  : UITools;
 
 export type InferUIMessageToolCall<UI_MESSAGE extends UIMessage> =
   | ValueOf<{

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -227,9 +227,92 @@ type DataUIMessageChunk<DATA_TYPES extends UIDataTypes> = ValueOf<{
   };
 }>;
 
+type ToolUIMessageChunk<TOOLS extends UITools> =
+  | ValueOf<{
+      [NAME in keyof TOOLS & string]: {
+        type: 'tool-input-available';
+        toolName: NAME;
+        toolCallId: string;
+        input: TOOLS[NAME]['input'];
+        callProviderMetadata?: ProviderMetadata;
+        providerExecuted?: boolean;
+      };
+    }>
+  | ValueOf<{
+      [NAME in keyof TOOLS & string]: {
+        type: 'tool-input-start';
+        toolName: NAME;
+        toolCallId: string;
+        input?: DeepPartial<TOOLS[NAME]['input']>;
+        providerExecuted?: boolean;
+      };
+    }>
+  | {
+      type: 'tool-input-delta';
+      toolName: string;
+      toolCallId: string;
+      inputDelta: string;
+    }
+  | ValueOf<{
+      [NAME in keyof TOOLS & string]: {
+        type: 'tool-output-available';
+        toolName: NAME;
+        toolCallId: string;
+        output: TOOLS[NAME]['output'];
+        callProviderMetadata?: ProviderMetadata;
+        preliminary?: boolean;
+      };
+    }>
+  | ValueOf<{
+      [NAME in keyof TOOLS & string]: {
+        type: 'tool-error';
+        toolName: NAME;
+        toolCallId: string;
+        errorText: string;
+        input?: TOOLS[NAME]['input'];
+        callProviderMetadata?: ProviderMetadata;
+      };
+    }>
+  | {
+      type: 'tool-input-available';
+      toolName: string;
+      toolCallId: string;
+      input: unknown;
+      callProviderMetadata?: ProviderMetadata;
+      providerExecuted?: boolean;
+      dynamic: true;
+    }
+  | {
+      type: 'tool-input-start';
+      toolName: string;
+      toolCallId: string;
+      input?: unknown;
+      providerExecuted?: boolean;
+      dynamic: true;
+    }
+  | {
+      type: 'tool-output-available';
+      toolName: string;
+      toolCallId: string;
+      output: unknown;
+      callProviderMetadata?: ProviderMetadata;
+      preliminary?: boolean;
+      dynamic: true;
+    }
+  | {
+      type: 'tool-error';
+      toolName: string;
+      toolCallId: string;
+      errorText: string;
+      input?: unknown;
+      callProviderMetadata?: ProviderMetadata;
+      dynamic: true;
+    };
+
 export type UIMessageChunk<
   METADATA = unknown,
-  DATA_TYPES extends UIDataTypes = UIDataTypes
+  DATA_TYPES extends UIDataTypes = UIDataTypes,
+  TOOLS extends UITools = UITools
 > =
   | { type: 'text-start'; id: string; providerMetadata?: ProviderMetadata }
   | {
@@ -248,43 +331,7 @@ export type UIMessageChunk<
     }
   | { type: 'reasoning-end'; id: string; providerMetadata?: ProviderMetadata }
   | { type: 'error'; errorText: string }
-  | {
-      type: 'tool-input-available';
-      toolName: string;
-      toolCallId: string;
-      input: unknown;
-      callProviderMetadata?: ProviderMetadata;
-      providerExecuted?: boolean;
-    }
-  | {
-      type: 'tool-input-start';
-      toolName: string;
-      toolCallId: string;
-      input?: unknown;
-      providerExecuted?: boolean;
-    }
-  | {
-      type: 'tool-input-delta';
-      toolName: string;
-      toolCallId: string;
-      inputDelta: string;
-    }
-  | {
-      type: 'tool-output-available';
-      toolName: string;
-      toolCallId: string;
-      output: unknown;
-      callProviderMetadata?: ProviderMetadata;
-      preliminary?: boolean;
-    }
-  | {
-      type: 'tool-error';
-      toolName: string;
-      toolCallId: string;
-      errorText: string;
-      input?: unknown;
-      callProviderMetadata?: ProviderMetadata;
-    }
+  | ToolUIMessageChunk<TOOLS>
   | { type: 'source-url'; sourceId: string; url: string; title?: string }
   | {
       type: 'source-document';
@@ -305,7 +352,8 @@ export type UIMessageChunk<
 
 export type InferUIMessageChunk<T extends UIMessage> = UIMessageChunk<
   InferUIMessageMetadata<T>,
-  InferUIMessageData<T>
+  InferUIMessageData<T>,
+  InferUIMessageTools<T>
 >;
 
 export interface ChatState<UI_MESSAGE extends UIMessage> {
@@ -334,13 +382,13 @@ export interface ChatTransport<UI_MESSAGE extends UIMessage> {
       trigger: 'submit-message' | 'regenerate-message';
       messageId?: string;
     } & ChatRequestOptions
-  ) => Promise<ReadableStream<UIMessageChunk>>;
+  ) => Promise<ReadableStream<InferUIMessageChunk<UI_MESSAGE>>>;
 
   reconnectToStream: (
     options: {
       chatId: string;
     } & ChatRequestOptions
-  ) => Promise<ReadableStream<UIMessageChunk> | null>;
+  ) => Promise<ReadableStream<InferUIMessageChunk<UI_MESSAGE>> | null>;
 }
 
 export type PrepareSendMessagesRequest<UI_MESSAGE extends UIMessage> = (

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -190,13 +190,15 @@ export type InferUIMessageData<T extends UIMessage> = T extends UIMessage<
   ? DATA_TYPES
   : UIDataTypes;
 
-export type InferUIMessageTools<T extends UIMessage> = T extends UIMessage<
-  unknown,
-  UIDataTypes,
-  infer TOOLS
->
-  ? TOOLS
-  : UITools;
+type _ExtractTools<
+  T extends UIMessage,
+  D extends UIDataTypes
+> = T extends UIMessage<unknown, D, infer TOOLS> ? TOOLS : UITools;
+
+export type InferUIMessageTools<T extends UIMessage> = _ExtractTools<
+  T,
+  InferUIMessageData<T>
+>;
 
 export type InferUIMessageToolCall<UI_MESSAGE extends UIMessage> =
   | ValueOf<{
@@ -247,12 +249,14 @@ type ToolUIMessageChunk<TOOLS extends UITools> =
         providerExecuted?: boolean;
       };
     }>
-  | {
-      type: 'tool-input-delta';
-      toolName: string;
-      toolCallId: string;
-      inputDelta: string;
-    }
+  | ValueOf<{
+      [NAME in keyof TOOLS & string]: {
+        type: 'tool-input-delta';
+        toolName: NAME;
+        toolCallId: string;
+        inputDelta: string;
+      };
+    }>
   | ValueOf<{
       [NAME in keyof TOOLS & string]: {
         type: 'tool-output-available';
@@ -288,6 +292,13 @@ type ToolUIMessageChunk<TOOLS extends UITools> =
       toolCallId: string;
       input?: unknown;
       providerExecuted?: boolean;
+      dynamic: true;
+    }
+  | {
+      type: 'tool-input-delta';
+      toolName: string;
+      toolCallId: string;
+      inputDelta: string;
       dynamic: true;
     }
   | {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Type tool chunks by UI message tool definitions and propagate typed chunks through transport/parser.

Replace the onToolCall any cast with InferUIMessageToolCall and keep dynamic tool calls explicitly flagged.


**Result**

internal type doesn't cast as any

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
