### PR TITLE
chore(examples): add recommend view to showcase with nova styles

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -62,7 +62,7 @@
     },
     {
       "path": "./packages/instantsearch.css/themes/nova-min.css",
-      "maxSize": "10 kB"
+      "maxSize": "10.25 kB"
     },
     {
       "path": "./packages/instantsearch.css/themes/satellite.css",

--- a/examples/js/showcase/src/App.tsx
+++ b/examples/js/showcase/src/App.tsx
@@ -1,4 +1,4 @@
-import { MapPin, Search, Sparkles } from "lucide-preact";
+import { MapPin, Search, Sparkles, Wand2 } from "lucide-preact";
 import { useState } from "preact/hooks";
 
 import { ColorModeSwitcher } from "./components/ColorModeSwitcher";
@@ -6,6 +6,7 @@ import { FlavorContext, type Flavor } from "./context/flavor";
 import { AgenticView } from "./views/AgenticView";
 import { GeoSearchView } from "./views/GeoSearchView";
 import { InstantSearchView } from "./views/InstantSearchView";
+import { RecommendView } from "./views/RecommendView";
 
 import type { LucideIcon } from "lucide-preact";
 import type { ComponentType } from "preact";
@@ -45,6 +46,12 @@ const experiences: Experience[] = [
     description: "Search through locations",
     icon: MapPin,
     view: GeoSearchView,
+  },
+  {
+    title: "Recommend",
+    description: "Personalized recommendations",
+    icon: Wand2,
+    view: RecommendView,
   },
 ];
 

--- a/examples/js/showcase/src/components/widgets/WidgetFrequentlyBoughtTogether.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetFrequentlyBoughtTogether.tsx
@@ -1,0 +1,25 @@
+import { carousel } from "instantsearch.js/es/templates";
+import { frequentlyBoughtTogether } from "instantsearch.js/es/widgets";
+
+import { useWidget } from "../../hooks/useWidget";
+
+import { renderCarouselHit } from "./ProductCard";
+
+interface Props {
+  objectIDs: string[];
+}
+
+export function WidgetFrequentlyBoughtTogether({ objectIDs }: Props) {
+  const ref = useWidget((el) =>
+    frequentlyBoughtTogether({
+      container: el,
+      objectIDs,
+      limit: 6,
+      templates: {
+        item: renderCarouselHit,
+        layout: carousel(),
+      },
+    }),
+  );
+  return <div ref={ref} />;
+}

--- a/examples/js/showcase/src/components/widgets/WidgetLookingSimilar.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetLookingSimilar.tsx
@@ -1,0 +1,25 @@
+import { carousel } from "instantsearch.js/es/templates";
+import { lookingSimilar } from "instantsearch.js/es/widgets";
+
+import { useWidget } from "../../hooks/useWidget";
+
+import { renderCarouselHit } from "./ProductCard";
+
+interface Props {
+  objectIDs: string[];
+}
+
+export function WidgetLookingSimilar({ objectIDs }: Props) {
+  const ref = useWidget((el) =>
+    lookingSimilar({
+      container: el,
+      objectIDs,
+      limit: 6,
+      templates: {
+        item: renderCarouselHit,
+        layout: carousel(),
+      },
+    }),
+  );
+  return <div ref={ref} />;
+}

--- a/examples/js/showcase/src/components/widgets/WidgetRelatedProducts.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetRelatedProducts.tsx
@@ -1,0 +1,25 @@
+import { carousel } from "instantsearch.js/es/templates";
+import { relatedProducts } from "instantsearch.js/es/widgets";
+
+import { useWidget } from "../../hooks/useWidget";
+
+import { renderCarouselHit } from "./ProductCard";
+
+interface Props {
+  objectIDs: string[];
+}
+
+export function WidgetRelatedProducts({ objectIDs }: Props) {
+  const ref = useWidget((el) =>
+    relatedProducts({
+      container: el,
+      objectIDs,
+      limit: 6,
+      templates: {
+        item: renderCarouselHit,
+        layout: carousel(),
+      },
+    }),
+  );
+  return <div ref={ref} />;
+}

--- a/examples/js/showcase/src/components/widgets/WidgetTrendingFacets.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetTrendingFacets.tsx
@@ -1,0 +1,21 @@
+import { trendingFacets } from 'instantsearch.js/es/widgets';
+
+import { useWidget } from '../../hooks/useWidget';
+
+interface Props {
+  facetName: string;
+}
+
+export function WidgetTrendingFacets({ facetName }: Props) {
+  const ref = useWidget((el) =>
+    trendingFacets({
+      container: el,
+      facetName,
+      limit: 5,
+      templates: {
+        item: (item, { html }) => html`<span>${item.facetValue}</span>`,
+      },
+    })
+  );
+  return <div ref={ref} />;
+}

