### PR TITLE
fix(instantsearch.css): move select reset from shared reset to Nova theme

### DIFF
--- a/packages/instantsearch.css/src/shared/_nova-common.scss
+++ b/packages/instantsearch.css/src/shared/_nova-common.scss
@@ -71,12 +71,6 @@ select[class^='ais-']:focus-visible {
   font-size: 0.75em;
 }
 
-// Strip native select appearance for custom chevron rendering
-select[class^='ais-'] {
-  appearance: none;
-  background: none;
-}
-
 // Custom select (MenuSelect, HitsPerPage, SortBy)
 .ais-MenuSelect,
 .ais-HitsPerPage,
@@ -100,6 +94,8 @@ select[class^='ais-'] {
 .ais-MenuSelect-select,
 .ais-HitsPerPage-select,
 .ais-SortBy-select {
+  appearance: none;
+  background: none;
   width: 100%;
   color: rgba(var(--ais-text-color-rgb), var(--ais-text-color-alpha));
   font: inherit;

--- a/packages/instantsearch.css/src/shared/_nova-common.scss
+++ b/packages/instantsearch.css/src/shared/_nova-common.scss
@@ -71,6 +71,11 @@ select[class^='ais-']:focus-visible {
   font-size: 0.75em;
 }
 
+select[class^='ais-'] {
+  appearance: none;
+  background: none;
+}
+
 // Custom select (MenuSelect, HitsPerPage, SortBy)
 .ais-MenuSelect,
 .ais-HitsPerPage,
@@ -94,8 +99,6 @@ select[class^='ais-']:focus-visible {
 .ais-MenuSelect-select,
 .ais-HitsPerPage-select,
 .ais-SortBy-select {
-  appearance: none;
-  background: none;
   width: 100%;
   color: rgba(var(--ais-text-color-rgb), var(--ais-text-color-alpha));
   font: inherit;

--- a/packages/instantsearch.css/src/shared/_nova-common.scss
+++ b/packages/instantsearch.css/src/shared/_nova-common.scss
@@ -71,6 +71,12 @@ select[class^='ais-']:focus-visible {
   font-size: 0.75em;
 }
 
+// Strip native select appearance for custom chevron rendering
+select[class^='ais-'] {
+  appearance: none;
+  background: none;
+}
+
 // Custom select (MenuSelect, HitsPerPage, SortBy)
 .ais-MenuSelect,
 .ais-HitsPerPage,

--- a/packages/instantsearch.css/src/themes/reset.scss
+++ b/packages/instantsearch.css/src/themes/reset.scss
@@ -8,11 +8,6 @@ a[class^='ais-'] {
   text-decoration: none;
 }
 
-select[class^='ais-'] {
-  appearance: none;
-  background: none;
-}
-
 // Reset all lists
 
 .ais-Breadcrumb-list,


### PR DESCRIPTION
## Summary

- Removes `select[class^='ais-'] { appearance: none; background: none; }` from `reset.scss` (shared across all themes)
- Adds it to `_nova-common.scss` (Nova-only), where it belongs

## Root cause

The selector `select[class^='ais-']` has specificity **0,1,1** (element + attribute), which is higher than the class-only selectors (0,1,0) used by the Satellite and Algolia themes to apply `background-image`, `background-position`, `background-repeat`, and `background-size` on their `<select>` widgets.

This meant the `background: none` shorthand in the reset silently won the cascade, breaking those themes:
- **Idle state**: the dropdown arrow image was suppressed entirely
- **Hover/focus state**: `background-image` was restored (those rules have specificity 0,2,0), but `background-position`/`background-repeat`/`background-size` were still controlled by the reset, causing the arrow SVG to tile across the whole element

The rule's purpose is purely to strip native browser select chrome so Nova can render its own custom chevron via an `::after` pseudo-element. It has no business being in the shared reset.

Fixes #7003

## Test plan

- [x] Satellite theme: `HitsPerPage` / `SortBy` selects show the dropdown arrow at idle, on hover, and on focus
- [x] Algolia theme: same widgets render correctly
- [x] Nova theme: custom chevron still renders (via `::after`) and native arrow is still suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)