### PR TITLE
test(common): support per-flavor skips and normalize recommend snapshots

### DIFF
--- a/tests/common/widgets/filter-suggestions/index.ts
+++ b/tests/common/widgets/filter-suggestions/index.ts
@@ -15,11 +15,12 @@ export type JSFilterSuggestionsWidgetParams = Omit<
 > &
   FilterSuggestionsConnectorParams;
 export type ReactFilterSuggestionsWidgetParams = FilterSuggestionsProps;
+export type VueFilterSuggestionsWidgetParams = FilterSuggestionsConnectorParams;
 
 type FilterSuggestionsWidgetParams = {
   javascript: JSFilterSuggestionsWidgetParams;
   react: ReactFilterSuggestionsWidgetParams;
-  vue: Record<string, never>;
+  vue: VueFilterSuggestionsWidgetParams;
 };
 
 declare module '../../common' {

--- a/tests/common/widgets/filter-suggestions/options.ts
+++ b/tests/common/widgets/filter-suggestions/options.ts
@@ -1,6 +1,8 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils';
 
+import { skippableTest } from '../../common';
+
 import type { FilterSuggestionsWidgetSetup } from '.';
 import type { TestOptions } from '../../common';
 import type { SearchResponse } from 'instantsearch.js';
@@ -10,10 +12,10 @@ const MIN_LOADING_DURATION_MS = 300;
 
 export function createOptionsTests(
   setup: FilterSuggestionsWidgetSetup,
-  { act }: Required<TestOptions>
+  { act, skippedTests = {} }: Required<TestOptions>
 ) {
   describe('options', () => {
-    test('throws without agentId', () => {
+    skippableTest('throws without agentId', skippedTests, () => {
       const searchClient = createSearchClient({});
 
       expect(() =>
@@ -93,7 +95,7 @@ export function createOptionsTests(
         widgetParams: {
           javascript: { agentId: 'test-agent-id', debounceMs: 0 },
           react: { agentId: 'test-agent-id', debounceMs: 0 },
-          vue: {},
+          vue: { agentId: 'test-agent-id', debounceMs: 0 },
         },
       });
 
@@ -144,7 +146,7 @@ export function createOptionsTests(
         widgetParams: {
           javascript: { agentId: 'test-agent-id' },
           react: { agentId: 'test-agent-id' },
-          vue: {},
+          vue: { agentId: 'test-agent-id' },
         },
       });
 
@@ -227,7 +229,11 @@ export function createOptionsTests(
             attributes: ['brand'],
             debounceMs: 0,
           },
-          vue: {},
+          vue: {
+            agentId: 'test-agent-id',
+            attributes: ['brand'],
+            debounceMs: 0,
+          },
         },
       });
 
@@ -308,7 +314,11 @@ export function createOptionsTests(
             transformItems,
             debounceMs: 0,
           },
-          vue: {},
+          vue: {
+            agentId: 'test-agent-id',
+            transformItems,
+            debounceMs: 0,
+          },
         },
       });
 

--- a/tests/common/widgets/filter-suggestions/templates.tsx
+++ b/tests/common/widgets/filter-suggestions/templates.tsx
@@ -2,6 +2,8 @@ import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils';
 import React from 'react';
 
+import { skippableDescribe } from '../../common';
+
 import type { FilterSuggestionsWidgetSetup } from '.';
 import type { TestOptions } from '../../common';
 
@@ -10,9 +12,9 @@ const MIN_LOADING_DURATION_MS = 300;
 
 export function createTemplatesTests(
   setup: FilterSuggestionsWidgetSetup,
-  { act }: Required<TestOptions>
+  { act, skippedTests = {} }: Required<TestOptions>
 ) {
-  describe('templates', () => {
+  skippableDescribe('templates', skippedTests, () => {
     test('renders with custom header template', async () => {
       const searchClient = createSearchClient({
         search: jest.fn(() =>
@@ -80,7 +82,7 @@ export function createTemplatesTests(
               <div className="custom-header">Custom Header</div>
             ),
           },
-          vue: {},
+          vue: { agentId: 'test-agent-id', debounceMs: 0 },
         },
       });
 
@@ -168,7 +170,7 @@ export function createTemplatesTests(
               <div className="custom-item">{suggestion.label}</div>
             ),
           },
-          vue: {},
+          vue: { agentId: 'test-agent-id', debounceMs: 0 },
         },
       });
 
@@ -227,7 +229,7 @@ export function createTemplatesTests(
               <div className="custom-empty">No suggestions</div>
             ),
           },
-          vue: {},
+          vue: { agentId: 'test-agent-id' },
         },
       });
 

--- a/tests/common/widgets/related-products/options.ts
+++ b/tests/common/widgets/related-products/options.ts
@@ -1,5 +1,5 @@
 import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
-import { wait } from '@instantsearch/testutils';
+import { normalizeSnapshot, wait } from '@instantsearch/testutils';
 import { TAG_PLACEHOLDER } from 'instantsearch.js/es/lib/utils';
 
 import type { RelatedProductsWidgetSetup } from '.';