--- a/examples/js/showcase/src/components/widgets/WidgetTrendingFacets.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetTrendingFacets.tsx
@@ -1,6 +1,6 @@
-import { trendingFacets } from 'instantsearch.js/es/widgets';
+import { trendingFacets } from "instantsearch.js/es/widgets";
 
-import { useWidget } from '../../hooks/useWidget';
+import { useWidget } from "../../hooks/useWidget";
 
 interface Props {
   facetName: string;
@@ -15,7 +15,7 @@ export function WidgetTrendingFacets({ facetName }: Props) {
       templates: {
         item: (item, { html }) => html`<span>${item.facetValue}</span>`,
       },
-    })
+    }),
   );
   return <div ref={ref} />;
 }

--- a/examples/js/showcase/src/components/widgets/WidgetTrendingItems.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetTrendingItems.tsx
@@ -1,9 +1,9 @@
-import { carousel } from 'instantsearch.js/es/templates';
-import { trendingItems } from 'instantsearch.js/es/widgets';
+import { carousel } from "instantsearch.js/es/templates";
+import { trendingItems } from "instantsearch.js/es/widgets";
 
-import { useWidget } from '../../hooks/useWidget';
+import { useWidget } from "../../hooks/useWidget";
 
-import { renderCarouselHit } from './ProductCard';
+import { renderCarouselHit } from "./ProductCard";
 
 export function WidgetTrendingItems() {
   const ref = useWidget((el) =>
@@ -14,7 +14,7 @@ export function WidgetTrendingItems() {
         item: renderCarouselHit,
         layout: carousel(),
       },
-    })
+    }),
   );
   return <div ref={ref} />;
 }

--- a/examples/js/showcase/src/components/widgets/WidgetTrendingItems.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetTrendingItems.tsx
@@ -1,0 +1,20 @@
+import { carousel } from 'instantsearch.js/es/templates';
+import { trendingItems } from 'instantsearch.js/es/widgets';
+
+import { useWidget } from '../../hooks/useWidget';
+
+import { renderCarouselHit } from './ProductCard';
+
+export function WidgetTrendingItems() {
+  const ref = useWidget((el) =>
+    trendingItems({
+      container: el,
+      limit: 6,
+      templates: {
+        item: renderCarouselHit,
+        layout: carousel(),
+      },
+    })
+  );
+  return <div ref={ref} />;
+}

--- a/examples/js/showcase/src/views/RecommendView.tsx
+++ b/examples/js/showcase/src/views/RecommendView.tsx
@@ -1,0 +1,77 @@
+import { liteClient as algoliasearch } from 'algoliasearch/lite';
+import instantsearch from 'instantsearch.js';
+import { useRef, useEffect } from 'preact/hooks';
+
+import { WidgetFrequentlyBoughtTogether } from '../components/widgets/WidgetFrequentlyBoughtTogether';
+import { WidgetLookingSimilar } from '../components/widgets/WidgetLookingSimilar';
+import { WidgetRelatedProducts } from '../components/widgets/WidgetRelatedProducts';
+import { WidgetTrendingFacets } from '../components/widgets/WidgetTrendingFacets';
+import { WidgetTrendingItems } from '../components/widgets/WidgetTrendingItems';
+import { WidgetSwitcher } from '../components/WidgetSwitcher';
+import { SearchContext } from '../context/search';
+
+const searchClient = algoliasearch(
+  'latency',
+  '6be0576ff61c053d5f9a3225e2a90f76'
+);
+
+const SEED_OBJECT_ID = '5723537';
+const TRENDING_FACET_NAME = 'brand';
+
+export function RecommendView() {
+  const searchRef = useRef<ReturnType<typeof instantsearch> | null>(null);
+  if (searchRef.current === null) {
+    searchRef.current = instantsearch({
+      indexName: 'instant_search',
+      searchClient,
+    });
+  }
+
+  useEffect(() => {
+    const search = searchRef.current!;
+    search.start();
+    return () => search.dispose();
+  }, []);
+
+  return (
+    <SearchContext.Provider value={searchRef.current}>
+      <div class="flex flex-col gap-2">
+        <WidgetSwitcher
+          widgets={[
+            {
+              title: 'frequentlyBoughtTogether',
+              body: () => (
+                <WidgetFrequentlyBoughtTogether objectIDs={[SEED_OBJECT_ID]} />
+              ),
+            },
+            {
+              title: 'relatedProducts',
+              body: () => (
+                <WidgetRelatedProducts objectIDs={[SEED_OBJECT_ID]} />
+              ),
+            },
+            {
+              title: 'lookingSimilar',
+              body: () => <WidgetLookingSimilar objectIDs={[SEED_OBJECT_ID]} />,
+            },
+          ]}
+        />
+
+        <WidgetSwitcher
+          widgets={[{ title: 'trendingItems', body: WidgetTrendingItems }]}
+        />
+
+        <WidgetSwitcher
+          widgets={[
+            {
+              title: 'trendingFacets',
+              body: () => (
+                <WidgetTrendingFacets facetName={TRENDING_FACET_NAME} />
+              ),
+            },
+          ]}
+        />
+      </div>
+    </SearchContext.Provider>
+  );
+}

