### PR TITLE
feat(instantsearch.css): share `AiModeButton` styles across themes

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -58,7 +58,7 @@
     },
     {
       "path": "./packages/instantsearch.css/themes/nova.css",
-      "maxSize": "10.5 kB"
+      "maxSize": "11 kB"
     },
     {
       "path": "./packages/instantsearch.css/themes/nova-min.css",

--- a/packages/instantsearch.css/src/components/ai-mode-button.scss
+++ b/packages/instantsearch.css/src/components/ai-mode-button.scss
@@ -2,6 +2,8 @@
 @use '../shared/_common';
 
 .ais-AiModeButton {
+  @extend %ais-focus-outline;
+
   align-items: center;
   background-color: rgba(var(--ais-primary-color-rgb), 0.08);
   border: 1px solid rgba(var(--ais-primary-color-rgb), 0.3);
@@ -29,12 +31,6 @@
       background-color: rgba(var(--ais-primary-color-rgb), 0.15);
       border-color: rgba(var(--ais-primary-color-rgb), 1);
     }
-  }
-
-  &:focus-visible {
-    border-color: rgba(var(--ais-primary-color-rgb), 1);
-    box-shadow: 0 0 0 1px rgba(var(--ais-primary-color-rgb), 1);
-    outline: 0;
   }
 
   svg {

--- a/packages/instantsearch.css/src/components/ai-mode-button.scss
+++ b/packages/instantsearch.css/src/components/ai-mode-button.scss
@@ -1,0 +1,45 @@
+@use '../shared/_variables';
+@use '../shared/_common';
+
+.ais-AiModeButton {
+  align-items: center;
+  background-color: rgba(var(--ais-primary-color-rgb), 0.08);
+  border: 1px solid rgba(var(--ais-primary-color-rgb), 0.3);
+  border-radius: var(--ais-border-radius-sm);
+  color: rgba(var(--ais-primary-color-rgb), 1);
+  cursor: pointer;
+  display: flex;
+  font-family: inherit;
+  font-size: calc(var(--ais-font-size) * 0.8125);
+  font-weight: var(--ais-font-weight-medium);
+  gap: calc(var(--ais-spacing) * 0.25);
+  line-height: 1;
+  padding: calc(var(--ais-spacing) * 0.375) calc(var(--ais-spacing) * 0.625);
+  white-space: nowrap;
+
+  transition: background-color var(--ais-transition-duration)
+      var(--ais-transition-timing-function),
+    border-color var(--ais-transition-duration)
+      var(--ais-transition-timing-function),
+    box-shadow var(--ais-transition-duration)
+      var(--ais-transition-timing-function);
+
+  @media (hover: hover) {
+    &:hover {
+      background-color: rgba(var(--ais-primary-color-rgb), 0.15);
+      border-color: rgba(var(--ais-primary-color-rgb), 1);
+    }
+  }
+
+  &:focus-visible {
+    border-color: rgba(var(--ais-primary-color-rgb), 1);
+    box-shadow: 0 0 0 1px rgba(var(--ais-primary-color-rgb), 1);
+    outline: 0;
+  }
+
+  svg {
+    flex-shrink: 0;
+    height: var(--ais-icon-size);
+    width: var(--ais-icon-size);
+  }
+}

--- a/packages/instantsearch.css/src/components/autocomplete.scss
+++ b/packages/instantsearch.css/src/components/autocomplete.scss
@@ -174,7 +174,7 @@
       }
 
       .ais-AiModeButton {
-        margin-right: 0.375rem;
+        margin-right: calc(var(--ais-spacing) * 0.25);
       }
     }
   }

--- a/packages/instantsearch.css/src/themes/algolia.scss
+++ b/packages/instantsearch.css/src/themes/algolia.scss
@@ -3,6 +3,7 @@
 @use '../shared/_common';
 @use '../components/chat';
 @use '../components/autocomplete';
+@use '../components/ai-mode-button';
 @use '../components/filter-suggestions';
 
 // Colors
