### PR TITLE
fix(recommend): remove unsupported queryParameters from trending-facets

### DIFF
--- a/packages/instantsearch.js/src/connectors/trending-facets/__tests__/connectTrendingFacets-test.ts
+++ b/packages/instantsearch.js/src/connectors/trending-facets/__tests__/connectTrendingFacets-test.ts
@@ -144,7 +144,7 @@ describe('connectTrendingFacets', () => {
       });
 
       expect(actual).toEqual(
-        // v4 TrendingFacetsQuery lacks fallbackParameters
+        // v4 TrendingFacetsQuery lacks queryParameters/fallbackParameters
         new RecommendParameters().addTrendingFacets({
           $$id: (widget as any).$$id,
           facetName: 'brand',
@@ -171,7 +171,7 @@ describe('connectTrendingFacets', () => {
       });
 
       expect(actual).toEqual(
-        // v4 TrendingFacetsQuery lacks fallbackParameters
+        // v4 TrendingFacetsQuery lacks queryParameters/fallbackParameters
         new RecommendParameters().addTrendingFacets({
           $$id: (widget as any).$$id,
           facetName: 'brand',

--- a/packages/instantsearch.js/src/connectors/trending-facets/__tests__/connectTrendingFacets-test.ts
+++ b/packages/instantsearch.js/src/connectors/trending-facets/__tests__/connectTrendingFacets-test.ts
@@ -135,7 +135,6 @@ describe('connectTrendingFacets', () => {
         facetName: 'brand',
         limit: 10,
         threshold: 95,
-        queryParameters: { userToken: 'token' },
         escapeHTML: false,
       });
 
@@ -145,13 +144,12 @@ describe('connectTrendingFacets', () => {
       });
 
       expect(actual).toEqual(
-        // v4 TrendingFacetsQuery lacks queryParameters/fallbackParameters
+        // v4 TrendingFacetsQuery lacks fallbackParameters
         new RecommendParameters().addTrendingFacets({
           $$id: (widget as any).$$id,
           facetName: 'brand',
           maxRecommendations: 10,
           threshold: 95,
-          queryParameters: { userToken: 'token' },
         } as any)
       );
     });
@@ -163,7 +161,6 @@ describe('connectTrendingFacets', () => {
         facetName: 'brand',
         limit: 10,
         threshold: 95,
-        queryParameters: { userToken: 'token' },
         escapeHTML: true,
         fallbackParameters: { query: 'query' },
       });
@@ -174,17 +171,12 @@ describe('connectTrendingFacets', () => {
       });
 
       expect(actual).toEqual(
-        // v4 TrendingFacetsQuery lacks queryParameters/fallbackParameters
+        // v4 TrendingFacetsQuery lacks fallbackParameters
         new RecommendParameters().addTrendingFacets({
           $$id: (widget as any).$$id,
           facetName: 'brand',
           maxRecommendations: 10,
           threshold: 95,
-          queryParameters: {
-            userToken: 'token',
-            highlightPostTag: '__/ais-highlight__',
-            highlightPreTag: '__ais-highlight__',
-          },
           fallbackParameters: {
             highlightPostTag: '__/ais-highlight__',
             highlightPreTag: '__ais-highlight__',

--- a/packages/instantsearch.js/src/connectors/trending-facets/connectTrendingFacets.ts
+++ b/packages/instantsearch.js/src/connectors/trending-facets/connectTrendingFacets.ts
@@ -171,8 +171,8 @@ export default (function connectTrendingFacets<
       },
 
       getWidgetParameters(state) {
-        // v4 TrendingFacetsQuery doesn't include fallbackParameters,
-        // but the v5 API and the helper support it.
+        // v4 TrendingFacetsQuery doesn't include queryParameters or
+        // fallbackParameters, but the v5 API and the helper support them.
         return state.removeParams(this.$$id!).addTrendingFacets({
           facetName,
           maxRecommendations: limit,

--- a/packages/instantsearch.js/src/connectors/trending-facets/connectTrendingFacets.ts
+++ b/packages/instantsearch.js/src/connectors/trending-facets/connectTrendingFacets.ts
@@ -50,13 +50,6 @@ export type TrendingFacetsConnectorParams = {
     'page' | 'hitsPerPage' | 'offset' | 'length'
   >;
   /**
-   * List of search parameters to send.
-   */
-  queryParameters?: Omit<
-    PlainSearchParameters,
-    'page' | 'hitsPerPage' | 'offset' | 'length'
-  >;
-  /**
    * Whether to escape HTML tags from items string values.
    *
    * @default true
@@ -98,7 +91,6 @@ export default (function connectTrendingFacets<
       limit,
       threshold,
       fallbackParameters,
-      queryParameters,
       // @MAJOR: this can default to false
       escapeHTML = true,
       transformItems = ((items) => items) as NonNullable<
@@ -107,9 +99,7 @@ export default (function connectTrendingFacets<
     } = widgetParams || {};
 
     if (!facetName) {
-      throw new Error(
-        withUsage('The `facetName` option is required.')
-      );
+      throw new Error(withUsage('The `facetName` option is required.'));
     }
 
     return {
@@ -181,8 +171,8 @@ export default (function connectTrendingFacets<
       },
 
       getWidgetParameters(state) {
-        // v4 TrendingFacetsQuery doesn't include queryParameters or
-        // fallbackParameters, but the v5 API and the helper support them.
+        // v4 TrendingFacetsQuery doesn't include fallbackParameters,
+        // but the v5 API and the helper support it.
         return state.removeParams(this.$$id!).addTrendingFacets({
           facetName,
           maxRecommendations: limit,
@@ -193,10 +183,6 @@ export default (function connectTrendingFacets<
                 ...(escapeHTML ? TAG_PLACEHOLDER : {}),
               }
             : undefined,
-          queryParameters: {
-            ...queryParameters,
-            ...(escapeHTML ? TAG_PLACEHOLDER : {}),
-          },
           $$id: this.$$id!,
         } as any);
       },

--- a/packages/instantsearch.js/src/widgets/trending-facets/trending-facets.tsx
+++ b/packages/instantsearch.js/src/widgets/trending-facets/trending-facets.tsx
@@ -185,7 +185,6 @@ export default (function trendingFacets(
     container,
     facetName,
     limit,
-    queryParameters,
     fallbackParameters,
     threshold,
     escapeHTML,
@@ -215,7 +214,6 @@ export default (function trendingFacets(
     ...makeWidget({
       facetName,
       limit,
-      queryParameters,
       fallbackParameters,
       threshold,
       escapeHTML,

--- a/packages/react-instantsearch/src/widgets/TrendingFacets.tsx
+++ b/packages/react-instantsearch/src/widgets/TrendingFacets.tsx
@@ -10,11 +10,7 @@ import type { UseTrendingFacetsProps } from 'react-instantsearch-core';
 
 type UiProps = Pick<
   TrendingFacetsUiComponentProps,
-  | 'items'
-  | 'itemComponent'
-  | 'headerComponent'
-  | 'emptyComponent'
-  | 'status'
+  'items' | 'itemComponent' | 'headerComponent' | 'emptyComponent' | 'status'
 >;
 
 export type TrendingFacetsProps = Omit<
@@ -37,7 +33,6 @@ export function TrendingFacets({
   limit,
   threshold,
   fallbackParameters,
-  queryParameters,
   escapeHTML,
   transformItems,
   itemComponent,
@@ -52,7 +47,6 @@ export function TrendingFacets({
       limit,
       threshold,
       fallbackParameters,
-      queryParameters,
       escapeHTML,
       transformItems,
     },


### PR DESCRIPTION
**Summary**

The Algolia Recommend API rejects `queryParameters` for the `trending-facets` model (returns HTTP 400), so the option could never be set in practice. This PR removes the option from the `trendingFacets` widget and connector across the InstantSearch packages.

<img width="2514" height="280" alt="image" src="https://github.com/user-attachments/assets/2e0db44a-cb20-4331-adbc-a37496365ff2" />

Related:
- Docs: algolia/docs-new#843
- [#6716](https://github.com/algolia/instantsearch/pull/6716) did the same kind of cleanup for `fallbackParameters` on FBT.

Changes:
- `connectTrendingFacets`: drop `queryParameters` from `TrendingFacetsConnectorParams`, the destructure, and the `addTrendingFacets({...})` call (only `fallbackParameters` still gets the `TAG_PLACEHOLDER` merge).
- `trendingFacets` (JS widget): drop the `queryParameters` pass-through.
- `TrendingFacets` (React widget): drop the `queryParameters` pass-through.
- Tests: update `getWidgetParameters` cases to no longer pass/expect `queryParameters`.

`useTrendingFacets` (react-instantsearch-core) re-exports the connector type directly, so the hook picks up the change automatically.

**Result**

```
PASS packages/instantsearch.js/src/widgets/trending-facets/__tests__/trending-facets.test.tsx
PASS packages/instantsearch.js/src/connectors/trending-facets/__tests__/connectTrendingFacets-test.ts
PASS packages/react-instantsearch/src/widgets/__tests__/TrendingFacets.test.tsx

Test Suites: 3 passed (+ legacy umd mirrors)
Tests:       31 passed
```

> [!NOTE]
> Technically a public-API removal on `trendingFacets`/`TrendingFacets`/`useTrendingFacets`. Since the Recommend endpoint rejected the option, no working code can depend on it.