--- a/examples/js/showcase/src/views/RecommendView.tsx
+++ b/examples/js/showcase/src/views/RecommendView.tsx
@@ -1,28 +1,28 @@
-import { liteClient as algoliasearch } from 'algoliasearch/lite';
-import instantsearch from 'instantsearch.js';
-import { useRef, useEffect } from 'preact/hooks';
+import { liteClient as algoliasearch } from "algoliasearch/lite";
+import instantsearch from "instantsearch.js";
+import { useRef, useEffect } from "preact/hooks";
 
-import { WidgetFrequentlyBoughtTogether } from '../components/widgets/WidgetFrequentlyBoughtTogether';
-import { WidgetLookingSimilar } from '../components/widgets/WidgetLookingSimilar';
-import { WidgetRelatedProducts } from '../components/widgets/WidgetRelatedProducts';
-import { WidgetTrendingFacets } from '../components/widgets/WidgetTrendingFacets';
-import { WidgetTrendingItems } from '../components/widgets/WidgetTrendingItems';
-import { WidgetSwitcher } from '../components/WidgetSwitcher';
-import { SearchContext } from '../context/search';
+import { WidgetFrequentlyBoughtTogether } from "../components/widgets/WidgetFrequentlyBoughtTogether";
+import { WidgetLookingSimilar } from "../components/widgets/WidgetLookingSimilar";
+import { WidgetRelatedProducts } from "../components/widgets/WidgetRelatedProducts";
+import { WidgetTrendingFacets } from "../components/widgets/WidgetTrendingFacets";
+import { WidgetTrendingItems } from "../components/widgets/WidgetTrendingItems";
+import { WidgetSwitcher } from "../components/WidgetSwitcher";
+import { SearchContext } from "../context/search";
 
 const searchClient = algoliasearch(
-  'latency',
-  '6be0576ff61c053d5f9a3225e2a90f76'
+  "latency",
+  "6be0576ff61c053d5f9a3225e2a90f76",
 );
 
