### PR TITLE
feat(chat): add `initialMessages` option

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -185,6 +185,9 @@ export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
    * are not applied.
    *
    * When `resume` is enabled, these messages are not applied.
+   *
+   * `initialUserMessage` is sent after `initialMessages` are applied, so an
+   * assistant welcome followed by a user prompt works.
    */
   initialMessages?: TUiMessage[];
 };
@@ -578,7 +581,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
 
         // Set initialMessages before registering callbacks to avoid
         // triggering re-renders during init
-        if (initialMessages && !resume && !hasExistingMessages) {
+        if (initialMessages?.length && !resume && !hasExistingMessages) {
           _chatInstance.messages = initialMessages;
         }
 

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -176,6 +176,17 @@ export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
    * When `resume` is enabled, this message is not sent.
    */
   initialUserMessage?: string;
+  /**
+   * Messages to pre-populate the chat with when it is initialized.
+   *
+   * These messages are set without triggering an AI response. They are only
+   * applied when the chat has no existing messages yet. If messages were
+   * restored or otherwise already exist when the widget starts, these messages
+   * are not applied.
+   *
+   * When `resume` is enabled, these messages are not applied.
+   */
+  initialMessages?: TUiMessage[];
 };
 
 export type ChatWidgetDescription<TUiMessage extends UIMessage = UIMessage> = {
@@ -279,6 +290,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       type = 'chat',
       context,
       initialUserMessage,
+      initialMessages,
       ...options
     } = widgetParams || {};
 
@@ -562,6 +574,14 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           };
         }
 
+        const hasExistingMessages = _chatInstance.messages.length > 0;
+
+        // Set initialMessages before registering callbacks to avoid
+        // triggering re-renders during init
+        if (initialMessages && !resume && !hasExistingMessages) {
+          _chatInstance.messages = initialMessages;
+        }
+
         _chatInstance['~registerErrorCallback'](render);
         _chatInstance['~registerMessagesCallback'](render);
         _chatInstance['~registerStatusCallback'](render);
@@ -570,11 +590,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           _chatInstance.resumeStream();
         }
 
-        if (
-          initialUserMessage &&
-          !resume &&
-          _chatInstance.messages.length === 0
-        ) {
+        if (initialUserMessage && !resume && !hasExistingMessages) {
           _chatInstance.sendMessage({ text: initialUserMessage });
         }
 

--- a/tests/common/connectors/chat/options.ts
+++ b/tests/common/connectors/chat/options.ts
@@ -94,6 +94,128 @@ export function createOptionsTests(
       expect(sendMessageSpy).not.toHaveBeenCalled();
     });
 
