### PR TITLE
chore(examples): support iframe auto-resize in showcase

### DIFF
--- a/examples/js/showcase/src/components/widgets/WidgetChat.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetChat.tsx
@@ -4,9 +4,11 @@ import {
   chatSidePanelLayout,
 } from "instantsearch.js/es/templates";
 import { chat } from "instantsearch.js/es/widgets";
+import { Sparkles } from "lucide-preact";
 import { useEffect, useRef } from "preact/hooks";
 
 import { useSearch } from "../../context/search";
+import { postToParent } from "../../utils/parentMessenger";
 
 import { renderCarouselHit } from "./ProductCard";
 
@@ -15,6 +17,12 @@ import type { ChatRenderState } from "instantsearch.js/es/connectors/chat/connec
 export type ChatLayout = "inline" | "overlay" | "sidePanel";
 
 const CHAT_AGENT_ID = "eedef238-5468-470d-bc37-f99fa741bd25";
+
+// The chat's overlay/sidePanel layouts use `position: fixed`, which anchors to
+// the iframe rather than the user's viewport when the showcase is embedded.
+// We hide the floating trigger via CSS and render this inline one instead.
+const IS_EMBEDDED =
+  typeof window !== "undefined" && window.parent !== window;
 
 type Props = {
   layout: ChatLayout;
@@ -26,6 +34,16 @@ export function WidgetChat({ layout, indexName }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const layoutRef = useRef(layout);
   layoutRef.current = layout;
+
+  const openChat = () => {
+    const chatState = search.renderState[indexName]?.chat as
+      | Partial<ChatRenderState>
+      | undefined;
+    chatState?.setOpen?.(true);
+    // The opened panel anchors to the iframe edge; ask the docs to scroll us
+    // into view so the panel doesn't appear far below the user's viewport.
+    postToParent({ type: "showcase-scroll-into-view" });
+  };
 
   useEffect(() => {
     const layouts = {
@@ -58,5 +76,19 @@ export function WidgetChat({ layout, indexName }: Props) {
     chatState?.setOpen?.(Boolean(chatState?.open));
   }, [layout, indexName, search]);
 
-  return <div ref={containerRef} />;
+  return (
+    <>
+      {IS_EMBEDDED && layout !== "inline" && (
+        <button
+          type="button"
+          onClick={openChat}
+          class="chat-inline-trigger inline-flex cursor-pointer items-center gap-2 self-start px-3 py-1.5 text-sm font-medium"
+        >
+          <Sparkles size={14} />
+          Open chat
+        </button>
+      )}
+      <div ref={containerRef} />
+    </>
+  );
 }

--- a/examples/js/showcase/src/main.tsx
+++ b/examples/js/showcase/src/main.tsx
@@ -1,8 +1,36 @@
 import { render } from "preact";
 
 import { App } from "./App";
+import { postToParent } from "./utils/parentMessenger";
 
 import "instantsearch.css/themes/nova.css";
 import "./style.css";
 
 render(<App />, document.getElementById("app")!);
+
+// Post content height to the docs parent so the iframe can resize to fit
+// (paired with iframe-resize.js in algolia/docs-new).
+if (window.parent && window.parent !== window) {
+  // No inner scrollbar needed; avoids a stray gutter on always-show-scrollbar OSes.
+  document.documentElement.style.overflow = "hidden";
+
+  // Lets stylesheets and components branch on the embedded state.
+  document.body.classList.add("is-embedded");
+
+  const postHeight = () => {
+    // Measure body, not documentElement: documentElement.scrollHeight floors
+    // to the viewport size and can't shrink. The +2 absorbs sub-pixel rounding.
+    const height =
+      Math.ceil(
+        Math.max(
+          document.body.scrollHeight,
+          document.body.getBoundingClientRect().bottom,
+        ),
+      ) + 2;
+    if (!Number.isFinite(height) || height < 100 || height > 10000) return;
+    postToParent({ type: "showcase-resize", height });
+  };
+
+  window.addEventListener("load", postHeight);
+  new ResizeObserver(postHeight).observe(document.body);
+}

--- a/examples/js/showcase/src/main.tsx
+++ b/examples/js/showcase/src/main.tsx
@@ -19,14 +19,13 @@ if (window.parent && window.parent !== window) {
 
   const postHeight = () => {
     // Measure body, not documentElement: documentElement.scrollHeight floors
-    // to the viewport size and can't shrink. The +2 absorbs sub-pixel rounding.
-    const height =
-      Math.ceil(
-        Math.max(
-          document.body.scrollHeight,
-          document.body.getBoundingClientRect().bottom,
-        ),
-      ) + 2;
+    // to the viewport size and can't shrink.
+    const height = Math.ceil(
+      Math.max(
+        document.body.scrollHeight,
+        document.body.getBoundingClientRect().bottom,
+      ),
+    );
     if (!Number.isFinite(height) || height < 100 || height > 10000) return;
     postToParent({ type: "showcase-resize", height });
   };

--- a/examples/js/showcase/src/style.css
+++ b/examples/js/showcase/src/style.css
@@ -87,3 +87,40 @@ body {
 [data-theme="dark"] .ais-CurrentRefinements--noRefinement::after {
   color: theme(--color-neutral-500);
 }
+
+/* When embedded, the floating chat trigger anchors to the iframe edge instead
+   of the user's viewport. Hide it; the chat tile renders an inline trigger. */
+.is-embedded .ais-Chat-toggleButtonWrapper {
+  display: none;
+}
+
+/* Inline "Open chat" trigger shown in the chat tile when embedded. Mirrors
+   the AIS primary button styling so it stays consistent with the rest of
+   the chat UI (and adapts to dark mode via the AIS theme variables). */
+.chat-inline-trigger {
+  background-color: rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
+  color: rgba(var(--ais-button-text-color-rgb), var(--ais-button-text-color-alpha));
+  border-radius: var(--ais-border-radius-sm);
+  box-shadow: var(--ais-shadow-xs);
+  transition: background-color var(--ais-transition-duration) var(--ais-transition-timing-function);
+}
+
+@media (hover: hover) {
+  .chat-inline-trigger:hover {
+    background-color: color-mix(
+      in srgb,
+      rgb(var(--ais-primary-color-rgb)),
+      rgb(var(--ais-background-color-rgb)) 20%
+    );
+  }
+}
+
+/* The chat's percentage-based sizing balloons when the iframe viewport equals
+   the full content height. Cap to an absolute size that fits in a typical
+   browser viewport, and anchor near the iframe's bottom so scroll-into-view
+   lands on the panel. */
+.is-embedded .ais-ChatOverlayLayout,
+.is-embedded .ais-ChatSidePanelLayout {
+  top: auto;
+  height: 600px;
+}

--- a/examples/js/showcase/src/utils/parentMessenger.ts
+++ b/examples/js/showcase/src/utils/parentMessenger.ts
@@ -1,0 +1,14 @@
+// Posts a message to the embedding docs page. No-op when this showcase isn't
+// loaded inside an iframe. The browser drops posts to non-matching origins,
+// so listing both prod and the local Mintlify dev origin is safe.
+const TARGET_ORIGINS = [
+  "https://www.algolia.com",
+  "http://localhost:3000",
+];
+
+export function postToParent(data: unknown): void {
+  if (typeof window === "undefined" || window.parent === window) return;
+  for (const origin of TARGET_ORIGINS) {
+    window.parent.postMessage(data, origin);
+  }
+}

--- a/examples/js/showcase/src/utils/parentMessenger.ts
+++ b/examples/js/showcase/src/utils/parentMessenger.ts
@@ -7,7 +7,6 @@ const TARGET_ORIGINS = [
 ];
 
 export function postToParent(data: unknown): void {
-  if (typeof window === "undefined" || window.parent === window) return;
   for (const origin of TARGET_ORIGINS) {
     window.parent.postMessage(data, origin);
   }


### PR DESCRIPTION
## Summary

When the showcase is embedded in the Algolia docs (currently hardcoded to `https://www.algolia.com`):

- `main.tsx` posts the body's content height to the parent via `postMessage`, observed with a `ResizeObserver` on `document.body`. The docs side applies it to the iframe so readers don't have to scroll inside the iframe.
- `documentElement.style.overflow = "hidden"` suppresses the inner scrollbar (which would otherwise show a gutter on always-show-scrollbar OSes).
- `document.body.classList.add("is-embedded")` lets stylesheets and components branch on the embedded state.
- The chat's overlay/sidePanel layouts use `position: fixed`, which anchors to the iframe (not the user's viewport) when embedded. Three fixes for that:
  - CSS caps `.ais-ChatOverlayLayout` / `.ais-ChatSidePanelLayout` to `height: 600px` when embedded so they don't span the full iframe.
  - The floating `ais-Chat-toggleButtonWrapper` is hidden when embedded.
  - `WidgetChat` renders an inline "Open chat" trigger inside the chat tile (using the AIS primary button theme variables for visual consistency). Clicking it opens the chat and posts `{ type: "showcase-scroll-into-view" }` so the docs page scrolls to bring the chat panel into view.

Standalone behavior (showcase opened directly at its public URL) is unchanged — every branch is gated on `window.parent !== window`.

Requires the matching parent-side change in algolia/docs-new#824. Each PR is a no-op without the other, so either can ship first.

## Test plan

Tested locally with the showcase embedded in a local docs build:

- [x] Standalone showcase URL: behavior is identical to before (overlay/sidePanel anchor to the browser viewport, no inline trigger).
- [x] Embedded showcase: iframe auto-fits its content; switching to a shorter tab (GeoSearch) shrinks the iframe back down.
- [x] Embedded showcase, Agentic tab: inline blue "Open chat" trigger renders inside the chat tile for `overlay` and `sidePanel` layouts; the real floating trigger is hidden.
- [x] Clicking "Open chat" smooth-scrolls the parent docs page so the chat panel is visible; for `sidePanel`, the scroll tracks the iframe while its marginRight animation grows the body width.
- [x] `inline` layout: no inline trigger button shown (the chat renders normally in the tile).