### PR TITLE
feat(filter-suggestions): deprecate filter suggestions

### DIFF
--- a/packages/instantsearch.js/src/connectors/filter-suggestions/connectFilterSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/filter-suggestions/connectFilterSuggestions.ts
@@ -5,6 +5,7 @@ import {
   getAppIdAndApiKey,
   getRefinements,
   noop,
+  warning,
 } from '../../lib/utils';
 
 import type {
@@ -125,11 +126,19 @@ export type FilterSuggestionsConnector = Connector<
   FilterSuggestionsConnectorParams
 >;
 
+/**
+ * @deprecated Filter suggestions are deprecated and will be removed in a future major version.
+ */
 const connectFilterSuggestions: FilterSuggestionsConnector =
   function connectFilterSuggestions(renderFn, unmountFn = noop) {
     checkRendering(renderFn, withUsage());
 
     return (widgetParams) => {
+      warning(
+        false,
+        'Filter suggestions are deprecated and will be removed in a future major version.'
+      );
+
       const {
         agentId,
         attributes,

--- a/packages/instantsearch.js/src/widgets/filter-suggestions/filter-suggestions.tsx
+++ b/packages/instantsearch.js/src/widgets/filter-suggestions/filter-suggestions.tsx
@@ -193,6 +193,9 @@ export type FilterSuggestionsWidget = WidgetFactory<
   FilterSuggestionsWidgetParams
 >;
 
+/**
+ * @deprecated Filter suggestions are deprecated and will be removed in a future major version.
+ */
 export default (function filterSuggestions(
   widgetParams: FilterSuggestionsWidgetParams & FilterSuggestionsConnectorParams
 ) {

--- a/packages/react-instantsearch-core/src/connectors/useFilterSuggestions.ts
+++ b/packages/react-instantsearch-core/src/connectors/useFilterSuggestions.ts
@@ -10,6 +10,9 @@ import type {
 
 export type UseFilterSuggestionsProps = FilterSuggestionsConnectorParams;
 
+/**
+ * @deprecated Filter suggestions are deprecated and will be removed in a future major version.
+ */
 export function useFilterSuggestions(
   props: UseFilterSuggestionsProps,
   additionalWidgetProperties?: AdditionalWidgetProperties

--- a/packages/react-instantsearch/src/widgets/FilterSuggestions.tsx
+++ b/packages/react-instantsearch/src/widgets/FilterSuggestions.tsx
@@ -43,6 +43,9 @@ export type FilterSuggestionsProps = Omit<
     emptyComponent?: FilterSuggestionsUiComponentProps['emptyComponent'];
   };
 
+/**
+ * @deprecated Filter suggestions are deprecated and will be removed in a future major version.
+ */
 export function FilterSuggestions({
   agentId,
   attributes,


### PR DESCRIPTION
## Summary

We're deprecating the filter-suggestions feature. This PR signals the deprecation in two ways without changing runtime behavior for existing users:

- Adds `@deprecated` JSDoc to the public surface (`connectFilterSuggestions`, the `filterSuggestions` widget, the `<FilterSuggestions>` React component, and the `useFilterSuggestions` hook) so IDEs render the strike-through / yellow squiggle.
- Logs a runtime deprecation warning via the existing dev-only `warning()` helper when the connector is instantiated. Placing it on the connector means the warning covers every entry point (JS widget, React component, hook) without duplication.

Out of scope: blocking new filter-suggestion agents from being created — that lives outside this repo.

## Test plan

- [x] `yarn test` passes (existing tests; `console.warn` is already jest-mocked in `tests/utils/setupTests.ts`, so the new `warning()` call doesn't pollute output)
- [x] In an example app that uses `filterSuggestions` / `<FilterSuggestions>`, confirm `[InstantSearch.js]: Filter suggestions are deprecated...` appears in the browser console once
- [x] In an IDE, hover the deprecated symbols and confirm the deprecation notice is shown