@@ -705,41 +706,6 @@ a[class^='ais-'] {
 .ais-SearchBox-loadingIcon {
   width: 16px;
   height: 16px;
-}
-
-.ais-AiModeButton {
-  align-items: center;
-  background-color: lighten($algolia-blue, 48%);
-  border: 1px solid lighten($algolia-blue, 30%);
-  border-radius: 5px;
-  color: $algolia-blue;
-  cursor: pointer;
-  display: flex;
-  font-family: inherit;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  gap: 0.25rem;
-  height: 28px;
-  line-height: 1;
-  padding: 0 0.625rem 0 0.375rem;
-  white-space: nowrap;
-}
-
-.ais-AiModeButton:hover {
-  background-color: lighten($algolia-blue, 40%);
-  border-color: $algolia-blue;
-}
-
-.ais-AiModeButton:focus {
-  border-color: $algolia-blue;
-  box-shadow: 0 0 0 1px $algolia-blue;
-  outline: 0;
-}
-
-.ais-AiModeButton svg {
-  flex-shrink: 0;
-  height: 16px;
-  width: 16px;
 }
 
 .ais-SearchBox-form .ais-AiModeButton {

--- a/packages/instantsearch.css/src/themes/nova.scss
+++ b/packages/instantsearch.css/src/themes/nova.scss
@@ -6,6 +6,7 @@
 
 @use '../components/chat';
 @use '../components/autocomplete';
+@use '../components/ai-mode-button';
 @use '../components/filter-suggestions';
 
 @use '../widgets/searchbox';

--- a/packages/instantsearch.css/src/themes/satellite.scss
+++ b/packages/instantsearch.css/src/themes/satellite.scss
@@ -3,6 +3,7 @@
 @use '../shared/_common';
 @use '../components/chat';
 @use '../components/autocomplete';
+@use '../components/ai-mode-button';
 @use '../components/filter-suggestions';
 
 ////////////////
@@ -543,41 +544,6 @@ $break-medium: 767px;
 // Algolia magnifier glass.
 .ais-SearchBox-submit {
   display: none;
-}
-
-.ais-AiModeButton {
-  align-items: center;
-  background-color: $nebula100;
-  border: 1px solid $nebula200;
-  border-radius: 6px;
-  color: $nebula600;
-  cursor: pointer;
-  display: flex;
-  font-family: inherit;
-  font-size: 0.8125rem;
-  font-weight: 500;
-  gap: 0.25rem;
-  height: 30px;
-  line-height: 1;
-  padding: 0 0.75rem 0 0.5rem;
-  white-space: nowrap;
-}
-
-.ais-AiModeButton:hover {
-  background-color: $nebula200;
-  border-color: $nebula600;
-}
-
-.ais-AiModeButton:focus {
-  border-color: $nebula600;
-  box-shadow: 0 0 0 1px $nebula600;
-  outline: 0;
-}
-
-.ais-AiModeButton svg {
-  flex-shrink: 0;
-  height: 16px;
-  width: 16px;
 }
 
 .ais-SearchBox-form .ais-AiModeButton {

--- a/packages/instantsearch.css/src/widgets/_searchbox.scss
+++ b/packages/instantsearch.css/src/widgets/_searchbox.scss
@@ -102,6 +102,12 @@
     }
   }
 
+  .ais-AiModeButton {
+    align-self: center;
+    margin-right: calc(var(--ais-spacing) * 0.25);
+    order: 4;
+  }
+
   .ais-SearchBox-reset {
     align-items: center;
     background: none;


### PR DESCRIPTION
**Summary**

The AI mode button was unstyled in the new Nova theme and duplicated as bespoke SCSS-variable-based blocks in `algolia.scss` and `satellite.scss`. Since AI mode is a recent addition, there's no brand-parity to preserve, so the button styling is now a single reusable partial built on CSS custom properties — consistent with `components/autocomplete.scss`.

Related to #6988.

**Result**

Rebuilt `packages/instantsearch.css` and verified the button renders and is styled correctly in all three themes via the `examples/js/showcase` app (SearchBox + Autocomplete contexts, light and dark modes).