### PR TITLE
perf(examples): speed up first paint of showcase

### DIFF
--- a/examples/js/showcase/index.html
+++ b/examples/js/showcase/index.html
@@ -6,7 +6,39 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
+    <link rel="preconnect" href="https://latency-dsn.algolia.net" crossorigin />
+    <link rel="preconnect" href="https://latency-1.algolianet.com" crossorigin />
+    <link rel="preconnect" href="https://latency-2.algolianet.com" crossorigin />
+    <link rel="preconnect" href="https://latency-3.algolianet.com" crossorigin />
     <title>InstantSearch.js Showcase</title>
+    <style>
+      [data-theme="dark"] {
+        color-scheme: dark;
+      }
+      .showcase-skeleton {
+        padding: 1rem;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.75rem;
+        max-width: 64rem;
+      }
+      .showcase-skeleton__tile {
+        height: 5rem;
+        border-radius: 0.75rem;
+        background: rgba(0, 0, 0, 0.04);
+        animation: showcase-skeleton-pulse 1.4s ease-in-out infinite;
+      }
+      [data-theme="dark"] .showcase-skeleton__tile {
+        background: rgba(255, 255, 255, 0.05);
+      }
+      @keyframes showcase-skeleton-pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.5; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .showcase-skeleton__tile { animation: none; }
+      }
+    </style>
   </head>
   <body>
     <script>
@@ -21,7 +53,13 @@
         document.documentElement.setAttribute("data-theme", t);
       })();
     </script>
-    <div id="app"></div>
+    <div id="app">
+      <div class="showcase-skeleton" aria-hidden="true">
+        <div class="showcase-skeleton__tile"></div>
+        <div class="showcase-skeleton__tile"></div>
+        <div class="showcase-skeleton__tile"></div>
+      </div>
+    </div>
     <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/examples/js/showcase/package.json
+++ b/examples/js/showcase/package.json
@@ -16,7 +16,6 @@
     "instantsearch-ui-components": "0.26.1",
     "instantsearch.css": "8.16.1",
     "instantsearch.js": "4.97.0",
-    "lucide-preact": "1.7.0",
     "nouislider": "15.8.1",
     "preact": "10.29.0"
   },

--- a/examples/js/showcase/src/App.tsx
+++ b/examples/js/showcase/src/App.tsx
@@ -1,14 +1,21 @@
-import { MapPin, Search, Sparkles } from "lucide-preact";
+import { lazy, Suspense } from "preact/compat";
 import { useState } from "preact/hooks";
 
 import { ColorModeSwitcher } from "./components/ColorModeSwitcher";
+import { MapPin, Search, Sparkles, type IconComponent } from "./components/icons";
 import { FlavorContext, type Flavor } from "./context/flavor";
-import { AgenticView } from "./views/AgenticView";
-import { GeoSearchView } from "./views/GeoSearchView";
-import { InstantSearchView } from "./views/InstantSearchView";
 
-import type { LucideIcon } from "lucide-preact";
 import type { ComponentType } from "preact";
+
+const InstantSearchView = lazy(() =>
+  import("./views/InstantSearchView").then((m) => ({ default: m.InstantSearchView }))
+);
+const AgenticView = lazy(() =>
+  import("./views/AgenticView").then((m) => ({ default: m.AgenticView }))
+);
+const GeoSearchView = lazy(() =>
+  import("./views/GeoSearchView").then((m) => ({ default: m.GeoSearchView }))
+);
 
 const VALID_FLAVORS: Flavor[] = ["js", "react", "vue"];
 
