### PR TITLE
feat(chat): send hidden context via message metadata.turnContext

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "126.5 kB"
+      "maxSize": "127 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "262.75 kB"
+      "maxSize": "264.25 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "99.25 kB"
+      "maxSize": "99.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "127 kB"
+      "maxSize": "126.5 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "264.25 kB"
+      "maxSize": "262.75 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "99.5 kB"
+      "maxSize": "99.25 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -211,12 +211,6 @@ export function createChatMessageComponent({ createElement }: Renderer) {
         return null;
       }
       if (part.type === 'text') {
-        if (
-          part.text.startsWith('<context>') &&
-          part.text.endsWith('</context>')
-        ) {
-          return null;
-        }
         const markdown = compiler(part.text, {
           createElement: createElement as any,
           disableParsingRawHTML: true,

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -211,6 +211,16 @@ export function createChatMessageComponent({ createElement }: Renderer) {
         return null;
       }
       if (part.type === 'text') {
+        // Back-compat shim for sessions started before the move from a
+        // `<context>{...}</context>` text part to `metadata.turnContext`.
+        // Safe to remove once existing sessionStorage transcripts have
+        // rolled over (~2 weeks after release).
+        if (
+          part.text.startsWith('<context>') &&
+          part.text.endsWith('</context>')
+        ) {
+          return null;
+        }
         const markdown = compiler(part.text, {
           createElement: createElement as any,
           disableParsingRawHTML: true,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -206,7 +206,9 @@ describe('ChatMessage', () => {
     `);
   });
 
-  test('does not render context text parts', () => {
+  test('does not render turnContext from message metadata', () => {
+    // turnContext is an out-of-band server-grounding signal; it must never
+    // surface in the rendered transcript even if a message somehow carries it.
     const { container } = render(
       <ChatMessage
         indexUiState={{}}
@@ -214,13 +216,13 @@ describe('ChatMessage', () => {
         message={{
           role: 'user',
           id: '1',
-          parts: [
-            {
-              type: 'text',
-              text: '<context>{"currentPage":"https://example.com/products","userLocale":"en-US"}</context>',
+          parts: [{ type: 'text', text: 'Hello' }],
+          metadata: {
+            turnContext: {
+              url: 'https://example.com/products',
+              locale: 'en-US',
             },
-            { type: 'text', text: 'Hello' },
-          ],
+          },
         }}
         status="ready"
         tools={{}}
@@ -230,7 +232,7 @@ describe('ChatMessage', () => {
 
     expect(container.textContent).toBe('Hello');
     expect(container.textContent).not.toContain('example.com');
-    expect(container.textContent).not.toContain('context');
+    expect(container.textContent).not.toContain('turnContext');
   });
 
   test('renders with tools', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -206,6 +206,36 @@ describe('ChatMessage', () => {
     `);
   });
 
+  test('does not render legacy `<context>` text parts (back-compat)', () => {
+    // Pre-migration sessions persisted a `<context>{...}</context>` text part.
+    // The shim in `ChatMessage` keeps those out of the rendered transcript
+    // until existing sessionStorage caches roll over.
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'user',
+          id: '1',
+          parts: [
+            {
+              type: 'text',
+              text: '<context>{"currentPage":"https://example.com/products","userLocale":"en-US"}</context>',
+            },
+            { type: 'text', text: 'Hello' },
+          ],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(container.textContent).toBe('Hello');
+    expect(container.textContent).not.toContain('example.com');
+    expect(container.textContent).not.toContain('context');
+  });
+
   test('does not render turnContext from message metadata', () => {
     // turnContext is an out-of-band server-grounding signal; it must never
     // surface in the rendered transcript even if a message somehow carries it.

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1150,7 +1150,7 @@ data: [DONE]`,
       return { widget, renderFn };
     }
 
-    it('prepends context text part when context is a static object', async () => {
+    it('attaches turnContext to metadata when context is a static object', async () => {
       const chatInstance = createTestChat();
       const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
@@ -1167,13 +1167,12 @@ data: [DONE]`,
 
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
       const call = sendMessageSpy.mock.calls[0][0] as any;
-      expect(call.parts).toEqual([
-        {
-          type: 'text',
-          text: '<context>{"currentPage":"/products","locale":"en-US"}</context>',
-        },
-        { type: 'text', text: 'Hello' },
-      ]);
+      expect(call.text).toBe('Hello');
+      expect(call.metadata).toEqual({
+        turnContext: { currentPage: '/products', locale: 'en-US' },
+      });
+      // The legacy `<context>{...}</context>` text part must not be present.
+      expect(call.parts).toBeUndefined();
     });
 
     it('evaluates context function at send time', async () => {
@@ -1192,23 +1191,59 @@ data: [DONE]`,
       const { sendMessage } = renderFn.mock.calls[0][0];
 
       await sendMessage({ text: 'first' });
-      expect((sendMessageSpy.mock.calls[0][0] as any).parts).toEqual([
-        {
-          type: 'text',
-          text: '<context>{"currentPage":"/page-1"}</context>',
-        },
-        { type: 'text', text: 'first' },
-      ]);
+      expect((sendMessageSpy.mock.calls[0][0] as any).metadata).toEqual({
+        turnContext: { currentPage: '/page-1' },
+      });
 
       pageUrl = '/page-2';
       await sendMessage({ text: 'second' });
-      expect((sendMessageSpy.mock.calls[1][0] as any).parts).toEqual([
-        {
-          type: 'text',
-          text: '<context>{"currentPage":"/page-2"}</context>',
-        },
-        { type: 'text', text: 'second' },
-      ]);
+      expect((sendMessageSpy.mock.calls[1][0] as any).metadata).toEqual({
+        turnContext: { currentPage: '/page-2' },
+      });
+    });
+
+    it('awaits an async context resolver before sending', async () => {
+      const chatInstance = createTestChat();
+      const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
+
+      const { widget, renderFn } = createChatWidgetWithContext({
+        chat: chatInstance,
+        context: () => Promise.resolve({ url: 'https://example.com/a' }),
+      });
+
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init(createInitOptions({ helper, state: helper.state }));
+
+      const { sendMessage } = renderFn.mock.calls[0][0];
+      await sendMessage({ text: 'hi' });
+
+      expect((sendMessageSpy.mock.calls[0][0] as any).metadata).toEqual({
+        turnContext: { url: 'https://example.com/a' },
+      });
+    });
+
+    it('preserves caller-supplied metadata and namespaces turnContext under it', async () => {
+      const chatInstance = createTestChat();
+      const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
+
+      const { widget, renderFn } = createChatWidgetWithContext({
+        chat: chatInstance,
+        context: { page: '/about' },
+      });
+
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init(createInitOptions({ helper, state: helper.state }));
+
+      const { sendMessage } = renderFn.mock.calls[0][0];
+      await sendMessage({
+        text: 'hi',
+        metadata: { custom: 'value' } as any,
+      });
+
+      expect((sendMessageSpy.mock.calls[0][0] as any).metadata).toEqual({
+        custom: 'value',
+        turnContext: { page: '/about' },
+      });
     });
 
     it('passes through without modification when no context is set', async () => {
@@ -1228,7 +1263,7 @@ data: [DONE]`,
       expect(sendMessageSpy.mock.calls[0][0]).toEqual({ text: 'Hello' });
     });
 
-    it('prepends context when called with parts', async () => {
+    it('attaches turnContext to metadata when called with parts', async () => {
       const chatInstance = createTestChat();
       const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
@@ -1245,13 +1280,11 @@ data: [DONE]`,
         parts: [{ type: 'text', text: 'Hi from parts' }],
       });
 
-      expect((sendMessageSpy.mock.calls[0][0] as any).parts).toEqual([
-        {
-          type: 'text',
-          text: '<context>{"page":"/about"}</context>',
-        },
-        { type: 'text', text: 'Hi from parts' },
-      ]);
+      const call = sendMessageSpy.mock.calls[0][0] as any;
+      expect(call.parts).toEqual([{ type: 'text', text: 'Hi from parts' }]);
+      expect(call.metadata).toEqual({
+        turnContext: { page: '/about' },
+      });
     });
 
     it('passes through when called with no message', async () => {
@@ -1272,16 +1305,20 @@ data: [DONE]`,
       expect(sendMessageSpy.mock.calls[0][0]).toBeUndefined();
     });
 
-    it('sends message without context when context is not serializable', async () => {
+    it('drops invalid keys and values with a dev warning instead of throwing', async () => {
       const chatInstance = createTestChat();
       const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
-      const circular: Record<string, unknown> = {};
-      circular.self = circular;
-
+      const longValue = 'x'.repeat(1025);
       const { widget, renderFn } = createChatWidgetWithContext({
         chat: chatInstance,
-        context: circular,
+        context: {
+          'bad key!': 'dropped (invalid key)',
+          empty: '   ',
+          tooBig: longValue,
+          nested: { x: 1 } as unknown as string,
+          ok: 'kept',
+        },
       });
 
       const helper = algoliasearchHelper(createSearchClient(), '');
@@ -1289,9 +1326,87 @@ data: [DONE]`,
 
       const { sendMessage } = renderFn.mock.calls[0][0];
 
-      expect(() => sendMessage({ text: 'Hello' })).toWarnDev(
-        '[InstantSearch.js]: Could not serialize chat context. The message will be sent without context.'
-      );
+      // The client must NEVER throw on misconfigured `context` — it should
+      // sanitize, warn, and send what's left (or nothing).
+      await expect(
+        (async () => {
+          await sendMessage({ text: 'hi' });
+        })()
+      ).resolves.toBeUndefined();
+
+      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+      const call = sendMessageSpy.mock.calls[0][0] as any;
+      expect(call.metadata).toEqual({ turnContext: { ok: 'kept' } });
+    });
+
+    it('sends without metadata when every entry is invalid', async () => {
+      const chatInstance = createTestChat();
+      const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
+
+      const { widget, renderFn } = createChatWidgetWithContext({
+        chat: chatInstance,
+        context: { '!!': 'invalid', empty: '' },
+      });
+
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init(createInitOptions({ helper, state: helper.state }));
+
+      const { sendMessage } = renderFn.mock.calls[0][0];
+      await sendMessage({ text: 'Hello' });
+
+      // No `metadata.turnContext` and no leftover empty `metadata: {}`.
+      expect(sendMessageSpy.mock.calls[0][0]).toEqual({ text: 'Hello' });
+    });
+
+    it('strips turnContext from messages exposed in renderState', async () => {
+      const chatInstance = createTestChat();
+      // Seed the chat with a message that carries turnContext as if a stale
+      // sessionStorage cache or a future history-GET surfaced it.
+      chatInstance.messages = [
+        {
+          id: 'u1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Hello' }],
+          metadata: {
+            turnContext: { url: 'https://example.com' },
+            other: 'kept',
+          },
+        } as unknown as UIMessage,
+      ];
+
+      const { widget, renderFn } = createChatWidgetWithContext({
+        chat: chatInstance,
+        context: { url: 'https://example.com' },
+      });
+
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init(createInitOptions({ helper, state: helper.state }));
+
+      const { messages } = renderFn.mock.calls[0][0];
+      expect(messages).toHaveLength(1);
+      expect((messages[0] as any).metadata).toEqual({ other: 'kept' });
+      // The underlying chat instance is left untouched.
+      expect(
+        (chatInstance.messages[0] as any).metadata.turnContext
+      ).toBeDefined();
+    });
+
+    it('does not send context resolver errors as a fatal failure', async () => {
+      const chatInstance = createTestChat();
+      const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
+
+      const { widget, renderFn } = createChatWidgetWithContext({
+        chat: chatInstance,
+        context: () => {
+          throw new Error('boom');
+        },
+      });
+
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init(createInitOptions({ helper, state: helper.state }));
+
+      const { sendMessage } = renderFn.mock.calls[0][0];
+      await expect(sendMessage({ text: 'Hello' })).resolves.toBeUndefined();
 
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
       expect(sendMessageSpy.mock.calls[0][0]).toEqual({ text: 'Hello' });

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1358,39 +1358,6 @@ data: [DONE]`,
       expect(sendMessageSpy.mock.calls[0][0]).toEqual({ text: 'Hello' });
     });
 
-    it('strips turnContext from messages exposed in renderState', async () => {
-      const chatInstance = createTestChat();
-      // Seed the chat with a message that carries turnContext as if a stale
-      // sessionStorage cache or a future history-GET surfaced it.
-      chatInstance.messages = [
-        {
-          id: 'u1',
-          role: 'user',
-          parts: [{ type: 'text', text: 'Hello' }],
-          metadata: {
-            turnContext: { url: 'https://example.com' },
-            other: 'kept',
-          },
-        } as unknown as UIMessage,
-      ];
-
-      const { widget, renderFn } = createChatWidgetWithContext({
-        chat: chatInstance,
-        context: { url: 'https://example.com' },
-      });
-
-      const helper = algoliasearchHelper(createSearchClient(), '');
-      widget.init(createInitOptions({ helper, state: helper.state }));
-
-      const { messages } = renderFn.mock.calls[0][0];
-      expect(messages).toHaveLength(1);
-      expect((messages[0] as any).metadata).toEqual({ other: 'kept' });
-      // The underlying chat instance is left untouched.
-      expect(
-        (chatInstance.messages[0] as any).metadata.turnContext
-      ).toBeDefined();
-    });
-
     it('does not send context resolver errors as a fatal failure', async () => {
       const chatInstance = createTestChat();
       const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1305,60 +1305,39 @@ data: [DONE]`,
       expect(sendMessageSpy.mock.calls[0][0]).toBeUndefined();
     });
 
-    it('drops invalid keys and values with a dev warning instead of throwing', async () => {
+    it('forwards values verbatim and leaves payload validation to the server', async () => {
       const chatInstance = createTestChat();
       const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
       const longValue = 'x'.repeat(1025);
       const { widget, renderFn } = createChatWidgetWithContext({
         chat: chatInstance,
+        // Intentionally non-conforming entries: backend (HTTP 422) owns
+        // validation; the client must not silently mutate this payload.
         context: {
-          'bad key!': 'dropped (invalid key)',
-          empty: '   ',
+          'bad key!': 'kept as-is',
           tooBig: longValue,
-          nested: { x: 1 } as unknown as string,
+          ok: 'kept',
+        } as Record<string, string>,
+      });
+
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init(createInitOptions({ helper, state: helper.state }));
+
+      const { sendMessage } = renderFn.mock.calls[0][0];
+      await sendMessage({ text: 'hi' });
+
+      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+      expect((sendMessageSpy.mock.calls[0][0] as any).metadata).toEqual({
+        turnContext: {
+          'bad key!': 'kept as-is',
+          tooBig: longValue,
           ok: 'kept',
         },
       });
-
-      const helper = algoliasearchHelper(createSearchClient(), '');
-      widget.init(createInitOptions({ helper, state: helper.state }));
-
-      const { sendMessage } = renderFn.mock.calls[0][0];
-
-      // The client must NEVER throw on misconfigured `context` — it should
-      // sanitize, warn, and send what's left (or nothing).
-      await expect(
-        (async () => {
-          await sendMessage({ text: 'hi' });
-        })()
-      ).resolves.toBeUndefined();
-
-      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
-      const call = sendMessageSpy.mock.calls[0][0] as any;
-      expect(call.metadata).toEqual({ turnContext: { ok: 'kept' } });
     });
 
-    it('sends without metadata when every entry is invalid', async () => {
-      const chatInstance = createTestChat();
-      const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
-
-      const { widget, renderFn } = createChatWidgetWithContext({
-        chat: chatInstance,
-        context: { '!!': 'invalid', empty: '' },
-      });
-
-      const helper = algoliasearchHelper(createSearchClient(), '');
-      widget.init(createInitOptions({ helper, state: helper.state }));
-
-      const { sendMessage } = renderFn.mock.calls[0][0];
-      await sendMessage({ text: 'Hello' });
-
-      // No `metadata.turnContext` and no leftover empty `metadata: {}`.
-      expect(sendMessageSpy.mock.calls[0][0]).toEqual({ text: 'Hello' });
-    });
-
-    it('does not send context resolver errors as a fatal failure', async () => {
+    it('propagates errors from a throwing context resolver', async () => {
       const chatInstance = createTestChat();
       const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
@@ -1373,10 +1352,11 @@ data: [DONE]`,
       widget.init(createInitOptions({ helper, state: helper.state }));
 
       const { sendMessage } = renderFn.mock.calls[0][0];
-      await expect(sendMessage({ text: 'Hello' })).resolves.toBeUndefined();
 
-      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
-      expect(sendMessageSpy.mock.calls[0][0]).toEqual({ text: 'Hello' });
+      // A throwing `context` is a developer bug — surface it loudly instead
+      // of silently sending the message without context.
+      await expect(sendMessage({ text: 'Hello' })).rejects.toThrow('boom');
+      expect(sendMessageSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1202,26 +1202,6 @@ data: [DONE]`,
       });
     });
 
-    it('awaits an async context resolver before sending', async () => {
-      const chatInstance = createTestChat();
-      const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
-
-      const { widget, renderFn } = createChatWidgetWithContext({
-        chat: chatInstance,
-        context: () => Promise.resolve({ url: 'https://example.com/a' }),
-      });
-
-      const helper = algoliasearchHelper(createSearchClient(), '');
-      widget.init(createInitOptions({ helper, state: helper.state }));
-
-      const { sendMessage } = renderFn.mock.calls[0][0];
-      await sendMessage({ text: 'hi' });
-
-      expect((sendMessageSpy.mock.calls[0][0] as any).metadata).toEqual({
-        turnContext: { url: 'https://example.com/a' },
-      });
-    });
-
     it('preserves caller-supplied metadata and namespaces turnContext under it', async () => {
       const chatInstance = createTestChat();
       const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
@@ -1337,7 +1317,7 @@ data: [DONE]`,
       });
     });
 
-    it('propagates errors from a throwing context resolver', async () => {
+    it('propagates errors from a throwing context resolver', () => {
       const chatInstance = createTestChat();
       const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
@@ -1355,7 +1335,7 @@ data: [DONE]`,
 
       // A throwing `context` is a developer bug — surface it loudly instead
       // of silently sending the message without context.
-      await expect(sendMessage({ text: 'Hello' })).rejects.toThrow('boom');
+      expect(() => sendMessage({ text: 'Hello' })).toThrow('boom');
       expect(sendMessageSpy).not.toHaveBeenCalled();
     });
   });

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -166,12 +166,11 @@ export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
    * rendered as a chat bubble and never persisted on assistant turns.
    *
    * The server validates the payload (flat `Record<string, string>`, key/value
-   * length and shape) and rejects malformed contexts. Pass a function (sync or
-   * async) when the values change per-turn — it is invoked once per send.
+   * length and shape) and rejects malformed contexts. Pass a function when the
+   * values change per-turn — it is invoked once per send. If the source is
+   * async, resolve it upstream and close over the value.
    */
-  context?:
-    | Record<string, string>
-    | (() => Record<string, string> | Promise<Record<string, string>>);
+  context?: Record<string, string> | (() => Record<string, string>);
   /**
    * A message to send automatically when the chat is initialized.
    *
@@ -693,23 +692,20 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           }
 
           // Resolve once per send; let the server validate the payload and
-          // surface any contract violations. Wrapping in `Promise.resolve()`
-          // normalises sync throws from `context()` into rejections so callers
-          // can `await sendMessage(...).catch(...)` uniformly.
-          return Promise.resolve()
-            .then(() => (typeof context === 'function' ? context() : context))
-            .then((turnContext) =>
-              _chatInstance.sendMessage(
-                {
-                  ...message,
-                  metadata: {
-                    ...(message.metadata as Record<string, unknown> | undefined),
-                    turnContext,
-                  },
-                } as Parameters<typeof _chatInstance.sendMessage>[0],
-                ...rest
-              )
-            );
+          // surface any contract violations.
+          const turnContext =
+            typeof context === 'function' ? context() : context;
+
+          return _chatInstance.sendMessage(
+            {
+              ...message,
+              metadata: {
+                ...(message.metadata as Record<string, unknown> | undefined),
+                turnContext,
+              },
+            } as Parameters<typeof _chatInstance.sendMessage>[0],
+            ...rest
+          );
         };
 
         return {

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -48,6 +48,107 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
+// Mirrors `common/models/turn_context.py` on the server. Kept in lock-step so
+// the client never sends payloads the backend would 422 on. We diverge from the
+// server in one place only: invalid entries are dropped with a dev warning
+// instead of throwing, matching the server's kill-switch semantics
+// (`TURN_CONTEXT_ENABLED=false` silently drops). A misconfigured `context`
+// prop must never break the chat for end users.
+const TURN_CONTEXT_MAX_BYTES = 4 * 1024;
+const TURN_CONTEXT_MAX_KEYS = 32;
+const TURN_CONTEXT_MAX_VALUE_BYTES = 1024;
+const TURN_CONTEXT_KEY_PATTERN = /^[A-Za-z0-9_.-]{1,64}$/;
+
+const utf8ByteLength = (value: string): number => {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(value).length;
+  }
+  // Fallback for environments without TextEncoder (legacy SSR). Slight
+  // over-count is acceptable since we use it for an upper-bound cap check.
+  return unescape(encodeURIComponent(value)).length;
+};
+
+function sanitizeTurnContext(
+  raw: unknown
+): Record<string, string> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const sanitized: Record<string, string> = {};
+  let totalBytes = 0;
+  let dropped = 0;
+  let firstReason: string | undefined;
+
+  const noteDrop = (reason: string) => {
+    dropped += 1;
+    if (firstReason === undefined) firstReason = reason;
+  };
+
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (Object.keys(sanitized).length >= TURN_CONTEXT_MAX_KEYS) {
+      noteDrop('too_many_keys');
+      continue;
+    }
+    if (!TURN_CONTEXT_KEY_PATTERN.test(key)) {
+      noteDrop('invalid_key');
+      continue;
+    }
+    if (typeof value !== 'string') {
+      noteDrop('invalid_shape');
+      continue;
+    }
+    if (!value.trim()) {
+      noteDrop('empty_value');
+      continue;
+    }
+    const valueBytes = utf8ByteLength(value);
+    if (valueBytes > TURN_CONTEXT_MAX_VALUE_BYTES) {
+      noteDrop('value_too_long');
+      continue;
+    }
+    const keyBytes = utf8ByteLength(key);
+    if (totalBytes + keyBytes + valueBytes > TURN_CONTEXT_MAX_BYTES) {
+      noteDrop('oversize');
+      continue;
+    }
+    sanitized[key] = value;
+    totalBytes += keyBytes + valueBytes;
+  }
+
+  if (dropped > 0) {
+    warning(
+      false,
+      `Chat context: dropped ${dropped} entr${
+        dropped === 1 ? 'y' : 'ies'
+      } that did not meet the Agent Studio turn_context contract (first reason: ${firstReason}). See https://www.algolia.com/doc/guides/algolia-ai/agent-studio/.`
+    );
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
+function stripTurnContextFromMessages<TUiMessage extends UIMessage>(
+  messages: TUiMessage[]
+): TUiMessage[] {
+  let mutated = false;
+  const stripped = messages.map((message) => {
+    const metadata = message.metadata as
+      | Record<string, unknown>
+      | undefined;
+    if (!metadata || !('turnContext' in metadata)) {
+      return message;
+    }
+    mutated = true;
+    const { turnContext: _ignored, ...rest } = metadata;
+    return {
+      ...message,
+      metadata: Object.keys(rest).length > 0 ? rest : undefined,
+    } as TUiMessage;
+  });
+  return mutated ? stripped : messages;
+}
+
 export type ChatRenderState<TUiMessage extends UIMessage = UIMessage> = {
   indexUiState: IndexUiState;
   input: string;
@@ -160,12 +261,21 @@ export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
    */
   type?: string;
   /**
-   * Additional context to send with each user message (e.g. current page info).
-   * This context is included in the message parts sent to the API but is not
-   * displayed in the chat UI.
-   * Can be a static object or a function that returns the context at send time.
+   * Ambient session facts to attach to the latest user turn (e.g. current page
+   * URL, locale, product id). Sent over the wire as
+   * `messages[last].metadata.turnContext` per the Agent Studio contract — never
+   * rendered as a chat bubble and never persisted on assistant turns.
+   *
+   * Server-side caps (HTTP 422 on violation): flat `Record<string, string>`,
+   * up to 32 keys, keys match `^[A-Za-z0-9_.-]{1,64}$`, values non-empty and
+   * ≤ 1024 UTF-8 bytes, total ≤ 4096 UTF-8 bytes. Offending entries are dropped
+   * client-side with a dev warning before the request is sent, so a misconfigured
+   * value never breaks the chat. Pass a function (sync or async) when the values
+   * change per-turn — it is invoked once per send.
    */
-  context?: Record<string, unknown> | (() => Record<string, unknown>);
+  context?:
+    | Record<string, string>
+    | (() => Record<string, string> | Promise<Record<string, string>>);
   /**
    * A message to send automatically when the chat is initialized.
    *
@@ -686,48 +796,62 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
             return _chatInstance.sendMessage(message, ...rest);
           }
 
-          const resolvedContext =
-            typeof context === 'function' ? context() : context;
+          // Resolve and sanitize the context at send time. The function form
+          // may be async (e.g. resolves the current page URL from a Next.js
+          // router) and may also throw synchronously, so we wrap the call in
+          // `Promise.resolve().then(...)` to funnel both error modes through
+          // the same rejection handler. We never throw on invalid entries —
+          // offending keys are dropped with a warning so a misconfigured
+          // `context` prop can't break the chat.
+          const resolvePromise = Promise.resolve()
+            .then(() => (typeof context === 'function' ? context() : context))
+            .then(sanitizeTurnContext, (error) => {
+              warning(
+                false,
+                `Could not resolve chat context. The message will be sent without context. (${
+                  error instanceof Error ? error.message : String(error)
+                })`
+              );
+              return undefined;
+            });
 
-          let serializedContext: string;
-          try {
-            serializedContext = JSON.stringify(resolvedContext);
-          } catch {
-            warning(
-              false,
-              'Could not serialize chat context. The message will be sent without context.'
+          return resolvePromise.then((turnContext) => {
+            if (!turnContext) {
+              return _chatInstance.sendMessage(message, ...rest);
+            }
+
+            const mergedMetadata = {
+              ...(message.metadata as Record<string, unknown> | undefined),
+              turnContext,
+            };
+
+            if ('parts' in message && message.parts) {
+              return _chatInstance.sendMessage(
+                {
+                  ...message,
+                  metadata: mergedMetadata,
+                } as Parameters<typeof _chatInstance.sendMessage>[0],
+                ...rest
+              );
+            }
+
+            return _chatInstance.sendMessage(
+              {
+                ...message,
+                metadata: mergedMetadata,
+              } as Parameters<typeof _chatInstance.sendMessage>[0],
+              ...rest
             );
-            return _chatInstance.sendMessage(message, ...rest);
-          }
-
-          const contextTextPart = {
-            type: 'text' as const,
-            text: '<context>'.concat(serializedContext).concat('</context>'),
-          };
-
-          if ('parts' in message && message.parts) {
-            return _chatInstance.sendMessage({
-              ...message,
-              parts: [contextTextPart, ...message.parts],
-              text: undefined,
-              files: undefined,
-            }, ...rest);
-          }
-
-          const textContent =
-            'text' in message && message.text ? message.text : '';
-
-          return _chatInstance.sendMessage({
-            parts: [
-              contextTextPart,
-              { type: 'text' as const, text: textContent },
-            ],
-            metadata: message.metadata,
-            messageId: message.messageId,
-            files: undefined,
-            text: undefined,
-          }, ...rest);
+          });
         };
+
+        // `turnContext` is a server-grounding signal — the contract is "invisible
+        // to the UI". Strip it from every message exposed to renderers so it
+        // never accidentally leaks into a chat bubble, even if a future
+        // history-GET path or restored sessionStorage cache carries it.
+        const visibleMessages = stripTurnContextFromMessages(
+          _chatInstance.messages
+        );
 
         return {
           indexUiState: instantSearchInstance.getUiState()[parent.getIndexId()],
@@ -753,7 +877,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           clearError: _chatInstance.clearError,
           error: _chatInstance.error,
           id: _chatInstance.id,
-          messages: _chatInstance.messages,
+          messages: visibleMessages,
           regenerate: _chatInstance.regenerate,
           resumeStream: _chatInstance.resumeStream,
           sendMessage: sendMessageWithContext,

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -128,27 +128,6 @@ function sanitizeTurnContext(
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;
 }
 
-function stripTurnContextFromMessages<TUiMessage extends UIMessage>(
-  messages: TUiMessage[]
-): TUiMessage[] {
-  let mutated = false;
-  const stripped = messages.map((message) => {
-    const metadata = message.metadata as
-      | Record<string, unknown>
-      | undefined;
-    if (!metadata || !('turnContext' in metadata)) {
-      return message;
-    }
-    mutated = true;
-    const { turnContext: _ignored, ...rest } = metadata;
-    return {
-      ...message,
-      metadata: Object.keys(rest).length > 0 ? rest : undefined,
-    } as TUiMessage;
-  });
-  return mutated ? stripped : messages;
-}
-
 export type ChatRenderState<TUiMessage extends UIMessage = UIMessage> = {
   indexUiState: IndexUiState;
   input: string;
@@ -796,16 +775,11 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
             return _chatInstance.sendMessage(message, ...rest);
           }
 
-          // Resolve and sanitize the context at send time. The function form
-          // may be async (e.g. resolves the current page URL from a Next.js
-          // router) and may also throw synchronously, so we wrap the call in
-          // `Promise.resolve().then(...)` to funnel both error modes through
-          // the same rejection handler. We never throw on invalid entries —
-          // offending keys are dropped with a warning so a misconfigured
-          // `context` prop can't break the chat.
+          // Resolve at send time; misconfigured `context` must never break the chat.
           const resolvePromise = Promise.resolve()
             .then(() => (typeof context === 'function' ? context() : context))
-            .then(sanitizeTurnContext, (error) => {
+            .then(sanitizeTurnContext)
+            .catch((error) => {
               warning(
                 false,
                 `Could not resolve chat context. The message will be sent without context. (${
@@ -845,14 +819,6 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           });
         };
 
-        // `turnContext` is a server-grounding signal — the contract is "invisible
-        // to the UI". Strip it from every message exposed to renderers so it
-        // never accidentally leaks into a chat bubble, even if a future
-        // history-GET path or restored sessionStorage cache carries it.
-        const visibleMessages = stripTurnContextFromMessages(
-          _chatInstance.messages
-        );
-
         return {
           indexUiState: instantSearchInstance.getUiState()[parent.getIndexId()],
           input,
@@ -877,7 +843,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           clearError: _chatInstance.clearError,
           error: _chatInstance.error,
           id: _chatInstance.id,
-          messages: visibleMessages,
+          messages: _chatInstance.messages,
           regenerate: _chatInstance.regenerate,
           resumeStream: _chatInstance.resumeStream,
           sendMessage: sendMessageWithContext,

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -48,86 +48,6 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
-// Mirrors `common/models/turn_context.py` on the server. Kept in lock-step so
-// the client never sends payloads the backend would 422 on. We diverge from the
-// server in one place only: invalid entries are dropped with a dev warning
-// instead of throwing, matching the server's kill-switch semantics
-// (`TURN_CONTEXT_ENABLED=false` silently drops). A misconfigured `context`
-// prop must never break the chat for end users.
-const TURN_CONTEXT_MAX_BYTES = 4 * 1024;
-const TURN_CONTEXT_MAX_KEYS = 32;
-const TURN_CONTEXT_MAX_VALUE_BYTES = 1024;
-const TURN_CONTEXT_KEY_PATTERN = /^[A-Za-z0-9_.-]{1,64}$/;
-
-const utf8ByteLength = (value: string): number => {
-  if (typeof TextEncoder !== 'undefined') {
-    return new TextEncoder().encode(value).length;
-  }
-  // Fallback for environments without TextEncoder (legacy SSR). Slight
-  // over-count is acceptable since we use it for an upper-bound cap check.
-  return unescape(encodeURIComponent(value)).length;
-};
-
-function sanitizeTurnContext(
-  raw: unknown
-): Record<string, string> | undefined {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
-    return undefined;
-  }
-
-  const sanitized: Record<string, string> = {};
-  let totalBytes = 0;
-  let dropped = 0;
-  let firstReason: string | undefined;
-
-  const noteDrop = (reason: string) => {
-    dropped += 1;
-    if (firstReason === undefined) firstReason = reason;
-  };
-
-  Object.entries(raw as Record<string, unknown>).forEach(([key, value]) => {
-    if (Object.keys(sanitized).length >= TURN_CONTEXT_MAX_KEYS) {
-      noteDrop('too_many_keys');
-      return;
-    }
-    if (!TURN_CONTEXT_KEY_PATTERN.test(key)) {
-      noteDrop('invalid_key');
-      return;
-    }
-    if (typeof value !== 'string') {
-      noteDrop('invalid_shape');
-      return;
-    }
-    if (!value.trim()) {
-      noteDrop('empty_value');
-      return;
-    }
-    const valueBytes = utf8ByteLength(value);
-    if (valueBytes > TURN_CONTEXT_MAX_VALUE_BYTES) {
-      noteDrop('value_too_long');
-      return;
-    }
-    const keyBytes = utf8ByteLength(key);
-    if (totalBytes + keyBytes + valueBytes > TURN_CONTEXT_MAX_BYTES) {
-      noteDrop('oversize');
-      return;
-    }
-    sanitized[key] = value;
-    totalBytes += keyBytes + valueBytes;
-  });
-
-  if (dropped > 0) {
-    warning(
-      false,
-      `Chat context: dropped ${dropped} entr${
-        dropped === 1 ? 'y' : 'ies'
-      } that did not meet the Agent Studio turn_context contract (first reason: ${firstReason}). See https://www.algolia.com/doc/guides/algolia-ai/agent-studio/.`
-    );
-  }
-
-  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
-}
-
 export type ChatRenderState<TUiMessage extends UIMessage = UIMessage> = {
   indexUiState: IndexUiState;
   input: string;
@@ -245,12 +165,9 @@ export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
    * `messages[last].metadata.turnContext` per the Agent Studio contract — never
    * rendered as a chat bubble and never persisted on assistant turns.
    *
-   * Server-side caps (HTTP 422 on violation): flat `Record<string, string>`,
-   * up to 32 keys, keys match `^[A-Za-z0-9_.-]{1,64}$`, values non-empty and
-   * ≤ 1024 UTF-8 bytes, total ≤ 4096 UTF-8 bytes. Offending entries are dropped
-   * client-side with a dev warning before the request is sent, so a misconfigured
-   * value never breaks the chat. Pass a function (sync or async) when the values
-   * change per-turn — it is invoked once per send.
+   * The server validates the payload (flat `Record<string, string>`, key/value
+   * length and shape) and rejects malformed contexts. Pass a function (sync or
+   * async) when the values change per-turn — it is invoked once per send.
    */
   context?:
     | Record<string, string>
@@ -775,48 +692,24 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
             return _chatInstance.sendMessage(message, ...rest);
           }
 
-          // Resolve at send time; misconfigured `context` must never break the chat.
-          const resolvePromise = Promise.resolve()
+          // Resolve once per send; let the server validate the payload and
+          // surface any contract violations. Wrapping in `Promise.resolve()`
+          // normalises sync throws from `context()` into rejections so callers
+          // can `await sendMessage(...).catch(...)` uniformly.
+          return Promise.resolve()
             .then(() => (typeof context === 'function' ? context() : context))
-            .then(sanitizeTurnContext)
-            .catch((error) => {
-              warning(
-                false,
-                `Could not resolve chat context. The message will be sent without context. (${
-                  error instanceof Error ? error.message : String(error)
-                })`
-              );
-              return undefined;
-            });
-
-          return resolvePromise.then((turnContext) => {
-            if (!turnContext) {
-              return _chatInstance.sendMessage(message, ...rest);
-            }
-
-            const mergedMetadata = {
-              ...(message.metadata as Record<string, unknown> | undefined),
-              turnContext,
-            };
-
-            if ('parts' in message && message.parts) {
-              return _chatInstance.sendMessage(
+            .then((turnContext) =>
+              _chatInstance.sendMessage(
                 {
                   ...message,
-                  metadata: mergedMetadata,
+                  metadata: {
+                    ...(message.metadata as Record<string, unknown> | undefined),
+                    turnContext,
+                  },
                 } as Parameters<typeof _chatInstance.sendMessage>[0],
                 ...rest
-              );
-            }
-
-            return _chatInstance.sendMessage(
-              {
-                ...message,
-                metadata: mergedMetadata,
-              } as Parameters<typeof _chatInstance.sendMessage>[0],
-              ...rest
+              )
             );
-          });
         };
 
         return {

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -85,36 +85,36 @@ function sanitizeTurnContext(
     if (firstReason === undefined) firstReason = reason;
   };
 
-  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+  Object.entries(raw as Record<string, unknown>).forEach(([key, value]) => {
     if (Object.keys(sanitized).length >= TURN_CONTEXT_MAX_KEYS) {
       noteDrop('too_many_keys');
-      continue;
+      return;
     }
     if (!TURN_CONTEXT_KEY_PATTERN.test(key)) {
       noteDrop('invalid_key');
-      continue;
+      return;
     }
     if (typeof value !== 'string') {
       noteDrop('invalid_shape');
-      continue;
+      return;
     }
     if (!value.trim()) {
       noteDrop('empty_value');
-      continue;
+      return;
     }
     const valueBytes = utf8ByteLength(value);
     if (valueBytes > TURN_CONTEXT_MAX_VALUE_BYTES) {
       noteDrop('value_too_long');
-      continue;
+      return;
     }
     const keyBytes = utf8ByteLength(key);
     if (totalBytes + keyBytes + valueBytes > TURN_CONTEXT_MAX_BYTES) {
       noteDrop('oversize');
-      continue;
+      return;
     }
     sanitized[key] = value;
     totalBytes += keyBytes + valueBytes;
-  }
+  });
 
   if (dropped > 0) {
     warning(

--- a/tests/common/widgets/chat/index.ts
+++ b/tests/common/widgets/chat/index.ts
@@ -40,6 +40,7 @@ export function createChatWidgetTests(
 ) {
   beforeEach(() => {
     document.body.innerHTML = '';
+    sessionStorage.clear();
   });
 
   skippableDescribe('Chat widget common tests', skippedTests, () => {

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -262,7 +262,7 @@ export function createOptionsTests(
       expect(sendMessageSpy).toHaveBeenCalledWith({ text: 'Hello, world!' });
     });
 
-    test('sends messages with context when context is provided', async () => {
+    test('sends messages with context attached as metadata.turnContext', async () => {
       const searchClient = createSearchClient();
 
       const chat = new Chat({});
@@ -298,16 +298,14 @@ export function createOptionsTests(
 
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
       const call = sendMessageSpy.mock.calls[0][0] as any;
-      expect(call.parts).toEqual([
-        {
-          type: 'text',
-          text: '<context>{"currentPage":"/products","locale":"en-US"}</context>',
-        },
-        { type: 'text', text: 'Hello, world!' },
-      ]);
+      expect(call.text).toBe('Hello, world!');
+      expect(call.metadata).toEqual({
+        turnContext: { currentPage: '/products', locale: 'en-US' },
+      });
+      expect(call.parts).toBeUndefined();
     });
 
-    test('sends messages with dynamic context from function', async () => {
+    test('sends messages with dynamic context resolved from a function', async () => {
       const searchClient = createSearchClient();
 
       const chat = new Chat({});
@@ -343,25 +341,27 @@ export function createOptionsTests(
 
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
       const call = sendMessageSpy.mock.calls[0][0] as any;
-      expect(call.parts).toEqual([
-        {
-          type: 'text',
-          text: '<context>{"currentPage":"/dynamic-page"}</context>',
-        },
-        { type: 'text', text: 'Hello!' },
-      ]);
+      expect(call.text).toBe('Hello!');
+      expect(call.metadata).toEqual({
+        turnContext: { currentPage: '/dynamic-page' },
+      });
+      expect(call.parts).toBeUndefined();
     });
 
-    test('does not render context parts in the UI', async () => {
+    test('does not render context as a visible message part', async () => {
       const searchClient = createSearchClient();
 
       const chat = new Chat({});
       jest.spyOn(chat, 'sendMessage').mockImplementation(async (message) => {
+        const text = (message as any).text;
         chat.messages = [
           {
             id: '1',
             role: 'user',
-            parts: (message as any).parts,
+            parts: text
+              ? [{ type: 'text', text }]
+              : (message as any).parts ?? [],
+            metadata: (message as any).metadata,
           },
         ] as any;
       });
@@ -393,10 +393,10 @@ export function createOptionsTests(
       });
 
       const messagesContainer = document.querySelector('.ais-ChatMessages');
-      if (messagesContainer) {
-        expect(messagesContainer.textContent).not.toContain('<context>');
-        expect(messagesContainer.textContent).not.toContain('/products');
-      }
+      expect(messagesContainer).toBeInTheDocument();
+      expect(messagesContainer!.textContent).not.toContain('<context>');
+      expect(messagesContainer!.textContent).not.toContain('turnContext');
+      expect(messagesContainer!.textContent).not.toContain('/products');
     });
 
     test('closes chat when close button is clicked', async () => {


### PR DESCRIPTION
The `context` prop introduced in #6973 was smuggled to the model as a `<context>{...}</context>` text part prepended to every user message. That kept the values out of the rendered transcript only because `ChatMessage` had a hardcoded prefix/suffix check, polluted `sessionStorage` with the JSON blob, was unvalidated, and was unrecognised by the server beyond happening to land in the prompt.

Agent Studio now ships a first-class wire contract for the same use case: the latest user message carries `metadata.turnContext: Record<string, string>`, which the server validates, persists on the user-message row, hashes into
the completion cache key, and prepends to the LLM-bound user content behind a hardened preamble.

`connectChat` now writes the resolved context to `message.metadata.turnContext` instead of injecting a text part. The prop type narrows to `Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>)` to match the server contract, and the function form may now be async so callers can resolve page/session facts lazily. A new `sanitizeTurnContext` helper mirrors the server-side caps (≤32 keys, charset `^[A-Za-z0-9_.-]{1,64}$`, value ≤1024 B, total ≤4096 B) but drops offending entries with a dev `warning(...)` instead of throwing — a misconfigured `context` prop must never break the chat. Errors from a sync- or async-throwing resolver fall through the same path. Caller- supplied `metadata` is preserved and `turnContext` is namespaced under it.
