### PR TITLE
chore: bump instantsearch.js bundlesize limits

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "126.25 kB"
+      "maxSize": "126.5 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "262 kB"
+      "maxSize": "262.25 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",


### PR DESCRIPTION
**Summary**

The `instantsearch.js` production and development bundles drifted just past their `bundlesize` budgets on master. This blocks every PR from going green on the bundlesize check (e.g. #7022).

| Bundle | Actual | Old limit | New limit | Headroom |
|---|---|---|---|---|
| `instantsearch.production.min.js` | 129310 B | 126.25 kB (129280 B) | 126.5 kB (129536 B) | 226 B |
| `instantsearch.development.js` | 268370 B | 262 kB (268288 B) | 262.25 kB (268544 B) | 174 B |

Smallest 0.25 kB bumps that fit, matching the project's surgical-bump precedent in git history.

**Result**

After merge, `bundlesize` should turn green on master and on any open PR (including #7022) on the next check run.