### PR TITLE
fix(feeds): rename searchScope to isolated

### DIFF
--- a/packages/instantsearch.js/src/connectors/feeds/__tests__/connectFeeds-test.ts
+++ b/packages/instantsearch.js/src/connectors/feeds/__tests__/connectFeeds-test.ts
@@ -28,27 +28,27 @@ describe('connectFeeds', () => {
       `);
     });
 
-    it('fails when searchScope is not global', () => {
+    it('fails when isolated is not false', () => {
       expect(() =>
         connectFeeds(() => {})({
           // @ts-expect-error
-          searchScope: 'local',
+          isolated: true,
         })
       ).toThrowErrorMatchingInlineSnapshot(`
-        "The \`searchScope\` option currently only supports \\"global\\".
+        "The \`isolated\` option currently only supports \`false\`.
 
         See documentation: https://www.algolia.com/doc/api-reference/widgets/feeds/js/#connector"
       `);
     });
 
-    it('fails when searchScope is missing', () => {
+    it('fails when isolated is missing', () => {
       expect(() =>
         connectFeeds(() => {})({
           // @ts-expect-error
-          searchScope: undefined,
+          isolated: undefined,
         })
       ).toThrowErrorMatchingInlineSnapshot(`
-        "The \`searchScope\` option currently only supports \\"global\\".
+        "The \`isolated\` option currently only supports \`false\`.
 
         See documentation: https://www.algolia.com/doc/api-reference/widgets/feeds/js/#connector"
       `);
@@ -60,7 +60,7 @@ describe('connectFeeds', () => {
     const unmount = jest.fn();
 
     const customFeeds = connectFeeds(render, unmount);
-    const widget = customFeeds({ searchScope: 'global' });
+    const widget = customFeeds({ isolated: false });
 
     expect(widget).toEqual(
       expect.objectContaining({
@@ -77,7 +77,7 @@ describe('connectFeeds', () => {
   describe('init', () => {
     it('throws when compositionID is not set', () => {
       const feedsWidget = connectFeeds(() => {})({
-        searchScope: 'global',
+        isolated: false,
       });
 
       expect(() => {
@@ -96,7 +96,7 @@ describe('connectFeeds', () => {
       } as any);
 
       const feedsWidget = connectFeeds(renderFn)({
-        searchScope: 'global',
+        isolated: false,
       });
 
       feedsWidget.init!(createInitOptions({ instantSearchInstance }));
@@ -106,7 +106,7 @@ describe('connectFeeds', () => {
         expect.objectContaining({
           feedIDs: [],
           widgetParams: {
-            searchScope: 'global',
+            isolated: false,
           },
         }),
         true
@@ -122,7 +122,7 @@ describe('connectFeeds', () => {
       } as any);
 
       const feedsWidget = connectFeeds(renderFn)({
-        searchScope: 'global',
+        isolated: false,
       });
 
       const results = createResultsWithFeeds(
@@ -150,7 +150,7 @@ describe('connectFeeds', () => {
       } as any);
 
       const feedsWidget = connectFeeds(renderFn)({
-        searchScope: 'global',
+        isolated: false,
         transformFeeds: (feeds) => feeds.reverse(),
       });
 
@@ -179,7 +179,7 @@ describe('connectFeeds', () => {
       } as any);
 
       const feedsWidget = connectFeeds(renderFn)({
-        searchScope: 'global',
+        isolated: false,
         transformFeeds: (feeds) =>
           feeds.filter((feedID) => feedID === 'products'),
       });
@@ -209,7 +209,7 @@ describe('connectFeeds', () => {
       } as any);
 
       const feedsWidget = connectFeeds(renderFn)({
-        searchScope: 'global',
+        isolated: false,
       });
 
       feedsWidget.init!(createInitOptions({ instantSearchInstance }));
@@ -233,7 +233,7 @@ describe('connectFeeds', () => {
       } as any);
 
       const feedsWidget = connectFeeds(renderFn)({
-        searchScope: 'global',
+        isolated: false,
       });
 
       const state = instantSearchInstance.helper!.state;
@@ -270,7 +270,7 @@ describe('connectFeeds', () => {
       } as any);
 
       const feedsWidget = connectFeeds(renderFn)({
-        searchScope: 'global',
+        isolated: false,
         transformFeeds: () => 'products' as any,
       });
 
@@ -325,7 +325,7 @@ describe('connectFeeds', () => {
         .mockReturnValue(instantSearchInstance.helper);
 
       const feedsWidget = connectFeeds(renderFn)({
-        searchScope: 'global',
+        isolated: false,
       });
 
       feedsWidget.init!(createInitOptions({ instantSearchInstance }));
@@ -361,7 +361,7 @@ describe('connectFeeds', () => {
         .mockReturnValue(instantSearchInstance.helper);
 
       const feedsWidget = connectFeeds(renderFn)({
-        searchScope: 'global',
+        isolated: false,
       });
 
       feedsWidget.init!(createInitOptions({ instantSearchInstance }));
@@ -381,7 +381,7 @@ describe('connectFeeds', () => {
         renderFn,
         unmountFn
       )({
-        searchScope: 'global',
+        isolated: false,
       });
 
       feedsWidget.dispose!({} as any);
@@ -393,7 +393,7 @@ describe('connectFeeds', () => {
   describe('getWidgetSearchParameters', () => {
     it('passes through search parameters unchanged', () => {
       const feedsWidget = connectFeeds(() => {})({
-        searchScope: 'global',
+        isolated: false,
       });
 
       const state = new SearchParameters({ index: 'test' });
@@ -406,7 +406,7 @@ describe('connectFeeds', () => {
   describe('getWidgetRenderState', () => {
     it('returns empty feedIDs when no results', () => {
       const feedsWidget = connectFeeds(() => {})({
-        searchScope: 'global',
+        isolated: false,
       });
 
       const renderState = feedsWidget.getWidgetRenderState(
@@ -418,7 +418,7 @@ describe('connectFeeds', () => {
 
     it('computes feedIDs from results (stateless)', () => {
       const feedsWidget = connectFeeds(() => {})({
-        searchScope: 'global',
+        isolated: false,
       });
 
       const results = createResultsWithFeeds(['a', 'b']);
@@ -432,7 +432,7 @@ describe('connectFeeds', () => {
 
     it('reconstructs SearchResults from plain feed objects (hydration)', () => {
       const feedsWidget = connectFeeds(() => {})({
-        searchScope: 'global',
+        isolated: false,
       });
 
       const state = new SearchParameters({ index: 'test' });
@@ -464,7 +464,7 @@ describe('connectFeeds', () => {
 
     it('reconstructs feeds after JSON.stringify/parse round-trip', () => {
       const feedsWidget = connectFeeds(() => {})({
-        searchScope: 'global',
+        isolated: false,
       });
 
       const state = new SearchParameters({ index: 'test' });
@@ -489,7 +489,7 @@ describe('connectFeeds', () => {
 
     it('leaves SearchResults feed entries unchanged', () => {
       const feedsWidget = connectFeeds(() => {})({
-        searchScope: 'global',
+        isolated: false,
       });
 
       const results = createResultsWithFeeds(['a', 'b']);
@@ -507,7 +507,7 @@ describe('connectFeeds', () => {
   describe('getRenderState', () => {
     it('merges feeds into renderState', () => {
       const feedsWidget = connectFeeds(() => {})({
-        searchScope: 'global',
+        isolated: false,
       });
 
       const renderState = feedsWidget.getRenderState({}, createRenderOptions());

--- a/packages/instantsearch.js/src/connectors/feeds/connectFeeds.ts
+++ b/packages/instantsearch.js/src/connectors/feeds/connectFeeds.ts
@@ -62,10 +62,10 @@ export type FeedsRenderState = {
 
 export type FeedsConnectorParams = {
   /**
-   * Explicit search scope. Currently only 'global' is supported
-   * (future-proofing for per-feed search parameters).
+   * Whether feeds are isolated from the global search scope.
+   * Currently only `false` is supported (future-proofing for per-feed search parameters).
    */
-  searchScope: 'global';
+  isolated: false;
 
   /**
    * Optional: transform/reorder/filter feed IDs before rendering.
@@ -93,11 +93,11 @@ const connectFeeds: FeedsConnector = function connectFeeds(
   checkRendering(renderFn, withUsage());
 
   return (widgetParams) => {
-    const { searchScope, transformFeeds = (feeds) => feeds } = widgetParams;
+    const { isolated, transformFeeds = (feeds) => feeds } = widgetParams;
 
-    if (searchScope !== 'global') {
+    if (isolated !== false) {
       throw new Error(
-        withUsage('The `searchScope` option currently only supports "global".')
+        withUsage('The `isolated` option currently only supports `false`.')
       );
     }
 

--- a/packages/instantsearch.js/src/lib/__tests__/composition-multifeed-ssr.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/composition-multifeed-ssr.test.ts
@@ -45,7 +45,7 @@ describe('composition multifeed SSR (integration)', () => {
     });
     search.addWidgets([
       connectSearchBox(() => {})({}),
-      connectFeeds(() => {})({ searchScope: 'global' }),
+      connectFeeds(() => {})({ isolated: false }),
     ]);
     search.start();
 
@@ -89,7 +89,7 @@ describe('composition multifeed SSR (integration)', () => {
     searchAfterJson._initialResults = roundTrip;
     searchAfterJson.addWidgets([
       connectSearchBox(() => {})({}),
-      connectFeeds(() => {})({ searchScope: 'global' }),
+      connectFeeds(() => {})({ isolated: false }),
     ]);
     searchAfterJson.start();
 

--- a/packages/instantsearch.js/src/widgets/__tests__/index.test.ts
+++ b/packages/instantsearch.js/src/widgets/__tests__/index.test.ts
@@ -190,7 +190,7 @@ function initiateAllWidgets(): Array<[WidgetNames, Widget | IndexWidget]> {
         return feedsWidget({
           container,
           widgets: () => [],
-          searchScope: 'global',
+          isolated: false,
         });
       }
       default: {

--- a/packages/instantsearch.js/src/widgets/feeds/__tests__/feeds-test.ts
+++ b/packages/instantsearch.js/src/widgets/feeds/__tests__/feeds-test.ts
@@ -39,7 +39,7 @@ describe('feeds()', () => {
           container: document.createElement('div'),
           // @ts-expect-error testing invalid input
           widgets: [],
-          searchScope: 'global',
+          isolated: false,
         })
       ).toThrowErrorMatchingInlineSnapshot(`
         "The \`widgets\` option expects a function.
@@ -53,7 +53,7 @@ describe('feeds()', () => {
         feeds({
           container: document.createElement('div'),
           widgets: () => [],
-          searchScope: 'global',
+          isolated: false,
         })
       ).not.toThrow();
     });
@@ -69,7 +69,7 @@ describe('feeds()', () => {
       const widget = feeds({
         container: userContainer,
         widgets: () => [],
-        searchScope: 'global',
+        isolated: false,
       });
 
       const parent = createParentWithHelper(instantSearchInstance);
@@ -89,7 +89,7 @@ describe('feeds()', () => {
       const widget = feeds({
         container: userContainer,
         widgets: widgetFactory,
-        searchScope: 'global',
+        isolated: false,
       });
 
       const parent = createParentWithHelper(instantSearchInstance);
@@ -136,7 +136,7 @@ describe('feeds()', () => {
       const widget = feeds({
         container: userContainer,
         widgets: widgetFactory,
-        searchScope: 'global',
+        isolated: false,
       });
 
       const parent = createParentWithHelper(instantSearchInstance);
@@ -167,7 +167,7 @@ describe('feeds()', () => {
       const widget = feeds({
         container: userContainer,
         widgets: widgetFactory,
-        searchScope: 'global',
+        isolated: false,
       });
 
       const parent = createParentWithHelper(instantSearchInstance);
@@ -206,7 +206,7 @@ describe('feeds()', () => {
       const widget = feeds({
         container: userContainer,
         widgets: widgetFactory,
-        searchScope: 'global',
+        isolated: false,
       });
 
       const parent = createParentWithHelper(instantSearchInstance);
@@ -255,7 +255,7 @@ describe('feeds()', () => {
       const widget = feeds({
         container: userContainer,
         widgets: widgetFactory,
-        searchScope: 'global',
+        isolated: false,
       });
 
       const parent = createParentWithHelper(instantSearchInstance);
@@ -325,7 +325,7 @@ describe('feeds()', () => {
           feedLabels.push(feedID);
           return [createWidget()];
         },
-        searchScope: 'global',
+        isolated: false,
       });
 
       const parent = createParentWithHelper(instantSearchInstance);
@@ -373,7 +373,7 @@ describe('feeds()', () => {
       const widget = feeds({
         container: userContainer,
         widgets: () => [createWidget()],
-        searchScope: 'global',
+        isolated: false,
       });
 
       const parent = createParentWithHelper(instantSearchInstance);
@@ -408,7 +408,7 @@ describe('feeds()', () => {
       const widget = feeds({
         container: userContainer,
         widgets: () => [createWidget()],
-        searchScope: 'global',
+        isolated: false,
       });
 
       const parent = createParentWithHelper(instantSearchInstance);
@@ -462,7 +462,7 @@ describe('feeds()', () => {
               container: feedContainer,
             }),
           ],
-          searchScope: 'global',
+          isolated: false,
         }),
       ]);
 

--- a/packages/react-instantsearch-core/src/components/__tests__/Feeds.integration.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/Feeds.integration.test.tsx
@@ -64,7 +64,7 @@ describe('Feeds (integration)', () => {
         compositionID="my-composition"
       >
         <Feeds
-          searchScope="global"
+          isolated={false}
           renderFeed={({ feedID }) => <FeedScopedChild feedID={feedID} />}
         />
       </InstantSearchMock>
@@ -117,7 +117,7 @@ describe('Feeds (integration)', () => {
           compositionID="my-composition"
         >
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => <FeedScopedChild feedID={feedID} />}
           />
         </InstantSearch>

--- a/packages/react-instantsearch-core/src/components/__tests__/Feeds.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/Feeds.test.tsx
@@ -89,7 +89,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => <FeedScopedChild feedID={feedID} />}
           />
         </IndexContext.Provider>
@@ -114,7 +114,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => <FeedScopedChild feedID={feedID} />}
           />
         </IndexContext.Provider>
@@ -139,7 +139,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => (
               <div data-testid={`feed-${feedID}`}>{feedID}</div>
             )}
@@ -158,7 +158,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => (
               <div data-testid={`feed-${feedID}`}>{feedID}</div>
             )}
@@ -192,7 +192,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => (
               <div data-testid={`feed-${feedID}`}>{feedID}</div>
             )}
@@ -212,7 +212,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => (
               <div data-testid={`feed-${feedID}`}>{feedID}</div>
             )}
@@ -229,7 +229,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => (
               <div data-testid={`feed-${feedID}`}>{feedID}</div>
             )}
@@ -264,7 +264,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => (
               <div data-testid={`feed-${feedID}`}>{feedID}</div>
             )}
@@ -282,7 +282,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => (
               <div data-testid={`feed-${feedID}`}>{feedID}</div>
             )}
@@ -301,7 +301,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => (
               <div data-testid={`feed-${feedID}`}>{feedID}</div>
             )}
@@ -335,7 +335,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) => <MountedFeed feedID={feedID} />}
           />
         </IndexContext.Provider>
@@ -363,7 +363,7 @@ describe('Feeds', () => {
       <InstantSearchContext.Provider value={instantSearch}>
         <IndexContext.Provider value={parentIndex as any}>
           <Feeds
-            searchScope="global"
+            isolated={false}
             renderFeed={({ feedID }) =>
               feedID === 'products' ? (
                 <div data-testid={`feed-${feedID}`}>{feedID}</div>

--- a/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
@@ -395,7 +395,7 @@ describe('getServerState', () => {
     const serverState = await getServerState(
       <InstantSearch searchClient={searchClient} compositionID="my-comp">
         <Feeds
-          searchScope="global"
+          isolated={false}
           renderFeed={() => <Hits hitComponent={Hit} />}
         />
       </InstantSearch>,

--- a/packages/vue-instantsearch/src/__tests__/index.js
+++ b/packages/vue-instantsearch/src/__tests__/index.js
@@ -79,7 +79,7 @@ function getAllComponents() {
       } else if (name === 'AisIndex') {
         props.indexName = 'indexName';
       } else if (name === 'AisFeeds') {
-        props.searchScope = 'global';
+        props.isolated = false;
       } else {
         props.attribute = 'attr';
       }

--- a/packages/vue-instantsearch/src/components/Feeds.js
+++ b/packages/vue-instantsearch/src/components/Feeds.js
@@ -38,8 +38,8 @@ export default {
     createSuitMixin({ name: 'Feeds' }),
   ],
   props: {
-    searchScope: {
-      type: String,
+    isolated: {
+      type: Boolean,
       required: true,
     },
     transformFeeds: {
@@ -172,7 +172,7 @@ export default {
   computed: {
     widgetParams() {
       return {
-        searchScope: this.searchScope,
+        isolated: this.isolated,
         transformFeeds: this.transformFeeds,
       };
     },

--- a/packages/vue-instantsearch/src/components/__tests__/Feeds-integration.js
+++ b/packages/vue-instantsearch/src/components/__tests__/Feeds-integration.js
@@ -26,7 +26,7 @@ describe('AisFeeds (integration)', () => {
         <InstantSearch
           v-bind="{ searchClient, indexName, compositionID }"
         >
-          <Feeds search-scope="global" v-slot="{ feedID }">
+          <Feeds :isolated="false" v-slot="{ feedID }">
             <ScopedFeed :feedid="feedID || 'default'" />
           </Feeds>
         </InstantSearch>

--- a/packages/vue-instantsearch/src/components/__tests__/Feeds.js
+++ b/packages/vue-instantsearch/src/components/__tests__/Feeds.js
@@ -20,13 +20,13 @@ describe('AisFeeds', () => {
     const transformFeeds = feeds => feeds;
     const wrapper = mount(Feeds, {
       propsData: {
-        searchScope: 'global',
+        isolated: false,
         transformFeeds,
       },
     });
 
     expect(wrapper.vm.widgetParams).toEqual({
-      searchScope: 'global',
+      isolated: false,
       transformFeeds,
     });
   });
@@ -40,7 +40,7 @@ describe('AisFeeds', () => {
     const wrapper = mount({
       components: { Feeds },
       template: `
-        <Feeds search-scope="global" v-slot="{ feedID }">
+        <Feeds :isolated="false" v-slot="{ feedID }">
           <div class="slot-feed">{{ feedID }}</div>
         </Feeds>
       `,
@@ -75,7 +75,7 @@ describe('AisFeeds', () => {
     const wrapper = mount({
       components: { Feeds },
       template: `
-        <Feeds search-scope="global" v-slot="{ feedID }">
+        <Feeds :isolated="false" v-slot="{ feedID }">
           <div class="slot-feed">{{ feedID }}</div>
         </Feeds>
       `,
@@ -111,7 +111,7 @@ describe('AisFeeds', () => {
     const wrapper = mount({
       components: { Feeds },
       template: `
-        <Feeds search-scope="global" v-slot="{ feedID }">
+        <Feeds :isolated="false" v-slot="{ feedID }">
           <div class="slot-feed">{{ feedID }}</div>
         </Feeds>
       `,
@@ -170,7 +170,7 @@ describe('AisFeeds', () => {
     const wrapper = mount({
       components: { Feeds, ScopedFeed },
       template: `
-        <Feeds search-scope="global" v-slot="{ feedID }">
+        <Feeds :isolated="false" v-slot="{ feedID }">
           <ScopedFeed :feedid="feedID" />
         </Feeds>
       `,
@@ -196,7 +196,7 @@ describe('AisFeeds', () => {
     const wrapper = mount({
       components: { Feeds },
       template: `
-        <Feeds search-scope="global" v-slot="{ feedID }">
+        <Feeds :isolated="false" v-slot="{ feedID }">
           <div v-if="feedID === 'products'" class="slot-feed">{{ feedID }}</div>
         </Feeds>
       `,


### PR DESCRIPTION
## Summary

- Renames the `searchScope: 'global'` required param on the Feeds widget/connector to `isolated: false` across all three flavors (instantsearch.js, react-instantsearch, vue-instantsearch)
- The new name aligns with the `isolated` convention used by the Index widget, making the API more consistent
- Kept the param **required** (no default) to preserve the ability to choose a default value when `isolated: true` (per-feed search scope) is supported in the future

Note that this is technically a breaking change, but if we release right now, it's not really been used by anyone yet.

## Test plan

- [x] All existing feeds tests pass (77 tests across 7 suites)
- [x] No behavioral changes — pure rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)