-const SEED_OBJECT_ID = '5723537';
-const TRENDING_FACET_NAME = 'brand';
+const SEED_OBJECT_ID = "5723537";
+const TRENDING_FACET_NAME = "brand";
 
 export function RecommendView() {
   const searchRef = useRef<ReturnType<typeof instantsearch> | null>(null);
   if (searchRef.current === null) {
     searchRef.current = instantsearch({
-      indexName: 'instant_search',
+      indexName: "instant_search",
       searchClient,
     });
   }
@@ -36,7 +36,7 @@ export function RecommendView() {
   // Carousel hits draw their hover overlay against `--ais-background-color`
   // (white). Drop the WidgetSwitcher's hover tint so the overlay stays readable.
   const carouselWrapperClass =
-    'hover:bg-transparent! dark:hover:bg-transparent!';
+    "hover:bg-transparent! dark:hover:bg-transparent!";
 
   return (
     <SearchContext.Provider value={searchRef.current}>
@@ -45,19 +45,19 @@ export function RecommendView() {
           class={carouselWrapperClass}
           widgets={[
             {
-              title: 'frequentlyBoughtTogether',
+              title: "frequentlyBoughtTogether",
               body: () => (
                 <WidgetFrequentlyBoughtTogether objectIDs={[SEED_OBJECT_ID]} />
               ),
             },
             {
-              title: 'relatedProducts',
+              title: "relatedProducts",
               body: () => (
                 <WidgetRelatedProducts objectIDs={[SEED_OBJECT_ID]} />
               ),
             },
             {
-              title: 'lookingSimilar',
+              title: "lookingSimilar",
               body: () => <WidgetLookingSimilar objectIDs={[SEED_OBJECT_ID]} />,
             },
           ]}
@@ -65,13 +65,13 @@ export function RecommendView() {
 
         <WidgetSwitcher
           class={carouselWrapperClass}
-          widgets={[{ title: 'trendingItems', body: WidgetTrendingItems }]}
+          widgets={[{ title: "trendingItems", body: WidgetTrendingItems }]}
         />
 
         <WidgetSwitcher
           widgets={[
             {
-              title: 'trendingFacets',
+              title: "trendingFacets",
               body: () => (
                 <WidgetTrendingFacets facetName={TRENDING_FACET_NAME} />
               ),

--- a/examples/js/showcase/src/views/RecommendView.tsx
+++ b/examples/js/showcase/src/views/RecommendView.tsx
@@ -33,10 +33,16 @@ export function RecommendView() {
     return () => search.dispose();
   }, []);
 
+  // Carousel hits draw their hover overlay against `--ais-background-color`
+  // (white). Drop the WidgetSwitcher's hover tint so the overlay stays readable.
+  const carouselWrapperClass =
+    'hover:bg-transparent! dark:hover:bg-transparent!';
+
   return (
     <SearchContext.Provider value={searchRef.current}>
       <div class="flex flex-col gap-2">
         <WidgetSwitcher
+          class={carouselWrapperClass}
           widgets={[
             {
               title: 'frequentlyBoughtTogether',
@@ -58,6 +64,7 @@ export function RecommendView() {
         />
 
         <WidgetSwitcher
+          class={carouselWrapperClass}
           widgets={[{ title: 'trendingItems', body: WidgetTrendingItems }]}
         />
 

--- a/packages/instantsearch.css/src/shared/_nova-common.scss
+++ b/packages/instantsearch.css/src/shared/_nova-common.scss
@@ -113,6 +113,18 @@ select[class^='ais-'] {
   }
 }
 
+// Recommend widgets
+.ais-FrequentlyBoughtTogether-title,
+.ais-LookingSimilar-title,
+.ais-RelatedProducts-title,
+.ais-TrendingFacets-title,
+.ais-TrendingItems-title {
+  margin: 0 0 calc(var(--ais-spacing) / 2);
+  color: rgba(var(--ais-muted-color-rgb), var(--ais-muted-color-alpha));
+  font-size: 0.875rem;
+  font-weight: var(--ais-font-weight-semibold);
+}
+
 // Checked checkbox
 input[class^='ais-'][type='checkbox']:checked {
   background-image: var(--ais-check-icon);

--- a/packages/instantsearch.css/src/themes/nova.scss
+++ b/packages/instantsearch.css/src/themes/nova.scss
@@ -28,3 +28,4 @@
 @use '../widgets/highlight';
 @use '../widgets/relevant-sort';
 @use '../widgets/powered-by';
+@use '../widgets/trending-facets';

--- a/packages/instantsearch.css/src/themes/reset.scss
+++ b/packages/instantsearch.css/src/themes/reset.scss
@@ -18,6 +18,7 @@ a[class^='ais-'] {
 .ais-FrequentlyBoughtTogether-list,
 .ais-LookingSimilar-list,
 .ais-RelatedProducts-list,
+.ais-TrendingFacets-list,
 .ais-TrendingItems-list,
 .ais-Results-list,
 .ais-InfiniteHits-list,

--- a/packages/instantsearch.css/src/widgets/_trending-facets.scss
+++ b/packages/instantsearch.css/src/widgets/_trending-facets.scss
@@ -1,0 +1,17 @@
+.ais-TrendingFacets-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: calc(var(--ais-spacing) / 2);
+}
+
+.ais-TrendingFacets-item {
+  border-radius: var(--ais-border-radius-full);
+  padding: calc(var(--ais-spacing) * 0.25) calc(var(--ais-spacing) * 0.75);
+  border: 1px solid rgba(var(--ais-muted-color-rgb), 0.3);
+  background-color: rgba(
+    var(--ais-background-color-rgb),
+    var(--ais-background-color-alpha)
+  );
+  color: rgba(var(--ais-text-color-rgb), var(--ais-text-color-alpha));
+  font-size: 0.875rem;
+}


### PR DESCRIPTION
**Summary**

Adds a `RecommendView` to the JS showcase wiring up the four recommend widgets (FrequentlyBoughtTogether, RelatedProducts, LookingSimilar, TrendingItems, TrendingFacets) and ships the nova styles needed to render them cleanly.

Stacked on top of #7044.

FX-3779

Includes:
- New `RecommendView` and `Widget*` wrappers in the showcase.
- `widgets/_trending-facets.scss` partial (chip layout for TrendingFacets — nova was the only theme without any TrendingFacets styles).
- Shared title rule in `_nova-common.scss` covering all 5 recommend widgets, mirroring the existing MenuSelect/HitsPerPage/SortBy precedent. Stops the default `<h3>` rendering as browser-bold inside each card.
- `.ais-TrendingFacets-list` added to the existing list reset block.

No hover state on the chip — items are inert by default; consumers wrapping items in `<a>`/`<button>` style hover themselves.

**Result**

In the showcase nova theme, the recommend section now renders with normalized titles across all 5 widgets, and TrendingFacets shows a wrapped row of subtle outlined pills.

<img width="1293" height="815" alt="image" src="https://github.com/user-attachments/assets/c3c3bdcf-21fc-4281-ab4e-56fd4323009a" />