### PR TITLE
feat(vue): port FilterSuggestions

### DIFF
--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -34,6 +34,7 @@ import {
   AisTrendingFacets,
   AisLookingSimilar,
   AisFrequentlyBoughtTogether,
+  AisFilterSuggestions,
 } from '../instantsearch';
 import { renderCompat } from '../util/vue-compat';
 
@@ -678,8 +679,25 @@ const testSetups = {
   createAutocompleteWidgetTests() {
     throw new Error('Autocomplete is not supported in Vue InstantSearch');
   },
-  createFilterSuggestionsWidgetTests() {
-    throw new Error('FilterSuggestions is not supported in Vue InstantSearch');
+  async createFilterSuggestionsWidgetTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisFilterSuggestions, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
+
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
   },
 };
 
@@ -721,7 +739,20 @@ const testOptions = {
     skippedTests: { 'Autocomplete widget common tests': true },
   },
   createFilterSuggestionsWidgetTests: {
-    skippedTests: { 'FilterSuggestions widget common tests': true },
+    // Vue batches DOM updates asynchronously; the shared tests assert
+    // immediately after `wait(...)`, so flush Vue's queue inside `act`.
+    act: async (cb) => {
+      await cb();
+      await nextTick();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await nextTick();
+    },
+    skippedTests: {
+      // React/JS pass UI factories that Vue cannot apply directly.
+      templates: true,
+      // Vue's `created` hook swallows the connector's synchronous throw.
+      'throws without agentId': true,
+    },
   },
 };
 

--- a/packages/vue-instantsearch/src/__tests__/index.js
+++ b/packages/vue-instantsearch/src/__tests__/index.js
@@ -90,6 +90,8 @@ function getAllComponents() {
         props.facetName = 'brand';
       } else if (name === 'AisTrendingItems') {
         // no required props
+      } else if (name === 'AisFilterSuggestions') {
+        props.agentId = 'test-agent-id';
       } else {
         props.attribute = 'attr';
       }

--- a/packages/vue-instantsearch/src/components/FilterSuggestions.js
+++ b/packages/vue-instantsearch/src/components/FilterSuggestions.js
@@ -1,0 +1,76 @@
+import { createFilterSuggestionsComponent } from 'instantsearch-ui-components';
+import { connectFilterSuggestions } from 'instantsearch.js/es/connectors/index';
+
+import { createSuitMixin } from '../mixins/suit';
+import { createWidgetMixin } from '../mixins/widget';
+import { Fragment, getScopedSlot, renderCompat } from '../util/vue-compat';
+
+export default {
+  name: 'AisFilterSuggestions',
+  mixins: [
+    createWidgetMixin(
+      { connector: connectFilterSuggestions },
+      { $$widgetType: 'ais.filterSuggestions' }
+    ),
+    createSuitMixin({ name: 'FilterSuggestions' }),
+  ],
+  props: {
+    agentId: {
+      type: String,
+      default: undefined,
+    },
+    attributes: {
+      type: Array,
+      default: undefined,
+    },
+    maxSuggestions: {
+      type: Number,
+      default: undefined,
+    },
+    debounceMs: {
+      type: Number,
+      default: undefined,
+    },
+    hitsToSample: {
+      type: Number,
+      default: undefined,
+    },
+    transformItems: {
+      type: Function,
+      default: undefined,
+    },
+    transport: {
+      type: Object,
+      default: undefined,
+    },
+  },
+  computed: {
+    widgetParams() {
+      return {
+        agentId: this.agentId,
+        attributes: this.attributes,
+        maxSuggestions: this.maxSuggestions,
+        debounceMs: this.debounceMs,
+        hitsToSample: this.hitsToSample,
+        transformItems: this.transformItems,
+        transport: this.transport,
+      };
+    },
+  },
+  render: renderCompat(function (h) {
+    if (!this.state) {
+      return null;
+    }
+
+    return h(createFilterSuggestionsComponent({ createElement: h, Fragment }), {
+      suggestions: this.state.suggestions,
+      isLoading: this.state.isLoading,
+      refine: this.state.refine,
+      skeletonCount: this.maxSuggestions,
+      itemComponent: getScopedSlot(this, 'item'),
+      headerComponent: getScopedSlot(this, 'header'),
+      emptyComponent: getScopedSlot(this, 'empty'),
+      classNames: this.classNames,
+    });
+  }),
+};

--- a/packages/vue-instantsearch/src/widgets.js
+++ b/packages/vue-instantsearch/src/widgets.js
@@ -28,6 +28,7 @@ export { default as AisTrendingItems } from './components/TrendingItems';
 export { default as AisTrendingFacets } from './components/TrendingFacets';
 export { default as AisLookingSimilar } from './components/LookingSimilar';
 export { default as AisFrequentlyBoughtTogether } from './components/FrequentlyBoughtTogether';
+export { default as AisFilterSuggestions } from './components/FilterSuggestions';
 export { default as AisStateResults } from './components/StateResults.vue';
 export { default as AisSearchBox } from './components/SearchBox.vue';
 export { default as AisSnippet } from './components/Snippet.vue';


### PR DESCRIPTION
**Stacked on top of #7032.**

## Summary

Adds \`AisFilterSuggestions\`, a render-function component that delegates to \`createFilterSuggestionsComponent\` from \`instantsearch-ui-components\`. Unlike the five recommendation widgets in the previous PR, \`connectFilterSuggestions\` exposes its own \`isLoading\` flag in its render state, so this widget doesn't need \`createRecommendMixin\`.

The Vue test setup uses the flushing \`act\` helper recommended in [\`testing.md\`](https://github.com/algolia/instantsearch/blob/chore%2Fport-widget-skill-gaps-mode/.claude/skills/port-widget/references/testing.md) so the fetch-based connector has time to settle. Reuses the per-test \`skippedTests\` keys introduced in #7030 for the two cases Vue cannot match:

- \`templates\` (React/JS pass function-valued component props).
- \`throws without agentId\` (Vue's \`created\` hook swallows the connector's synchronous throw).

## Test plan

- [x] \`npx jest packages/vue-instantsearch/src/__tests__/common-widgets.test.js --testNamePattern=\"FilterSuggestions\" --no-coverage\` — 4 passing, 4 skipped (\`throws without agentId\` + 3 \`templates\`) on Vue 2.
- [x] Same suite on Vue 3 (via \`scripts/prepare-vue3.js\`) — same result.
- [x] \`npx jest packages/react-instantsearch/src/__tests__/common-widgets.test.tsx packages/instantsearch.js/src/__tests__/common-widgets.test.tsx --testNamePattern=\"FilterSuggestions\" --no-coverage\` — React and JS still green after the per-flavor params changes.