### PR TITLE
feat(chat): conversation-limit error UI and widget copy

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/Chat.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/Chat.tsx
@@ -152,12 +152,10 @@ export function createChatComponent({ createElement, Fragment }: Renderer) {
     } = userProps;
 
     const startNewConversationError =
-      messagesProps.status === 'error' &&
-      isStartNewConversationError(error);
+      messagesProps.status === 'error' && isStartNewConversationError(error);
 
     const requestOriginNotAllowedError =
-      messagesProps.status === 'error' &&
-      isRequestOriginNotAllowedError(error);
+      messagesProps.status === 'error' && isRequestOriginNotAllowedError(error);
 
     const promptBlockedByKnownChatError =
       startNewConversationError || requestOriginNotAllowedError;
@@ -180,7 +178,7 @@ export function createChatComponent({ createElement, Fragment }: Renderer) {
         onStartNewConversation={
           messagesProps.onStartNewConversation ??
           ((startNewConversationError || requestOriginNotAllowedError) &&
-            headerStartNewConversation
+          headerStartNewConversation
             ? headerStartNewConversation
             : undefined)
         }

--- a/packages/instantsearch-ui-components/src/components/chat/Chat.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/Chat.tsx
@@ -1,6 +1,11 @@
 /** @jsx createElement */
 /** @jsxFrag Fragment */
 
+import {
+  isRequestOriginNotAllowedError,
+  isStartNewConversationError,
+} from '../../lib/utils/chat';
+
 import { createChatHeaderComponent } from './ChatHeader';
 import { createChatMessagesComponent } from './ChatMessages';
 import { createChatOverlayLayoutComponent } from './ChatOverlayLayout';
@@ -146,6 +151,20 @@ export function createChatComponent({ createElement, Fragment }: Renderer) {
       ...props
     } = userProps;
 
+    const startNewConversationError =
+      messagesProps.status === 'error' &&
+      isStartNewConversationError(error);
+
+    const requestOriginNotAllowedError =
+      messagesProps.status === 'error' &&
+      isRequestOriginNotAllowedError(error);
+
+    const promptBlockedByKnownChatError =
+      startNewConversationError || requestOriginNotAllowedError;
+
+    const headerStartNewConversation =
+      headerProps.onNewConversation ?? headerProps.onClear;
+
     const headerComponent = createElement(HeaderComponent || ChatHeader, {
       ...headerProps,
       classNames: classNames.header,
@@ -157,6 +176,14 @@ export function createChatComponent({ createElement, Fragment }: Renderer) {
         {...messagesProps}
         classNames={classNames.messages}
         messageClassNames={classNames.message}
+        error={error}
+        onStartNewConversation={
+          messagesProps.onStartNewConversation ??
+          ((startNewConversationError || requestOriginNotAllowedError) &&
+            headerStartNewConversation
+            ? headerStartNewConversation
+            : undefined)
+        }
         suggestionsElement={createElement(
           SuggestionsComponent || ChatPromptSuggestions,
           {
@@ -167,10 +194,16 @@ export function createChatComponent({ createElement, Fragment }: Renderer) {
       />
     );
 
-    const promptComponent = createElement(PromptComponent || ChatPrompt, {
-      ...promptProps,
-      classNames: classNames.prompt,
-    });
+    const promptComponent = promptBlockedByKnownChatError
+      ? null
+      : createElement(PromptComponent || ChatPrompt, {
+          ...promptProps,
+          classNames: classNames.prompt,
+          disabled: promptProps.disabled,
+          autoFocus: promptProps.autoFocus,
+          placeholder: promptProps.placeholder,
+          translations: promptProps.translations,
+        });
 
     const toggleButtonComponent = createElement(
       ToggleButtonComponent || ChatToggleButton,
@@ -201,7 +234,7 @@ export function createChatComponent({ createElement, Fragment }: Renderer) {
         status={messagesProps.status}
         tools={messagesProps.tools}
         isClearing={messagesProps.isClearing}
-        clearMessages={headerProps.onClear}
+        onNewConversation={headerStartNewConversation}
         onClearTransitionEnd={messagesProps.onClearTransitionEnd}
         suggestions={suggestionsProps.suggestions}
         sendMessage={sendMessage}

--- a/packages/instantsearch-ui-components/src/components/chat/ChatHeader.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatHeader.tsx
@@ -75,13 +75,22 @@ export type ChatHeaderOwnProps = {
    */
   onClose: () => void;
   /**
-   * Callback when the clear button is clicked
+   * Callback when the clear / “new conversation” text button is clicked
    */
   onClear?: () => void;
+  /**
+   * Same role as {@link onClear} when the host passes the Agent Studio / widget
+   * naming (`clearMessages` wired here).
+   */
+  onNewConversation?: () => void;
   /**
    * Whether the clear button is enabled
    */
   canClear?: boolean;
+  /**
+   * Same role as {@link canClear} for {@link onNewConversation}.
+   */
+  canStartNewConversation?: boolean;
   /**
    * Optional close icon component
    */
@@ -119,7 +128,9 @@ export function createChatHeaderComponent({ createElement }: Renderer) {
       onToggleMaximize,
       onClose,
       onClear,
-      canClear = false,
+      onNewConversation,
+      canClear,
+      canStartNewConversation,
       closeIconComponent: CloseIcon,
       minimizeIconComponent: MinimizeIcon,
       maximizeIconComponent: MaximizeIcon,
@@ -136,6 +147,10 @@ export function createChatHeaderComponent({ createElement }: Renderer) {
       clearLabel: 'Clear',
       ...userTranslations,
     };
+
+    const clearAction = onClear ?? onNewConversation;
+    const canRunClear =
+      (canClear ?? canStartNewConversation ?? false) && Boolean(clearAction);
 
     const defaultMaximizeIcon = maximized ? (
       <MinimizeIconDefault createElement={createElement} />
@@ -161,13 +176,13 @@ export function createChatHeaderComponent({ createElement }: Renderer) {
           {translations.title}
         </span>
         <div className={cx('ais-ChatHeader-actions')}>
-          {onClear && (
+          {clearAction && (
             <Button
               variant="ghost"
               size="sm"
               className={cx('ais-ChatHeader-clear', classNames.clear)}
-              onClick={onClear}
-              disabled={!canClear}
+              onClick={clearAction}
+              disabled={!canRunClear}
             >
               {translations.clearLabel}
             </Button>

--- a/packages/instantsearch-ui-components/src/components/chat/ChatInlineLayout.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatInlineLayout.tsx
@@ -19,7 +19,7 @@ export function createChatInlineLayoutComponent({ createElement }: Renderer) {
       messages: _messages,
       status: _status,
       isClearing: _isClearing,
-      clearMessages: _clearMessages,
+      onNewConversation: _onNewConversation,
       onClearTransitionEnd: _onClearTransitionEnd,
       suggestions: _suggestions,
       tools: _tools,

--- a/packages/instantsearch-ui-components/src/components/chat/ChatInlineLayout.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatInlineLayout.tsx
@@ -33,14 +33,14 @@ export function createChatInlineLayoutComponent({ createElement }: Renderer) {
     return (
       <div
         {...rest}
-        className={cx('ais-Chat', 'ais-ChatInlineLayout', classNames.root, className)}
+        className={cx(
+          'ais-Chat',
+          'ais-ChatInlineLayout',
+          classNames.root,
+          className
+        )}
       >
-        <div
-          className={cx(
-            'ais-Chat-container',
-            classNames.container
-          )}
-        >
+        <div className={cx('ais-Chat-container', classNames.container)}>
           {headerComponent}
           {messagesComponent}
           {promptComponent}

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageError.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageError.tsx
@@ -1,10 +1,14 @@
 /** @jsx createElement */
+/** @jsxFrag Fragment */
 
+import { cx } from '../../lib';
 import { createButtonComponent } from '../Button';
 
 import { ReloadIcon } from './icons';
 
 import type { ComponentProps, Renderer } from '../../types';
+
+export type ChatMessageErrorVariant = 'default' | 'conversationLimit';
 
 export type ChatMessageErrorTranslations = {
   /**
@@ -15,13 +19,29 @@ export type ChatMessageErrorTranslations = {
    * Retry button text
    */
   retryText: string;
+  /**
+   * Text for the conversation-limit action (link-style button).
+   */
+  conversationLimitActionLabel: string;
 };
 
 export type ChatMessageErrorProps = ComponentProps<'article'> & {
   /**
+   * Presentation variant; `conversationLimit` is the emphasized alert layout
+   * (bordered block, primary copy) for non-retryable cases: start a new chat
+   * (thread depth, recursion, `max_output_tokens`, …), Agent Studio allowed-domains
+   * / request-origin errors, etc. Optional actions depend on callbacks, not only
+   * on this variant.
+   */
+  variant?: ChatMessageErrorVariant;
+  /**
    * Callback for reload action
    */
   onReload?: () => void;
+  /**
+   * When `variant` is `conversationLimit`, shown as a link-style control (e.g. same handler as header Clear).
+   */
+  onStartNewConversation?: () => void;
   /**
    * Custom action buttons
    */
@@ -34,34 +54,64 @@ export type ChatMessageErrorProps = ComponentProps<'article'> & {
 
 export function createChatMessageErrorComponent({
   createElement,
-}: Pick<Renderer, 'createElement'>) {
+  Fragment,
+}: Pick<Renderer, 'createElement' | 'Fragment'>) {
   const Button = createButtonComponent({ createElement });
 
   return function ChatMessageError(userProps: ChatMessageErrorProps) {
     const {
+      variant = 'default',
       onReload,
+      onStartNewConversation,
       actions,
       translations: userTranslations,
+      className,
       ...props
     } = userProps;
     const translations: Required<ChatMessageErrorTranslations> = {
       errorMessage:
         'Sorry, we are not able to generate a response at the moment. Please retry or contact support.',
       retryText: 'Retry',
+      conversationLimitActionLabel: 'Start a new conversation',
       ...userTranslations,
     };
 
+    const isConversationLimit = variant === 'conversationLimit';
+
     return (
       <article
-        className="ais-ChatMessageError ais-ChatMessage ais-ChatMessage--left ais-ChatMessage--subtle"
+        className={cx(
+          'ais-ChatMessageError ais-ChatMessage ais-ChatMessage--left ais-ChatMessage--subtle',
+          isConversationLimit && 'ais-ChatMessageError--conversationLimit',
+          className
+        )}
         {...props}
       >
         <div className="ais-ChatMessage-container">
           <div className="ais-ChatMessage-content">
-            <div className="ais-ChatMessage-message">
-              {translations.errorMessage}
-            </div>
-            {(actions || onReload) && (
+            {isConversationLimit ? (
+              <Fragment>
+                <p className="ais-ChatMessageError-primary">
+                  {translations.errorMessage}
+                </p>
+                {onStartNewConversation && (
+                  <div className="ais-ChatMessageError-hint">
+                    <button
+                      type="button"
+                      className="ais-ChatMessageError-link"
+                      onClick={() => onStartNewConversation()}
+                    >
+                      {translations.conversationLimitActionLabel}
+                    </button>
+                  </div>
+                )}
+              </Fragment>
+            ) : (
+              <div className="ais-ChatMessage-message">
+                {translations.errorMessage}
+              </div>
+            )}
+            {(actions || (!isConversationLimit && onReload)) && (
               <div className="ais-ChatMessage-actions">
                 {actions ? (
                   actions.map((action, index) => (

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -2,8 +2,11 @@
 
 import { cx } from '../../lib';
 import {
+  getChatErrorDisplayMessage,
   getTextContent,
   hasTextContent,
+  isRequestOriginNotAllowedError,
+  isStartNewConversationError,
   isPartText,
 } from '../../lib/utils/chat';
 import { createButtonComponent } from '../Button';
@@ -65,6 +68,29 @@ export type ChatMessagesTranslations = {
    * Label for the feedback spinner
    */
   sendingFeedbackLabel?: string;
+  /**
+   * Label for the “start a new conversation” action (link-style) when the error
+   * is non-retryable (limits, allowlist, etc.).
+   */
+  conversationLimitActionLabel?: string;
+  /**
+   * Overrides the default message for “start a new conversation” errors
+   * (otherwise the API error text is shown). When omitted,
+   * {@link getChatErrorDisplayMessage} applies; use
+   * {@link registerStartNewConversationErrorDisplayResolver} for global customization.
+   */
+  conversationLimitErrorMessage?: string;
+  /**
+   * Overrides copy for retryable / generic chat errors.
+   * When omitted, {@link getChatErrorDisplayMessage} applies built-in mappings.
+   */
+  genericChatErrorMessage?: string;
+  /**
+   * Overrides copy for Agent Studio “request origin not allowed” (HTTP 403) errors.
+   * When omitted, the API error text is shown; this key is used instead of
+   * {@link genericChatErrorMessage} for that error only.
+   */
+  requestOriginNotAllowedErrorMessage?: string;
 };
 
 export type ChatMessagesClassNames = {
@@ -213,6 +239,19 @@ export type ChatMessagesProps<
    * Map of message IDs to their feedback state.
    */
   feedbackState?: Record<string, 'sending' | 0 | 1>;
+  /**
+   * When `status` is `error`, used to show `error.message` (e.g. API error text).
+   */
+  error?: Error;
+  /**
+   * Current server/client conversation id (from the chat connector). Used to
+   * remount the error row when the thread changes so UI never shows a stale line.
+   */
+  conversationId?: string;
+  /**
+   * When the conversation thread depth limit is hit, invoked from the in-thread action (e.g. same as header Clear).
+   */
+  onStartNewConversation?: () => void;
 };
 
 const copyToClipboard = (message: ChatMessageBase) => {
@@ -360,6 +399,7 @@ export function createChatMessagesComponent({
   });
   const DefaultErrorComponent = createChatMessageErrorComponent({
     createElement,
+    Fragment,
   });
 
   return function ChatMessages<
@@ -396,6 +436,9 @@ export function createChatMessagesComponent({
       suggestionsElement,
       onFeedback,
       feedbackState,
+      error,
+      conversationId,
+      onStartNewConversation,
       ...props
     } = userProps;
 
@@ -407,6 +450,7 @@ export function createChatMessagesComponent({
       thumbsDownLabel: 'Dislike',
       feedbackThankYouText: 'Thanks for your feedback!',
       sendingFeedbackLabel: 'Sending feedback...',
+      conversationLimitActionLabel: 'Start a new conversation',
       ...userTranslations,
     };
 
@@ -442,6 +486,44 @@ export function createChatMessagesComponent({
     const DefaultMessage = MessageComponent || DefaultMessageComponent;
     const DefaultLoader = LoaderComponent || DefaultLoaderComponent;
     const DefaultError = ErrorComponent || DefaultErrorComponent;
+
+    const startNewConversationError =
+      status === 'error' && isStartNewConversationError(error);
+
+    const requestOriginNotAllowedError =
+      status === 'error' && isRequestOriginNotAllowedError(error);
+
+    const errorMessageForDisplay =
+      status === 'error' && error?.message
+        ? startNewConversationError
+          ? translations.conversationLimitErrorMessage ??
+            getChatErrorDisplayMessage(error) ??
+            error.message
+          : requestOriginNotAllowedError
+            ? translations.requestOriginNotAllowedErrorMessage ??
+              getChatErrorDisplayMessage(error) ??
+              error.message
+            : translations.genericChatErrorMessage ??
+              getChatErrorDisplayMessage(error) ??
+              error.message
+        : undefined;
+
+    const errorComponentTranslations =
+      errorMessageForDisplay !== undefined ||
+      startNewConversationError ||
+      requestOriginNotAllowedError
+        ? {
+            ...(errorMessageForDisplay !== undefined
+              ? { errorMessage: errorMessageForDisplay }
+              : {}),
+            ...(startNewConversationError || requestOriginNotAllowedError
+              ? {
+                  conversationLimitActionLabel:
+                    translations.conversationLimitActionLabel,
+                }
+              : {}),
+          }
+        : undefined;
 
     return (
       <div
@@ -510,7 +592,31 @@ export function createChatMessagesComponent({
               />
             )}
 
-            {status === 'error' && <DefaultError onReload={onReload} />}
+            {status === 'error' && (
+              <DefaultError
+                key={
+                  error
+                    ? `${conversationId ?? 'no-conv'}:${error.name}:${error.message}:${(error.stack ?? '').slice(0, 160)}`
+                    : 'chat-error-no-error-instance'
+                }
+                variant={
+                  startNewConversationError || requestOriginNotAllowedError
+                    ? 'conversationLimit'
+                    : 'default'
+                }
+                onReload={
+                  startNewConversationError || requestOriginNotAllowedError
+                    ? undefined
+                    : onReload
+                }
+                onStartNewConversation={
+                  startNewConversationError || requestOriginNotAllowedError
+                    ? onStartNewConversation
+                    : undefined
+                }
+                translations={errorComponentTranslations}
+              />
+            )}
           </div>
         </div>
 

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -33,7 +33,13 @@ import type {
 } from './ChatMessage';
 import type { ChatMessageErrorProps } from './ChatMessageError';
 import type { ChatMessageLoaderProps } from './ChatMessageLoader';
-import type { ChatEmptyProps, ChatLayoutOwnProps, ChatMessageBase, ChatStatus, ClientSideTools } from './types';
+import type {
+  ChatEmptyProps,
+  ChatLayoutOwnProps,
+  ChatMessageBase,
+  ChatStatus,
+  ClientSideTools,
+} from './types';
 
 export type ChatMessagesTranslations = {
   /**
@@ -500,12 +506,12 @@ export function createChatMessagesComponent({
             getChatErrorDisplayMessage(error) ??
             error.message
           : requestOriginNotAllowedError
-            ? translations.requestOriginNotAllowedErrorMessage ??
-              getChatErrorDisplayMessage(error) ??
-              error.message
-            : translations.genericChatErrorMessage ??
-              getChatErrorDisplayMessage(error) ??
-              error.message
+          ? translations.requestOriginNotAllowedErrorMessage ??
+            getChatErrorDisplayMessage(error) ??
+            error.message
+          : translations.genericChatErrorMessage ??
+            getChatErrorDisplayMessage(error) ??
+            error.message
         : undefined;
 
     const errorComponentTranslations =
@@ -596,7 +602,9 @@ export function createChatMessagesComponent({
               <DefaultError
                 key={
                   error
-                    ? `${conversationId ?? 'no-conv'}:${error.name}:${error.message}:${(error.stack ?? '').slice(0, 160)}`
+                    ? `${conversationId ?? 'no-conv'}:${error.name}:${
+                        error.message
+                      }:${(error.stack ?? '').slice(0, 160)}`
                     : 'chat-error-no-error-instance'
                 }
                 variant={

--- a/packages/instantsearch-ui-components/src/components/chat/ChatOverlayLayout.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatOverlayLayout.tsx
@@ -19,7 +19,7 @@ export function createChatOverlayLayoutComponent({ createElement }: Renderer) {
       messages: _messages,
       status: _status,
       isClearing: _isClearing,
-      clearMessages: _clearMessages,
+      onNewConversation: _onNewConversation,
       onClearTransitionEnd: _onClearTransitionEnd,
       suggestions: _suggestions,
       tools: _tools,

--- a/packages/instantsearch-ui-components/src/components/chat/ChatSidePanelLayout.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatSidePanelLayout.tsx
@@ -28,7 +28,7 @@ export function createChatSidePanelLayoutComponent({
       messages: _messages,
       status: _status,
       isClearing: _isClearing,
-      clearMessages: _clearMessages,
+      onNewConversation: _onNewConversation,
       onClearTransitionEnd: _onClearTransitionEnd,
       suggestions: _suggestions,
       tools: _tools,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/Chat.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/Chat.test.tsx
@@ -238,4 +238,93 @@ describe('Chat', () => {
       </div>
     `);
   });
+
+  test('hides prompt when conversation-limit error is present', () => {
+    const { container } = render(
+      <Chat
+        open
+        sendMessage={jest.fn() as any}
+        regenerate={jest.fn() as any}
+        stop={jest.fn() as any}
+        error={
+          new Error(
+            'Conversation has reached its maximum thread depth of 3 messages.'
+          )
+        }
+        headerProps={{ onClose: jest.fn() }}
+        messagesProps={{
+          messages: [],
+          indexUiState: {},
+          setIndexUiState: jest.fn(),
+          tools: {},
+          onReload: jest.fn(),
+          onClose: jest.fn(),
+          status: 'error',
+        }}
+        promptProps={{}}
+        toggleButtonProps={{ open: true, onClick: jest.fn() }}
+        suggestionsProps={{ onSuggestionClick: jest.fn() }}
+      />
+    );
+
+    expect(container.querySelector('.ais-ChatPrompt')).toBeNull();
+  });
+
+  test('hides prompt when rate limit error is present', () => {
+    const { container } = render(
+      <Chat
+        open
+        sendMessage={jest.fn() as any}
+        regenerate={jest.fn() as any}
+        stop={jest.fn() as any}
+        error={new Error('Rate limit exceeded. Retry after 60 seconds.')}
+        headerProps={{ onClose: jest.fn() }}
+        messagesProps={{
+          messages: [],
+          indexUiState: {},
+          setIndexUiState: jest.fn(),
+          tools: {},
+          onReload: jest.fn(),
+          onClose: jest.fn(),
+          status: 'error',
+        }}
+        promptProps={{}}
+        toggleButtonProps={{ open: true, onClick: jest.fn() }}
+        suggestionsProps={{ onSuggestionClick: jest.fn() }}
+      />
+    );
+
+    expect(container.querySelector('.ais-ChatPrompt')).toBeNull();
+  });
+
+  test('hides prompt when request origin is not allowed', () => {
+    const { container } = render(
+      <Chat
+        open
+        sendMessage={jest.fn() as any}
+        regenerate={jest.fn() as any}
+        stop={jest.fn() as any}
+        error={
+          new Error(
+            'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.'
+          )
+        }
+        headerProps={{ onClose: jest.fn() }}
+        messagesProps={{
+          messages: [],
+          indexUiState: {},
+          setIndexUiState: jest.fn(),
+          tools: {},
+          onReload: jest.fn(),
+          onClose: jest.fn(),
+          status: 'error',
+        }}
+        promptProps={{}}
+        toggleButtonProps={{ open: true, onClick: jest.fn() }}
+        suggestionsProps={{ onSuggestionClick: jest.fn() }}
+      />
+    );
+
+    expect(container.querySelector('.ais-ChatPrompt')).toBeNull();
+  });
 });

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatInlineLayout.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatInlineLayout.test.tsx
@@ -23,7 +23,7 @@ describe('ChatInlineLayout', () => {
     messages: [],
     status: 'ready' as const,
     isClearing: false,
-    clearMessages: jest.fn(),
+      onNewConversation: jest.fn(),
     onClearTransitionEnd: jest.fn(),
     tools: {},
     sendMessage: jest.fn() as any,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatInlineLayout.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatInlineLayout.test.tsx
@@ -23,7 +23,7 @@ describe('ChatInlineLayout', () => {
     messages: [],
     status: 'ready' as const,
     isClearing: false,
-      onNewConversation: jest.fn(),
+    onNewConversation: jest.fn(),
     onClearTransitionEnd: jest.fn(),
     tools: {},
     sendMessage: jest.fn() as any,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 /** @jsx createElement */
-import { render } from '@testing-library/preact';
+import { fireEvent, render } from '@testing-library/preact';
 import { Fragment, createElement } from 'preact';
 
 import { createChatMessagesComponent } from '../ChatMessages';
@@ -254,6 +254,306 @@ describe('ChatMessages', () => {
         container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
       ).toHaveLength(0);
     });
+  });
+
+  test('shows API error message when status is error and error is set', () => {
+    const apiMessage =
+      'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
+
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error(apiMessage)}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessageError-primary')?.textContent
+    ).toBe(apiMessage);
+  });
+
+  test('conversation depth error shows API text only, no link or retry without handler', () => {
+    const apiMessage =
+      'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
+
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error(apiMessage)}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessageError--conversationLimit')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('.ais-ChatMessageError-primary')?.textContent
+    ).toBe(apiMessage);
+    expect(container.querySelector('.ais-ChatMessageError-link')).toBeNull();
+    expect(container.querySelector('.ais-ChatMessage-errorAction')).toBeNull();
+  });
+
+  test('conversation depth error renders start-new link when handler is provided', () => {
+    const apiMessage =
+      'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
+    const onStartNewConversation = jest.fn();
+
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error(apiMessage)}
+        onStartNewConversation={onStartNewConversation}
+      />
+    );
+
+    const link = container.querySelector(
+      '.ais-ChatMessageError-link'
+    );
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe('Start a new conversation');
+
+    fireEvent.click(link!);
+    expect(onStartNewConversation).toHaveBeenCalledTimes(1);
+  });
+
+  test('recursion limit error surfaces API text', () => {
+    const long =
+      'Recursion limit of 5 reached without hitting a stop condition. You can increase the limit by setting the `recursion_limit` config key.';
+
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error(long)}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessageError-primary')?.textContent
+    ).toBe(long);
+  });
+
+  test('max_output_tokens error uses conversation-limit variant like thread depth', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error('Response is incomplete due to: max_output_tokens')}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessageError--conversationLimit')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('.ais-ChatMessageError-primary')?.textContent
+    ).toBe('Response is incomplete due to: max_output_tokens');
+    expect(container.querySelector('.ais-ChatMessage-errorAction')).toBeNull();
+    expect(container.querySelector('.ais-ChatMessageError-link')).toBeNull();
+  });
+
+  test('max_output_tokens error renders start-new link when handler is provided', () => {
+    const onStartNewConversation = jest.fn();
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error('Response is incomplete due to: max_output_tokens')}
+        onStartNewConversation={onStartNewConversation}
+      />
+    );
+
+    const link = container.querySelector(
+      '.ais-ChatMessageError-link'
+    );
+    expect(link).not.toBeNull();
+    fireEvent.click(link!);
+    expect(onStartNewConversation).toHaveBeenCalledTimes(1);
+  });
+
+  test('rate limit error uses conversation-limit variant and API text', () => {
+    const apiMessage = 'Rate limit exceeded. Retry after 60 seconds.';
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error(apiMessage)}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessageError--conversationLimit')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('.ais-ChatMessageError-primary')?.textContent
+    ).toBe(apiMessage);
+    expect(container.querySelector('.ais-ChatMessage-errorAction')).toBeNull();
+  });
+
+  test('rate limit error renders start-new link when handler is provided', () => {
+    const onStartNewConversation = jest.fn();
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error('HTTP error: 429 Too Many Requests')}
+        onStartNewConversation={onStartNewConversation}
+      />
+    );
+
+    const link = container.querySelector(
+      '.ais-ChatMessageError-link'
+    );
+    expect(link).not.toBeNull();
+    fireEvent.click(link!);
+    expect(onStartNewConversation).toHaveBeenCalledTimes(1);
+  });
+
+  test('request origin not allowed error uses conversation-limit layout without retry', () => {
+    const apiMessage =
+      'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.';
+    const onReload = jest.fn();
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={onReload}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error(apiMessage)}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessageError--conversationLimit')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('.ais-ChatMessageError-primary')?.textContent
+    ).toBe(apiMessage);
+    expect(container.querySelector('.ais-ChatMessage-errorAction')).toBeNull();
+    expect(onReload).not.toHaveBeenCalled();
+  });
+
+  test('request origin error renders start-new link when handler is provided', () => {
+    const apiMessage =
+      'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.';
+    const onStartNewConversation = jest.fn();
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error(apiMessage)}
+        onStartNewConversation={onStartNewConversation}
+      />
+    );
+
+    const link = container.querySelector(
+      '.ais-ChatMessageError-link'
+    );
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toBe('Start a new conversation');
+    fireEvent.click(link!);
+    expect(onStartNewConversation).toHaveBeenCalledTimes(1);
+  });
+
+  test('requestOriginNotAllowedErrorMessage translation overrides default copy', () => {
+    const apiMessage =
+      'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.';
+
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error(apiMessage)}
+        translations={{
+          requestOriginNotAllowedErrorMessage: 'Origin blocked — fix in Studio',
+        }}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessageError-primary')?.textContent
+    ).toBe('Origin blocked — fix in Studio');
+  });
+
+  test('conversationLimitErrorMessage translation overrides default message', () => {
+    const apiMessage =
+      'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
+
+    const { container } = render(
+      <ChatMessages
+        messages={[]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+        status="error"
+        error={new Error(apiMessage)}
+        translations={{
+          conversationLimitErrorMessage: 'Thread limit — start over',
+        }}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessageError-primary')?.textContent
+    ).toBe('Thread limit — start over');
   });
 
   test('renders with custom class names', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -161,7 +161,9 @@ describe('ChatMessages', () => {
       );
 
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(2);
     });
 
@@ -179,7 +181,9 @@ describe('ChatMessages', () => {
       );
 
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(0);
     });
 
@@ -201,7 +205,9 @@ describe('ChatMessages', () => {
         container.querySelector('.ais-ChatMessage-feedbackSpinner')
       ).not.toBeNull();
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(0);
     });
 
@@ -251,7 +257,9 @@ describe('ChatMessages', () => {
       );
 
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(0);
     });
   });
@@ -324,9 +332,7 @@ describe('ChatMessages', () => {
       />
     );
 
-    const link = container.querySelector(
-      '.ais-ChatMessageError-link'
-    );
+    const link = container.querySelector('.ais-ChatMessageError-link');
     expect(link).not.toBeNull();
     expect(link?.textContent).toBe('Start a new conversation');
 
@@ -396,9 +402,7 @@ describe('ChatMessages', () => {
       />
     );
 
-    const link = container.querySelector(
-      '.ais-ChatMessageError-link'
-    );
+    const link = container.querySelector('.ais-ChatMessageError-link');
     expect(link).not.toBeNull();
     fireEvent.click(link!);
     expect(onStartNewConversation).toHaveBeenCalledTimes(1);
@@ -444,9 +448,7 @@ describe('ChatMessages', () => {
       />
     );
 
-    const link = container.querySelector(
-      '.ais-ChatMessageError-link'
-    );
+    const link = container.querySelector('.ais-ChatMessageError-link');
     expect(link).not.toBeNull();
     fireEvent.click(link!);
     expect(onStartNewConversation).toHaveBeenCalledTimes(1);
@@ -497,9 +499,7 @@ describe('ChatMessages', () => {
       />
     );
 
-    const link = container.querySelector(
-      '.ais-ChatMessageError-link'
-    );
+    const link = container.querySelector('.ais-ChatMessageError-link');
     expect(link).not.toBeNull();
     expect(link?.textContent).toBe('Start a new conversation');
     fireEvent.click(link!);

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatOverlayLayout.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatOverlayLayout.test.tsx
@@ -23,7 +23,7 @@ describe('ChatOverlayLayout', () => {
     messages: [],
     status: 'ready' as const,
     isClearing: false,
-    clearMessages: jest.fn(),
+      onNewConversation: jest.fn(),
     onClearTransitionEnd: jest.fn(),
     tools: {},
     sendMessage: jest.fn() as any,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatOverlayLayout.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatOverlayLayout.test.tsx
@@ -23,7 +23,7 @@ describe('ChatOverlayLayout', () => {
     messages: [],
     status: 'ready' as const,
     isClearing: false,
-      onNewConversation: jest.fn(),
+    onNewConversation: jest.fn(),
     onClearTransitionEnd: jest.fn(),
     tools: {},
     sendMessage: jest.fn() as any,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatSidePanelLayout.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatSidePanelLayout.test.tsx
@@ -27,7 +27,7 @@ describe('ChatSidePanelLayout', () => {
     messages: [],
     status: 'ready' as const,
     isClearing: false,
-      onNewConversation: jest.fn(),
+    onNewConversation: jest.fn(),
     onClearTransitionEnd: jest.fn(),
     tools: {},
     sendMessage: jest.fn() as any,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatSidePanelLayout.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatSidePanelLayout.test.tsx
@@ -27,7 +27,7 @@ describe('ChatSidePanelLayout', () => {
     messages: [],
     status: 'ready' as const,
     isClearing: false,
-    clearMessages: jest.fn(),
+      onNewConversation: jest.fn(),
     onClearTransitionEnd: jest.fn(),
     tools: {},
     sendMessage: jest.fn() as any,

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -476,7 +476,10 @@ export type ChatLayoutOwnProps<
   tools: ClientSideTools;
 } & Pick<ChatState<TMessage>, 'messages'> &
   Partial<Pick<ChatState<TMessage>, 'status'>> &
-  Pick<AbstractChat<TMessage>, 'sendMessage' | 'regenerate' | 'stop' | 'error'> &
+  Pick<
+    AbstractChat<TMessage>,
+    'sendMessage' | 'regenerate' | 'stop' | 'error'
+  > &
   ComponentProps<'div'>;
 
 export type ClientSideToolComponentProps = {
@@ -532,4 +535,3 @@ export type ChatEmptyProps = {
    */
   setInput?: (input: string) => void;
 };
-

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -353,6 +353,7 @@ export interface ChatTransport<TUIMessage extends UIMessage> {
 
   reconnectToStream: (options: {
     chatId: string;
+    abortSignal?: AbortSignal;
   }) => Promise<ReadableStream<unknown> | null>;
 }
 
@@ -465,11 +466,11 @@ export type ChatLayoutOwnProps<
   maximized: boolean;
   headerComponent: JSX.Element;
   messagesComponent: JSX.Element;
-  promptComponent: JSX.Element;
+  promptComponent: JSX.Element | null;
   toggleButtonComponent: JSX.Element;
   classNames?: { root?: string | string[]; container?: string | string[] };
   isClearing?: boolean;
-  clearMessages?: () => void;
+  onNewConversation?: () => void;
   onClearTransitionEnd?: () => void;
   suggestions?: string[];
   tools: ClientSideTools;

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat.test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat.test.ts
@@ -43,7 +43,9 @@ describe('isConversationThreadDepthLimitError', () => {
   test('returns false for LangGraph recursion errors (use isStartNewConversationError)', () => {
     expect(
       isConversationThreadDepthLimitError(
-        new Error('Recursion limit of 5 reached. recursion_limit GRAPH_RECURSION_LIMIT')
+        new Error(
+          'Recursion limit of 5 reached. recursion_limit GRAPH_RECURSION_LIMIT'
+        )
       )
     ).toBe(false);
   });
@@ -89,7 +91,9 @@ describe('isStartNewConversationError', () => {
       )
     ).toBe(true);
     expect(
-      isStartNewConversationError(new Error('HTTP error: 429 Too Many Requests'))
+      isStartNewConversationError(
+        new Error('HTTP error: 429 Too Many Requests')
+      )
     ).toBe(true);
   });
 
@@ -215,9 +219,9 @@ describe('getStartNewConversationErrorDisplayMessage', () => {
   test('prefers recursion when the same payload also mentions thread depth', () => {
     const combined =
       'Recursion limit of 5 reached.\nConversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
-    expect(getStartNewConversationErrorDisplayMessage(new Error(combined))).toBe(
-      combined
-    );
+    expect(
+      getStartNewConversationErrorDisplayMessage(new Error(combined))
+    ).toBe(combined);
   });
 
   test('unwraps JSON message field for thread depth display', () => {
@@ -250,7 +254,9 @@ describe('getStartNewConversationErrorDisplayMessage', () => {
   test('surfaces rate limit API text', () => {
     const msg = 'Rate limit exceeded. Retry after 60 seconds.';
     expect(isStartNewConversationError(new Error(msg))).toBe(true);
-    expect(getStartNewConversationErrorDisplayMessage(new Error(msg))).toBe(msg);
+    expect(getStartNewConversationErrorDisplayMessage(new Error(msg))).toBe(
+      msg
+    );
     expect(getChatErrorDisplayMessage(new Error(msg))).toBe(msg);
   });
 

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat.test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat.test.ts
@@ -1,0 +1,313 @@
+import {
+  flattenErrorMessageForMatching,
+  genericChatErrorDisplayResolvers,
+  getChatErrorDisplayMessage,
+  getStartNewConversationErrorDisplayMessage,
+  isConversationThreadDepthLimitError,
+  isPartText,
+  isRequestOriginNotAllowedError,
+  isStartNewConversationError,
+  registerGenericChatErrorDisplayResolver,
+  registerNewConversationErrorMatcher,
+  registerStartNewConversationErrorDisplayResolver,
+  newConversationErrorMatchers,
+  startNewConversationErrorDisplayResolvers,
+} from '../chat';
+
+describe('isConversationThreadDepthLimitError', () => {
+  test('returns true for Agent Studio thread depth wording', () => {
+    expect(
+      isConversationThreadDepthLimitError(
+        new Error(
+          'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('is case-insensitive', () => {
+    expect(
+      isConversationThreadDepthLimitError(
+        new Error('MAXIMUM THREAD DEPTH reached')
+      )
+    ).toBe(true);
+  });
+
+  test('returns false for other errors', () => {
+    expect(
+      isConversationThreadDepthLimitError(new Error('HTTP error: 500'))
+    ).toBe(false);
+    expect(isConversationThreadDepthLimitError(undefined)).toBe(false);
+  });
+
+  test('returns false for LangGraph recursion errors (use isStartNewConversationError)', () => {
+    expect(
+      isConversationThreadDepthLimitError(
+        new Error('Recursion limit of 5 reached. recursion_limit GRAPH_RECURSION_LIMIT')
+      )
+    ).toBe(false);
+  });
+});
+
+describe('isStartNewConversationError', () => {
+  test('includes thread depth', () => {
+    expect(
+      isStartNewConversationError(
+        new Error(
+          'Conversation has reached its maximum thread depth of 3 messages.'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('detects LangGraph / stream errorText with nested JSON', () => {
+    const raw =
+      '"{\\"error\\": \\"Recursion limit of 5 reached without hitting a stop condition. \\\\nFor troubleshooting: GRAPH_RECURSION_LIMIT\\"}"';
+    expect(isStartNewConversationError(new Error(raw))).toBe(true);
+  });
+
+  test('detects Recursion limit of after flattening JSON', () => {
+    const raw = JSON.stringify({
+      error:
+        'Recursion limit of 5 reached. Set recursion_limit in config. See GRAPH_RECURSION_LIMIT',
+    });
+    expect(isStartNewConversationError(new Error(raw))).toBe(true);
+  });
+
+  test('detects max_output_tokens / incomplete response (same UX as thread depth)', () => {
+    expect(
+      isStartNewConversationError(
+        new Error('Response is incomplete due to: max_output_tokens')
+      )
+    ).toBe(true);
+  });
+
+  test('detects rate limiting (phrase and HTTP 429)', () => {
+    expect(
+      isStartNewConversationError(
+        new Error('Rate limit exceeded. Retry after 60 seconds.')
+      )
+    ).toBe(true);
+    expect(
+      isStartNewConversationError(new Error('HTTP error: 429 Too Many Requests'))
+    ).toBe(true);
+  });
+
+  test('does not match on GRAPH_RECURSION_LIMIT alone without Recursion limit of', () => {
+    expect(
+      isStartNewConversationError(
+        new Error('See https://docs.../GRAPH_RECURSION_LIMIT')
+      )
+    ).toBe(false);
+  });
+
+  test('returns false for unrelated errors', () => {
+    expect(isStartNewConversationError(new Error('HTTP error: 500'))).toBe(
+      false
+    );
+    expect(isStartNewConversationError(undefined)).toBe(false);
+  });
+
+  test('registerNewConversationErrorMatcher extends behavior', () => {
+    const len = newConversationErrorMatchers.length;
+    registerNewConversationErrorMatcher((m) => m.includes('CUSTOM_XYZ'));
+    expect(isStartNewConversationError(new Error('CUSTOM_XYZ'))).toBe(true);
+    newConversationErrorMatchers.pop();
+    expect(newConversationErrorMatchers.length).toBe(len);
+  });
+});
+
+describe('isRequestOriginNotAllowedError', () => {
+  test('returns true for Agent Studio 403 origin message', () => {
+    expect(
+      isRequestOriginNotAllowedError(
+        new Error(
+          'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('unwraps JSON message field', () => {
+    const body = JSON.stringify({
+      message:
+        'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.',
+    });
+    expect(isRequestOriginNotAllowedError(new Error(body))).toBe(true);
+  });
+
+  test('returns false for unrelated errors', () => {
+    expect(isRequestOriginNotAllowedError(new Error('HTTP error: 403'))).toBe(
+      false
+    );
+    expect(isRequestOriginNotAllowedError(undefined)).toBe(false);
+  });
+});
+
+describe('getChatErrorDisplayMessage', () => {
+  test('surfaces Agent Studio request-origin API message', () => {
+    const api =
+      'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.';
+    expect(getChatErrorDisplayMessage(new Error(api))).toBe(api);
+  });
+
+  test('registerGenericChatErrorDisplayResolver overrides built-in origin copy', () => {
+    const len = genericChatErrorDisplayResolvers.length;
+    registerGenericChatErrorDisplayResolver((flat) =>
+      flat.includes('allowed domains list') ? 'Custom origin hint' : null
+    );
+    expect(
+      getChatErrorDisplayMessage(
+        new Error(
+          'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.'
+        )
+      )
+    ).toBe('Custom origin hint');
+    genericChatErrorDisplayResolvers.shift();
+    expect(genericChatErrorDisplayResolvers.length).toBe(len);
+  });
+
+  test('surfaces max_output_tokens / incomplete response API text', () => {
+    const msg = 'Response is incomplete due to: max_output_tokens';
+    expect(getChatErrorDisplayMessage(new Error(msg))).toBe(msg);
+  });
+
+  test('unwraps JSON-wrapped stream error (error field)', () => {
+    const inner = 'Response is incomplete due to: max_output_tokens';
+    const wrapped = JSON.stringify({
+      error: inner,
+    });
+    expect(getChatErrorDisplayMessage(new Error(wrapped))).toBe(inner);
+  });
+
+  test('delegates to start-new conversation and surfaces thread depth API text', () => {
+    expect(
+      getChatErrorDisplayMessage(
+        new Error(
+          'Conversation has reached its maximum thread depth of 3 messages.'
+        )
+      )
+    ).toBe('Conversation has reached its maximum thread depth of 3 messages.');
+  });
+});
+
+describe('getStartNewConversationErrorDisplayMessage', () => {
+  test('surfaces thread depth API text', () => {
+    expect(
+      getStartNewConversationErrorDisplayMessage(
+        new Error(
+          'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.'
+        )
+      )
+    ).toBe(
+      'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.'
+    );
+  });
+
+  test('surfaces LangGraph recursion API text', () => {
+    const long =
+      'Recursion limit of 5 reached without hitting a stop condition. You can increase the limit by setting the `recursion_limit` config key. For troubleshooting, visit: https://example.com';
+    expect(getStartNewConversationErrorDisplayMessage(new Error(long))).toBe(
+      long
+    );
+  });
+
+  test('prefers recursion when the same payload also mentions thread depth', () => {
+    const combined =
+      'Recursion limit of 5 reached.\nConversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
+    expect(getStartNewConversationErrorDisplayMessage(new Error(combined))).toBe(
+      combined
+    );
+  });
+
+  test('unwraps JSON message field for thread depth display', () => {
+    const inner =
+      'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
+    const body = JSON.stringify({
+      message: inner,
+    });
+    expect(getStartNewConversationErrorDisplayMessage(new Error(body))).toBe(
+      inner
+    );
+  });
+
+  test('surfaces max_output_tokens API text', () => {
+    const msg = 'Response is incomplete due to: max_output_tokens';
+    expect(getStartNewConversationErrorDisplayMessage(new Error(msg))).toBe(
+      msg
+    );
+  });
+
+  test('surfaces max steps API text', () => {
+    const msg = 'Maximum steps (25) exceeded for this run.';
+    expect(isStartNewConversationError(new Error(msg))).toBe(true);
+    expect(getStartNewConversationErrorDisplayMessage(new Error(msg))).toBe(
+      msg
+    );
+    expect(getChatErrorDisplayMessage(new Error(msg))).toBe(msg);
+  });
+
+  test('surfaces rate limit API text', () => {
+    const msg = 'Rate limit exceeded. Retry after 60 seconds.';
+    expect(isStartNewConversationError(new Error(msg))).toBe(true);
+    expect(getStartNewConversationErrorDisplayMessage(new Error(msg))).toBe(msg);
+    expect(getChatErrorDisplayMessage(new Error(msg))).toBe(msg);
+  });
+
+  test('thread depth API text never maps to max_output copy', () => {
+    const api =
+      'Conversation has reached its maximum thread depth of 3 messages. Please start a new conversation.';
+    expect(getStartNewConversationErrorDisplayMessage(new Error(api))).toBe(
+      api
+    );
+    expect(getChatErrorDisplayMessage(new Error(api))).toBe(api);
+  });
+
+  test('returns undefined when not a start-new error', () => {
+    expect(
+      getStartNewConversationErrorDisplayMessage(new Error('HTTP 500'))
+    ).toBeUndefined();
+  });
+
+  test('registerStartNewConversationErrorDisplayResolver prepends custom copy', () => {
+    const matcherLen = newConversationErrorMatchers.length;
+    const resolverLen = startNewConversationErrorDisplayResolvers.length;
+    registerNewConversationErrorMatcher((m) => m.includes('CUSTOM_ABC'));
+    registerStartNewConversationErrorDisplayResolver((flat) =>
+      flat.includes('CUSTOM_ABC') ? 'Custom message' : null
+    );
+    expect(
+      getStartNewConversationErrorDisplayMessage(new Error('CUSTOM_ABC detail'))
+    ).toBe('Custom message');
+    startNewConversationErrorDisplayResolvers.shift();
+    newConversationErrorMatchers.pop();
+    expect(startNewConversationErrorDisplayResolvers.length).toBe(resolverLen);
+    expect(newConversationErrorMatchers.length).toBe(matcherLen);
+  });
+});
+
+describe('flattenErrorMessageForMatching', () => {
+  test('unwraps stringified JSON with error field', () => {
+    const inner = { error: 'Recursion limit of 5 reached. recursion_limit' };
+    const raw = JSON.stringify(JSON.stringify(inner));
+    const flat = flattenErrorMessageForMatching(raw);
+    expect(flat).toContain('Recursion limit');
+    expect(flat).toContain('recursion_limit');
+  });
+
+  test('unwraps JSON with message field', () => {
+    const inner = {
+      message:
+        'Conversation has reached its maximum thread depth of 3 messages.',
+    };
+    const flat = flattenErrorMessageForMatching(JSON.stringify(inner));
+    expect(flat).toContain('maximum thread depth');
+  });
+});
+
+describe('isPartText', () => {
+  test('narrows type for text parts', () => {
+    expect(isPartText({ type: 'text', text: 'x' })).toBe(true);
+    expect(isPartText({ type: 'step-start' } as any)).toBe(false);
+  });
+});

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -78,9 +78,7 @@ export function flattenErrorMessageForMatching(raw: string): string {
  */
 function getUnwrappedApiErrorDisplayMessage(error: Error): string {
   const segments = collectErrorMessageSegments(error.message);
-  return segments.length > 1
-    ? segments[segments.length - 1]
-    : error.message;
+  return segments.length > 1 ? segments[segments.length - 1] : error.message;
 }
 
 /**

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -15,3 +15,384 @@ export const isPartText = (
 ): part is Extract<ChatMessageBase['parts'][number], { type: 'text' }> => {
   return part.type === 'text';
 };
+
+/**
+ * Unwraps nested JSON / double-encoded strings from streaming `error` chunks
+ * (e.g. LangGraph `errorText` payloads). Each segment is one unwrap step; the
+ * last entry is the innermost string (when wrapping exists).
+ */
+function collectErrorMessageSegments(raw: string): string[] {
+  const segments: string[] = [raw];
+  let remaining = raw.trim();
+
+  for (let depth = 0; depth < 8; depth += 1) {
+    try {
+      const parsed: unknown = JSON.parse(remaining);
+      if (typeof parsed === 'string') {
+        segments.push(parsed);
+        remaining = parsed.trim();
+        continue;
+      }
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        'message' in parsed &&
+        typeof (parsed as { message: unknown }).message === 'string'
+      ) {
+        const inner = (parsed as { message: string }).message;
+        segments.push(inner);
+        remaining = inner.trim();
+        continue;
+      }
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        'error' in parsed &&
+        typeof (parsed as { error: unknown }).error === 'string'
+      ) {
+        const inner = (parsed as { error: string }).error;
+        segments.push(inner);
+        remaining = inner.trim();
+        continue;
+      }
+      break;
+    } catch {
+      break;
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Unwraps nested JSON / double-encoded strings from streaming `error` chunks
+ * (e.g. LangGraph `errorText` payloads) into one searchable string.
+ */
+export function flattenErrorMessageForMatching(raw: string): string {
+  return collectErrorMessageSegments(raw).join('\n');
+}
+
+/**
+ * API / transport error text for display: {@link Error.message}, or the
+ * innermost unwrapped string when the message is JSON-wrapped.
+ */
+function getUnwrappedApiErrorDisplayMessage(error: Error): string {
+  const segments = collectErrorMessageSegments(error.message);
+  return segments.length > 1
+    ? segments[segments.length - 1]
+    : error.message;
+}
+
+/**
+ * Predicate on the flattened error string. Register more at runtime via
+ * {@link registerNewConversationErrorMatcher} for product-specific API errors.
+ */
+export type NewConversationErrorMatcher = (flatMessage: string) => boolean;
+
+/**
+ * True when the flattened text indicates thread / conversation depth limit
+ * (wording varies by API).
+ */
+function matchesThreadDepthLimitError(flatLower: string): boolean {
+  return (
+    flatLower.includes('maximum thread depth') ||
+    flatLower.includes('max thread depth') ||
+    (flatLower.includes('thread depth') && flatLower.includes('conversation'))
+  );
+}
+
+/**
+ * True for stream/model output limit — uses `max_output` as a token/code, not
+ * substrings of words like “maximum”. Runs on lowercased text so casing matches
+ * the `includes` checks and the `max_output` token regex.
+ */
+function matchesMaxOutputIncompleteError(flatLower: string): boolean {
+  if (flatLower.includes('max_output_tokens')) {
+    return true;
+  }
+  if (
+    flatLower.includes('response is incomplete') &&
+    /\bmax_output\b/.test(flatLower)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * True for LangGraph-style recursion limit errors (wording varies by API).
+ */
+function matchesRecursionLimitError(flatLower: string): boolean {
+  return flatLower.includes('recursion limit of');
+}
+
+/**
+ * Agent / graph “max steps” style limits (wording varies by API).
+ */
+function matchesMaxStepsLimitError(flatLower: string): boolean {
+  return (
+    flatLower.includes('max_steps') ||
+    flatLower.includes('max steps') ||
+    flatLower.includes('maximum steps') ||
+    flatLower.includes('step limit')
+  );
+}
+
+/**
+ * HTTP / API rate limiting (429, “too many requests”, etc.).
+ */
+function matchesRateLimitError(flatLower: string): boolean {
+  if (
+    flatLower.includes('rate limit') ||
+    flatLower.includes('rate_limit') ||
+    flatLower.includes('ratelimit')
+  ) {
+    return true;
+  }
+  if (flatLower.includes('too many requests')) {
+    return true;
+  }
+  if (flatLower.includes('throttl')) {
+    return true;
+  }
+  if (/\b429\b/.test(flatLower)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Default matchers for errors where the user should start a new conversation
+ * (same UX: conversation-limit alert, “Start a new conversation”, hidden prompt, etc.).
+ */
+export const newConversationErrorMatchers: NewConversationErrorMatcher[] = [
+  (m) => matchesThreadDepthLimitError(m.toLowerCase()),
+  (m) => matchesRecursionLimitError(m.toLowerCase()),
+  (m) => matchesMaxStepsLimitError(m.toLowerCase()),
+  (m) => matchesMaxOutputIncompleteError(m.toLowerCase()),
+  (m) => matchesRateLimitError(m.toLowerCase()),
+];
+
+/**
+ * Register an extra matcher (e.g. for a new Agent Studio error code) without
+ * forking the library.
+ */
+export function registerNewConversationErrorMatcher(
+  fn: NewConversationErrorMatcher
+): void {
+  newConversationErrorMatchers.push(fn);
+}
+
+/**
+ * Maps a flattened API error string to a short, user-facing line. Return
+ * `null` or `undefined` to try the next resolver; if none match, the raw
+ * {@link Error.message} is shown.
+ */
+export type StartNewConversationErrorDisplayResolver = (
+  flatMessage: string,
+  rawMessage: string
+) => string | null | undefined;
+
+/** Legacy shortened copy for LangGraph / agent recursion limits. */
+export const START_NEW_CONVERSATION_RECURSION_MESSAGE =
+  'Recursion limit reached';
+
+const defaultStartNewConversationErrorDisplayResolvers: StartNewConversationErrorDisplayResolver[] =
+  [];
+
+/**
+ * Resolvers run in order (index `0` first). Use
+ * {@link registerStartNewConversationErrorDisplayResolver} to prepend
+ * product-specific mappings ahead of the defaults.
+ */
+export const startNewConversationErrorDisplayResolvers: StartNewConversationErrorDisplayResolver[] =
+  [...defaultStartNewConversationErrorDisplayResolvers];
+
+export function registerStartNewConversationErrorDisplayResolver(
+  resolver: StartNewConversationErrorDisplayResolver
+): void {
+  startNewConversationErrorDisplayResolvers.unshift(resolver);
+}
+
+/**
+ * Legacy shortened copy for thread-depth limits. Thread-depth errors now use
+ * the API message in the UI; this remains for backwards compatibility.
+ */
+export const START_NEW_CONVERSATION_THREAD_DEPTH_MESSAGE =
+  'Conversation has reached its maximum thread depth';
+
+/** Legacy shortened copy for `max_output_tokens` / incomplete stream output. */
+export const START_NEW_CONVERSATION_MAX_OUTPUT_MESSAGE =
+  "Token limit reached — the answer couldn't finish.";
+
+function resolveStartNewConversationErrorDisplayMessage(error: Error): string {
+  const flat = flattenErrorMessageForMatching(error.message);
+  const flatLower = flat.toLowerCase();
+
+  // Ordered “map”: first matching rule wins. Put strict / unambiguous signals first,
+  // then recursion before thread depth: some payloads still mention “thread depth”
+  // from an earlier turn or bundle multiple hints; when recursion is the active
+  // failure it must win over the broader thread-depth phrase match.
+  // 1) Output token / incomplete response (`max_output_tokens`, etc.).
+  if (matchesMaxOutputIncompleteError(flatLower)) {
+    return getUnwrappedApiErrorDisplayMessage(error);
+  }
+  // 2) Recursion limit (LangGraph, etc.).
+  if (matchesRecursionLimitError(flatLower)) {
+    return getUnwrappedApiErrorDisplayMessage(error);
+  }
+  // 3) Max steps (agent / graph limits).
+  if (matchesMaxStepsLimitError(flatLower)) {
+    return getUnwrappedApiErrorDisplayMessage(error);
+  }
+  // 4) Rate limiting (HTTP 429, “too many requests”, …).
+  if (matchesRateLimitError(flatLower)) {
+    return getUnwrappedApiErrorDisplayMessage(error);
+  }
+  // 5) Optional product-specific resolvers (prepend with registerStartNewConversationErrorDisplayResolver).
+  for (const resolver of startNewConversationErrorDisplayResolvers) {
+    const resolved = resolver(flat, error.message);
+    if (resolved != null && resolved !== '') {
+      return resolved;
+    }
+  }
+  // 6) Thread / conversation depth — API text.
+  if (matchesThreadDepthLimitError(flatLower)) {
+    return getUnwrappedApiErrorDisplayMessage(error);
+  }
+  return error.message;
+}
+
+/**
+ * User-facing copy for “start a new conversation” errors (API message for
+ * built-in cases, plus optional display resolvers). Returns `undefined` when
+ * the error is not treated as a start-new-conversation error.
+ */
+export function getStartNewConversationErrorDisplayMessage(
+  error: Error | undefined
+): string | undefined {
+  if (!error?.message || !isStartNewConversationError(error)) {
+    return undefined;
+  }
+  return resolveStartNewConversationErrorDisplayMessage(error);
+}
+
+/**
+ * Maps a flattened API / stream error string to a short user-facing line for
+ * errors that are not “start a new conversation”. Prefer
+ * {@link registerNewConversationErrorMatcher} when the UX should match
+ * thread-depth / recursion (alert + new conversation).
+ */
+export type GenericChatErrorDisplayResolver = (
+  flatMessage: string,
+  rawMessage: string
+) => string | null | undefined;
+
+/**
+ * Legacy stable line for Agent Studio HTTP 403 when the origin is not allowlisted.
+ * The UI now shows the API message by default.
+ */
+export const REQUEST_ORIGIN_NOT_ALLOWED_MESSAGE =
+  'Request origin is not in the allowed domains list. Add your domain in Agent Studio settings.';
+
+function matchesRequestOriginNotAllowedError(flatLower: string): boolean {
+  return (
+    flatLower.includes('request origin is not in the allowed domains') ||
+    (flatLower.includes('request origin') &&
+      flatLower.includes('allowed domains list'))
+  );
+}
+
+/**
+ * HTTP / Agent Studio error when the app origin is missing from allowed domains.
+ */
+export function isRequestOriginNotAllowedError(
+  error: Error | undefined
+): boolean {
+  if (!error?.message) {
+    return false;
+  }
+  const flat = flattenErrorMessageForMatching(error.message);
+  return matchesRequestOriginNotAllowedError(flat.toLowerCase());
+}
+
+const defaultGenericChatErrorDisplayResolvers: GenericChatErrorDisplayResolver[] =
+  [
+    (flat, rawMessage) => {
+      if (matchesRequestOriginNotAllowedError(flat.toLowerCase())) {
+        return getUnwrappedApiErrorDisplayMessage(new Error(rawMessage));
+      }
+      return null;
+    },
+  ];
+
+/**
+ * Resolvers for generic chat errors (not “start new conversation”). Includes a
+ * default mapping for Agent Studio HTTP 403 “request origin not allowed”.
+ * Prepend custom resolvers with {@link registerGenericChatErrorDisplayResolver}.
+ */
+export const genericChatErrorDisplayResolvers: GenericChatErrorDisplayResolver[] =
+  [...defaultGenericChatErrorDisplayResolvers];
+
+export function registerGenericChatErrorDisplayResolver(
+  resolver: GenericChatErrorDisplayResolver
+): void {
+  genericChatErrorDisplayResolvers.unshift(resolver);
+}
+
+function resolveGenericChatErrorDisplayMessage(error: Error): string {
+  const flat = flattenErrorMessageForMatching(error.message);
+  for (const resolver of genericChatErrorDisplayResolvers) {
+    const resolved = resolver(flat, error.message);
+    if (resolved != null && resolved !== '') {
+      return resolved;
+    }
+  }
+  return error.message;
+}
+
+/**
+ * User-facing error line for chat: “start new conversation” errors (API text),
+ * then optional generic resolvers (e.g. request origin), then {@link Error.message}.
+ */
+export function getChatErrorDisplayMessage(
+  error: Error | undefined
+): string | undefined {
+  if (!error?.message) {
+    return undefined;
+  }
+  if (isStartNewConversationError(error)) {
+    return getStartNewConversationErrorDisplayMessage(error) ?? error.message;
+  }
+  return resolveGenericChatErrorDisplayMessage(error);
+}
+
+/**
+ * Whether this error should get the “start a new conversation” treatment
+ * (thread depth, recursion, max steps, `max_output_tokens` / incomplete output,
+ * rate limiting, and any registered matchers).
+ */
+export function isStartNewConversationError(error: Error | undefined): boolean {
+  if (!error?.message) {
+    return false;
+  }
+  const flat = flattenErrorMessageForMatching(error.message);
+  return newConversationErrorMatchers.some((fn) => fn(flat));
+}
+
+/**
+ * Detects Agent Studio (and similar) errors when the chat thread has reached
+ * its maximum depth. Message wording comes from the completions API.
+ *
+ * Prefer {@link isStartNewConversationError} for UI that should also cover
+ * recursion limits and other recoverable-by-new-chat errors.
+ */
+export function isConversationThreadDepthLimitError(
+  error: Error | undefined
+): boolean {
+  if (!error?.message) {
+    return false;
+  }
+  const flat = flattenErrorMessageForMatching(error.message);
+  return matchesThreadDepthLimitError(flat.toLowerCase());
+}

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -321,9 +321,7 @@ type ChatWrapperProps = {
       | ((props: ChatMessageLoaderProps) => JSX.Element)
       | undefined;
     errorComponent: ((props: ChatMessageErrorProps) => JSX.Element) | undefined;
-    emptyComponent:
-      | ((props: ChatEmptyProps) => JSX.Element)
-      | undefined;
+    emptyComponent: ((props: ChatEmptyProps) => JSX.Element) | undefined;
     actionsComponent:
       | ((props: { actions: ChatMessageActionProps[] }) => JSX.Element)
       | undefined;
@@ -699,7 +697,8 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
         regenerateLabel: templates.messages?.regenerateLabelText,
         conversationLimitErrorMessage:
           templates.messages?.conversationLimitErrorMessageText,
-        genericChatErrorMessage: templates.messages?.genericChatErrorMessageText,
+        genericChatErrorMessage:
+          templates.messages?.genericChatErrorMessageText,
       });
 
     const assistantMessageTemplateProps = prepareTemplateProps({

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -295,6 +295,7 @@ type ChatWrapperProps = {
   regenerate: ChatRenderState['regenerate'];
   stop: ChatRenderState['stop'];
   error: ChatRenderState['error'];
+  chatInstanceId: ChatRenderState['id'];
   isClearing: boolean;
   clearMessages: () => void;
   onClearTransitionEnd: () => void;
@@ -369,6 +370,7 @@ function ChatWrapper({
   regenerate,
   stop,
   error,
+  chatInstanceId,
   isClearing,
   clearMessages,
   onClearTransitionEnd,
@@ -382,6 +384,7 @@ function ChatWrapper({
   suggestionsProps,
   state,
 }: ChatWrapperProps) {
+  const displayError = chatStatus === 'error' ? error : undefined;
   const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
     useStickToBottom({
       initial: 'smooth',
@@ -401,7 +404,7 @@ function ChatWrapper({
       sendMessage={sendMessage}
       regenerate={regenerate}
       stop={stop}
-      error={error}
+      error={displayError}
       toggleButtonComponent={toggleButtonProps.layoutComponent}
       toggleButtonProps={{
         open: chatOpen,
@@ -415,8 +418,10 @@ function ChatWrapper({
         onClose: () => setChatOpen(false),
         maximized,
         onToggleMaximize: () => setMaximized(!maximized),
-        onClear: clearMessages,
-        canClear: Boolean(chatMessages?.length) && !isClearing,
+        onNewConversation: clearMessages,
+        canStartNewConversation:
+          (Boolean(chatMessages?.length) || chatStatus === 'error') &&
+          !isClearing,
         closeIconComponent: headerProps.closeIconComponent,
         minimizeIconComponent: headerProps.minimizeIconComponent,
         maximizeIconComponent: headerProps.maximizeIconComponent,
@@ -449,6 +454,7 @@ function ChatWrapper({
         messageTranslations: messagesProps.messageTranslations,
         sendMessage: messagesProps.sendMessage,
         setInput: messagesProps.setInput,
+        conversationId: chatInstanceId,
       }}
       promptProps={{
         promptRef: promptProps.promptRef,
@@ -518,6 +524,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
       suggestions,
       sendChatMessageFeedback: onFeedback,
       feedbackState,
+      id: chatInstanceId,
     } = props;
 
     if (__DEV__ && error) {
@@ -631,7 +638,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
         minimizeLabel: templates.header?.minimizeLabelText,
         maximizeLabel: templates.header?.maximizeLabelText,
         closeLabel: templates.header?.closeLabelText,
-        clearLabel: templates.header?.clearLabelText,
+        newConversationLabel: templates.header?.newConversationLabelText,
       });
 
     const messagesTemplateProps = prepareTemplateProps({
@@ -690,6 +697,9 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
         loaderText: templates.messages?.loaderText,
         copyToClipboardLabel: templates.messages?.copyToClipboardLabelText,
         regenerateLabel: templates.messages?.regenerateLabelText,
+        conversationLimitErrorMessage:
+          templates.messages?.conversationLimitErrorMessageText,
+        genericChatErrorMessage: templates.messages?.genericChatErrorMessageText,
       });
 
     const assistantMessageTemplateProps = prepareTemplateProps({
@@ -923,6 +933,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
           regenerate={regenerate}
           stop={stop}
           error={error}
+          chatInstanceId={chatInstanceId}
           isClearing={isClearing}
           clearMessages={clearMessages}
           onClearTransitionEnd={onClearTransitionEnd}
@@ -1081,9 +1092,9 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
        */
       closeLabelText: string;
       /**
-       * Text for the clear button
+       * Accessible label for the new-conversation control
        */
-      clearLabelText: string;
+      newConversationLabelText: string;
     }>;
 
     /**
@@ -1114,6 +1125,16 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
        * Label for the regenerate action
        */
       regenerateLabelText?: string;
+      /**
+       * Overrides the default message for “start a new conversation” errors
+       * (otherwise the API error text is shown). When omitted, built-in mappings apply.
+       */
+      conversationLimitErrorMessageText?: string;
+      /**
+       * Overrides short copy for other chat errors (e.g. output limit). When
+       * omitted, built-in mappings from instantsearch-ui-components apply.
+       */
+      genericChatErrorMessageText?: string;
     }>;
 
     /**


### PR DESCRIPTION
## Summary

Wire ChatMessages error state to chat utils: conversation-limit layout, API-facing primary text, optional Start new conversation, and hidden prompt when input is blocked. Update ChatMessageError for the limit variant and link. Align instantsearch.js widget template docs with translations.