### PR TITLE
fix(chat): regenerate chat id on clearMessages

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -359,6 +359,62 @@ describe('connectChat', () => {
       expect(updatedRenderState.messages).toHaveLength(0);
     });
 
+    it('regenerates the chat id on transition end so the server starts a fresh conversation', () => {
+      const { getRenderState } = getInitializedWidget();
+
+      const renderState = getRenderState();
+      const initialId = renderState.id;
+
+      renderState.setMessages([
+        {
+          id: '1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      ]);
+      renderState.clearMessages();
+      renderState.onClearTransitionEnd();
+
+      const updatedRenderState = getRenderState();
+      expect(updatedRenderState.id).toEqual(expect.any(String));
+      expect(updatedRenderState.id).not.toBe(initialId);
+    });
+
+    it('regenerates the id even when the consumer owns the Chat instance', () => {
+      const chatInstance = new Chat<UIMessage>({
+        transport: {
+          sendMessages: jest.fn(),
+          reconnectToStream: jest.fn(),
+        },
+      });
+      const initialId = chatInstance.id;
+
+      const renderFn = jest.fn();
+      const widget = connectChat(renderFn)({
+        chat: chatInstance,
+        transport: { api: 'http://unused' },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init(createInitOptions({ helper }));
+
+      const renderState = widget.getWidgetRenderState(
+        createInitOptions({ helper })
+      );
+
+      renderState.setMessages([
+        {
+          id: '1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      ]);
+      renderState.clearMessages();
+      renderState.onClearTransitionEnd();
+
+      expect(chatInstance.id).toEqual(expect.any(String));
+      expect(chatInstance.id).not.toBe(initialId);
+    });
+
     it('updates messages', () => {
       const { getRenderState } = getInitializedWidget();
 

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -366,6 +366,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
     const onClearTransitionEnd = () => {
       setMessages([]);
       _chatInstance.clearError();
+      _chatInstance.regenerateId();
       feedbackState = {};
       setIsClearing(false);
     };

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -391,6 +391,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   };
 
   /**
+   * Regenerate the chat id. Use this to start a fresh conversation on the
+   * server while keeping the same Chat instance and its registered listeners.
+   */
+  regenerateId = (): void => {
+    (this as { id: string }).id = this.generateId();
+  };
+
+  /**
    * Add a tool result for a tool call.
    */
   addToolResult = <TTool extends keyof InferUIMessageTools<TUIMessage>>({

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -395,7 +395,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * server while keeping the same Chat instance and its registered listeners.
    */
   regenerateId = (): void => {
-    (this as { id: string }).id = this.generateId();
+    (this as Omit<this, 'id'> & { id: string }).id = this.generateId();
   };
 
   /**

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -2,6 +2,7 @@
 import { processStream } from './stream-parser';
 import { generateId as defaultGenerateId, SerialJobExecutor } from './utils';
 
+import type { MutableKeys } from '../../types';
 import type {
   ChatInit,
   ChatRequestOptions,
@@ -22,7 +23,6 @@ import type {
   ChatOnFinishCallback,
   ChatOnDataCallback,
 } from './types';
-import type { MutableKeys } from '../../types';
 
 type ActiveResponse<TChunk extends UIMessageChunk = UIMessageChunk> = {
   abortController: AbortController;

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -22,6 +22,7 @@ import type {
   ChatOnFinishCallback,
   ChatOnDataCallback,
 } from './types';
+import type { MutableKeys } from '../../types';
 
 type ActiveResponse<TChunk extends UIMessageChunk = UIMessageChunk> = {
   abortController: AbortController;
@@ -395,7 +396,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * server while keeping the same Chat instance and its registered listeners.
    */
   regenerateId = (): void => {
-    (this as Omit<this, 'id'> & { id: string }).id = this.generateId();
+    (this as MutableKeys<this, 'id'>).id = this.generateId();
   };
 
   /**

--- a/packages/instantsearch.js/src/types/utils.ts
+++ b/packages/instantsearch.js/src/types/utils.ts
@@ -24,3 +24,10 @@ export type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
  */
 export type PartialKeys<TObj, TKeys extends keyof TObj> = Omit<TObj, TKeys> &
   Partial<Pick<TObj, TKeys>>;
+
+/**
+ * Make certain keys of an object writable (strip the `readonly` modifier).
+ */
+export type MutableKeys<TObj, TKeys extends keyof TObj> = Omit<TObj, TKeys> & {
+  -readonly [P in TKeys]: TObj[P];
+};


### PR DESCRIPTION
## Summary

- `Chat#id` was generated once at instance creation and never refreshed, so the `chatId` field in every request body kept identifying the same server-side conversation thread even after `clearMessages()`.
- Adds `regenerateId()` to `AbstractChat` (a single audited mutation point — `id` stays `readonly` externally) and calls it from the connector's `onClearTransitionEnd`, alongside the existing `setMessages([])` and `clearError()`.
- Applies whether the `Chat` is connector-owned or supplied by the consumer via `{ chat }`, matching how the surrounding state wipes already mutate consumer-provided instances.

## Test plan

- [x] `yarn jest packages/instantsearch.js/src/connectors/chat packages/instantsearch.js/src/lib/chat packages/instantsearch.js/src/lib/ai-lite` — 47 tests pass
- [x] New tests cover id regeneration for both connector-owned and consumer-owned `Chat` instances
- [x] No new TypeScript errors introduced (the one pre-existing `streamInput` error on master is unrelated)
- [x] Manually verify in a chat-enabled app: clear conversation → send new message → request body carries a fresh `chatId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)