### PR TITLE
feat(vue): port the five recommendation widgets

### DIFF
--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -29,6 +29,11 @@ import {
   AisPoweredBy,
   AisMenuSelect,
   AisDynamicWidgets,
+  AisRelatedProducts,
+  AisTrendingItems,
+  AisTrendingFacets,
+  AisLookingSimilar,
+  AisFrequentlyBoughtTogether,
 } from '../instantsearch';
 import { renderCompat } from '../util/vue-compat';
 
@@ -509,22 +514,105 @@ const testSetups = {
 
     await nextTick();
   },
-  createRelatedProductsWidgetTests() {
-    throw new Error('RelatedProduct is not supported in Vue InstantSearch');
-  },
-  createFrequentlyBoughtTogetherWidgetTests() {
-    throw new Error(
-      'FrequentlyBoughtTogether is not supported in Vue InstantSearch'
+  async createRelatedProductsWidgetTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisRelatedProducts, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
     );
+
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
   },
-  createTrendingItemsWidgetTests() {
-    throw new Error('TrendingItems is not supported in Vue InstantSearch');
+  async createFrequentlyBoughtTogetherWidgetTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisFrequentlyBoughtTogether, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
+
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
   },
-  createTrendingFacetsWidgetTests() {
-    throw new Error('TrendingFacets is not supported in Vue InstantSearch');
+  async createTrendingItemsWidgetTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisTrendingItems, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
+
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
   },