+    test('sets initialMessages on init', async () => {
+      const chat = new Chat({});
+
+      const options: SetupOptions<ChatConnectorSetup> = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient(),
+        },
+        widgetParams: {
+          chat,
+          agentId: 'agentId',
+          initialMessages: [
+            {
+              id: '1',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+            },
+          ],
+        } as any,
+      };
+
+      await setup(options);
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(chat.messages).toHaveLength(1);
+      expect(chat.messages[0]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+        })
+      );
+    });
+
+    test('does not set initialMessages when messages already exist', async () => {
+      const chat = new Chat({
+        messages: [
+          {
+            id: '1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Previous message' }],
+          },
+        ],
+      });
+
+      const options: SetupOptions<ChatConnectorSetup> = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient(),
+        },
+        widgetParams: {
+          chat,
+          agentId: 'agentId',
+          initialMessages: [
+            {
+              id: '2',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+            },
+          ],
+        } as any,
+      };
+
+      await setup(options);
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(chat.messages).toHaveLength(1);
+      expect(chat.messages[0]).toEqual(
+        expect.objectContaining({
+          role: 'user',
+          parts: [{ type: 'text', text: 'Previous message' }],
+        })
+      );
+    });
+
+    test('applies initialMessages and sends initialUserMessage together', async () => {
+      sessionStorage.clear();
+      const chat = new Chat({});
+      const sendMessageSpy = jest
+        .spyOn(chat, 'sendMessage')
+        .mockResolvedValue(undefined);
+
+      const options: SetupOptions<ChatConnectorSetup> = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient(),
+        },
+        widgetParams: {
+          chat,
+          agentId: 'agentId',
+          initialMessages: [
+            {
+              id: '1',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+            },
+          ],
+          initialUserMessage: 'Hello, AI!',
+        } as any,
+      };
+
+      await setup(options);
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(chat.messages).toHaveLength(1);
+      expect(chat.messages[0]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+        })
+      );
+      expect(sendMessageSpy).toHaveBeenCalledWith({ text: 'Hello, AI!' });
+    });
+
     test('provides `input` state to persist text input', async () => {
       const options: SetupOptions<ChatConnectorSetup> = {
         instantSearchOptions: {

--- a/tests/common/connectors/chat/options.ts
+++ b/tests/common/connectors/chat/options.ts
@@ -95,6 +95,7 @@ export function createOptionsTests(
     });
 
     test('sets initialMessages on init', async () => {
+      sessionStorage.clear();
       const chat = new Chat({});
 
       const options: SetupOptions<ChatConnectorSetup> = {
@@ -214,6 +215,39 @@ export function createOptionsTests(
         })
       );
       expect(sendMessageSpy).toHaveBeenCalledWith({ text: 'Hello, AI!' });
+    });
+
+    test('does not set initialMessages when resume is enabled', async () => {
+      sessionStorage.clear();
+      const chat = new Chat({});
+      jest.spyOn(chat, 'resumeStream').mockResolvedValue(undefined);
+
+      const options: SetupOptions<ChatConnectorSetup> = {
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient: createSearchClient(),
+        },
+        widgetParams: {
+          chat,
+          agentId: 'agentId',
+          resume: true,
+          initialMessages: [
+            {
+              id: '1',
+              role: 'assistant',
+              parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+            },
+          ],
+        } as any,
+      };
+
+      await setup(options);
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(chat.messages).toHaveLength(0);
     });
 
     test('provides `input` state to persist text input', async () => {

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -118,6 +118,111 @@ export function createOptionsTests(
       expect(sendMessageSpy).not.toHaveBeenCalled();
     });
 
+    test('sets initialMessages on init', async () => {
+      sessionStorage.clear();
+      const searchClient = createSearchClient();
+
+      const chat = new Chat({});
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            initialMessages: [
+              {
+                id: '1',
+                role: 'assistant',
+                parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+              },
+            ],
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            initialMessages: [
+              {
+                id: '1',
+                role: 'assistant',
+                parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+              },
+            ],
+          },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(chat.messages).toHaveLength(1);
+      expect(chat.messages[0]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+        })
+      );
+    });
+
+    test('does not set initialMessages when messages already exist', async () => {
+      const searchClient = createSearchClient();
+
+      const chat = new Chat({
+        messages: [
+          {
+            id: '1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'Previous message' }],
+          },
+        ],
+      });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            initialMessages: [
+              {
+                id: '2',
+                role: 'assistant',
+                parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+              },
+            ],
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            initialMessages: [
+              {
+                id: '2',
+                role: 'assistant',
+                parts: [{ type: 'text', text: 'Welcome! How can I help?' }],
+              },
+            ],
+          },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(chat.messages).toHaveLength(1);
+      expect(chat.messages[0]).toEqual(
+        expect.objectContaining({
+          role: 'user',
+          parts: [{ type: 'text', text: 'Previous message' }],
+        })
+      );
+    });
+
     test('sends messages when prompt is submitted', async () => {
       const searchClient = createSearchClient();
 


### PR DESCRIPTION
## Summary

Adds an `initialMessages` option to the Chat connector, as discussed in #6956.

- `initialMessages` pre-populates the chat with messages on initialization **without triggering an AI response**
- Only applied when the chat has no existing messages (e.g., not restored from storage)
- Not applied when `resume` is enabled
- Can be used alongside `initialUserMessage` — `initialMessages` sets the displayed messages, then `initialUserMessage` sends a message that triggers AI

This serves a different purpose from `initialUserMessage`: use `initialMessages` for welcome messages or pre-seeded conversation history, and `initialUserMessage` to automatically trigger an AI response on init.

## Test plan

- [x] Connector test: sets `initialMessages` on init
- [x] Connector test: does not set `initialMessages` when messages already exist
- [x] Connector test: applies `initialMessages` and sends `initialUserMessage` together
- [x] Widget test (JS + React): sets `initialMessages` on init
- [x] Widget test (JS + React): does not set `initialMessages` when messages already exist
- [x] Lint passes with 0 errors
- [x] Type-check passes (no new errors)