### PR TITLE
fix(react-instantsearch-nextjs): preserve URL on mount with nested <Index>

### DIFF
--- a/packages/react-instantsearch-nextjs/src/__tests__/useInstantSearchRouting.test.tsx
+++ b/packages/react-instantsearch-nextjs/src/__tests__/useInstantSearchRouting.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import { Index, SearchBox } from 'react-instantsearch';
+
+import { InstantSearchNext } from '../InstantSearchNext';
+
+const mockPathname = jest.fn();
+const mockSearchParams = jest.fn();
+jest.mock('next/navigation', () => ({
+  ...jest.requireActual('next/navigation'),
+  usePathname() {
+    return mockPathname();
+  },
+  useSearchParams() {
+    return mockSearchParams();
+  },
+}));
+
+describe('routing', () => {
+  beforeEach(() => {
+    mockPathname.mockReturnValue('/search');
+    mockSearchParams.mockReturnValue(new URLSearchParams());
+    window.history.replaceState({}, '', '/search');
+  });
+
+  // Reproduces https://github.com/algolia/instantsearch/issues/6980:
+  // a nested <Index> only mounts its children on a second render pass, so
+  // the on-mount [pathname, searchParams] effect used to wipe the URL.
+  it('preserves URL on mount with a nested <Index> and custom stateMapping', async () => {
+    const indexName = 'instant_search';
+    const indexId = `${indexName}_web`;
+
+    mockSearchParams.mockReturnValue(new URLSearchParams('q=iphone'));
+    window.history.replaceState({}, '', '/search?q=iphone');
+
+    const client = createSearchClient();
+
+    await act(async () => {
+      render(
+        <InstantSearchNext
+          searchClient={client}
+          routing={{
+            stateMapping: {
+              stateToRoute(uiState) {
+                const query = uiState[indexId]?.query;
+                return query ? { q: query } : {};
+              },
+              routeToState(routeState: { q?: string } = {}) {
+                return {
+                  [indexId]: {
+                    query: routeState.q,
+                  },
+                };
+              },
+            },
+          }}
+        >
+          <Index indexName={indexName} indexId={indexId}>
+            <SearchBox />
+          </Index>
+        </InstantSearchNext>
+      );
+    });
+
+    // Wait longer than the default `writeDelay` (400ms) to let any debounced
+    // `pushState` from the router middleware run.
+    await act(async () => {
+      await wait(500);
+    });
+
+    expect(window.location.search).toBe('?q=iphone');
+  });
+
+  it('preserves URL on mount without a nested <Index>', async () => {
+    const indexName = 'instant_search';
+
+    mockSearchParams.mockReturnValue(new URLSearchParams('q=iphone'));
+    window.history.replaceState({}, '', '/search?q=iphone');
+
+    const client = createSearchClient();
+
+    await act(async () => {
+      render(
+        <InstantSearchNext
+          searchClient={client}
+          indexName={indexName}
+          routing={{
+            stateMapping: {
+              stateToRoute(uiState) {
+                const query = uiState[indexName]?.query;
+                return query ? { q: query } : {};
+              },
+              routeToState(routeState: { q?: string } = {}) {
+                return {
+                  [indexName]: {
+                    query: routeState.q,
+                  },
+                };
+              },
+            },
+          }}
+        >
+          <SearchBox />
+        </InstantSearchNext>
+      );
+    });
+
+    await act(async () => {
+      await wait(500);
+    });
+
+    expect(window.location.search).toBe('?q=iphone');
+  });
+
+  it('reacts to pathname/searchParams changes after mount', async () => {
+    const indexName = 'indexName';
+
+    mockSearchParams.mockReturnValue(new URLSearchParams());
+    window.history.replaceState({}, '', '/search');
+
+    const client = createSearchClient();
+
+    const { rerender } = render(
+      <InstantSearchNext
+        searchClient={client}
+        indexName={indexName}
+        routing={true}
+      >
+        <SearchBox />
+      </InstantSearchNext>
+    );
+
+    await act(async () => {
+      await wait(500);
+    });
+
+    expect(window.location.search).toBe('');
+
+    // Simulate Next.js client-side navigation updating
+    // `pathname`/`searchParams` to a URL that already has the query in it.
+    mockPathname.mockReturnValue('/search');
+    mockSearchParams.mockReturnValue(
+      new URLSearchParams('indexName%5Bquery%5D=iphone')
+    );
+    window.history.pushState({}, '', '/search?indexName%5Bquery%5D=iphone');
+
+    await act(async () => {
+      rerender(
+        <InstantSearchNext
+          searchClient={client}
+          indexName={indexName}
+          routing={true}
+        >
+          <SearchBox />
+        </InstantSearchNext>
+      );
+    });
+
+    await act(async () => {
+      await wait(500);
+    });
+
+    expect(window.location.search).toBe('?indexName%5Bquery%5D=iphone');
+  });
+});
+
+afterAll(() => {
+  jest.resetAllMocks();
+});

