### PR TITLE
feat(cli): scaffold `@instantsearch/cli` with `init`/`add`/`introspect` stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local planning notes (Ralph-loop trackers, etc.)
+plans/
+
 # Dependencies
 node_modules/
 

--- a/packages/instantsearch-cli/.oxlintrc.json
+++ b/packages/instantsearch-cli/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.oxlintrc.json"]
+}

--- a/packages/instantsearch-cli/__tests__/__utils__/helpers.ts
+++ b/packages/instantsearch-cli/__tests__/__utils__/helpers.ts
@@ -1,0 +1,15 @@
+import { run } from '../../src/run';
+
+export async function runCapturing(
+  argv: string[]
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+
+  const exitCode = await run(argv, {
+    stdout: (chunk) => stdout.push(chunk),
+    stderr: (chunk) => stderr.push(chunk),
+  });
+
+  return { exitCode, stdout: stdout.join(''), stderr: stderr.join('') };
+}

--- a/packages/instantsearch-cli/__tests__/classify-error.test.ts
+++ b/packages/instantsearch-cli/__tests__/classify-error.test.ts
@@ -1,0 +1,67 @@
+import { CommanderError } from 'commander';
+
+import { classifyError } from '../src/run';
+
+describe('classifyError', () => {
+  it('classifies commander.invalidOptionArgument as invalid_flag', () => {
+    const error = new CommanderError(
+      1,
+      'commander.invalidOptionArgument',
+      "option '--api-version <n>' argument 'foo' is invalid"
+    );
+
+    expect(classifyError(error)).toEqual({
+      code: 'invalid_flag',
+      message: "option '--api-version <n>' argument 'foo' is invalid",
+    });
+  });
+
+  it('classifies commander.unknownOption as unknown_flag', () => {
+    const error = new CommanderError(
+      1,
+      'commander.unknownOption',
+      "error: unknown option '--bogus'"
+    );
+
+    expect(classifyError(error)).toEqual({
+      code: 'unknown_flag',
+      message: expect.stringContaining('--bogus'),
+    });
+  });
+
+  it('classifies commander.unknownCommand as unknown_command', () => {
+    const error = new CommanderError(
+      1,
+      'commander.unknownCommand',
+      "error: unknown command 'bogus'"
+    );
+
+    expect(classifyError(error)).toEqual({
+      code: 'unknown_command',
+      message: expect.stringContaining('bogus'),
+    });
+  });
+
+  it('classifies an unhandled Commander code as internal_error without a bug-report hint', () => {
+    const error = new CommanderError(
+      1,
+      'commander.missingArgument',
+      "error: missing required argument 'name'"
+    );
+
+    const result = classifyError(error);
+    expect(result.code).toBe('internal_error');
+    expect(result.message).toBe("missing required argument 'name'");
+  });
+
+  it('classifies non-Commander errors as internal_error with a bug-report hint', () => {
+    const error = new Error('boom');
+
+    expect(classifyError(error)).toEqual({
+      code: 'internal_error',
+      message: expect.stringMatching(
+        /boom.*github\.com\/algolia\/instantsearch\/issues/is
+      ),
+    });
+  });
+});

--- a/packages/instantsearch-cli/__tests__/global-options.test.ts
+++ b/packages/instantsearch-cli/__tests__/global-options.test.ts
@@ -1,0 +1,33 @@
+import { createProgram } from '../src/program';
+
+const silentIO = {
+  stdout: () => undefined,
+  stderr: () => undefined,
+};
+
+describe('global options', () => {
+  describe('--json implies --yes', () => {
+    it('sets yes=true when --json is passed', async () => {
+      const program = createProgram(silentIO);
+      await program.parseAsync(['init', '--json'], { from: 'user' });
+
+      expect(program.opts()).toMatchObject({ json: true, yes: true });
+    });
+  });
+
+  describe('--yes', () => {
+    it('is a standalone global flag (yes=true, json=false)', async () => {
+      const program = createProgram(silentIO);
+      await program.parseAsync(['init', '--yes'], { from: 'user' });
+
+      expect(program.opts()).toMatchObject({ json: false, yes: true });
+    });
+
+    it('defaults to false when neither --yes nor --json is passed', async () => {
+      const program = createProgram(silentIO);
+      await program.parseAsync(['init'], { from: 'user' });
+
+      expect(program.opts()).toMatchObject({ json: false, yes: false });
+    });
+  });
+});

