### PR TITLE
fix(instantsearch.css): skip hover styles on disabled items in Nova theme

### DIFF
--- a/packages/instantsearch.css/src/widgets/_numeric-menu.scss
+++ b/packages/instantsearch.css/src/widgets/_numeric-menu.scss
@@ -63,7 +63,7 @@
 }
 
 @media (hover: hover) {
-  .ais-NumericMenu-label:hover {
+  .ais-NumericMenu-label:not(:has(:disabled)):hover {
     background-color: rgba(var(--ais-muted-color-rgb), 0.1);
     color: rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
 
@@ -72,7 +72,8 @@
     }
   }
 
-  .ais-NumericMenu-item--selected .ais-NumericMenu-label:hover {
+  .ais-NumericMenu-item--selected
+    .ais-NumericMenu-label:not(:has(:disabled)):hover {
     background-color: rgba(var(--ais-muted-color-rgb), 0.2);
   }
 }

--- a/packages/instantsearch.css/src/widgets/_refinement-list.scss
+++ b/packages/instantsearch.css/src/widgets/_refinement-list.scss
@@ -32,7 +32,7 @@
 }
 
 @media (hover: hover) {
-  .ais-RefinementList-label:hover {
+  .ais-RefinementList-label:not(:has(:disabled)):hover {
     background-color: rgba(var(--ais-muted-color-rgb), 0.1);
     color: rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
 
@@ -41,7 +41,8 @@
     }
   }
 
-  .ais-RefinementList-item--selected .ais-RefinementList-label:hover {
+  .ais-RefinementList-item--selected
+    .ais-RefinementList-label:not(:has(:disabled)):hover {
     background-color: rgba(var(--ais-muted-color-rgb), 0.2);
   }
 }

--- a/packages/instantsearch.css/src/widgets/_toggle-refinement.scss
+++ b/packages/instantsearch.css/src/widgets/_toggle-refinement.scss
@@ -11,7 +11,7 @@
 }
 
 @media (hover: hover) {
-  .ais-ToggleRefinement-label:hover {
+  .ais-ToggleRefinement-label:not(:has(:disabled)):hover {
     color: rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
 
     .ais-ToggleRefinement-checkbox {


### PR DESCRIPTION
**Summary**

Closes #6984.

In the Nova theme, `:hover` effects on refinement-list (and similar) labels kept applying even when the inner input was disabled. The actual disabled element is the `<input>`, not the `<label>`, so the hover selectors never matched the disabled state.

This PR guards the hover rules with `:not(:has(:disabled))` on the label in the three widgets that follow the label-wrapping-an-input pattern:

- `packages/instantsearch.css/src/widgets/_refinement-list.scss` (the widget called out in the issue)
- `packages/instantsearch.css/src/widgets/_toggle-refinement.scss`
- `packages/instantsearch.css/src/widgets/_numeric-menu.scss`

These files are imported only by `src/themes/nova.scss`, so the change is scoped to the Nova theme. `:has()` is already used in `themes/algolia.scss`, so browser support is consistent with what the package already assumes.