--- a/packages/react-instantsearch-nextjs/src/__tests__/useInstantSearchRouting.test.tsx
+++ b/packages/react-instantsearch-nextjs/src/__tests__/useInstantSearchRouting.test.tsx
@@ -46,6 +46,7 @@ describe('routing', () => {
         <InstantSearchNext
           searchClient={client}
           routing={{
+            router: { writeDelay: 0 },
             stateMapping: {
               stateToRoute(uiState) {
                 const query = uiState[indexId]?.query;
@@ -68,10 +69,8 @@ describe('routing', () => {
       );
     });
 
-    // Wait longer than the default `writeDelay` (400ms) to let any debounced
-    // `pushState` from the router middleware run.
     await act(async () => {
-      await wait(500);
+      await wait(0);
     });
 
     expect(window.location.search).toBe('?q=iphone');
@@ -91,6 +90,7 @@ describe('routing', () => {
           searchClient={client}
           indexName={indexName}
           routing={{
+            router: { writeDelay: 0 },
             stateMapping: {
               stateToRoute(uiState) {
                 const query = uiState[indexName]?.query;
@@ -112,7 +112,7 @@ describe('routing', () => {
     });
 
     await act(async () => {
-      await wait(500);
+      await wait(0);
     });
 
     expect(window.location.search).toBe('?q=iphone');
@@ -126,18 +126,20 @@ describe('routing', () => {
 
     const client = createSearchClient();
 
+    const routing = { router: { writeDelay: 0 } };
+
     const { rerender } = render(
       <InstantSearchNext
         searchClient={client}
         indexName={indexName}
-        routing={true}
+        routing={routing}
       >
         <SearchBox />
       </InstantSearchNext>
     );
 
     await act(async () => {
-      await wait(500);
+      await wait(0);
     });
 
     expect(window.location.search).toBe('');
@@ -155,7 +157,7 @@ describe('routing', () => {
         <InstantSearchNext
           searchClient={client}
           indexName={indexName}
-          routing={true}
+          routing={routing}
         >
           <SearchBox />
         </InstantSearchNext>
@@ -163,7 +165,7 @@ describe('routing', () => {
     });
 
     await act(async () => {
-      await wait(500);
+      await wait(0);
     });
 
     expect(window.location.search).toBe('?indexName%5Bquery%5D=iphone');

--- a/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
+++ b/packages/react-instantsearch-nextjs/src/useInstantSearchRouting.ts
@@ -23,8 +23,25 @@ export function useInstantSearchRouting<
     useRef<InstantSearchProps<TUiState, TRouteState>['routing']>(null);
   const onUpdateRef = useRef<() => void>(null);
   const isUnmounting = useRef(false);
+  // Skip the on-mount fire of the effect below: `subscribe()` already merges
+  // the URL into `_initialUiState`, and a redundant `setUiState` can wipe the
+  // URL with a nested `<Index>` (see #6980).
+  const previousRouteRef = useRef<string | null>(null);
 
   useEffect(() => {
+    const currentRoute = `${pathname ?? ''}?${searchParams?.toString() ?? ''}`;
+
+    if (previousRouteRef.current === currentRoute) {
+      return;
+    }
+
+    const isFirstRun = previousRouteRef.current === null;
+    previousRouteRef.current = currentRoute;
+
+    if (isFirstRun) {
+      return;
+    }
+
     if (onUpdateRef.current) {
       onUpdateRef.current();
     }


### PR DESCRIPTION
**Summary**

Fixes #6980 and CR-11362.

`InstantSearchNext` was intermittently dropping query parameters from the URL on mount when widgets were nested inside an `<Index>` wrapper.

The router middleware's `subscribe()` already merges the URL into `_initialUiState` before `mainIndex.init` runs, so the `[pathname, searchParams]` effect in `useInstantSearchRouting` was firing a redundant `setUiState` on mount. With a nested `<Index>`, the inner index's children only mount on a second render pass, so when this redundant update propagated down, the nested helper had no widgets registered yet. `helper.setState` then rebuilt an empty `localUiState`, and the router middleware later wrote that empty state back to the URL.

The fix skips the on-mount fire of that effect (tracking the previous route via a ref) so we only react to genuine post-mount `pathname` / `searchParams` changes.

**Result**

Added `packages/react-instantsearch-nextjs/src/__tests__/useInstantSearchRouting.test.tsx` with three cases:
- preserves URL on mount with a nested `<Index>` and custom `stateMapping` (fails without the fix)
- preserves URL on mount without a nested `<Index>` (regression check)
- reacts to pathname/searchParams changes after mount