### PR TITLE
feat(chat): add error matching and API-facing display rules

### DIFF
--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat.test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat.test.ts
@@ -1,0 +1,313 @@
+import {
+  flattenErrorMessageForMatching,
+  genericChatErrorDisplayResolvers,
+  getChatErrorDisplayMessage,
+  getStartNewConversationErrorDisplayMessage,
+  isConversationThreadDepthLimitError,
+  isPartText,
+  isRequestOriginNotAllowedError,
+  isStartNewConversationError,
+  registerGenericChatErrorDisplayResolver,
+  registerNewConversationErrorMatcher,
+  registerStartNewConversationErrorDisplayResolver,
+  newConversationErrorMatchers,
+  startNewConversationErrorDisplayResolvers,
+} from '../chat';
+
+describe('isConversationThreadDepthLimitError', () => {
+  test('returns true for Agent Studio thread depth wording', () => {
+    expect(
+      isConversationThreadDepthLimitError(
+        new Error(
+          'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('is case-insensitive', () => {
+    expect(
+      isConversationThreadDepthLimitError(
+        new Error('MAXIMUM THREAD DEPTH reached')
+      )
+    ).toBe(true);
+  });
+
+  test('returns false for other errors', () => {
+    expect(
+      isConversationThreadDepthLimitError(new Error('HTTP error: 500'))
+    ).toBe(false);
+    expect(isConversationThreadDepthLimitError(undefined)).toBe(false);
+  });
+
+  test('returns false for LangGraph recursion errors (use isStartNewConversationError)', () => {
+    expect(
+      isConversationThreadDepthLimitError(
+        new Error('Recursion limit of 5 reached. recursion_limit GRAPH_RECURSION_LIMIT')
+      )
+    ).toBe(false);
+  });
+});
+
+describe('isStartNewConversationError', () => {
+  test('includes thread depth', () => {
+    expect(
+      isStartNewConversationError(
+        new Error(
+          'Conversation has reached its maximum thread depth of 3 messages.'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('detects LangGraph / stream errorText with nested JSON', () => {
+    const raw =
+      '"{\\"error\\": \\"Recursion limit of 5 reached without hitting a stop condition. \\\\nFor troubleshooting: GRAPH_RECURSION_LIMIT\\"}"';
+    expect(isStartNewConversationError(new Error(raw))).toBe(true);
+  });
+
+  test('detects Recursion limit of after flattening JSON', () => {
+    const raw = JSON.stringify({
+      error:
+        'Recursion limit of 5 reached. Set recursion_limit in config. See GRAPH_RECURSION_LIMIT',
+    });
+    expect(isStartNewConversationError(new Error(raw))).toBe(true);
+  });
+
+  test('detects max_output_tokens / incomplete response (same UX as thread depth)', () => {
+    expect(
+      isStartNewConversationError(
+        new Error('Response is incomplete due to: max_output_tokens')
+      )
+    ).toBe(true);
+  });
+
+  test('detects rate limiting (phrase and HTTP 429)', () => {
+    expect(
+      isStartNewConversationError(
+        new Error('Rate limit exceeded. Retry after 60 seconds.')
+      )
+    ).toBe(true);
+    expect(
+      isStartNewConversationError(new Error('HTTP error: 429 Too Many Requests'))
+    ).toBe(true);
+  });
+
+  test('does not match on GRAPH_RECURSION_LIMIT alone without Recursion limit of', () => {
+    expect(
+      isStartNewConversationError(
+        new Error('See https://docs.../GRAPH_RECURSION_LIMIT')
+      )
+    ).toBe(false);
+  });
+
+  test('returns false for unrelated errors', () => {
+    expect(isStartNewConversationError(new Error('HTTP error: 500'))).toBe(
+      false
+    );
+    expect(isStartNewConversationError(undefined)).toBe(false);
+  });
+
+  test('registerNewConversationErrorMatcher extends behavior', () => {
+    const len = newConversationErrorMatchers.length;
+    registerNewConversationErrorMatcher((m) => m.includes('CUSTOM_XYZ'));
+    expect(isStartNewConversationError(new Error('CUSTOM_XYZ'))).toBe(true);
+    newConversationErrorMatchers.pop();
+    expect(newConversationErrorMatchers.length).toBe(len);
+  });
+});
+
+describe('isRequestOriginNotAllowedError', () => {
+  test('returns true for Agent Studio 403 origin message', () => {
+    expect(
+      isRequestOriginNotAllowedError(
+        new Error(
+          'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('unwraps JSON message field', () => {
+    const body = JSON.stringify({
+      message:
+        'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.',
+    });
+    expect(isRequestOriginNotAllowedError(new Error(body))).toBe(true);
+  });
+
+  test('returns false for unrelated errors', () => {
+    expect(isRequestOriginNotAllowedError(new Error('HTTP error: 403'))).toBe(
+      false
+    );
+    expect(isRequestOriginNotAllowedError(undefined)).toBe(false);
+  });
+});
+
+describe('getChatErrorDisplayMessage', () => {
+  test('surfaces Agent Studio request-origin API message', () => {
+    const api =
+      'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.';
+    expect(getChatErrorDisplayMessage(new Error(api))).toBe(api);
+  });
+
+  test('registerGenericChatErrorDisplayResolver overrides built-in origin copy', () => {
+    const len = genericChatErrorDisplayResolvers.length;
+    registerGenericChatErrorDisplayResolver((flat) =>
+      flat.includes('allowed domains list') ? 'Custom origin hint' : null
+    );
+    expect(
+      getChatErrorDisplayMessage(
+        new Error(
+          'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.'
+        )
+      )
+    ).toBe('Custom origin hint');
+    genericChatErrorDisplayResolvers.shift();
+    expect(genericChatErrorDisplayResolvers.length).toBe(len);
+  });
+
+  test('surfaces max_output_tokens / incomplete response API text', () => {
+    const msg = 'Response is incomplete due to: max_output_tokens';
+    expect(getChatErrorDisplayMessage(new Error(msg))).toBe(msg);
+  });
+
+  test('unwraps JSON-wrapped stream error (error field)', () => {
+    const inner = 'Response is incomplete due to: max_output_tokens';
+    const wrapped = JSON.stringify({
+      error: inner,
+    });
+    expect(getChatErrorDisplayMessage(new Error(wrapped))).toBe(inner);
+  });
+
+  test('delegates to start-new conversation and surfaces thread depth API text', () => {
+    expect(
+      getChatErrorDisplayMessage(
+        new Error(
+          'Conversation has reached its maximum thread depth of 3 messages.'
+        )
+      )
+    ).toBe('Conversation has reached its maximum thread depth of 3 messages.');
+  });
+});
+
+describe('getStartNewConversationErrorDisplayMessage', () => {
+  test('surfaces thread depth API text', () => {
+    expect(
+      getStartNewConversationErrorDisplayMessage(
+        new Error(
+          'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.'
+        )
+      )
+    ).toBe(
+      'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.'
+    );
+  });
+
+  test('surfaces LangGraph recursion API text', () => {
+    const long =
+      'Recursion limit of 5 reached without hitting a stop condition. You can increase the limit by setting the `recursion_limit` config key. For troubleshooting, visit: https://example.com';
+    expect(getStartNewConversationErrorDisplayMessage(new Error(long))).toBe(
+      long
+    );
+  });
+
+  test('prefers recursion when the same payload also mentions thread depth', () => {
+    const combined =
+      'Recursion limit of 5 reached.\nConversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
+    expect(getStartNewConversationErrorDisplayMessage(new Error(combined))).toBe(
+      combined
+    );
+  });
+
+  test('unwraps JSON message field for thread depth display', () => {
+    const inner =
+      'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
+    const body = JSON.stringify({
+      message: inner,
+    });
+    expect(getStartNewConversationErrorDisplayMessage(new Error(body))).toBe(
+      inner
+    );
+  });
+
+  test('surfaces max_output_tokens API text', () => {
+    const msg = 'Response is incomplete due to: max_output_tokens';
+    expect(getStartNewConversationErrorDisplayMessage(new Error(msg))).toBe(
+      msg
+    );
+  });
+
+  test('surfaces max steps API text', () => {
+    const msg = 'Maximum steps (25) exceeded for this run.';
+    expect(isStartNewConversationError(new Error(msg))).toBe(true);
+    expect(getStartNewConversationErrorDisplayMessage(new Error(msg))).toBe(
+      msg
+    );
+    expect(getChatErrorDisplayMessage(new Error(msg))).toBe(msg);
+  });
+
+  test('surfaces rate limit API text', () => {
+    const msg = 'Rate limit exceeded. Retry after 60 seconds.';
+    expect(isStartNewConversationError(new Error(msg))).toBe(true);
+    expect(getStartNewConversationErrorDisplayMessage(new Error(msg))).toBe(msg);
+    expect(getChatErrorDisplayMessage(new Error(msg))).toBe(msg);
+  });
+
+  test('thread depth API text never maps to max_output copy', () => {
+    const api =
+      'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
+    expect(getStartNewConversationErrorDisplayMessage(new Error(api))).toBe(
+      api
+    );
+    expect(getChatErrorDisplayMessage(new Error(api))).toBe(api);
+  });
+
+  test('returns undefined when not a start-new error', () => {
+    expect(
+      getStartNewConversationErrorDisplayMessage(new Error('HTTP 500'))
+    ).toBeUndefined();
+  });
+
+  test('registerStartNewConversationErrorDisplayResolver prepends custom copy', () => {
+    const matcherLen = newConversationErrorMatchers.length;
+    const resolverLen = startNewConversationErrorDisplayResolvers.length;
+    registerNewConversationErrorMatcher((m) => m.includes('CUSTOM_ABC'));
+    registerStartNewConversationErrorDisplayResolver((flat) =>
+      flat.includes('CUSTOM_ABC') ? 'Custom message' : null
+    );
+    expect(
+      getStartNewConversationErrorDisplayMessage(new Error('CUSTOM_ABC detail'))
+    ).toBe('Custom message');
+    startNewConversationErrorDisplayResolvers.shift();
+    newConversationErrorMatchers.pop();
+    expect(startNewConversationErrorDisplayResolvers.length).toBe(resolverLen);
+    expect(newConversationErrorMatchers.length).toBe(matcherLen);
+  });
+});
+
+describe('flattenErrorMessageForMatching', () => {
+  test('unwraps stringified JSON with error field', () => {
+    const inner = { error: 'Recursion limit of 5 reached. recursion_limit' };
+    const raw = JSON.stringify(JSON.stringify(inner));
+    const flat = flattenErrorMessageForMatching(raw);
+    expect(flat).toContain('Recursion limit');
+    expect(flat).toContain('recursion_limit');
+  });
+
+  test('unwraps JSON with message field', () => {
+    const inner = {
+      message:
+        'Conversation has reached its maximum thread depth of 3 messages.',
+    };
+    const flat = flattenErrorMessageForMatching(JSON.stringify(inner));
+    expect(flat).toContain('maximum thread depth');
+  });
+});
+
+describe('isPartText', () => {
+  test('narrows type for text parts', () => {
+    expect(isPartText({ type: 'text', text: 'x' })).toBe(true);
+    expect(isPartText({ type: 'step-start' } as any)).toBe(false);
+  });
+});

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -15,3 +15,384 @@ export const isPartText = (
 ): part is Extract<ChatMessageBase['parts'][number], { type: 'text' }> => {
   return part.type === 'text';
 };
+
+/**
+ * Unwraps nested JSON / double-encoded strings from streaming `error` chunks
+ * (e.g. LangGraph `errorText` payloads). Each segment is one unwrap step; the
+ * last entry is the innermost string (when wrapping exists).
+ */
+function collectErrorMessageSegments(raw: string): string[] {
+  const segments: string[] = [raw];
+  let remaining = raw.trim();
+
+  for (let depth = 0; depth < 8; depth += 1) {
+    try {
+      const parsed: unknown = JSON.parse(remaining);
+      if (typeof parsed === 'string') {
+        segments.push(parsed);
+        remaining = parsed.trim();
+        continue;
+      }
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        'message' in parsed &&
+        typeof (parsed as { message: unknown }).message === 'string'
+      ) {
+        const inner = (parsed as { message: string }).message;
+        segments.push(inner);
+        remaining = inner.trim();
+        continue;
+      }
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        'error' in parsed &&
+        typeof (parsed as { error: unknown }).error === 'string'
+      ) {
+        const inner = (parsed as { error: string }).error;
+        segments.push(inner);
+        remaining = inner.trim();
+        continue;
+      }
+      break;
+    } catch {
+      break;
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Unwraps nested JSON / double-encoded strings from streaming `error` chunks
+ * (e.g. LangGraph `errorText` payloads) into one searchable string.
+ */
+export function flattenErrorMessageForMatching(raw: string): string {
+  return collectErrorMessageSegments(raw).join('\n');
+}
+
+/**
+ * API / transport error text for display: {@link Error.message}, or the
+ * innermost unwrapped string when the message is JSON-wrapped.
+ */
+function getUnwrappedApiErrorDisplayMessage(error: Error): string {
+  const segments = collectErrorMessageSegments(error.message);
+  return segments.length > 1
+    ? segments[segments.length - 1]
+    : error.message;
+}
+
+/**
+ * Predicate on the flattened error string. Register more at runtime via
+ * {@link registerNewConversationErrorMatcher} for product-specific API errors.
+ */
+export type NewConversationErrorMatcher = (flatMessage: string) => boolean;
+
+/**
+ * True when the flattened text indicates thread / conversation depth limit
+ * (wording varies by API).
+ */
+function matchesThreadDepthLimitError(flatLower: string): boolean {
+  return (
+    flatLower.includes('maximum thread depth') ||
+    flatLower.includes('max thread depth') ||
+    (flatLower.includes('thread depth') && flatLower.includes('conversation'))
+  );
+}
+
+/**
+ * True for stream/model output limit — uses `max_output` as a token/code, not
+ * substrings of words like “maximum”. Runs on lowercased text so casing matches
+ * the `includes` checks and the `max_output` token regex.
+ */
+function matchesMaxOutputIncompleteError(flatLower: string): boolean {
+  if (flatLower.includes('max_output_tokens')) {
+    return true;
+  }
+  if (
+    flatLower.includes('response is incomplete') &&
+    /\bmax_output\b/.test(flatLower)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * True for LangGraph-style recursion limit errors (wording varies by API).
+ */
+function matchesRecursionLimitError(flatLower: string): boolean {
+  return flatLower.includes('recursion limit of');
+}
+
+/**
+ * Agent / graph “max steps” style limits (wording varies by API).
+ */
+function matchesMaxStepsLimitError(flatLower: string): boolean {
+  return (
+    flatLower.includes('max_steps') ||
+    flatLower.includes('max steps') ||
+    flatLower.includes('maximum steps') ||
+    flatLower.includes('step limit')
+  );
+}
+
+/**
+ * HTTP / API rate limiting (429, “too many requests”, etc.).
+ */
+function matchesRateLimitError(flatLower: string): boolean {
+  if (
+    flatLower.includes('rate limit') ||
+    flatLower.includes('rate_limit') ||
+    flatLower.includes('ratelimit')
+  ) {
+    return true;
+  }
+  if (flatLower.includes('too many requests')) {
+    return true;
+  }
+  if (flatLower.includes('throttl')) {
+    return true;
+  }
+  if (/\b429\b/.test(flatLower)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Default matchers for errors where the user should start a new conversation
+ * (same UX: conversation-limit alert, “Start a new conversation”, hidden prompt, etc.).
+ */
+export const newConversationErrorMatchers: NewConversationErrorMatcher[] = [
+  (m) => matchesThreadDepthLimitError(m.toLowerCase()),
+  (m) => matchesRecursionLimitError(m.toLowerCase()),
+  (m) => matchesMaxStepsLimitError(m.toLowerCase()),
+  (m) => matchesMaxOutputIncompleteError(m.toLowerCase()),
+  (m) => matchesRateLimitError(m.toLowerCase()),
+];
+
+/**
+ * Register an extra matcher (e.g. for a new Agent Studio error code) without
+ * forking the library.
+ */
+export function registerNewConversationErrorMatcher(
+  fn: NewConversationErrorMatcher
+): void {
+  newConversationErrorMatchers.push(fn);
+}
+
+/**
+ * Maps a flattened API error string to a short, user-facing line. Return
+ * `null` or `undefined` to try the next resolver; if none match, the raw
+ * {@link Error.message} is shown.
+ */
+export type StartNewConversationErrorDisplayResolver = (
+  flatMessage: string,
+  rawMessage: string
+) => string | null | undefined;
+
+/** Legacy shortened copy for LangGraph / agent recursion limits. */
+export const START_NEW_CONVERSATION_RECURSION_MESSAGE =
+  'Recursion limit reached';
+
+const defaultStartNewConversationErrorDisplayResolvers: StartNewConversationErrorDisplayResolver[] =
+  [];
+
+/**
+ * Resolvers run in order (index `0` first). Use
+ * {@link registerStartNewConversationErrorDisplayResolver} to prepend
+ * product-specific mappings ahead of the defaults.
+ */
+export const startNewConversationErrorDisplayResolvers: StartNewConversationErrorDisplayResolver[] =
+  [...defaultStartNewConversationErrorDisplayResolvers];
+
+export function registerStartNewConversationErrorDisplayResolver(
+  resolver: StartNewConversationErrorDisplayResolver
+): void {
+  startNewConversationErrorDisplayResolvers.unshift(resolver);
+}
+
+/**
+ * Legacy shortened copy for thread-depth limits. Thread-depth errors now use
+ * the API message in the UI; this remains for backwards compatibility.
+ */
+export const START_NEW_CONVERSATION_THREAD_DEPTH_MESSAGE =
+  'Conversation has reached its maximum thread depth';
+
+/** Legacy shortened copy for `max_output_tokens` / incomplete stream output. */
+export const START_NEW_CONVERSATION_MAX_OUTPUT_MESSAGE =
+  "Token limit reached — the answer couldn't finish.";
+
+function resolveStartNewConversationErrorDisplayMessage(error: Error): string {
+  const flat = flattenErrorMessageForMatching(error.message);
+  const flatLower = flat.toLowerCase();
+
+  // Ordered “map”: first matching rule wins. Put strict / unambiguous signals first,
+  // then recursion before thread depth: some payloads still mention “thread depth”
+  // from an earlier turn or bundle multiple hints; when recursion is the active
+  // failure it must win over the broader thread-depth phrase match.
+  // 1) Output token / incomplete response (`max_output_tokens`, etc.).
+  if (matchesMaxOutputIncompleteError(flatLower)) {
+    return getUnwrappedApiErrorDisplayMessage(error);
+  }
+  // 2) Recursion limit (LangGraph, etc.).
+  if (matchesRecursionLimitError(flatLower)) {
+    return getUnwrappedApiErrorDisplayMessage(error);
+  }
+  // 3) Max steps (agent / graph limits).
+  if (matchesMaxStepsLimitError(flatLower)) {
+    return getUnwrappedApiErrorDisplayMessage(error);
+  }
+  // 4) Rate limiting (HTTP 429, “too many requests”, …).
+  if (matchesRateLimitError(flatLower)) {
+    return getUnwrappedApiErrorDisplayMessage(error);
+  }
+  // 5) Optional product-specific resolvers (prepend with registerStartNewConversationErrorDisplayResolver).
+  for (const resolver of startNewConversationErrorDisplayResolvers) {
+    const resolved = resolver(flat, error.message);
+    if (resolved != null && resolved !== '') {
+      return resolved;
+    }
+  }
+  // 6) Thread / conversation depth — API text.
+  if (matchesThreadDepthLimitError(flatLower)) {
+    return getUnwrappedApiErrorDisplayMessage(error);
+  }
+  return error.message;
+}
+
+/**
+ * User-facing copy for “start a new conversation” errors (API message for
+ * built-in cases, plus optional display resolvers). Returns `undefined` when
+ * the error is not treated as a start-new-conversation error.
+ */
+export function getStartNewConversationErrorDisplayMessage(
+  error: Error | undefined
+): string | undefined {
+  if (!error?.message || !isStartNewConversationError(error)) {
+    return undefined;
+  }
+  return resolveStartNewConversationErrorDisplayMessage(error);
+}
+
+/**
+ * Maps a flattened API / stream error string to a short user-facing line for
+ * errors that are not “start a new conversation”. Prefer
+ * {@link registerNewConversationErrorMatcher} when the UX should match
+ * thread-depth / recursion (alert + new conversation).
+ */
+export type GenericChatErrorDisplayResolver = (
+  flatMessage: string,
+  rawMessage: string
+) => string | null | undefined;
+
+/**
+ * Legacy stable line for Agent Studio HTTP 403 when the origin is not allowlisted.
+ * The UI now shows the API message by default.
+ */
+export const REQUEST_ORIGIN_NOT_ALLOWED_MESSAGE =
+  'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.';
+
+function matchesRequestOriginNotAllowedError(flatLower: string): boolean {
+  return (
+    flatLower.includes('request origin is not in the allowed domains') ||
+    (flatLower.includes('request origin') &&
+      flatLower.includes('allowed domains list'))
+  );
+}
+
+/**
+ * HTTP / Agent Studio error when the app origin is missing from allowed domains.
+ */
+export function isRequestOriginNotAllowedError(
+  error: Error | undefined
+): boolean {
+  if (!error?.message) {
+    return false;
+  }
+  const flat = flattenErrorMessageForMatching(error.message);
+  return matchesRequestOriginNotAllowedError(flat.toLowerCase());
+}
+
+const defaultGenericChatErrorDisplayResolvers: GenericChatErrorDisplayResolver[] =
+  [
+    (flat, rawMessage) => {
+      if (matchesRequestOriginNotAllowedError(flat.toLowerCase())) {
+        return getUnwrappedApiErrorDisplayMessage(new Error(rawMessage));
+      }
+      return null;
+    },
+  ];
+
+/**
+ * Resolvers for generic chat errors (not “start new conversation”). Includes a
+ * default mapping for Agent Studio HTTP 403 “request origin not allowed”.
+ * Prepend custom resolvers with {@link registerGenericChatErrorDisplayResolver}.
+ */
+export const genericChatErrorDisplayResolvers: GenericChatErrorDisplayResolver[] =
+  [...defaultGenericChatErrorDisplayResolvers];
+
+export function registerGenericChatErrorDisplayResolver(
+  resolver: GenericChatErrorDisplayResolver
+): void {
+  genericChatErrorDisplayResolvers.unshift(resolver);
+}
+
+function resolveGenericChatErrorDisplayMessage(error: Error): string {
+  const flat = flattenErrorMessageForMatching(error.message);
+  for (const resolver of genericChatErrorDisplayResolvers) {
+    const resolved = resolver(flat, error.message);
+    if (resolved != null && resolved !== '') {
+      return resolved;
+    }
+  }
+  return error.message;
+}
+
+/**
+ * User-facing error line for chat: “start new conversation” errors (API text),
+ * then optional generic resolvers (e.g. request origin), then {@link Error.message}.
+ */
+export function getChatErrorDisplayMessage(
+  error: Error | undefined
+): string | undefined {
+  if (!error?.message) {
+    return undefined;
+  }
+  if (isStartNewConversationError(error)) {
+    return getStartNewConversationErrorDisplayMessage(error) ?? error.message;
+  }
+  return resolveGenericChatErrorDisplayMessage(error);
+}
+
+/**
+ * Whether this error should get the “start a new conversation” treatment
+ * (thread depth, recursion, max steps, `max_output_tokens` / incomplete output,
+ * rate limiting, and any registered matchers).
+ */
+export function isStartNewConversationError(error: Error | undefined): boolean {
+  if (!error?.message) {
+    return false;
+  }
+  const flat = flattenErrorMessageForMatching(error.message);
+  return newConversationErrorMatchers.some((fn) => fn(flat));
+}
+
+/**
+ * Detects Agent Studio (and similar) errors when the chat thread has reached
+ * its maximum depth. Message wording comes from the completions API.
+ *
+ * Prefer {@link isStartNewConversationError} for UI that should also cover
+ * recursion limits and other recoverable-by-new-chat errors.
+ */
+export function isConversationThreadDepthLimitError(
+  error: Error | undefined
+): boolean {
+  if (!error?.message) {
+    return false;
+  }
+  const flat = flattenErrorMessageForMatching(error.message);
+  return matchesThreadDepthLimitError(flat.toLowerCase());
+}


### PR DESCRIPTION
## Summary

Centralize chat error classification and user-facing strings in chat utils: thread depth, recursion, max steps, max output, rate limiting, and request origin.