### PR TITLE
fix(autocomplete): close panel when clicking AI mode button

### DIFF
--- a/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
+++ b/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
@@ -824,6 +824,10 @@ function AutocompleteWrapper<TItem extends BaseHit>({
       onAiModeClick={
         aiMode
           ? () => {
+              setIsOpen(false);
+              if (isDetached) {
+                setIsModalOpen(false);
+              }
               const indexId = targetIndex!.getIndexId();
               const chatState = instantSearchInstance.renderState[indexId]
                 ?.chat as Partial<ChatRenderState> | undefined;

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -889,6 +889,10 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
       onAiModeClick={
         aiMode
           ? () => {
+              setIsOpen(false);
+              if (isDetached) {
+                setIsModalOpen(false);
+              }
               if (chatRenderState) {
                 chatRenderState.setOpen?.(true);
                 if (resolvedQuery.trim()) {

--- a/tests/common/widgets/autocomplete/options.tsx
+++ b/tests/common/widgets/autocomplete/options.tsx
@@ -2632,6 +2632,77 @@ export function createOptionsTests(
       });
     });
 
+    describe('aiMode', () => {
+      test('closes the panel when clicking the AI mode button', async () => {
+        const searchClient = createMockedSearchClient(
+          createMultiSearchResponse(
+            createSingleSearchResponse({
+              index: 'indexName',
+              hits: [{ objectID: '1', name: 'Item 1' }],
+            })
+          )
+        );
+
+        await setup({
+          instantSearchOptions: {
+            indexName: 'indexName',
+            searchClient,
+          },
+          widgetParams: {
+            javascript: {
+              aiMode: true,
+              indices: [
+                {
+                  indexName: 'indexName',
+                  templates: {
+                    item: (props) => props.item.name,
+                  },
+                },
+              ],
+            },
+            react: {
+              aiMode: true,
+              indices: [
+                {
+                  indexName: 'indexName',
+                  itemComponent: (props) => props.item.name,
+                },
+              ],
+            },
+            vue: {},
+          },
+        });
+
+        await act(async () => {
+          await wait(0);
+        });
+
+        const input = screen.getByRole('combobox', { name: /submit/i });
+
+        await act(async () => {
+          userEvent.click(input);
+          await wait(0);
+        });
+
+        expect(
+          document.querySelector('.ais-AutocompletePanel--open')
+        ).toBeInTheDocument();
+
+        const aiModeButton =
+          document.querySelector<HTMLButtonElement>('.ais-AiModeButton');
+        expect(aiModeButton).toBeInTheDocument();
+
+        await act(async () => {
+          userEvent.click(aiModeButton!);
+          await wait(0);
+        });
+
+        expect(
+          document.querySelector('.ais-AutocompletePanel--open')
+        ).not.toBeInTheDocument();
+      });
+    });
+
     describe('noResults', () => {
       test('renders noResults template when index returns empty hits', async () => {
         const searchClient = createMockedSearchClient(


### PR DESCRIPTION
**Summary**

Clicking the AI mode button in the Autocomplete widget's search box previously left the suggestions panel (and the detached modal, when applicable) open in the background while the chat opened on top. This PR makes the `onAiModeClick` handler close the panel first, so switching to AI mode cleanly dismisses the suggestions.

**Result**

Added a common test that asserts the panel closes on AI mode click:

- `tests/common/widgets/autocomplete/options.tsx`: new `describe('aiMode')` block covering `closes the panel when clicking the AI mode button`.

Verified locally:

- `npx jest packages/react-instantsearch/src/__tests__/common-widgets.test.tsx -t "Autocomplete widget common tests"` — 42/42 passed (new test included).
- `npx jest packages/instantsearch.js/src/__tests__/common-widgets.test.tsx -t "ai mode"` — passed in the real `packages/instantsearch.js` suite.