### PR TITLE
feat(autocomplete): add missing `classNames`/`cssClasses` support

### DIFF
--- a/packages/instantsearch-ui-components/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/Autocomplete.tsx
@@ -52,6 +52,94 @@ export type AutocompleteClassNames = {
    * Class names to apply to the detached search button clear button
    */
   detachedSearchButtonClear: string | string[];
+  /**
+   * Class names to apply to the detached search button clear icon
+   */
+  detachedSearchButtonClearIcon: string | string[];
+  /**
+   * Class names to apply to the detached search button search icon
+   */
+  detachedSearchButtonSearchIcon: string | string[];
+  /**
+   * Class names to apply to the panel
+   */
+  panel: string | string[];
+  /**
+   * Class names to apply to the panel when open
+   */
+  panelOpen: string | string[];
+  /**
+   * Class names to apply to the panel layout
+   */
+  panelLayout: string | string[];
+  /**
+   * Class names to apply to the search form
+   */
+  form: string | string[];
+  /**
+   * Class names to apply to the input wrapper prefix
+   */
+  inputWrapperPrefix: string | string[];
+  /**
+   * Class names to apply to the back button
+   */
+  backButton: string | string[];
+  /**
+   * Class names to apply to the back button icon
+   */
+  backButtonIcon: string | string[];
+  /**
+   * Class names to apply to the label
+   */
+  label: string | string[];
+  /**
+   * Class names to apply to the submit button
+   */
+  submitButton: string | string[];
+  /**
+   * Class names to apply to the submit button icon
+   */
+  submitButtonIcon: string | string[];
+  /**
+   * Class names to apply to the loading indicator
+   */
+  loadingIndicator: string | string[];
+  /**
+   * Class names to apply to the loading indicator icon
+   */
+  loadingIndicatorIcon: string | string[];
+  /**
+   * Class names to apply to the input wrapper
+   */
+  inputWrapper: string | string[];
+  /**
+   * Class names to apply to the search input
+   */
+  input: string | string[];
+  /**
+   * Class names to apply to the input wrapper suffix
+   */
+  inputWrapperSuffix: string | string[];
+  /**
+   * Class names to apply to the reset button
+   */
+  resetButton: string | string[];
+  /**
+   * Class names to apply to the reset button icon
+   */
+  resetButtonIcon: string | string[];
+  /**
+   * Class names to apply to the AI mode button
+   */
+  aiModeButton: string | string[];
+  /**
+   * Class names to apply to the AI mode button icon
+   */
+  aiModeButtonIcon: string | string[];
+  /**
+   * Class names to apply to the AI mode button label
+   */
+  aiModeButtonLabel: string | string[];
 };
 
 export function createAutocompleteComponent({ createElement }: Renderer) {

--- a/packages/instantsearch-ui-components/src/components/autocomplete/AutocompleteDetachedSearchButton.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/AutocompleteDetachedSearchButton.tsx
@@ -60,7 +60,10 @@ export function createAutocompleteDetachedSearchButtonComponent({
             classNames.detachedSearchButtonIcon
           )}
         >
-          <SearchIcon createElement={createElement} />
+          <SearchIcon
+            createElement={createElement}
+            className={classNames.detachedSearchButtonSearchIcon}
+          />
         </div>
         <div
           className={cx(
@@ -92,7 +95,10 @@ export function createAutocompleteDetachedSearchButtonComponent({
               onClear();
             }}
           >
-            <ClearIcon createElement={createElement} />
+            <ClearIcon
+              createElement={createElement}
+              className={classNames.detachedSearchButtonClearIcon}
+            />
           </button>
         )}
       </div>

--- a/packages/instantsearch-ui-components/src/components/autocomplete/AutocompletePanel.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/AutocompletePanel.tsx
@@ -15,6 +15,10 @@ export type AutocompletePanelClassNames = {
    */
   root: string | string[];
   /**
+   * Class names to apply to the root element when the panel is open
+   */
+  open: string | string[];
+  /**
    * Class names to apply to the layout element
    */
   layout: string | string[];
@@ -32,6 +36,7 @@ export function createAutocompletePanelComponent({ createElement }: Renderer) {
           'ais-AutocompletePanel',
           !hidden && 'ais-AutocompletePanel--open',
           classNames.root,
+          !hidden && classNames.open,
           props.className
         )}
         onMouseDown={(event) => {

--- a/packages/instantsearch-ui-components/src/components/autocomplete/AutocompleteSearch.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/AutocompleteSearch.tsx
@@ -1,4 +1,6 @@
 /** @jsx createElement */
+import { cx } from '../../lib/cx';
+
 import {
   AiModeIcon,
   BackIcon,
@@ -8,6 +10,7 @@ import {
 } from './icons';
 
 import type { ComponentProps, Renderer } from '../..';
+import type { AutocompleteClassNames } from './Autocomplete';
 
 export type AutocompleteSearchProps = {
   inputProps: ComponentProps<'input'>;
@@ -18,6 +21,7 @@ export type AutocompleteSearchProps = {
   isDetached?: boolean;
   submitTitle?: string;
   onAiModeClick?: () => void;
+  classNames?: Partial<AutocompleteClassNames>;
 };
 
 export function createAutocompleteSearchComponent({ createElement }: Renderer) {
@@ -31,6 +35,7 @@ export function createAutocompleteSearchComponent({ createElement }: Renderer) {
       isDetached,
       submitTitle,
       onAiModeClick,
+      classNames = {},
     } = userProps;
 
     const isBackButton = Boolean(isDetached && onCancel);
@@ -39,7 +44,7 @@ export function createAutocompleteSearchComponent({ createElement }: Renderer) {
 
     return (
       <form
-        className="ais-AutocompleteForm"
+        className={cx('ais-AutocompleteForm', classNames.form)}
         action=""
         noValidate
         role="search"
@@ -48,48 +53,74 @@ export function createAutocompleteSearchComponent({ createElement }: Renderer) {
         }}
         onReset={() => inputRef.current?.focus()}
       >
-        <div className="ais-AutocompleteInputWrapperPrefix">
+        <div
+          className={cx(
+            'ais-AutocompleteInputWrapperPrefix',
+            classNames.inputWrapperPrefix
+          )}
+        >
           {isBackButton && (
             <button
-              className="ais-AutocompleteBackButton"
+              className={cx(
+                'ais-AutocompleteBackButton',
+                classNames.backButton
+              )}
               type="button"
               title={resolvedCancelTitle}
               onClick={onCancel}
               hidden={isSearchStalled}
             >
-              <BackIcon createElement={createElement} />
+              <BackIcon
+                createElement={createElement}
+                className={classNames.backButtonIcon}
+              />
             </button>
           )}
           {/* Always render the label so aria-labelledby on the input keeps working */}
           <label
-            className="ais-AutocompleteLabel"
+            className={cx('ais-AutocompleteLabel', classNames.label)}
             aria-label="Submit"
             htmlFor={inputProps.id}
             id={`${inputProps.id}-label`}
             hidden={isBackButton || undefined}
           >
             <button
-              className="ais-AutocompleteSubmitButton"
+              className={cx(
+                'ais-AutocompleteSubmitButton',
+                classNames.submitButton
+              )}
               type="submit"
               title="Submit"
               hidden={isSearchStalled}
             >
-              <SubmitIcon createElement={createElement} />
+              <SubmitIcon
+                createElement={createElement}
+                className={classNames.submitButtonIcon}
+              />
             </button>
           </label>
           <div
-            className="ais-AutocompleteLoadingIndicator"
+            className={cx(
+              'ais-AutocompleteLoadingIndicator',
+              classNames.loadingIndicator
+            )}
             hidden={!isSearchStalled}
           >
             <LoadingIcon
               createElement={createElement}
               isSearchStalled={isSearchStalled}
+              className={classNames.loadingIndicatorIcon}
             />
           </div>
         </div>
-        <div className="ais-AutocompleteInputWrapper">
+        <div
+          className={cx(
+            'ais-AutocompleteInputWrapper',
+            classNames.inputWrapper
+          )}
+        >
           <input
-            className="ais-AutocompleteInput"
+            className={cx('ais-AutocompleteInput', classNames.input)}
             aria-autocomplete="both"
             aria-labelledby={`${inputProps.id}-label`}
             autoComplete="off"
@@ -103,19 +134,30 @@ export function createAutocompleteSearchComponent({ createElement }: Renderer) {
             {...inputProps}
           />
         </div>
-        <div className="ais-AutocompleteInputWrapperSuffix">
+        <div
+          className={cx(
+            'ais-AutocompleteInputWrapperSuffix',
+            classNames.inputWrapperSuffix
+          )}
+        >
           <button
-            className="ais-AutocompleteClearButton"
+            className={cx(
+              'ais-AutocompleteClearButton',
+              classNames.resetButton
+            )}
             type="reset"
             title="Clear"
             hidden={query.length === 0 || isSearchStalled}
             onClick={onClear}
           >
-            <ClearIcon createElement={createElement} />
+            <ClearIcon
+              createElement={createElement}
+              className={classNames.resetButtonIcon}
+            />
           </button>
           {onAiModeClick && (
             <button
-              className="ais-AiModeButton"
+              className={cx('ais-AiModeButton', classNames.aiModeButton)}
               type="button"
               title="AI Mode"
               onClick={(e) => {
@@ -123,8 +165,18 @@ export function createAutocompleteSearchComponent({ createElement }: Renderer) {
                 onAiModeClick();
               }}
             >
-              <AiModeIcon createElement={createElement} />
-              <span className="ais-AiModeButton-label">AI Mode</span>
+              <AiModeIcon
+                createElement={createElement}
+                className={classNames.aiModeButtonIcon}
+              />
+              <span
+                className={cx(
+                  'ais-AiModeButton-label',
+                  classNames.aiModeButtonLabel
+                )}
+              >
+                AI Mode
+              </span>
             </button>
           )}
         </div>

--- a/packages/instantsearch-ui-components/src/components/autocomplete/__tests__/AutocompleteSearch.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/__tests__/AutocompleteSearch.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { createElement, createRef, Fragment } from 'preact';
 
 import { createAutocompleteDetachedFormContainerComponent } from '../AutocompleteDetachedFormContainer';
+import { createAutocompleteDetachedSearchButtonComponent } from '../AutocompleteDetachedSearchButton';
 import { createAutocompletePanelComponent } from '../AutocompletePanel';
 import { createAutocompleteSearchComponent } from '../AutocompleteSearch';
 
@@ -231,6 +232,76 @@ describe('AutocompletePanel', () => {
     expect(
       container.querySelector('.ais-AutocompletePanelLayout')
     ).toHaveClass('custom-layout');
+  });
+
+  test('applies open classNames when panel is visible', () => {
+    const { container } = render(
+      <AutocompletePanel
+        id="panel"
+        role="grid"
+        aria-labelledby="input"
+        hidden={false}
+        classNames={{ open: 'custom-open' }}
+      >
+        <div>results</div>
+      </AutocompletePanel>
+    );
+
+    expect(container.querySelector('.ais-AutocompletePanel')).toHaveClass(
+      'custom-open'
+    );
+  });
+
+  test('does not apply open classNames when panel is hidden', () => {
+    const { container } = render(
+      <AutocompletePanel
+        id="panel"
+        role="grid"
+        aria-labelledby="input"
+        hidden={true}
+        classNames={{ open: 'custom-open' }}
+      >
+        <div>results</div>
+      </AutocompletePanel>
+    );
+
+    expect(
+      container.querySelector('.ais-AutocompletePanel')
+    ).not.toHaveClass('custom-open');
+  });
+});
+
+describe('AutocompleteDetachedSearchButton', () => {
+  const AutocompleteDetachedSearchButton =
+    createAutocompleteDetachedSearchButtonComponent({
+      createElement,
+      Fragment,
+    });
+
+  test('applies classNames to search and clear icons', () => {
+    const { container } = render(
+      <AutocompleteDetachedSearchButton
+        query="test"
+        onClick={jest.fn()}
+        onClear={jest.fn()}
+        translations={{
+          detachedCancelButtonText: 'Cancel',
+          detachedSearchButtonTitle: 'Search',
+          detachedClearButtonTitle: 'Clear',
+        }}
+        classNames={{
+          detachedSearchButtonSearchIcon: 'custom-search-icon',
+          detachedSearchButtonClearIcon: 'custom-clear-icon',
+        }}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-AutocompleteDetachedSearchIcon')
+    ).toHaveClass('custom-search-icon');
+    expect(
+      container.querySelector('.ais-AutocompleteClearIcon')
+    ).toHaveClass('custom-clear-icon');
   });
 });
 

--- a/packages/instantsearch-ui-components/src/components/autocomplete/__tests__/AutocompleteSearch.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/__tests__/AutocompleteSearch.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { createElement, createRef, Fragment } from 'preact';
 
 import { createAutocompleteDetachedFormContainerComponent } from '../AutocompleteDetachedFormContainer';
+import { createAutocompletePanelComponent } from '../AutocompletePanel';
 import { createAutocompleteSearchComponent } from '../AutocompleteSearch';
 
 const AutocompleteSearch = createAutocompleteSearchComponent({
@@ -58,6 +59,129 @@ describe('AutocompleteSearch', () => {
     ).not.toBeNull();
   });
 
+  test('merges custom classNames with default ais-* classes', () => {
+    const inputRef = createRef<HTMLInputElement>();
+    const { container } = render(
+      <AutocompleteSearch
+        inputProps={{
+          id: 'classnames-search',
+          ref: inputRef,
+          onInput: jest.fn(),
+        }}
+        onClear={jest.fn()}
+        query="test"
+        isSearchStalled={false}
+        classNames={{
+          form: 'custom-form',
+          input: 'custom-input',
+          submitButton: 'custom-submit',
+          resetButton: 'custom-clear',
+        }}
+      />
+    );
+
+    expect(container.querySelector('.ais-AutocompleteForm')).toHaveClass(
+      'custom-form'
+    );
+    expect(container.querySelector('.ais-AutocompleteInput')).toHaveClass(
+      'custom-input'
+    );
+    expect(
+      container.querySelector('.ais-AutocompleteSubmitButton')
+    ).toHaveClass('custom-submit');
+    expect(
+      container.querySelector('.ais-AutocompleteClearButton')
+    ).toHaveClass('custom-clear');
+  });
+
+  test('applies classNames to all elements including detached and AI mode', () => {
+    const inputRef = createRef<HTMLInputElement>();
+    const { container } = render(
+      <AutocompleteSearch
+        inputProps={{
+          id: 'full-classnames',
+          ref: inputRef,
+          onInput: jest.fn(),
+        }}
+        onClear={jest.fn()}
+        query="test"
+        isSearchStalled={false}
+        onCancel={jest.fn()}
+        isDetached={true}
+        onAiModeClick={jest.fn()}
+        classNames={{
+          form: 'c-form',
+          inputWrapperPrefix: 'c-prefix',
+          backButton: 'c-back',
+          backButtonIcon: 'c-back-icon',
+          label: 'c-label',
+          submitButton: 'c-submit',
+          submitButtonIcon: 'c-submit-icon',
+          loadingIndicator: 'c-loading',
+          loadingIndicatorIcon: 'c-loading-icon',
+          inputWrapper: 'c-input-wrapper',
+          input: 'c-input',
+          inputWrapperSuffix: 'c-suffix',
+          resetButton: 'c-clear',
+          resetButtonIcon: 'c-clear-icon',
+          aiModeButton: 'c-ai',
+          aiModeButtonIcon: 'c-ai-icon',
+          aiModeButtonLabel: 'c-ai-label',
+        }}
+      />
+    );
+
+    expect(container.querySelector('.ais-AutocompleteForm')).toHaveClass(
+      'c-form'
+    );
+    expect(
+      container.querySelector('.ais-AutocompleteInputWrapperPrefix')
+    ).toHaveClass('c-prefix');
+    expect(container.querySelector('.ais-AutocompleteBackButton')).toHaveClass(
+      'c-back'
+    );
+    expect(container.querySelector('.ais-AutocompleteBackIcon')).toHaveClass(
+      'c-back-icon'
+    );
+    expect(container.querySelector('.ais-AutocompleteLabel')).toHaveClass(
+      'c-label'
+    );
+    expect(
+      container.querySelector('.ais-AutocompleteSubmitButton')
+    ).toHaveClass('c-submit');
+    expect(
+      container.querySelector('.ais-AutocompleteSubmitIcon')
+    ).toHaveClass('c-submit-icon');
+    expect(
+      container.querySelector('.ais-AutocompleteLoadingIndicator')
+    ).toHaveClass('c-loading');
+    expect(
+      container.querySelector('.ais-AutocompleteLoadingIcon')
+    ).toHaveClass('c-loading-icon');
+    expect(
+      container.querySelector('.ais-AutocompleteInputWrapper')
+    ).toHaveClass('c-input-wrapper');
+    expect(container.querySelector('.ais-AutocompleteInput')).toHaveClass(
+      'c-input'
+    );
+    expect(
+      container.querySelector('.ais-AutocompleteInputWrapperSuffix')
+    ).toHaveClass('c-suffix');
+    expect(
+      container.querySelector('.ais-AutocompleteClearButton')
+    ).toHaveClass('c-clear');
+    expect(
+      container.querySelector('.ais-AutocompleteClearIcon')
+    ).toHaveClass('c-clear-icon');
+    expect(container.querySelector('.ais-AiModeButton')).toHaveClass('c-ai');
+    expect(container.querySelector('.ais-AiModeButton-icon')).toHaveClass(
+      'c-ai-icon'
+    );
+    expect(container.querySelector('.ais-AiModeButton-label')).toHaveClass(
+      'c-ai-label'
+    );
+  });
+
   test('renders the submit button in non-detached mode', () => {
     const inputRef = createRef<HTMLInputElement>();
     const { container, getByTitle } = render(
@@ -79,6 +203,34 @@ describe('AutocompleteSearch', () => {
     ).not.toBeNull();
     expect(container.querySelector('.ais-AutocompleteBackButton')).toBeNull();
     expect(container.querySelector('.ais-AutocompleteBackIcon')).toBeNull();
+  });
+});
+
+describe('AutocompletePanel', () => {
+  const AutocompletePanel = createAutocompletePanelComponent({
+    createElement,
+    Fragment,
+  });
+
+  test('merges custom classNames with default ais-* classes', () => {
+    const { container } = render(
+      <AutocompletePanel
+        id="panel"
+        role="grid"
+        aria-labelledby="input"
+        hidden={false}
+        classNames={{ root: 'custom-panel', layout: 'custom-layout' }}
+      >
+        <div>results</div>
+      </AutocompletePanel>
+    );
+
+    expect(container.querySelector('.ais-AutocompletePanel')).toHaveClass(
+      'custom-panel'
+    );
+    expect(
+      container.querySelector('.ais-AutocompletePanelLayout')
+    ).toHaveClass('custom-layout');
   });
 });
 

--- a/packages/instantsearch-ui-components/src/components/autocomplete/icons.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/icons.tsx
@@ -1,7 +1,11 @@
 /** @jsx createElement */
+import { cx } from '../../lib/cx';
+
 import type { Renderer } from '../../types';
 
-type IconProps = Pick<Renderer, 'createElement'>;
+type IconProps = Pick<Renderer, 'createElement'> & {
+  className?: string | string[];
+};
 
 type LoadingIconProps = IconProps & {
   isSearchStalled: boolean;
@@ -29,10 +33,10 @@ function syncLoadingSvgAnimation(
   }
 }
 
-export function SubmitIcon({ createElement }: IconProps) {
+export function SubmitIcon({ createElement, className }: IconProps) {
   return (
     <svg
-      className="ais-AutocompleteSubmitIcon"
+      className={cx('ais-AutocompleteSubmitIcon', className)}
       viewBox="0 0 24 24"
       fill="currentColor"
     >
@@ -44,10 +48,11 @@ export function SubmitIcon({ createElement }: IconProps) {
 export function LoadingIcon({
   createElement,
   isSearchStalled,
+  className,
 }: LoadingIconProps) {
   return (
     <svg
-      className="ais-AutocompleteLoadingIcon"
+      className={cx('ais-AutocompleteLoadingIcon', className)}
       viewBox="0 0 100 100"
       ref={(element) => syncLoadingSvgAnimation(element, isSearchStalled)}
     >
@@ -73,10 +78,10 @@ export function LoadingIcon({
   );
 }
 
-export function ClearIcon({ createElement }: IconProps) {
+export function ClearIcon({ createElement, className }: IconProps) {
   return (
     <svg
-      className="ais-AutocompleteClearIcon"
+      className={cx('ais-AutocompleteClearIcon', className)}
       viewBox="0 0 24 24"
       fill="currentColor"
     >
@@ -109,10 +114,10 @@ export function ApplyIcon({ createElement }: IconProps) {
   );
 }
 
-export function AiModeIcon({ createElement }: IconProps) {
+export function AiModeIcon({ createElement, className }: IconProps) {
   return (
     <svg
-      className="ais-AiModeButton-icon"
+      className={cx('ais-AiModeButton-icon', className)}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 20 20"
@@ -136,10 +141,10 @@ export function AiModeIcon({ createElement }: IconProps) {
   );
 }
 
-export function SearchIcon({ createElement }: IconProps) {
+export function SearchIcon({ createElement, className }: IconProps) {
   return (
     <svg
-      className="ais-AutocompleteDetachedSearchIcon"
+      className={cx('ais-AutocompleteDetachedSearchIcon', className)}
       viewBox="0 0 24 24"
       fill="currentColor"
     >
@@ -148,10 +153,10 @@ export function SearchIcon({ createElement }: IconProps) {
   );
 }
 
-export function BackIcon({ createElement }: IconProps) {
+export function BackIcon({ createElement, className }: IconProps) {
   return (
     <svg
-      className="ais-AutocompleteBackIcon"
+      className={cx('ais-AutocompleteBackIcon', className)}
       viewBox="0 0 24 24"
       fill="currentColor"
     >

--- a/packages/instantsearch-ui-components/src/components/autocomplete/icons.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/icons.tsx
@@ -92,7 +92,7 @@ export function ClearIcon({ createElement, className }: IconProps) {
 
 export function ClockIcon({ createElement, className }: IconProps) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <svg className={cx(className)} viewBox="0 0 24 24" fill="currentColor">
       <path d="M12.516 6.984v5.25l4.5 2.672-0.75 1.266-5.25-3.188v-6h1.5zM12 20.016q3.281 0 5.648-2.367t2.367-5.648-2.367-5.648-5.648-2.367-5.648 2.367-2.367 5.648 2.367 5.648 5.648 2.367zM12 2.016q4.125 0 7.055 2.93t2.93 7.055-2.93 7.055-7.055 2.93-7.055-2.93-2.93-7.055 2.93-7.055 7.055-2.93z"></path>
     </svg>
   );
@@ -100,7 +100,7 @@ export function ClockIcon({ createElement, className }: IconProps) {
 
 export function TrashIcon({ createElement, className }: IconProps) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <svg className={cx(className)} viewBox="0 0 24 24" fill="currentColor">
       <path d="M18 7v13c0 0.276-0.111 0.525-0.293 0.707s-0.431 0.293-0.707 0.293h-10c-0.276 0-0.525-0.111-0.707-0.293s-0.293-0.431-0.293-0.707v-13zM17 5v-1c0-0.828-0.337-1.58-0.879-2.121s-1.293-0.879-2.121-0.879h-4c-0.828 0-1.58 0.337-2.121 0.879s-0.879 1.293-0.879 2.121v1h-4c-0.552 0-1 0.448-1 1s0.448 1 1 1h1v13c0 0.828 0.337 1.58 0.879 2.121s1.293 0.879 2.121 0.879h10c0.828 0 1.58-0.337 2.121-0.879s0.879-1.293 0.879-2.121v-13h1c0.552 0 1-0.448 1-1s-0.448-1-1-1zM9 5v-1c0-0.276 0.111-0.525 0.293-0.707s0.431-0.293 0.707-0.293h4c0.276 0 0.525 0.111 0.707 0.293s0.293 0.431 0.293 0.707v1zM9 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1zM13 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1z"></path>
     </svg>
   );
@@ -108,7 +108,7 @@ export function TrashIcon({ createElement, className }: IconProps) {
 
 export function ApplyIcon({ createElement, className }: IconProps) {
   return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <svg className={cx(className)} viewBox="0 0 24 24" fill="currentColor">
       <path d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z"></path>
     </svg>
   );

--- a/packages/instantsearch-ui-components/src/components/autocomplete/icons.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/icons.tsx
@@ -90,25 +90,25 @@ export function ClearIcon({ createElement, className }: IconProps) {
   );
 }
 
-export function ClockIcon({ createElement }: IconProps) {
+export function ClockIcon({ createElement, className }: IconProps) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor">
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
       <path d="M12.516 6.984v5.25l4.5 2.672-0.75 1.266-5.25-3.188v-6h1.5zM12 20.016q3.281 0 5.648-2.367t2.367-5.648-2.367-5.648-5.648-2.367-5.648 2.367-2.367 5.648 2.367 5.648 5.648 2.367zM12 2.016q4.125 0 7.055 2.93t2.93 7.055-2.93 7.055-7.055 2.93-7.055-2.93-2.93-7.055 2.93-7.055 7.055-2.93z"></path>
     </svg>
   );
 }
 
-export function TrashIcon({ createElement }: IconProps) {
+export function TrashIcon({ createElement, className }: IconProps) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor">
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
       <path d="M18 7v13c0 0.276-0.111 0.525-0.293 0.707s-0.431 0.293-0.707 0.293h-10c-0.276 0-0.525-0.111-0.707-0.293s-0.293-0.431-0.293-0.707v-13zM17 5v-1c0-0.828-0.337-1.58-0.879-2.121s-1.293-0.879-2.121-0.879h-4c-0.828 0-1.58 0.337-2.121 0.879s-0.879 1.293-0.879 2.121v1h-4c-0.552 0-1 0.448-1 1s0.448 1 1 1h1v13c0 0.828 0.337 1.58 0.879 2.121s1.293 0.879 2.121 0.879h10c0.828 0 1.58-0.337 2.121-0.879s0.879-1.293 0.879-2.121v-13h1c0.552 0 1-0.448 1-1s-0.448-1-1-1zM9 5v-1c0-0.276 0.111-0.525 0.293-0.707s0.431-0.293 0.707-0.293h4c0.276 0 0.525 0.111 0.707 0.293s0.293 0.431 0.293 0.707v1zM9 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1zM13 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1z"></path>
     </svg>
   );
 }
 
-export function ApplyIcon({ createElement }: IconProps) {
+export function ApplyIcon({ createElement, className }: IconProps) {
   return (
-    <svg viewBox="0 0 24 24" fill="currentColor">
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
       <path d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z"></path>
     </svg>
   );

--- a/packages/instantsearch-ui-components/src/components/autocomplete/icons.tsx
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/icons.tsx
@@ -92,7 +92,7 @@ export function ClearIcon({ createElement, className }: IconProps) {
 
 export function ClockIcon({ createElement, className }: IconProps) {
   return (
-    <svg className={cx(className)} viewBox="0 0 24 24" fill="currentColor">
+    <svg className={cx(className) || undefined} viewBox="0 0 24 24" fill="currentColor">
       <path d="M12.516 6.984v5.25l4.5 2.672-0.75 1.266-5.25-3.188v-6h1.5zM12 20.016q3.281 0 5.648-2.367t2.367-5.648-2.367-5.648-5.648-2.367-5.648 2.367-2.367 5.648 2.367 5.648 5.648 2.367zM12 2.016q4.125 0 7.055 2.93t2.93 7.055-2.93 7.055-7.055 2.93-7.055-2.93-2.93-7.055 2.93-7.055 7.055-2.93z"></path>
     </svg>
   );
@@ -100,7 +100,7 @@ export function ClockIcon({ createElement, className }: IconProps) {
 
 export function TrashIcon({ createElement, className }: IconProps) {
   return (
-    <svg className={cx(className)} viewBox="0 0 24 24" fill="currentColor">
+    <svg className={cx(className) || undefined} viewBox="0 0 24 24" fill="currentColor">
       <path d="M18 7v13c0 0.276-0.111 0.525-0.293 0.707s-0.431 0.293-0.707 0.293h-10c-0.276 0-0.525-0.111-0.707-0.293s-0.293-0.431-0.293-0.707v-13zM17 5v-1c0-0.828-0.337-1.58-0.879-2.121s-1.293-0.879-2.121-0.879h-4c-0.828 0-1.58 0.337-2.121 0.879s-0.879 1.293-0.879 2.121v1h-4c-0.552 0-1 0.448-1 1s0.448 1 1 1h1v13c0 0.828 0.337 1.58 0.879 2.121s1.293 0.879 2.121 0.879h10c0.828 0 1.58-0.337 2.121-0.879s0.879-1.293 0.879-2.121v-13h1c0.552 0 1-0.448 1-1s-0.448-1-1-1zM9 5v-1c0-0.276 0.111-0.525 0.293-0.707s0.431-0.293 0.707-0.293h4c0.276 0 0.525 0.111 0.707 0.293s0.293 0.431 0.293 0.707v1zM9 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1zM13 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1z"></path>
     </svg>
   );
@@ -108,7 +108,7 @@ export function TrashIcon({ createElement, className }: IconProps) {
 
 export function ApplyIcon({ createElement, className }: IconProps) {
   return (
-    <svg className={cx(className)} viewBox="0 0 24 24" fill="currentColor">
+    <svg className={cx(className) || undefined} viewBox="0 0 24 24" fill="currentColor">
       <path d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z"></path>
     </svg>
   );

--- a/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
+++ b/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
@@ -856,11 +856,19 @@ function AutocompleteWrapper<TItem extends BaseHit>({
             }
           : undefined
       }
+      classNames={cssClasses}
     />
   );
 
   const panelContent = (
-    <AutocompletePanel {...getPanelProps()}>
+    <AutocompletePanel
+      {...getPanelProps()}
+      classNames={{
+        root: cssClasses?.panel,
+        open: cssClasses?.panelOpen,
+        layout: cssClasses?.panelLayout,
+      }}
+    >
       {templates.panel ? (
         <TemplateComponent
           {...renderState.templateProps}

--- a/packages/react-instantsearch/src/components/AutocompleteSearch.tsx
+++ b/packages/react-instantsearch/src/components/AutocompleteSearch.tsx
@@ -1,7 +1,11 @@
 import { createAutocompleteSearchComponent } from 'instantsearch-ui-components';
 import React, { createElement, Fragment } from 'react';
 
-import type { ComponentProps, Pragma } from 'instantsearch-ui-components';
+import type {
+  AutocompleteClassNames,
+  ComponentProps,
+  Pragma,
+} from 'instantsearch-ui-components';
 
 const AutocompleteSearchComponent = createAutocompleteSearchComponent({
   createElement: createElement as Pragma,
@@ -18,6 +22,7 @@ export type AutocompleteSearchProps = {
   isDetached?: boolean;
   submitTitle?: string;
   onAiModeClick?: () => void;
+  classNames?: Partial<AutocompleteClassNames>;
 };
 
 export function AutocompleteSearch({
@@ -30,6 +35,7 @@ export function AutocompleteSearch({
   isDetached,
   submitTitle,
   onAiModeClick,
+  classNames,
 }: AutocompleteSearchProps) {
   return (
     <AutocompleteSearchComponent
@@ -47,6 +53,7 @@ export function AutocompleteSearch({
       isDetached={isDetached}
       submitTitle={submitTitle}
       onAiModeClick={onAiModeClick}
+      classNames={classNames}
     />
   );
 }

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -917,11 +917,15 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
             }
           : undefined
       }
+      classNames={classNames}
     />
   );
 
   const panelContent = (
-    <AutocompletePanel {...getPanelProps()}>
+    <AutocompletePanel
+      {...getPanelProps()}
+      classNames={{ root: classNames?.panel, open: classNames?.panelOpen, layout: classNames?.panelLayout }}
+    >
       {PanelComponent ? (
         <PanelComponent
           elements={elements}


### PR DESCRIPTION
**Summary**

The Autocomplete widget only exposed `classNames` for the root element and the detached shell (overlay, container, search button). The search form, panel, and all icons had no `classNames` support, they were only reachable via hardcoded `ais-*` CSS selectors, making utility-first CSS frameworks (Tailwind, UnoCSS) unusable for those elements.

This extends `AutocompleteClassNames` with new keys covering the search form (input, buttons, loading indicator), the panel (root, open state, layout), all icons (submit, reset, back, loading, AI mode, detached search, detached clear), and the AI mode button. The same `classNames`/`cssClasses` prop now reaches every visible element.

**Not covered in this PR:** the shared item layout elements (`ais-AutocompleteItem*`) used by Suggestion, RecentSearch, and PromptSuggestion. These are already styleable through per-index `classNames`/`cssClasses`, but not through the top-level prop.

**Result**

Every visible element in the Autocomplete widget is now styleable through the top-level `classNames`/`cssClasses` prop. Users on utility-first CSS frameworks can style the entire widget without targeting `ais-*` selectors. And coding agents can style Autocomplete much more reliably as well.

Docs PR: https://github.com/algolia/docs-new/pull/801