--- a/packages/instantsearch-cli/__tests__/help.test.ts
+++ b/packages/instantsearch-cli/__tests__/help.test.ts
@@ -1,0 +1,12 @@
+import { createProgram } from '../src/program';
+
+describe('--help', () => {
+  it('lists init, add, and introspect commands', () => {
+    const program = createProgram();
+    const help = program.helpInformation();
+
+    expect(help).toMatch(/\binit\b/);
+    expect(help).toMatch(/\badd\b/);
+    expect(help).toMatch(/\bintrospect\b/);
+  });
+});

--- a/packages/instantsearch-cli/__tests__/human-output.test.ts
+++ b/packages/instantsearch-cli/__tests__/human-output.test.ts
@@ -1,0 +1,15 @@
+import { runCapturing } from './__utils__/helpers';
+
+describe.each(['init', 'add', 'introspect'])(
+  '%s (no --json)',
+  (command) => {
+    it('emits human-readable output, not a JSON envelope', async () => {
+      const { exitCode, stdout, stderr } = await runCapturing([command]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe('');
+      expect(stdout).toContain(command);
+      expect(stdout.trimStart().startsWith('{')).toBe(false);
+    });
+  }
+);

--- a/packages/instantsearch-cli/__tests__/internal-error.test.ts
+++ b/packages/instantsearch-cli/__tests__/internal-error.test.ts
@@ -19,7 +19,6 @@ describe('internal_error', () => {
     expect(JSON.parse(stdout.join(''))).toEqual({
       ok: false,
       command: expect.any(String),
-      apiVersion: 1,
       code: 'internal_error',
       message: expect.stringMatching(
         /disk full.*github\.com\/algolia\/instantsearch\/issues/is

--- a/packages/instantsearch-cli/__tests__/internal-error.test.ts
+++ b/packages/instantsearch-cli/__tests__/internal-error.test.ts
@@ -1,0 +1,51 @@
+import { run } from '../src/run';
+
+describe('internal_error', () => {
+  it('emits an internal_error envelope on an unexpected throw when --json is set', async () => {
+    const stdout: string[] = [];
+    let firstCall = true;
+    const exitCode = await run(['add', '--json'], {
+      stdout: (chunk) => {
+        if (firstCall) {
+          firstCall = false;
+          throw new Error('disk full');
+        }
+        stdout.push(chunk);
+      },
+      stderr: () => undefined,
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(JSON.parse(stdout.join(''))).toEqual({
+      ok: false,
+      command: expect.any(String),
+      apiVersion: 1,
+      code: 'internal_error',
+      message: expect.stringMatching(
+        /disk full.*github\.com\/algolia\/instantsearch\/issues/is
+      ),
+    });
+  });
+
+  it('writes a bug-report hint to stderr without --json', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let firstCall = true;
+    const exitCode = await run(['add'], {
+      stdout: (chunk) => {
+        if (firstCall) {
+          firstCall = false;
+          throw new Error('disk full');
+        }
+        stdout.push(chunk);
+      },
+      stderr: (chunk) => stderr.push(chunk),
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout.join('')).toBe('');
+    expect(stderr.join('')).toMatch(
+      /disk full.*github\.com\/algolia\/instantsearch\/issues/is
+    );
+  });
+});

--- a/packages/instantsearch-cli/__tests__/json-envelope.test.ts
+++ b/packages/instantsearch-cli/__tests__/json-envelope.test.ts
@@ -14,7 +14,6 @@ describe.each(['init', 'add', 'introspect'])(
       expect(JSON.parse(stdout)).toEqual({
         ok: true,
         command,
-        apiVersion: 1,
         filesCreated: expect.any(Array),
         nextSteps: expect.any(Array),
       });

--- a/packages/instantsearch-cli/__tests__/json-envelope.test.ts
+++ b/packages/instantsearch-cli/__tests__/json-envelope.test.ts
@@ -1,0 +1,23 @@
+import { runCapturing } from './__utils__/helpers';
+
+describe.each(['init', 'add', 'introspect'])(
+  '%s --json',
+  (command) => {
+    it('emits a well-formed success envelope on stdout', async () => {
+      const { exitCode, stdout, stderr } = await runCapturing([
+        command,
+        '--json',
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe('');
+      expect(JSON.parse(stdout)).toEqual({
+        ok: true,
+        command,
+        apiVersion: 1,
+        filesCreated: expect.any(Array),
+        nextSteps: expect.any(Array),
+      });
+    });
+  }
+);

--- a/packages/instantsearch-cli/__tests__/package.test.ts
+++ b/packages/instantsearch-cli/__tests__/package.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const packageJson = JSON.parse(
+  readFileSync(join(__dirname, '..', 'package.json'), 'utf8')
+);
+
+describe('package metadata', () => {
+  it('is named @instantsearch/cli', () => {
+    expect(packageJson.name).toBe('@instantsearch/cli');
+  });
+
+  it('exposes an instantsearch bin', () => {
+    expect(packageJson.bin).toHaveProperty('instantsearch');
+  });
+});

--- a/packages/instantsearch-cli/__tests__/unknown-command.test.ts
+++ b/packages/instantsearch-cli/__tests__/unknown-command.test.ts
@@ -14,7 +14,6 @@ describe('unknown command', () => {
     expect(JSON.parse(stdout)).toEqual({
       ok: false,
       command: PROGRAM_NAME,
-      apiVersion: 1,
       code: 'unknown_command',
       message: expect.stringContaining('bogus-command'),
     });

--- a/packages/instantsearch-cli/__tests__/unknown-command.test.ts
+++ b/packages/instantsearch-cli/__tests__/unknown-command.test.ts
@@ -1,0 +1,41 @@
+import { PROGRAM_NAME } from '../src/program';
+
+import { runCapturing } from './__utils__/helpers';
+
+describe('unknown command', () => {
+  it('emits an unknown_command failure envelope when --json is set', async () => {
+    const { exitCode, stdout, stderr } = await runCapturing([
+      'bogus-command',
+      '--json',
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toBe('');
+    expect(JSON.parse(stdout)).toEqual({
+      ok: false,
+      command: PROGRAM_NAME,
+      apiVersion: 1,
+      code: 'unknown_command',
+      message: expect.stringContaining('bogus-command'),
+    });
+  });
+
+  it('emits a single human-readable error line on stderr without --json', async () => {
+    const { exitCode, stdout, stderr } = await runCapturing(['bogus-command']);
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('bogus-command');
+    expect(stderr).not.toMatch(/^error:/i);
+    expect(stderr.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('keeps the envelope message single-line even for inputs Commander would suggest a match for', async () => {
+    const { stdout } = await runCapturing(['introspct', '--json']);
+
+    const envelope = JSON.parse(stdout);
+    expect(envelope.code).toBe('unknown_command');
+    expect(envelope.message).not.toMatch(/Did you mean/i);
+    expect(envelope.message.split('\n')).toHaveLength(1);
+  });
+});

--- a/packages/instantsearch-cli/__tests__/unknown-flag.test.ts
+++ b/packages/instantsearch-cli/__tests__/unknown-flag.test.ts
@@ -50,15 +50,4 @@ describe('unknown flag', () => {
     expect(stderr).not.toContain('error: unknown option');
     expect(stderr.trim().split('\n')).toHaveLength(1);
   });
-
-  it('does not produce an unknown_flag envelope for an unknown command', async () => {
-    const { exitCode, stdout, stderr } = await runCapturing([
-      'bogus-command',
-      '--json',
-    ]);
-
-    expect(exitCode).not.toBe(0);
-    expect(stdout).toBe('');
-    expect(stderr).toContain('bogus-command');
-  });
 });

--- a/packages/instantsearch-cli/__tests__/unknown-flag.test.ts
+++ b/packages/instantsearch-cli/__tests__/unknown-flag.test.ts
@@ -15,7 +15,6 @@ describe('unknown flag', () => {
     expect(JSON.parse(stdout)).toEqual({
       ok: false,
       command: 'init',
-      apiVersion: 1,
       code: 'unknown_flag',
       message: expect.stringContaining('--bogus-flag'),
     });
@@ -32,7 +31,6 @@ describe('unknown flag', () => {
     expect(JSON.parse(stdout)).toEqual({
       ok: false,
       command: PROGRAM_NAME,
-      apiVersion: 1,
       code: 'unknown_flag',
       message: expect.stringContaining('--bogus-flag'),
     });

--- a/packages/instantsearch-cli/__tests__/unknown-flag.test.ts
+++ b/packages/instantsearch-cli/__tests__/unknown-flag.test.ts
@@ -1,0 +1,64 @@
+import { PROGRAM_NAME } from '../src/program';
+
+import { runCapturing } from './__utils__/helpers';
+
+describe('unknown flag', () => {
+  it('emits an unknown_flag failure envelope when --json is set', async () => {
+    const { exitCode, stdout, stderr } = await runCapturing([
+      'init',
+      '--json',
+      '--bogus-flag',
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toBe('');
+    expect(JSON.parse(stdout)).toEqual({
+      ok: false,
+      command: 'init',
+      apiVersion: 1,
+      code: 'unknown_flag',
+      message: expect.stringContaining('--bogus-flag'),
+    });
+  });
+
+  it('emits an unknown_flag envelope at the program level too', async () => {
+    const { exitCode, stdout, stderr } = await runCapturing([
+      '--json',
+      '--bogus-flag',
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toBe('');
+    expect(JSON.parse(stdout)).toEqual({
+      ok: false,
+      command: PROGRAM_NAME,
+      apiVersion: 1,
+      code: 'unknown_flag',
+      message: expect.stringContaining('--bogus-flag'),
+    });
+  });
+
+  it('emits a single human-readable error line on stderr without --json', async () => {
+    const { exitCode, stdout, stderr } = await runCapturing([
+      'init',
+      '--bogus-flag',
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('--bogus-flag');
+    expect(stderr).not.toContain('error: unknown option');
+    expect(stderr.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('does not produce an unknown_flag envelope for an unknown command', async () => {
+    const { exitCode, stdout, stderr } = await runCapturing([
+      'bogus-command',
+      '--json',
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('bogus-command');
+  });
+});

--- a/packages/instantsearch-cli/__tests__/version.test.ts
+++ b/packages/instantsearch-cli/__tests__/version.test.ts
@@ -1,0 +1,18 @@
+import semver from 'semver';
+
+import version from '../src/version';
+
+import { runCapturing } from './__utils__/helpers';
+
+describe('version', () => {
+  it('is a valid semver string', () => {
+    expect(semver.valid(version)).not.toBeNull();
+  });
+
+  it('--version prints it', async () => {
+    const { stdout, stderr } = await runCapturing(['--version']);
+
+    expect(stdout).toContain(version);
+    expect(stderr).toBe('');
+  });
+});

--- a/packages/instantsearch-cli/jest.config.js
+++ b/packages/instantsearch-cli/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '/__utils__/'],
+  transform: {
+    '^.+\\.(j|t)sx?$': ['babel-jest', { rootMode: 'upward' }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+};

--- a/packages/instantsearch-cli/package.json
+++ b/packages/instantsearch-cli/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@instantsearch/cli",
+  "version": "0.0.0",
+  "private": true,
+  "description": "CLI for scaffolding and integrating InstantSearch projects.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/algolia/instantsearch"
+  },
+  "author": "Algolia <support@algolia.com>",
+  "bin": {
+    "instantsearch": "src/cli.ts"
+  },
+  "scripts": {
+    "test": "jest",
+    "version": "./scripts/version.cjs"
+  },
+  "dependencies": {
+    "commander": "11.1.0"
+  },
+  "devDependencies": {
+    "@types/jest": "27.4.0",
+    "@types/node": "18.11.13",
+    "@types/semver": "7.5.8",
+    "semver": "7.7.3"
+  }
+}

--- a/packages/instantsearch-cli/scripts/version.cjs
+++ b/packages/instantsearch-cli/scripts/version.cjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const version = require('../package.json').version;
+
+fs.writeFileSync(
+  path.resolve(__dirname, '../src/version.ts'),
+  `export default '${version}';\n`
+);

--- a/packages/instantsearch-cli/src/cli.ts
+++ b/packages/instantsearch-cli/src/cli.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { run } from './run';
+
+async function main(): Promise<void> {
+  try {
+    process.exit(await run(process.argv.slice(2)));
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.stack : error}\n`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/instantsearch-cli/src/envelope.ts
+++ b/packages/instantsearch-cli/src/envelope.ts
@@ -1,0 +1,44 @@
+const API_VERSION = 1;
+
+type SuccessEnvelope = {
+  ok: true;
+  command: string;
+  apiVersion: typeof API_VERSION;
+  filesCreated: string[];
+  nextSteps: string[];
+};
+
+type FailureEnvelope = {
+  ok: false;
+  command: string;
+  apiVersion: typeof API_VERSION;
+  code: string;
+  message: string;
+};
+
+type Envelope = SuccessEnvelope | FailureEnvelope;
+
+export function successEnvelope(
+  command: string,
+  details: { filesCreated?: string[]; nextSteps?: string[] } = {}
+): SuccessEnvelope {
+  return {
+    ok: true,
+    command,
+    apiVersion: API_VERSION,
+    filesCreated: details.filesCreated ?? [],
+    nextSteps: details.nextSteps ?? [],
+  };
+}
+
+export function failureEnvelope(
+  command: string,
+  code: string,
+  message: string
+): FailureEnvelope {
+  return { ok: false, command, apiVersion: API_VERSION, code, message };
+}
+
+export function formatEnvelope(envelope: Envelope): string {
+  return `${JSON.stringify(envelope)}\n`;
+}

--- a/packages/instantsearch-cli/src/envelope.ts
+++ b/packages/instantsearch-cli/src/envelope.ts
@@ -1,9 +1,6 @@
-const API_VERSION = 1;
-
 type SuccessEnvelope = {
   ok: true;
   command: string;
-  apiVersion: typeof API_VERSION;
   filesCreated: string[];
   nextSteps: string[];
 };
@@ -11,7 +8,6 @@ type SuccessEnvelope = {
 type FailureEnvelope = {
   ok: false;
   command: string;
-  apiVersion: typeof API_VERSION;
   code: string;
   message: string;
 };
@@ -25,7 +21,6 @@ export function successEnvelope(
   return {
     ok: true,
     command,
-    apiVersion: API_VERSION,
     filesCreated: details.filesCreated ?? [],
     nextSteps: details.nextSteps ?? [],
   };
@@ -36,7 +31,7 @@ export function failureEnvelope(
   code: string,
   message: string
 ): FailureEnvelope {
-  return { ok: false, command, apiVersion: API_VERSION, code, message };
+  return { ok: false, command, code, message };
 }
 
 export function formatEnvelope(envelope: Envelope): string {

--- a/packages/instantsearch-cli/src/io.ts
+++ b/packages/instantsearch-cli/src/io.ts
@@ -1,0 +1,11 @@
+export type IO = {
+  stdout: (chunk: string) => void;
+  stderr: (chunk: string) => void;
+};
+
+export function defaultIO(): IO {
+  return {
+    stdout: (chunk) => process.stdout.write(chunk),
+    stderr: (chunk) => process.stderr.write(chunk),
+  };
+}

--- a/packages/instantsearch-cli/src/program.ts
+++ b/packages/instantsearch-cli/src/program.ts
@@ -1,0 +1,88 @@
+import { Command, Option } from 'commander';
+
+import { formatEnvelope, successEnvelope } from './envelope';
+import { defaultIO, type IO } from './io';
+import version from './version';
+
+type StubDescriptor = {
+  name: string;
+  description: string;
+  humanSummary: string;
+  nextSteps: string[];
+};
+
+const STUBS = [
+  {
+    name: 'init',
+    description:
+      'Scaffold a new InstantSearch project in the current directory.',
+    humanSummary:
+      'init: stub command — no files were created in this slice.',
+    nextSteps: [
+      "Run 'instantsearch init --help' once project scaffolding lands.",
+    ],
+  },
+  {
+    name: 'add',
+    description:
+      'Add a widget or capability to an existing InstantSearch project.',
+    humanSummary:
+      'add: stub command — no files were created in this slice.',
+    nextSteps: [
+      "Run 'instantsearch add --help' once the add command is implemented.",
+    ],
+  },
+  {
+    name: 'introspect',
+    description:
+      'Inspect an Algolia index and report its searchable structure.',
+    humanSummary:
+      'introspect: stub command — no Algolia calls are made in this slice.',
+    nextSteps: [
+      "Run 'instantsearch introspect --help' once introspection lands.",
+    ],
+  },
+] as const satisfies readonly StubDescriptor[];
+
+export const PROGRAM_NAME = 'instantsearch';
+export const KNOWN_COMMANDS: ReadonlyArray<string> = STUBS.map((s) => s.name);
+
+export function createProgram(io: IO = defaultIO()): Command {
+  const program = new Command();
+
+  program
+    .name(PROGRAM_NAME)
+    .description('CLI for scaffolding and integrating InstantSearch projects.')
+    .version(version)
+    .addOption(
+      new Option('--json', 'emit machine-readable JSON envelopes').default(false)
+    )
+    .exitOverride()
+    .configureOutput({
+      writeOut: (str) => io.stdout(str),
+      writeErr: (str) => io.stderr(str),
+    });
+
+  for (const stub of STUBS) {
+    program
+      .command(stub.name)
+      .description(stub.description)
+      .action((_options, cmd: Command) => {
+        const { json } = cmd.optsWithGlobals<{ json: boolean }>();
+        if (json) {
+          io.stdout(
+            formatEnvelope(
+              successEnvelope(stub.name, {
+                filesCreated: [],
+                nextSteps: [...stub.nextSteps],
+              })
+            )
+          );
+        } else {
+          io.stdout(`${stub.humanSummary}\n`);
+        }
+      });
+  }
+
+  return program;
+}

--- a/packages/instantsearch-cli/src/program.ts
+++ b/packages/instantsearch-cli/src/program.ts
@@ -54,8 +54,17 @@ export function createProgram(io: IO = defaultIO()): Command {
     .name(PROGRAM_NAME)
     .description('CLI for scaffolding and integrating InstantSearch projects.')
     .version(version)
+    .showSuggestionAfterError(false)
     .addOption(
-      new Option('--json', 'emit machine-readable JSON envelopes').default(false)
+      new Option('--json', 'emit machine-readable JSON envelopes')
+        .default(false)
+        .implies({ yes: true })
+    )
+    .addOption(
+      new Option(
+        '--yes',
+        'run non-interactively; fail if required inputs are missing'
+      ).default(false)
     )
     .exitOverride()
     .configureOutput({

--- a/packages/instantsearch-cli/src/run.ts
+++ b/packages/instantsearch-cli/src/run.ts
@@ -1,0 +1,78 @@
+import { CommanderError } from 'commander';
+
+import { failureEnvelope, formatEnvelope } from './envelope';
+import { defaultIO, type IO } from './io';
+import { createProgram, KNOWN_COMMANDS, PROGRAM_NAME } from './program';
+
+export async function run(
+  argv: string[],
+  options: Partial<IO> = {}
+): Promise<number> {
+  const io: IO = { ...defaultIO(), ...options };
+  const errBuffer: string[] = [];
+  const program = createProgram({
+    stdout: io.stdout,
+    stderr: (chunk) => errBuffer.push(chunk),
+  });
+
+  try {
+    await program.parseAsync(argv, { from: 'user' });
+    return 0;
+  } catch (error) {
+    if (!(error instanceof CommanderError)) {
+      flush(errBuffer, io);
+      throw error;
+    }
+    if (
+      error.code === 'commander.helpDisplayed' ||
+      error.code === 'commander.version'
+    ) {
+      flush(errBuffer, io);
+      return 0;
+    }
+    if (error.code === 'commander.unknownOption') {
+      emitUnknownFlagEnvelope(argv, error, io);
+      return error.exitCode;
+    }
+    flush(errBuffer, io);
+    return error.exitCode;
+  }
+}
+
+function flush(buffer: string[], io: IO): void {
+  if (buffer.length === 0) return;
+  io.stderr(buffer.join(''));
+  buffer.length = 0;
+}
+
+function emitUnknownFlagEnvelope(
+  argv: string[],
+  error: CommanderError,
+  io: IO
+): void {
+  const badFlag = extractBadFlag(error.message);
+  const envelope = failureEnvelope(
+    detectCommand(argv),
+    'unknown_flag',
+    badFlag ? `Unknown flag: ${badFlag}` : error.message
+  );
+
+  if (argv.includes('--json')) {
+    io.stdout(formatEnvelope(envelope));
+  } else {
+    io.stderr(`${envelope.message}\n`);
+  }
+}
+
+function detectCommand(argv: string[]): string {
+  for (const token of argv) {
+    if (token.startsWith('-')) continue;
+    if (KNOWN_COMMANDS.includes(token)) return token;
+  }
+  return PROGRAM_NAME;
+}
+
+function extractBadFlag(message: string): string | null {
+  const match = message.match(/'([^']+)'/);
+  return match ? match[1] : null;
+}

--- a/packages/instantsearch-cli/src/run.ts
+++ b/packages/instantsearch-cli/src/run.ts
@@ -69,7 +69,7 @@ export function classifyError(error: unknown): {
   const detail = error instanceof Error ? error.message : String(error);
   return {
     code: 'internal_error',
-    message: `${detail}\nThis is a bug. Please file a report at ${BUG_REPORT_URL}.`,
+    message: `${detail}. This is a bug. Please file a report at ${BUG_REPORT_URL}.`,
   };
 }
 

--- a/packages/instantsearch-cli/src/run.ts
+++ b/packages/instantsearch-cli/src/run.ts
@@ -4,6 +4,14 @@ import { failureEnvelope, formatEnvelope } from './envelope';
 import { defaultIO, type IO } from './io';
 import { createProgram, KNOWN_COMMANDS, PROGRAM_NAME } from './program';
 
+const BUG_REPORT_URL = 'https://github.com/algolia/instantsearch/issues/new';
+
+type ParserFailureCode =
+  | 'unknown_flag'
+  | 'invalid_flag'
+  | 'unknown_command'
+  | 'internal_error';
+
 export async function run(
   argv: string[],
   options: Partial<IO> = {}
@@ -19,49 +27,50 @@ export async function run(
     await program.parseAsync(argv, { from: 'user' });
     return 0;
   } catch (error) {
-    if (!(error instanceof CommanderError)) {
-      flush(errBuffer, io);
-      throw error;
-    }
     if (
-      error.code === 'commander.helpDisplayed' ||
-      error.code === 'commander.version'
+      error instanceof CommanderError &&
+      (error.code === 'commander.helpDisplayed' ||
+        error.code === 'commander.version')
     ) {
-      flush(errBuffer, io);
+      io.stderr(errBuffer.join(''));
       return 0;
     }
-    if (error.code === 'commander.unknownOption') {
-      emitUnknownFlagEnvelope(argv, error, io);
-      return error.exitCode;
+
+    const { code, message } = classifyError(error);
+    const envelope = failureEnvelope(detectCommand(argv), code, message);
+    if (argv.includes('--json')) {
+      io.stdout(formatEnvelope(envelope));
+    } else {
+      io.stderr(`${envelope.message}\n`);
     }
-    flush(errBuffer, io);
-    return error.exitCode;
+    return error instanceof CommanderError ? error.exitCode : 1;
   }
 }
 
-function flush(buffer: string[], io: IO): void {
-  if (buffer.length === 0) return;
-  io.stderr(buffer.join(''));
-  buffer.length = 0;
-}
-
-function emitUnknownFlagEnvelope(
-  argv: string[],
-  error: CommanderError,
-  io: IO
-): void {
-  const badFlag = extractBadFlag(error.message);
-  const envelope = failureEnvelope(
-    detectCommand(argv),
-    'unknown_flag',
-    badFlag ? `Unknown flag: ${badFlag}` : error.message
-  );
-
-  if (argv.includes('--json')) {
-    io.stdout(formatEnvelope(envelope));
-  } else {
-    io.stderr(`${envelope.message}\n`);
+export function classifyError(error: unknown): {
+  code: ParserFailureCode;
+  message: string;
+} {
+  if (error instanceof CommanderError) {
+    const message = error.message.replace(/^error:\s*/i, '');
+    switch (error.code) {
+      case 'commander.unknownOption':
+        return { code: 'unknown_flag', message };
+      case 'commander.unknownCommand':
+        return { code: 'unknown_command', message };
+      case 'commander.invalidArgument':
+      case 'commander.invalidOptionArgument':
+        return { code: 'invalid_flag', message };
+      default:
+        return { code: 'internal_error', message };
+    }
   }
+
+  const detail = error instanceof Error ? error.message : String(error);
+  return {
+    code: 'internal_error',
+    message: `${detail}\nThis is a bug. Please file a report at ${BUG_REPORT_URL}.`,
+  };
 }
 
 function detectCommand(argv: string[]): string {
@@ -70,9 +79,4 @@ function detectCommand(argv: string[]): string {
     if (KNOWN_COMMANDS.includes(token)) return token;
   }
   return PROGRAM_NAME;
-}
-
-function extractBadFlag(message: string): string | null {
-  const match = message.match(/'([^']+)'/);
-  return match ? match[1] : null;
 }

--- a/packages/instantsearch-cli/src/version.ts
+++ b/packages/instantsearch-cli/src/version.ts
@@ -1,0 +1,1 @@
+export default '0.0.0';

--- a/packages/instantsearch-cli/tsconfig.json
+++ b/packages/instantsearch-cli/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src", "__tests__"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6931,7 +6931,7 @@
   dependencies:
     jest-diff "*"
 
-"@types/jest@*", "@types/jest@^27.4.0":
+"@types/jest@*", "@types/jest@27.4.0", "@types/jest@^27.4.0":
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.0.tgz#037ab8b872067cae842a320841693080f9cb84ed"
   integrity sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==
@@ -7198,6 +7198,11 @@
   integrity sha512-hP/pI5N9pqX4nEK58myrx3A04M2cm+q5kXpIE+va4HsiJO+HV1hkUprcA83DURMFUaAHAGZDDOaKPWtW4UuYew==
   dependencies:
     "@types/node" "*"
+
+"@types/semver@7.5.8":
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
 
 "@types/semver@^7.3.9":
   version "7.5.0"
@@ -11724,6 +11729,11 @@ command-line-usage@^4.1.0:
     table-layout "^0.4.2"
     typical "^2.6.1"
 
+commander@11.1.0, commander@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
+
 commander@2.17.1, commander@2.17.x, commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
@@ -11743,11 +11753,6 @@ commander@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
-
-commander@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
-  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
 commander@^2.18.0, commander@^2.19.0, commander@^2.20.0, commander@^2.9.0:
   version "2.20.3"
@@ -28168,7 +28173,7 @@ semver@7.3.4:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.7.1, semver@^7.7.2:
+semver@7.7.3, semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.7.1, semver@^7.7.2:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==


### PR DESCRIPTION
## Summary

First PR for a new package, `@instantsearch/cli`. Sets up the package itself, the `instantsearch` executable, the three top-level commands (`init`, `add`, `introspect`) as stubs for now, and the conventions every later command will follow.

## What lands here

- A `@instantsearch/cli` package with an `instantsearch` bin entry
- `init`, `add`, `introspect` registered as subcommands (stubbed — they print a placeholder line and exit cleanly)
- A `--json` flag for machine-readable output, intended for scripts and agents
- A `--yes` flag for non-interactive runs, automatically enabled whenever `--json` is set
- A defined set of failure codes for things the CLI itself rejects (bad flag name, bad flag value, unknown subcommand, unexpected crash)

## Output shape

Every command, under `--json`, prints one line of JSON:

- success: `{ ok: true, command, filesCreated, nextSteps }`
- failure: `{ ok: false, command, code, message }`

Without `--json`, commands print a short human-readable line on stdout (success) or stderr (failure). Exit code is non-zero on failure either way.

Breaking changes to the envelope shape are signaled through the package's semver (no separate `apiVersion` field).

## Failure codes the parser owns

- `unknown_flag` — flag name the CLI doesn't define
- `invalid_flag` — flag value the CLI rejects
- `unknown_command` — subcommand the CLI doesn't define
- `internal_error` — unexpected crash; the message asks the user to file a bug

Individual commands can declare their own failure codes on top of these (e.g. `missing_required_flag`); the four above are the ones the CLI's flag parser and command router are responsible for.