### PR TITLE
chore(ci): harden oxlint auto-fix workflow

### DIFF
--- a/.github/prompts/lint-fix.md
+++ b/.github/prompts/lint-fix.md
@@ -23,13 +23,15 @@ After your edits, the file list in `inScopeFiles` must report **zero violations 
 
 ## How to verify
 
-Run oxlint scoped to one or more in-scope files and grep for the rule's `code` field:
+Run oxlint scoped to one or more in-scope files:
 
 ```bash
 node_modules/.bin/oxlint --type-aware -f json <file> [<file>...]
 ```
 
 Each diagnostic's `code` looks like `eslint(no-debugger)` or `typescript-eslint(consistent-type-imports)`. You succeed when no diagnostic for the targeted rule remains in any in-scope file.
+
+If the JSON output is too large to inline, Claude Code persists it to a path it shows you (e.g. `/home/runner/.claude/.../tool-results/<id>.txt`) — use the `Read` (or `Grep`) tool on that exact path. Do not try to redirect, pipe, or use other shell utilities; only `node_modules/.bin/oxlint` is on the allowlist.
 
 `yarn lint:fix` applies oxlint's autofixer (already run before you started; remaining violations are the ones the autofixer can't handle).
 

--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -90,12 +90,13 @@ jobs:
       - name: Run Claude Code
         if: steps.pick.outputs.status == 'ok'
         timeout-minutes: 18
+        continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           claude -p "$(cat .github/prompts/lint-fix.md)" \
             --allowedTools "Read,Edit,Write,Glob,Grep,Bash(node_modules/.bin/oxlint *)" \
-            --max-turns 30 \
+            --max-turns 60 \
             --verbose \
             --output-format stream-json \
             < /dev/null

--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -292,9 +292,7 @@ jobs:
             --head "$BRANCH" \
             --draft \
             --title "$TITLE" \
-            --body-file "$BODY_FILE" \
-            --label "chore" \
-            --label "automated")
+            --body-file "$BODY_FILE")
           echo "Created PR: $PR_URL"
 
           # Team reviewer assignment requires org-read scope, which the default

--- a/scripts/lint/__tests__/pick-rule.test.js
+++ b/scripts/lint/__tests__/pick-rule.test.js
@@ -8,12 +8,12 @@ const {
 
 describe('parseArgs', () => {
   it('returns defaults when given no flags', () => {
-    expect(parseArgs([])).toEqual({ rule: 'auto', maxFiles: 20, out: null });
+    expect(parseArgs([])).toEqual({ rule: 'auto', maxFiles: 10, out: null });
   });
 
   it('parses --rule and --out as space-separated values', () => {
     expect(parseArgs(['--rule', 'eslint(no-debugger)', '--out', 'x.json']))
-      .toEqual({ rule: 'eslint(no-debugger)', maxFiles: 20, out: 'x.json' });
+      .toEqual({ rule: 'eslint(no-debugger)', maxFiles: 10, out: 'x.json' });
   });
 
   it('parses --flag=value form', () => {

--- a/scripts/lint/pick-rule.cjs
+++ b/scripts/lint/pick-rule.cjs
@@ -14,7 +14,7 @@ const oxlintBin = path.join(
 const skipListPath = path.join(__dirname, 'auto-fix-skip.json');
 
 const LINT_TARGETS = ['packages', 'scripts', 'tests', 'specs'];
-const DEFAULT_MAX_FILES = 20;
+const DEFAULT_MAX_FILES = 10;
 
 // Files matching these patterns are off-limits to the auto-fix bot.
 // Keep in sync with the DENY_REGEX in .github/workflows/lint-fix.yml, which


### PR DESCRIPTION
**Summary**

The first dry run of the [Lint Auto-Fix workflow](https://github.com/algolia/instantsearch/actions/runs/25670322101/job/75353561568) failed at `Run Claude Code` with `error_max_turns`. Three small fixes:

- `continue-on-error: true` on the agent step — its exit code conflates many failure modes; the downstream verification steps are the real quality gates.
- `--max-turns 30 → 60` — 30 was below the floor for the default `maxFiles: 20` scope (~43-turn minimum).
- One-sentence prompt nudge — when oxlint output is auto-persisted by Claude Code, tell the agent to `Read` the path instead of trying blocked shell workarounds.

Two follow-ups added in subsequent commits:

- `DEFAULT_MAX_FILES: 20 → 10` in `pick-rule.cjs` so a single agent run finishes within budget; remaining files are deferred to subsequent runs via the existing `deferredFiles` mechanism.
- Drop `--label "chore" --label "automated"` from `gh pr create` — those labels don't exist in this repo and made the otherwise-successful run fail at the very last step.

**Result**

Verified end-to-end on this branch: [run #25675835107](https://github.com/algolia/instantsearch/actions/runs/25675835107) completed successfully in 2m50s on rule `eslint-plugin-react-hooks(exhaustive-deps)` and opened #7023 with the agent's edits to `Feeds.tsx`. Every quality gate passed and the PR was created without manual intervention.