### PR TITLE
refactor(instantsearch.css): share carousel styles between chat and recommend widgets

### DIFF
--- a/packages/instantsearch.css/src/components/_carousel.scss
+++ b/packages/instantsearch.css/src/components/_carousel.scss
@@ -1,0 +1,126 @@
+@use '../shared/_common';
+
+.ais-Carousel {
+  position: relative;
+  margin-bottom: var(--ais-spacing);
+
+  a {
+    color: rgba(var(--ais-text-color-rgb), var(--ais-text-color-alpha));
+    text-decoration: none;
+  }
+}
+
+.ais-Carousel-list {
+  @extend .ais-Scrollbar;
+  @extend %ais-focus-outline;
+
+  gap: 0;
+  grid-auto-columns: var(--ais-carousel-item-width) !important;
+  outline: none;
+}
+
+.ais-Carousel-hit {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--ais-spacing) * 0.5);
+  border-radius: var(--ais-border-radius-md);
+  padding: calc(var(--ais-spacing) * 0.5);
+  height: 100%;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: var(--ais-border-radius-md);
+    background-color: rgba(var(--ais-muted-color-rgb), 0);
+    pointer-events: none;
+    z-index: -1;
+    transform: scale(0.95);
+
+    transition: all var(--ais-transition-duration)
+      var(--ais-transition-timing-function);
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      &::before {
+        background-color: rgba(var(--ais-muted-color-rgb), 0.1);
+        transform: scale(1);
+      }
+
+      .ais-Carousel-hit-image img {
+        transform: scale(1.05);
+      }
+    }
+  }
+
+  &:active:not(:disabled) {
+    &::before {
+      background-color: rgba(var(--ais-muted-color-rgb), 0.2);
+    }
+  }
+
+  &:has(:focus-visible) {
+    outline: 2px solid
+      rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
+    outline-offset: 2px;
+  }
+}
+
+.ais-Carousel-hit-title {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.ais-Carousel-hit-link {
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+  }
+
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+.ais-Carousel-hit-image {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  border-radius: var(--ais-border-radius-md);
+  overflow: hidden;
+
+  img {
+    transition: transform var(--ais-transition-duration)
+      var(--ais-transition-timing-function);
+  }
+}
+
+.ais-Carousel-hit-favorite {
+  position: absolute;
+  top: calc(var(--ais-spacing) * 0.5);
+  right: calc(var(--ais-spacing) * 0.5);
+  z-index: 1;
+}
+
+.ais-Carousel-hit-title {
+  font-weight: normal;
+
+  a {
+    font-size: var(--ais-spacing);
+  }
+}
+
+.ais-Carousel-hit-title,
+.ais-Carousel-hit-price {
+  margin: 0;
+}
+
+.ais-Carousel-hit-price {
+  font-weight: var(--ais-font-weight-semibold);
+  margin-top: auto;
+}

--- a/packages/instantsearch.css/src/components/_carousel.scss
+++ b/packages/instantsearch.css/src/components/_carousel.scss
@@ -15,7 +15,7 @@
   @extend %ais-focus-outline;
 
   gap: 0;
-  grid-auto-columns: var(--ais-carousel-item-width) !important;
+  grid-auto-columns: var(--ais-carousel-item-width);
   outline: none;
 }
 
@@ -68,13 +68,6 @@
   }
 }
 