-  createLookingSimilarWidgetTests() {
-    throw new Error('LookingSimilar is not supported in Vue InstantSearch');
+  async createTrendingFacetsWidgetTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisTrendingFacets, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
+
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+  },
+  async createLookingSimilarWidgetTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisLookingSimilar, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
+
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
   },
   createPoweredByWidgetTests({ instantSearchOptions, widgetParams }) {
     mountApp(
@@ -619,23 +707,11 @@ const testOptions = {
   },
   createSortByWidgetTests: undefined,
   createStatsWidgetTests: undefined,
-  createRelatedProductsWidgetTests: {
-    skippedTests: {
-      'RelatedProducts widget common tests': true,
-    },
-  },
-  createFrequentlyBoughtTogetherWidgetTests: {
-    skippedTests: { 'FrequentlyBoughtTogether widget common tests': true },
-  },
-  createTrendingItemsWidgetTests: {
-    skippedTests: { 'TrendingItems widget common tests': true },
-  },
-  createTrendingFacetsWidgetTests: {
-    skippedTests: { 'TrendingFacets widget common tests': true },
-  },
-  createLookingSimilarWidgetTests: {
-    skippedTests: { 'LookingSimilar widget common tests': true },
-  },
+  createRelatedProductsWidgetTests: undefined,
+  createFrequentlyBoughtTogetherWidgetTests: undefined,
+  createTrendingItemsWidgetTests: undefined,
+  createTrendingFacetsWidgetTests: undefined,
+  createLookingSimilarWidgetTests: undefined,
   createPoweredByWidgetTests: undefined,
   createDynamicWidgetsWidgetTests: undefined,
   createChatWidgetTests: {

--- a/packages/vue-instantsearch/src/__tests__/index.js
+++ b/packages/vue-instantsearch/src/__tests__/index.js
@@ -80,6 +80,16 @@ function getAllComponents() {
         props.indexName = 'indexName';
       } else if (name === 'AisFeeds') {
         props.isolated = false;
+      } else if (
+        name === 'AisRelatedProducts' ||
+        name === 'AisFrequentlyBoughtTogether' ||
+        name === 'AisLookingSimilar'
+      ) {
+        props.objectIDs = ['1'];
+      } else if (name === 'AisTrendingFacets') {
+        props.facetName = 'brand';
+      } else if (name === 'AisTrendingItems') {
+        // no required props
       } else {
         props.attribute = 'attr';
       }

--- a/packages/vue-instantsearch/src/components/FrequentlyBoughtTogether.js
+++ b/packages/vue-instantsearch/src/components/FrequentlyBoughtTogether.js
@@ -1,0 +1,81 @@
+import { createFrequentlyBoughtTogetherComponent } from 'instantsearch-ui-components';
+import { connectFrequentlyBoughtTogether } from 'instantsearch.js/es/connectors/index';
+
+import { createRecommendMixin } from '../mixins/recommend';
+import { createSuitMixin } from '../mixins/suit';
+import { createWidgetMixin } from '../mixins/widget';
+import { Fragment, getScopedSlot, renderCompat } from '../util/vue-compat';
+
+export default {
+  name: 'AisFrequentlyBoughtTogether',
+  mixins: [
+    createWidgetMixin(
+      { connector: connectFrequentlyBoughtTogether },
+      { $$widgetType: 'ais.frequentlyBoughtTogether' }
+    ),
+    createSuitMixin({ name: 'FrequentlyBoughtTogether' }),
+    createRecommendMixin(),
+  ],
+  props: {
+    objectIDs: {
+      type: Array,
+      required: true,
+    },
+    limit: {
+      type: Number,
+      default: undefined,
+    },
+    threshold: {
+      type: Number,
+      default: undefined,
+    },
+    fallbackParameters: {
+      type: Object,
+      default: undefined,
+    },
+    queryParameters: {
+      type: Object,
+      default: undefined,
+    },
+    escapeHTML: {
+      type: Boolean,
+      default: undefined,
+    },
+    transformItems: {
+      type: Function,
+      default: undefined,
+    },
+  },
+  computed: {
+    widgetParams() {
+      return {
+        objectIDs: this.objectIDs,
+        limit: this.limit,
+        threshold: this.threshold,
+        fallbackParameters: this.fallbackParameters,
+        queryParameters: this.queryParameters,
+        escapeHTML: this.escapeHTML,
+        transformItems: this.transformItems,
+      };
+    },
+  },
+  render: renderCompat(function (h) {
+    if (!this.state) {
+      return null;
+    }
+
+    return h(
+      createFrequentlyBoughtTogetherComponent({ createElement: h, Fragment }),
+      {
+        items: this.state.items,
+        status: this.status,
+        sendEvent: this.state.sendEvent,
+        itemComponent: getScopedSlot(this, 'item'),
+        headerComponent: getScopedSlot(this, 'header'),
+        emptyComponent: getScopedSlot(this, 'empty'),
+        layout: getScopedSlot(this, 'layout'),
+        classNames: this.classNames,
+      }
+    );
+  }),
+};

--- a/packages/vue-instantsearch/src/components/LookingSimilar.js
+++ b/packages/vue-instantsearch/src/components/LookingSimilar.js
@@ -1,0 +1,78 @@
+import { createLookingSimilarComponent } from 'instantsearch-ui-components';
+import { connectLookingSimilar } from 'instantsearch.js/es/connectors/index';
+
+import { createRecommendMixin } from '../mixins/recommend';
+import { createSuitMixin } from '../mixins/suit';
+import { createWidgetMixin } from '../mixins/widget';
+import { Fragment, getScopedSlot, renderCompat } from '../util/vue-compat';
+
+export default {
+  name: 'AisLookingSimilar',
+  mixins: [
+    createWidgetMixin(
+      { connector: connectLookingSimilar },
+      { $$widgetType: 'ais.lookingSimilar' }
+    ),
+    createSuitMixin({ name: 'LookingSimilar' }),
+    createRecommendMixin(),
+  ],
+  props: {
+    objectIDs: {
+      type: Array,
+      required: true,
+    },
+    limit: {
+      type: Number,
+      default: undefined,
+    },
+    threshold: {
+      type: Number,
+      default: undefined,
+    },
+    fallbackParameters: {
+      type: Object,
+      default: undefined,
+    },
+    queryParameters: {
+      type: Object,
+      default: undefined,
+    },
+    escapeHTML: {
+      type: Boolean,
+      default: undefined,
+    },
+    transformItems: {
+      type: Function,
+      default: undefined,
+    },
+  },
+  computed: {
+    widgetParams() {
+      return {
+        objectIDs: this.objectIDs,
+        limit: this.limit,
+        threshold: this.threshold,
+        fallbackParameters: this.fallbackParameters,
+        queryParameters: this.queryParameters,
+        escapeHTML: this.escapeHTML,
+        transformItems: this.transformItems,
+      };
+    },
+  },
+  render: renderCompat(function (h) {
+    if (!this.state) {
+      return null;
+    }
+
+    return h(createLookingSimilarComponent({ createElement: h, Fragment }), {
+      items: this.state.items,
+      status: this.status,
+      sendEvent: this.state.sendEvent,
+      itemComponent: getScopedSlot(this, 'item'),
+      headerComponent: getScopedSlot(this, 'header'),
+      emptyComponent: getScopedSlot(this, 'empty'),
+      layout: getScopedSlot(this, 'layout'),
+      classNames: this.classNames,
+    });
+  }),
+};

--- a/packages/vue-instantsearch/src/components/RelatedProducts.js
+++ b/packages/vue-instantsearch/src/components/RelatedProducts.js
@@ -1,0 +1,83 @@
+import { createRelatedProductsComponent } from 'instantsearch-ui-components';
+import { connectRelatedProducts } from 'instantsearch.js/es/connectors/index';
+
+import { createRecommendMixin } from '../mixins/recommend';
+import { createSuitMixin } from '../mixins/suit';
+import { createWidgetMixin } from '../mixins/widget';
+import { Fragment, getScopedSlot, renderCompat } from '../util/vue-compat';
+
+export default {
+  name: 'AisRelatedProducts',
+  mixins: [
+    createWidgetMixin(
+      { connector: connectRelatedProducts },
+      { $$widgetType: 'ais.relatedProducts' }
+    ),
+    createSuitMixin({ name: 'RelatedProducts' }),
+    createRecommendMixin(),
+  ],
+  props: {
+    objectIDs: {
+      type: Array,
+      required: true,
+    },
+    limit: {
+      type: Number,
+      default: undefined,
+    },
+    threshold: {
+      type: Number,
+      default: undefined,
+    },
+    fallbackParameters: {
+      type: Object,
+      default: undefined,
+    },
+    queryParameters: {
+      type: Object,
+      default: undefined,
+    },
+    escapeHTML: {
+      type: Boolean,
+      default: undefined,
+    },
+    transformItems: {
+      type: Function,
+      default: undefined,
+    },
+  },
+  computed: {
+    widgetParams() {
+      return {
+        objectIDs: this.objectIDs,
+        limit: this.limit,
+        threshold: this.threshold,
+        fallbackParameters: this.fallbackParameters,
+        queryParameters: this.queryParameters,
+        escapeHTML: this.escapeHTML,
+        transformItems: this.transformItems,
+      };
+    },
+  },
+  render: renderCompat(function (h) {
+    if (!this.state) {
+      return null;
+    }
+
+    const itemSlot = getScopedSlot(this, 'item');
+    const headerSlot = getScopedSlot(this, 'header');
+    const emptySlot = getScopedSlot(this, 'empty');
+    const layoutSlot = getScopedSlot(this, 'layout');
+
+    return h(createRelatedProductsComponent({ createElement: h, Fragment }), {
+      items: this.state.items,
+      status: this.status,
+      sendEvent: this.state.sendEvent,
+      itemComponent: itemSlot,
+      headerComponent: headerSlot,
+      emptyComponent: emptySlot,
+      layout: layoutSlot,
+      classNames: this.classNames,
+    });
+  }),
+};

--- a/packages/vue-instantsearch/src/components/TrendingFacets.js
+++ b/packages/vue-instantsearch/src/components/TrendingFacets.js
@@ -1,0 +1,76 @@
+import { createTrendingFacetsComponent } from 'instantsearch-ui-components';
+import { connectTrendingFacets } from 'instantsearch.js/es/connectors/index';
+
+import { createRecommendMixin } from '../mixins/recommend';
+import { createSuitMixin } from '../mixins/suit';
+import { createWidgetMixin } from '../mixins/widget';
+import { Fragment, getScopedSlot, renderCompat } from '../util/vue-compat';
+
+export default {
+  name: 'AisTrendingFacets',
+  mixins: [
+    createWidgetMixin(
+      { connector: connectTrendingFacets },
+      { $$widgetType: 'ais.trendingFacets' }
+    ),
+    createSuitMixin({ name: 'TrendingFacets' }),
+    createRecommendMixin(),
+  ],
+  props: {
+    facetName: {
+      type: String,
+      required: true,
+    },
+    limit: {
+      type: Number,
+      default: undefined,
+    },
+    threshold: {
+      type: Number,
+      default: undefined,
+    },
+    fallbackParameters: {
+      type: Object,
+      default: undefined,
+    },
+    queryParameters: {
+      type: Object,
+      default: undefined,
+    },
+    escapeHTML: {
+      type: Boolean,
+      default: undefined,
+    },
+    transformItems: {
+      type: Function,
+      default: undefined,
+    },
+  },
+  computed: {
+    widgetParams() {
+      return {
+        facetName: this.facetName,
+        limit: this.limit,
+        threshold: this.threshold,
+        fallbackParameters: this.fallbackParameters,
+        queryParameters: this.queryParameters,
+        escapeHTML: this.escapeHTML,
+        transformItems: this.transformItems,
+      };
+    },
+  },
+  render: renderCompat(function (h) {
+    if (!this.state) {
+      return null;
+    }
+
+    return h(createTrendingFacetsComponent({ createElement: h, Fragment }), {
+      items: this.state.items,
+      status: this.status,
+      itemComponent: getScopedSlot(this, 'item'),
+      headerComponent: getScopedSlot(this, 'header'),
+      emptyComponent: getScopedSlot(this, 'empty'),
+      classNames: this.classNames,
+    });
+  }),
+};

--- a/packages/vue-instantsearch/src/components/TrendingItems.js
+++ b/packages/vue-instantsearch/src/components/TrendingItems.js
@@ -1,0 +1,86 @@
+import { createTrendingItemsComponent } from 'instantsearch-ui-components';
+import { connectTrendingItems } from 'instantsearch.js/es/connectors/index';
+
+import { createRecommendMixin } from '../mixins/recommend';
+import { createSuitMixin } from '../mixins/suit';
+import { createWidgetMixin } from '../mixins/widget';
+import { Fragment, getScopedSlot, renderCompat } from '../util/vue-compat';
+
+export default {
+  name: 'AisTrendingItems',
+  mixins: [
+    createWidgetMixin(
+      { connector: connectTrendingItems },
+      { $$widgetType: 'ais.trendingItems' }
+    ),
+    createSuitMixin({ name: 'TrendingItems' }),
+    createRecommendMixin(),
+  ],
+  props: {
+    facetName: {
+      type: String,
+      default: undefined,
+    },
+    facetValue: {
+      type: String,
+      default: undefined,
+    },
+    limit: {
+      type: Number,
+      default: undefined,
+    },
+    threshold: {
+      type: Number,
+      default: undefined,
+    },
+    fallbackParameters: {
+      type: Object,
+      default: undefined,
+    },
+    queryParameters: {
+      type: Object,
+      default: undefined,
+    },
+    escapeHTML: {
+      type: Boolean,
+      default: undefined,
+    },
+    transformItems: {
+      type: Function,
+      default: undefined,
+    },
+  },
+  computed: {
+    widgetParams() {
+      const facetParameters =
+        this.facetName && this.facetValue
+          ? { facetName: this.facetName, facetValue: this.facetValue }
+          : {};
+      return {
+        ...facetParameters,
+        limit: this.limit,
+        threshold: this.threshold,
+        fallbackParameters: this.fallbackParameters,
+        queryParameters: this.queryParameters,
+        escapeHTML: this.escapeHTML,
+        transformItems: this.transformItems,
+      };
+    },
+  },
+  render: renderCompat(function (h) {
+    if (!this.state) {
+      return null;
+    }
+
+    return h(createTrendingItemsComponent({ createElement: h, Fragment }), {
+      items: this.state.items,
+      status: this.status,
+      sendEvent: this.state.sendEvent,
+      itemComponent: getScopedSlot(this, 'item'),
+      headerComponent: getScopedSlot(this, 'header'),
+      emptyComponent: getScopedSlot(this, 'empty'),
+      layout: getScopedSlot(this, 'layout'),
+      classNames: this.classNames,
+    });
+  }),
+};

--- a/packages/vue-instantsearch/src/mixins/recommend.js
+++ b/packages/vue-instantsearch/src/mixins/recommend.js
@@ -1,0 +1,29 @@
+import { isVue3 } from '../util/vue-compat';
+
+/**
+ * Mixin for recommendation widgets that wrap shared `createXxxComponent`
+ * factories from `instantsearch-ui-components`. Tracks
+ * `instantSearchInstance.status` reactively so the shared component can show
+ * its empty state once the search settles.
+ */
+export const createRecommendMixin = () => ({
+  data() {
+    return {
+      status: this.instantSearchInstance.status || 'idle',
+    };
+  },
+  created() {
+    if (typeof this.instantSearchInstance.addListener !== 'function') {
+      return;
+    }
+    this.updateStatus = () => {
+      this.status = this.instantSearchInstance.status;
+    };
+    this.instantSearchInstance.addListener('render', this.updateStatus);
+  },
+  [isVue3 ? 'beforeUnmount' : 'beforeDestroy']() {
+    if (this.updateStatus) {
+      this.instantSearchInstance.removeListener('render', this.updateStatus);
+    }
+  },
+});

--- a/packages/vue-instantsearch/src/widgets.js
+++ b/packages/vue-instantsearch/src/widgets.js
@@ -23,6 +23,11 @@ export { default as AisQueryRuleCustomData } from './components/QueryRuleCustomD
 export { default as AisRangeInput } from './components/RangeInput.vue';
 export { default as AisRatingMenu } from './components/RatingMenu.vue';
 export { default as AisRefinementList } from './components/RefinementList.vue';
+export { default as AisRelatedProducts } from './components/RelatedProducts';
+export { default as AisTrendingItems } from './components/TrendingItems';
+export { default as AisTrendingFacets } from './components/TrendingFacets';
+export { default as AisLookingSimilar } from './components/LookingSimilar';
+export { default as AisFrequentlyBoughtTogether } from './components/FrequentlyBoughtTogether';
 export { default as AisStateResults } from './components/StateResults.vue';
 export { default as AisSearchBox } from './components/SearchBox.vue';
 export { default as AisSnippet } from './components/Snippet.vue';


### PR DESCRIPTION
**Stacked on top of #7031.**

## Summary

Adds Vue wrappers for the recommendation/recommend-shared family — \`AisRelatedProducts\`, \`AisTrendingItems\`, \`AisTrendingFacets\`, \`AisLookingSimilar\`, \`AisFrequentlyBoughtTogether\`. Each one is a small render-function component that delegates to the matching \`createXxxComponent\` factory from \`instantsearch-ui-components\`, following the \`Hits.js\` precedent.

- New \`mixins/recommend.js\`: subscribes to the InstantSearch render lifecycle to track \`instantSearchInstance.status\` reactively. The shared UI factories need it to switch between "render items" and "render empty state." Defensive: if the surrounding harness provides a stub instance without \`addListener\` (the package's registry tests do), it falls back to \`'idle'\` and skips the subscription.
- Replaces the corresponding "X is not supported in Vue InstantSearch" placeholders in \`packages/vue-instantsearch/src/__tests__/common-widgets.test.js\` with real test setups that wait through a microtask plus two Vue ticks so the asynchronous Recommend response settles before assertions. Clears the per-suite \`skippedTests\` entries.

## Test plan

- [x] \`npx jest packages/vue-instantsearch --no-coverage\` — 50 suites green, 596 passing on Vue 2.
- [x] \`node scripts/prepare-vue3.js && npx jest packages/vue-instantsearch\` — 50 suites green, 590 passing on Vue 3.
- [x] All five recommendation widget common-test suites pass (\`renders with default props\`, \`renders transformed items\`, \`renders with no results\`, \`passes parameters correctly\`, \`escapes html entities\`, \`a click on a link with modifier doesn't search\`).

Next in the stack: Vue FilterSuggestions.