@@ -27,8 +27,11 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(document.querySelector('.ais-RelatedProducts'))
-        .toMatchInlineSnapshot(`
+      expect(
+        document.querySelector('.ais-RelatedProducts')
+      ).toMatchNormalizedInlineSnapshot(
+        normalizeSnapshot,
+        `
         <section
           class="ais-RelatedProducts"
         >
@@ -106,8 +109,11 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(document.querySelector('.ais-RelatedProducts'))
-        .toMatchInlineSnapshot(`
+      expect(
+        document.querySelector('.ais-RelatedProducts')
+      ).toMatchNormalizedInlineSnapshot(
+        normalizeSnapshot,
+        `
         <section
           class="ais-RelatedProducts"
         >
@@ -163,8 +169,11 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(document.querySelector('.ais-RelatedProducts'))
-        .toMatchInlineSnapshot(`
+      expect(
+        document.querySelector('.ais-RelatedProducts')
+      ).toMatchNormalizedInlineSnapshot(
+        normalizeSnapshot,
+        `
         <section
           class="ais-RelatedProducts ais-RelatedProducts--empty"
         >

--- a/tests/common/widgets/trending-facets/options.ts
+++ b/tests/common/widgets/trending-facets/options.ts
@@ -1,5 +1,5 @@
 import { createTrendingFacetsSearchClient } from '@instantsearch/mocks/fixtures';
-import { wait } from '@instantsearch/testutils';
+import { normalizeSnapshot, wait } from '@instantsearch/testutils';
 
 import type { TrendingFacetsWidgetSetup } from '.';
 import type { TestOptions } from '../../common';
@@ -26,8 +26,11 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(document.querySelector('.ais-TrendingFacets'))
-        .toMatchInlineSnapshot(`
+      expect(
+        document.querySelector('.ais-TrendingFacets')
+      ).toMatchNormalizedInlineSnapshot(
+        normalizeSnapshot,
+        `
         <section
           class="ais-TrendingFacets"
         >
@@ -81,8 +84,11 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(document.querySelector('.ais-TrendingFacets'))
-        .toMatchInlineSnapshot(`
+      expect(
+        document.querySelector('.ais-TrendingFacets')
+      ).toMatchNormalizedInlineSnapshot(
+        normalizeSnapshot,
+        `
         <section
           class="ais-TrendingFacets"
         >
@@ -131,8 +137,11 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(document.querySelector('.ais-TrendingFacets'))
-        .toMatchInlineSnapshot(`
+      expect(
+        document.querySelector('.ais-TrendingFacets')
+      ).toMatchNormalizedInlineSnapshot(
+        normalizeSnapshot,
+        `
         <section
           class="ais-TrendingFacets ais-TrendingFacets--empty"
         >

--- a/tests/common/widgets/trending-items/options.ts
+++ b/tests/common/widgets/trending-items/options.ts
@@ -1,5 +1,5 @@
 import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
-import { wait } from '@instantsearch/testutils';
+import { normalizeSnapshot, wait } from '@instantsearch/testutils';
 import { TAG_PLACEHOLDER } from 'instantsearch.js/es/lib/utils';
 
 import type { TrendingItemsWidgetSetup } from '.';
@@ -25,8 +25,11 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(document.querySelector('.ais-TrendingItems'))
-        .toMatchInlineSnapshot(`
+      expect(
+        document.querySelector('.ais-TrendingItems')
+      ).toMatchNormalizedInlineSnapshot(
+        normalizeSnapshot,
+        `
         <section
           class="ais-TrendingItems"
         >
@@ -103,8 +106,11 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(document.querySelector('.ais-TrendingItems'))
-        .toMatchInlineSnapshot(`
+      expect(
+        document.querySelector('.ais-TrendingItems')
+      ).toMatchNormalizedInlineSnapshot(
+        normalizeSnapshot,
+        `
         <section
           class="ais-TrendingItems"
         >
@@ -159,8 +165,11 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(document.querySelector('.ais-TrendingItems'))
-        .toMatchInlineSnapshot(`
+      expect(
+        document.querySelector('.ais-TrendingItems')
+      ).toMatchNormalizedInlineSnapshot(
+        normalizeSnapshot,
+        `
         <section
           class="ais-TrendingItems ais-TrendingItems--empty"
         >


### PR DESCRIPTION
**Stacked on top of #7029.**

## Summary

Test infrastructure changes needed before the Vue recommendation/FilterSuggestions ports can land. No widget changes.

- \`tests/common/widgets/filter-suggestions/options.ts\` and \`templates.tsx\` now use \`skippableTest\` / \`skippableDescribe\` for the cases Vue cannot reproduce 1:1:
  - The synchronous \`throws without agentId\` check (Vue's \`created\` hook swallows the throw).
  - The \`templates\` describe block (React/JS pass function-valued \`templates\`/\`headerComponent\`/\`itemComponent\`/\`emptyComponent\` props that Vue can't apply directly).
- \`tests/common/widgets/filter-suggestions/index.ts\` exports a real \`VueFilterSuggestionsWidgetParams\` type (previously \`vue: Record<string, never>\`), and every test case in this suite now fills in proper Vue connector params (previously \`vue: {}\`).
- The three recommendation widget suites (\`related-products\`, \`trending-items\`, \`trending-facets\`) now snapshot via \`toMatchNormalizedInlineSnapshot(normalizeSnapshot, …)\`, matching the existing \`looking-similar\` / \`frequently-bought-together\` pattern. Required because Vue 3 wraps native \`<Fragment>\` content with extra whitespace text nodes that the normalizer already strips.

## Test plan

- [x] \`npx jest packages/react-instantsearch packages/instantsearch.js --no-coverage\` — 310 suites green.
- [x] Existing Vue 2 and Vue 3 suites still pass on these tests.

Next in the stack: React widgets.