### PR TITLE
fix(instantsearch.js): ignore non-object top-level URL params in simpleStateMapping

### DIFF
--- a/packages/instantsearch.js/src/lib/stateMappings/__tests__/simple-test.ts
+++ b/packages/instantsearch.js/src/lib/stateMappings/__tests__/simple-test.ts
@@ -120,6 +120,23 @@ describe('simpleStateMapping', () => {
       });
     });
 
+    it('ignores non-object top-level params (e.g. UTM params)', () => {
+      const stateMapping = simpleStateMapping();
+      const actual = stateMapping.routeToState({
+        // @ts-expect-error simulating qs.parse() output with flat string params
+        utm_medium: 'test',
+        indexName: {
+          query: 'zamboni',
+        },
+      });
+
+      expect(actual).toEqual({
+        indexName: {
+          query: 'zamboni',
+        },
+      });
+    });
+
     it('passes non-UiState through', () => {
       const stateMapping = simpleStateMapping<{
         [indexId in string]: UiState[indexId] & { spy: string[] };

--- a/packages/instantsearch.js/src/lib/stateMappings/simple.ts
+++ b/packages/instantsearch.js/src/lib/stateMappings/simple.ts
@@ -28,10 +28,16 @@ export default function simpleStateMapping<
 
     routeToState(routeState = {} as TUiState) {
       return Object.keys(routeState).reduce(
-        (state, indexId) => ({
-          ...state,
-          [indexId]: getIndexStateWithoutConfigure(routeState[indexId]),
-        }),
+        (state, indexId) => {
+          const indexState = routeState[indexId];
+          if (typeof indexState !== 'object' || indexState === null) {
+            return state;
+          }
+          return {
+            ...state,
+            [indexId]: getIndexStateWithoutConfigure(indexState),
+          };
+        },
         {} as TUiState
       );
     },


### PR DESCRIPTION
## Summary

- Fixes a regression introduced in v4.90.0 ([#6886](https://github.com/algolia/instantsearch/pull/6886)) where the migration from Babel to SWC exposed a latent bug in `simpleStateMapping`
- Non-search URL params like UTM codes (`?utm_medium=test`) are parsed by `qs` into top-level string values; `routeToState` was passing these strings to `getIndexStateWithoutConfigure` as if they were index UI state objects
- SWC compiles object-rest spread using `Reflect.ownKeys`, which throws a `TypeError` on non-object values (Babel used `Object.keys`, which silently returns `[]` for strings)
- Fix: skip any top-level route key whose value is not an object in `routeToState`

Closes #7010

## Test plan

- [x] New unit test: `ignores non-object top-level params (e.g. UTM params)` in `simple-test.ts` — verifies string-valued keys are dropped and real index state passes through unchanged
- [x] All existing `simpleStateMapping` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)