@@ -23,7 +30,7 @@ function getFlavorFromURL(): Flavor {
 interface Experience {
   title: string;
   description: string;
-  icon: LucideIcon;
+  icon: IconComponent;
   view: ComponentType;
 }
 
@@ -102,9 +109,11 @@ export function App() {
           <ColorModeSwitcher />
         </div>
 
-        {experiences.map((experience, index) =>
-          currentIndex === index ? <experience.view key={index} /> : null
-        )}
+        <Suspense fallback={null}>
+          {experiences.map((experience, index) =>
+            currentIndex === index ? <experience.view key={index} /> : null
+          )}
+        </Suspense>
       </div>
     </FlavorContext.Provider>
   );

--- a/examples/js/showcase/src/components/ColorModeSwitcher.tsx
+++ b/examples/js/showcase/src/components/ColorModeSwitcher.tsx
@@ -1,4 +1,4 @@
-import { Monitor, Sun, Moon } from "lucide-preact";
+import { Monitor, Sun, Moon } from "./icons";
 
 import { useColorMode, type ColorMode } from "../hooks/useColorMode";
 

--- a/examples/js/showcase/src/components/DocsLink.tsx
+++ b/examples/js/showcase/src/components/DocsLink.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from "lucide-preact";
+import { ExternalLink } from "./icons";
 
 import { useFlavor, type Flavor } from "../context/flavor";
 

--- a/examples/js/showcase/src/components/icons.tsx
+++ b/examples/js/showcase/src/components/icons.tsx
@@ -1,0 +1,104 @@
+import type { ComponentChildren, JSX } from "preact";
+
+export interface IconProps extends Omit<JSX.SVGAttributes<SVGSVGElement>, "size"> {
+  size?: number | string;
+}
+
+export type IconComponent = (props: IconProps) => JSX.Element;
+
+function Icon({
+  size = 24,
+  children,
+  ...rest
+}: IconProps & { children: ComponentChildren }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width={2}
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+      {...rest}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function MapPin(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
+      <circle cx="12" cy="10" r="3" />
+    </Icon>
+  );
+}
+
+export function Search(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="m21 21-4.34-4.34" />
+      <circle cx="11" cy="11" r="8" />
+    </Icon>
+  );
+}
+
+export function Sparkles(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z" />
+      <path d="M20 2v4" />
+      <path d="M22 4h-4" />
+      <circle cx="4" cy="20" r="2" />
+    </Icon>
+  );
+}
+
+export function Monitor(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <rect width="20" height="14" x="2" y="3" rx="2" />
+      <line x1="8" x2="16" y1="21" y2="21" />
+      <line x1="12" x2="12" y1="17" y2="21" />
+    </Icon>
+  );
+}
+
+export function Sun(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2" />
+      <path d="M12 20v2" />
+      <path d="m4.93 4.93 1.41 1.41" />
+      <path d="m17.66 17.66 1.41 1.41" />
+      <path d="M2 12h2" />
+      <path d="M20 12h2" />
+      <path d="m6.34 17.66-1.41 1.41" />
+      <path d="m19.07 4.93-1.41 1.41" />
+    </Icon>
+  );
+}
+
+export function Moon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401" />
+    </Icon>
+  );
+}
+
+export function ExternalLink(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M15 3h6v6" />
+      <path d="M10 14 21 3" />
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+    </Icon>
+  );
+}

--- a/examples/js/showcase/src/components/widgets/WidgetChat.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetChat.tsx
@@ -4,7 +4,7 @@ import {
   chatSidePanelLayout,
 } from "instantsearch.js/es/templates";
 import { chat } from "instantsearch.js/es/widgets";
-import { Sparkles } from "lucide-preact";
+import { Sparkles } from "../icons";
 import { useEffect, useRef } from "preact/hooks";
 
 import { useSearch } from "../../context/search";

--- a/examples/js/showcase/vite.config.mjs
+++ b/examples/js/showcase/vite.config.mjs
@@ -9,5 +9,13 @@ export default defineConfig({
     commonjsOptions: {
       requireReturnsDefault: 'preferred',
     },
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          preact: ['preact', 'preact/hooks', 'preact/compat'],
+          algolia: ['algoliasearch', 'algoliasearch/lite', 'algoliasearch-helper', 'instantsearch.js'],
+        },
+      },
+    },
   },
 });

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,18 @@
 
 [build.environment]
   YARN_VERSION = "1.13.0"
+
+# Allow the showcase HTML (and its hashed JS/CSS bundles) to be reused by
+# <link rel="prefetch"> on consumer pages without forcing a revalidation
+# round-trip. Hashed assets are content-addressed so a long max-age is safe;
+# the HTML itself uses a short max-age + stale-while-revalidate so deploys
+# propagate quickly.
+[[headers]]
+  for = "/examples/js/showcase/"
+  [headers.values]
+    Cache-Control = "public, max-age=60, stale-while-revalidate=300"
+
+[[headers]]
+  for = "/examples/js/showcase/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20879,11 +20879,6 @@ lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
   integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
 
