### PR TITLE
fix(examples): update React SSR example for ESM

### DIFF
--- a/examples/react/ssr/package.json
+++ b/examples/react/ssr/package.json
@@ -3,14 +3,14 @@
   "version": "6.122.0",
   "private": true,
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "build": "vite build && vite build --ssr src/server.jsx",
     "start": "yarn build && node dist/server.js"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "4.2.1",
-    "vite": "5.0.7",
-    "vite-plugin-commonjs": "0.10.0"
+    "vite": "5.0.7"
   },
   "dependencies": {
     "algoliasearch": "5.1.1",

--- a/examples/react/ssr/src/server.jsx
+++ b/examples/react/ssr/src/server.jsx
@@ -1,4 +1,5 @@
-import { join } from 'path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import express from 'express';
 import React from 'react';
@@ -7,6 +8,9 @@ import { getServerState } from 'react-instantsearch';
 
 import App from './App';
 import { responsesCache } from './searchClient';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const app = express();
 

--- a/examples/react/ssr/vite.config.mjs
+++ b/examples/react/ssr/vite.config.mjs
@@ -1,31 +1,26 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
-import commonjs from 'vite-plugin-commonjs';
 
-export default defineConfig(({ isSsrBuild }) => {
-  const isSSR = Boolean(isSsrBuild);
-
-  return {
-    plugins: [commonjs(), react()],
-    build: isSSR
-      ? {
-          outDir: 'dist',
-          emptyOutDir: false,
-          rollupOptions: {
-            output: {
-              entryFileNames: 'server.js',
-              format: 'cjs',
-            },
-          },
-        }
-      : {
-          outDir: 'dist',
-          rollupOptions: {
-            input: 'src/browser.jsx',
-            output: {
-              entryFileNames: 'assets/bundle.js',
-            },
+export default defineConfig(({ isSsrBuild }) => ({
+  plugins: [react()],
+  build: isSsrBuild
+    ? {
+        outDir: 'dist',
+        emptyOutDir: false,
+        rollupOptions: {
+          output: {
+            entryFileNames: 'server.js',
+            format: 'esm',
           },
         },
-  };
-});
+      }
+    : {
+        outDir: 'dist',
+        rollupOptions: {
+          input: 'src/browser.jsx',
+          output: {
+            entryFileNames: 'assets/bundle.js',
+          },
+        },
+      },
+}));


### PR DESCRIPTION
Fix #6950

**Summary**

The React / Express SSR example currently fails in a fresh CodeSandbox environment because the SSR build emits CommonJS while depending on ESM packages. After switching the SSR output to ESM, the server also needs to avoid CommonJS globals like `__dirname`.

This PR updates the example so the SSR build and server entry use ESM consistently.

Changes:
- Removes `vite-plugin-commonjs`
- Adds `"type": "module"` to the example package
- Builds the SSR server output as ESM
- Replaces `__dirname` usage with `import.meta.url` / `fileURLToPath`

**Result**

Verified the SSR example in CodeSandbox using the current dependency versions from `master`.

Confirmed:
- The build completes successfully
- The server starts without `ERR_REQUIRE_ESM`
- The server no longer fails with `__dirname is not defined`

I also attempted to run the example locally with:

```sh
yarn --cwd examples/react/ssr start
```

The local run did not complete because my local monorepo build produced a generated workspace artifact importing instantsearch.jsundefined from react-instantsearch-core, which appears unrelated to this SSR example change. The CodeSandbox verification above was done against the updated example files and current dependency versions.