-.ais-Carousel-hit-title {
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-}
-
 .ais-Carousel-hit-link {
   &::before {
     content: '';
@@ -108,6 +101,10 @@
 }
 
 .ais-Carousel-hit-title {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   font-weight: normal;
 
   a {

--- a/packages/instantsearch.css/src/components/chat.scss
+++ b/packages/instantsearch.css/src/components/chat.scss
@@ -13,5 +13,5 @@
 @use 'chat/chat-message-loader';
 @use 'chat/chat-greeting';
 @use 'chat/chat-prompt';
-@use 'chat/chat-carousel';
+@use 'chat/chat-tool-results';
 @use 'chat/chat-suggestions';

--- a/packages/instantsearch.css/src/components/chat.scss
+++ b/packages/instantsearch.css/src/components/chat.scss
@@ -1,6 +1,7 @@
 @use '../themes/reset';
 @use '../shared/_variables';
 @use '../shared/_common';
+@use 'carousel';
 @use 'button';
 @use 'chat/chat';
 @use 'chat/chat-overlay-layout';

--- a/packages/instantsearch.css/src/components/chat/_chat-tool-results.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-tool-results.scss
@@ -1,5 +1,4 @@
 @use '../../shared/_variables';
-@use '../../shared/_common';
 
 .ais-ChatMessage-message {
   .ais-ChatToolSearchIndexCarouselHeader,
@@ -82,15 +81,8 @@
     font-style: italic;
   }
 
+  // Chat-only carousel overrides on top of `components/_carousel.scss`
   .ais-Carousel {
-    position: relative;
-    margin-bottom: var(--ais-spacing);
-
-    a {
-      color: rgba(var(--ais-text-color-rgb), var(--ais-text-color-alpha));
-      text-decoration: none;
-    }
-
     &::before,
     &::after {
       content: '';
@@ -128,131 +120,18 @@
   }
 
   .ais-Carousel-list {
-    @extend .ais-Scrollbar;
-    @extend %ais-focus-outline;
-
-    gap: 0;
-    grid-auto-columns: var(--ais-chat-carousel-item-width) !important;
     margin-left: calc(-1 * var(--ais-spacing));
     margin-right: calc(-1 * var(--ais-spacing));
     padding-left: calc(var(--ais-spacing) * 0.5);
     padding-right: calc(var(--ais-spacing) * 0.5);
     scroll-padding-left: calc(var(--ais-spacing) * 0.5);
     scroll-padding-right: calc(var(--ais-spacing) * 0.5);
-    outline: none;
 
-    // Single item takes more space
     &:has(.ais-Carousel-item:only-child) {
       grid-auto-columns: calc(
-        var(--ais-chat-carousel-item-width) * 1.5
+        var(--ais-carousel-item-width) * 1.5
       ) !important;
     }
-  }
-
-  .ais-Carousel-hit {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: calc(var(--ais-spacing) * 0.5);
-    border-radius: var(--ais-border-radius-md);
-    padding: calc(var(--ais-spacing) * 0.5);
-    height: 100%;
-
-    &::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      border-radius: var(--ais-border-radius-md);
-      background-color: rgba(var(--ais-muted-color-rgb), 0);
-      pointer-events: none;
-      z-index: -1;
-      transform: scale(0.95);
-
-      transition: all var(--ais-transition-duration)
-        var(--ais-transition-timing-function);
-    }
-
-    @media (hover: hover) {
-      &:hover {
-        &::before {
-          background-color: rgba(var(--ais-muted-color-rgb), 0.1);
-          transform: scale(1);
-        }
-
-        .ais-Carousel-hit-image img {
-          transform: scale(1.05);
-        }
-      }
-    }
-
-    &:active:not(:disabled) {
-      &::before {
-        background-color: rgba(var(--ais-muted-color-rgb), 0.2);
-      }
-    }
-
-    &:has(:focus-visible) {
-      outline: 2px solid
-        rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
-      outline-offset: 2px;
-    }
-  }
-
-  .ais-Carousel-hit-title {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-  }
-
-  .ais-Carousel-hit-link {
-    &::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-    }
-
-    &:focus-visible {
-      outline: none;
-    }
-  }
-
-  .ais-Carousel-hit-image {
-    position: relative;
-    display: flex;
-    justify-content: center;
-    border-radius: var(--ais-border-radius-md);
-    overflow: hidden;
-
-    img {
-      transition: transform var(--ais-transition-duration)
-        var(--ais-transition-timing-function);
-    }
-  }
-
-  .ais-Carousel-hit-favorite {
-    position: absolute;
-    top: calc(var(--ais-spacing) * 0.5);
-    right: calc(var(--ais-spacing) * 0.5);
-    z-index: 1;
-  }
-
-  .ais-Carousel-hit-title {
-    font-weight: normal;
-
-    a {
-      font-size: var(--ais-spacing);
-    }
-  }
-
-  .ais-Carousel-hit-title,
-  .ais-Carousel-hit-price {
-    margin: 0;
-  }
-
-  .ais-Carousel-hit-price {
-    font-weight: var(--ais-font-weight-semibold);
-    margin-top: auto;
   }
 
   @media (max-width: variables.$ais-chat-breakpoint) {

--- a/packages/instantsearch.css/src/shared/_variables.scss
+++ b/packages/instantsearch.css/src/shared/_variables.scss
@@ -76,8 +76,8 @@ $ais-chat-breakpoint: 680px;
   --ais-chat-maximized-height: 100%;
   --ais-chat-margin: 1.5rem;
 
-  /* Chat carousel component */
-  --ais-chat-carousel-item-width: calc(var(--ais-spacing) * 10);
+  /* Carousel component */
+  --ais-carousel-item-width: calc(var(--ais-spacing) * 10);
 
   /* Hit grid */
   --ais-hit-min-width: 200px;

--- a/packages/instantsearch.css/src/themes/nova.scss
+++ b/packages/instantsearch.css/src/themes/nova.scss
@@ -5,6 +5,7 @@
 @use '../shared/_nova-common';
 
 @use '../components/chat';
+@use '../components/carousel';
 @use '../components/autocomplete';
 @use '../components/ai-mode-button';
 @use '../components/filter-suggestions';


### PR DESCRIPTION
**Summary**

Extract the carousel SCSS that was previously living inside chat into a shared `_carousel.scss` component, so recommend widgets in nova can use the same styles without duplicating the rules.

Stacked on top of #7043.

**Result**

- New `src/components/_carousel.scss` partial used by both chat and nova themes.
- `_chat-carousel.scss` renamed to `_chat-tool-results.scss` (chat-specific rules only).
- Net: 132 insertions / 126 deletions — mostly a move.