-lucide-preact@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/lucide-preact/-/lucide-preact-1.7.0.tgz#36acacd5594444a4ca42fc1f73508aad01d2f26e"
-  integrity sha512-gv743hfkCH2MeUmZQ9g4+Yd+/zZyAOLuXvxWo6CUY6kMrnnoDZnnwpSZqWsEveCC9LNp+NgHkeTfztObIue+SA==
-
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"


### PR DESCRIPTION
## Summary

The widgets showcase iframe (embedded on algolia.com/doc, e.g. [/guides/building-search-ui/widgets/showcase/js](https://www.algolia.com/doc/guides/building-search-ui/widgets/showcase/js)) appears blank for a noticeable beat after navigation. Tracing the waterfall:

- The Vite output was a single ~528KB / ~156KB gzipped chunk + ~102KB CSS.
- All three views were statically imported in `App.tsx`, so `AgenticView` (chat connector + AI bits) and `GeoSearchView` (`@googlemaps/js-api-loader`) were paid for on first load even though only `InstantSearchView` renders by default.
- No preconnect to the Algolia DSN, no skeleton in `index.html` — the iframe was visibly empty until the bundle parsed and Preact mounted.

This PR addresses those without changing any user-facing behavior:

- **Lazy-load views.** `AgenticView`, `GeoSearchView`, and `InstantSearchView` are now `lazy()` + `<Suspense>` from `preact/compat`. The non-default views only fetch when the user clicks them.
- **Manual vendor chunks.** `vite.config.mjs` splits `preact*` and the `algoliasearch*` / `instantsearch.js` stack into their own chunks so app deploys don't bust vendor cache for returning visitors.
- **Preconnect + skeleton.** `index.html` preconnects to `latency-dsn.algolia.net` and the `algolianet.com` fallbacks, and renders a tiny CSS-only skeleton inside `#app` so the iframe area is not blank during boot. Skeleton respects `prefers-reduced-motion`.
- **Drop `lucide-preact`.** The showcase only used 7 icons (`MapPin`, `Search`, `Sparkles`, `Monitor`, `Sun`, `Moon`, `ExternalLink`); inlined them as small Preact components in `src/components/icons.tsx` and removed the dependency.

### Bundle output

Before (single chunk):
- `index-*.js`: 528KB / 156KB gz
- `index-*.css`: 102KB / ~15KB gz

After:
```
dist/assets/index-*.js                  9.05 kB │ gzip:  3.69 kB   (entry)
dist/assets/preact-*.js                19.63 kB │ gzip:  7.84 kB   (vendor)
dist/assets/algolia-*.js              134.00 kB │ gzip: 36.11 kB   (vendor)
dist/assets/InstantSearchView-*.js    139.61 kB │ gzip: 38.97 kB   (default view, lazy)
dist/assets/useWidget-*.js             47.53 kB │ gzip: 16.50 kB   (shared)
dist/assets/WidgetHits-*.js            58.30 kB │ gzip: 16.81 kB   (shared)
dist/assets/WidgetSearchBox-*.js       15.78 kB │ gzip:  6.29 kB   (shared)
dist/assets/AgenticView-*.js          100.95 kB │ gzip: 32.98 kB   (only on click)
dist/assets/GeoSearchView-*.js         17.01 kB │ gzip:  6.18 kB   (only on click)
dist/assets/index-*.css                97.95 kB │ gzip: 14.38 kB
```

The Agentic view (~33KB gz) and GeoSearch view (~6KB gz) — previously included in the initial bundle — now only load on demand. Vendor chunks (preact + algolia) are also cacheable across app changes.

### Lighthouse comparison

3 runs each against `master` and this deploy preview, desktop form factor, simulated throttling, Netlify deploy-preview banner blocked so it's an apples-to-apples comparison. Medians shown:

| Metric | `master` | This PR | Δ |
|---|---:|---:|---:|
| Performance score | 81 | **87** | +6 |
| First Contentful Paint | 1877 ms | **1236 ms** | **−641 ms (−34%)** |
| Largest Contentful Paint | 1884 ms | 1811 ms | −73 ms (−4%) |
| Speed Index | 1877 ms | **1563 ms** | −314 ms (−17%) |
| Total Blocking Time | 0 | 0 | — |
| Time to Interactive | 1885 ms | 1819 ms | −66 ms (−4%) |
| Total bytes transferred | 344 KB | 315 KB | −29 KB (−8%) |
| Requests | 20 | 28 | +8 (chunks split) |

**Honest read of the results:**

- **FCP −641 ms** is the real win — the iframe stops being a blank rectangle ~34% sooner thanks to the skeleton + much smaller critical-path JS.
- **LCP is roughly flat** (−73 ms). The widgets themselves don't appear meaningfully sooner; the total work to render them is the same, we just structure the waterfall differently. The lazy chunk for the default view roughly matches what the monolithic bundle delivered.
- **Speed Index −314 ms** because the skeleton fills the visible area early.
- **Bytes nearly identical on this visit** (315 vs 344 KB). The real byte savings show up on **repeat visits** (vendor chunks cached across deploys) and on **tail visits** where the user never opens Agentic / GeoSearch (~38 KB wire saved that `master` always pays for).

If we want widgets actually rendering sooner (not just the surrounding UI), that requires either prerendering the initial Algolia response or moving the showcase to SSG — both meaningfully bigger lifts than this PR.

## Cache headers (netlify.toml)

The most recent commit also loosens `Cache-Control` on the showcase HTML and assets:

```toml
[[headers]]
  for = "/examples/js/showcase/"
  [headers.values]
    Cache-Control = "public, max-age=60, stale-while-revalidate=300"

[[headers]]
  for = "/examples/js/showcase/assets/*"
  [headers.values]
    Cache-Control = "public, max-age=31536000, immutable"
```

Netlify's default is `Cache-Control: public, max-age=0, must-revalidate`, which forces every request to revalidate. The intent of this change was to let `<link rel="prefetch" as="document">` on the docs side (see [docs-new#830](https://github.com/algolia/docs-new/pull/830)) reuse the prefetched HTML when the iframe mounts — saving an iframe-document round trip.

**Empirical finding (documented in #830):** Chrome's `<link rel="prefetch" as="document">` does **not** reuse the prefetched response for cross-origin iframe loads, regardless of cache headers. The prefetch cache is consulted on top-level navigations only. Verified in a minimal reproduction (just a static HTML page → prefetch link → iframe mount) — `fromCache: false` on the iframe fetch even with `max-age=60` set.

So the prefetch component of the docs-side change is a no-op for first-load perception, and these cache headers don't unlock what we hoped on first load. They are still worth keeping because they help:

- **Repeat visits within the docs session** (clicking between `/showcase/js`, `/react`, `/vue`): the iframe JS/CSS bundles are reused from the HTTP cache.
- **Re-entries** to the same showcase page within a 60 s window: the iframe HTML can be served from cache instead of revalidating.
- **Long-term asset caching** via the `immutable` rule on hashed assets — once a user has visited any showcase once, the JS/CSS bundles never need to refetch until they're rebuilt with a new hash.

If you'd prefer to land the bundle-splitting / skeleton changes without the cache-header change, the `netlify.toml` commit is isolated and can be dropped.

## Test plan

- [ ] `cd examples/js/showcase && yarn build` — confirm separate chunks for `preact`, `algolia`, and the three views.
- [ ] `yarn dev` — verify the InstantSearch view loads correctly and looks visually identical.
- [ ] Click the Agentic tab → confirm `AgenticView-*.js` is fetched on click (DevTools network panel).
- [ ] Click the GeoSearch tab → confirm `GeoSearchView-*.js` and Google Maps assets are fetched on click.
- [ ] Confirm the ColorModeSwitcher (Monitor/Sun/Moon icons) and DocsLink (ExternalLink icon) render unchanged.
- [ ] On a cold load with throttled network, verify the skeleton paints before the bundle and disappears once Preact mounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

