### PR TITLE
feat(cli): add manifest module for reading, writing, validating instantsearch.json

### DIFF
--- a/packages/instantsearch-cli/__tests__/manifest.test.ts
+++ b/packages/instantsearch-cli/__tests__/manifest.test.ts
@@ -1,0 +1,213 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  MANIFEST_API_VERSION,
+  readManifest,
+  serializeManifest,
+  validateManifest,
+  writeManifest,
+  type Manifest,
+} from '../src/manifest';
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'instantsearch-cli-manifest-'));
+}
+
+function validManifest(overrides: Partial<Manifest> = {}): Manifest {
+  return {
+    apiVersion: MANIFEST_API_VERSION,
+    flavor: 'react',
+    framework: 'vite',
+    typescript: true,
+    componentsPath: 'src/components',
+    libPath: 'src/lib',
+    aliases: { '@/*': ['./src/*'] },
+    algolia: {
+      appId: 'APP_ID',
+      searchApiKey: 'SEARCH_KEY',
+    },
+    features: [
+      { name: 'search', path: 'src/features/search', indexName: 'products' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('manifest', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('readManifest', () => {
+    it('returns the parsed manifest when JSON is valid', () => {
+      const filePath = path.join(tempDir, 'instantsearch.json');
+      const manifest = validManifest();
+      fs.writeFileSync(filePath, serializeManifest(manifest), 'utf8');
+
+      const result = readManifest(filePath, { command: 'introspect' });
+
+      expect(result).toEqual({ ok: true, manifest });
+    });
+
+    it('returns invalid_manifest for malformed JSON', () => {
+      const filePath = path.join(tempDir, 'instantsearch.json');
+      fs.writeFileSync(filePath, '{ not valid json', 'utf8');
+
+      const result = readManifest(filePath, { command: 'add' });
+
+      expect(result).toEqual({
+        ok: false,
+        command: 'add',
+        apiVersion: 1,
+        code: 'invalid_manifest',
+        message: expect.stringContaining('not valid JSON'),
+      });
+    });
+
+    it('returns not_found when the file does not exist', () => {
+      const filePath = path.join(tempDir, 'missing.json');
+
+      const result = readManifest(filePath, { command: 'add' });
+
+      expect(result).toEqual({
+        ok: false,
+        command: 'add',
+        apiVersion: 1,
+        code: 'not_found',
+        message: expect.stringContaining(filePath),
+      });
+    });
+
+    it('returns invalid_manifest when the schema is violated', () => {
+      const filePath = path.join(tempDir, 'instantsearch.json');
+      const bad = { ...validManifest(), apiVersion: 2 };
+      fs.writeFileSync(filePath, JSON.stringify(bad), 'utf8');
+
+      const result = readManifest(filePath, { command: 'introspect' });
+
+      expect(result).toMatchObject({
+        ok: false,
+        command: 'introspect',
+        code: 'invalid_manifest',
+      });
+    });
+  });
+
+  describe('writeManifest', () => {
+    it('writes a manifest that round-trips byte-identically', () => {
+      const filePath = path.join(tempDir, 'instantsearch.json');
+      const manifest = validManifest();
+
+      const writeResult = writeManifest(filePath, manifest, {
+        command: 'init',
+      });
+      expect(writeResult).toEqual({ ok: true, path: filePath });
+
+      const writtenBytes = fs.readFileSync(filePath);
+      expect(writtenBytes.equals(Buffer.from(serializeManifest(manifest)))).toBe(
+        true
+      );
+
+      const readResult = readManifest(filePath, { command: 'introspect' });
+      expect(readResult).toEqual({ ok: true, manifest });
+    });
+
+    it('returns manifest_exists when init points at an existing path', () => {
+      const filePath = path.join(tempDir, 'instantsearch.json');
+      fs.writeFileSync(filePath, serializeManifest(validManifest()), 'utf8');
+
+      const result = writeManifest(filePath, validManifest(), {
+        command: 'init',
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        command: 'init',
+        apiVersion: 1,
+        code: 'manifest_exists',
+        message: expect.stringContaining(filePath),
+      });
+    });
+
+  });
+
+  describe('validateManifest', () => {
+    it('accepts a fully populated manifest', () => {
+      const manifest = validManifest();
+      const result = validateManifest(manifest, { command: 'introspect' });
+      expect(result).toEqual({ ok: true, manifest });
+    });
+
+    it.each([
+      'flavor',
+      'framework',
+      'typescript',
+      'componentsPath',
+      'libPath',
+      'aliases',
+      'algolia',
+      'features',
+    ])('rejects missing "%s" with invalid_manifest', (field) => {
+      const manifest = validManifest();
+      delete (manifest as Record<string, unknown>)[field];
+
+      const result = validateManifest(manifest, { command: 'init' });
+
+      expect(result).toMatchObject({
+        ok: false,
+        command: 'init',
+        apiVersion: 1,
+        code: 'invalid_manifest',
+      });
+    });
+
+    it('rejects malformed feature entries', () => {
+      const manifest = validManifest({
+        features: [
+          { name: 'search', path: '', indexName: 'products' },
+        ],
+      });
+
+      const result = validateManifest(manifest, { command: 'add' });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: 'invalid_manifest',
+        message: expect.stringContaining('features[0].path'),
+      });
+    });
+
+    it('rejects malformed algolia credentials', () => {
+      const manifest = validManifest({
+        algolia: { appId: 'APP', searchApiKey: 123 as unknown as string },
+      });
+
+      const result = validateManifest(manifest, { command: 'init' });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: 'invalid_manifest',
+        message: expect.stringContaining('algolia.searchApiKey'),
+      });
+    });
+
+    it('rejects an apiVersion that does not equal 1', () => {
+      const manifest = { ...validManifest(), apiVersion: 2 as unknown as 1 };
+      const result = validateManifest(manifest, { command: 'init' });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: 'invalid_manifest',
+        message: expect.stringContaining('apiVersion'),
+      });
+    });
+  });
+});

--- a/packages/instantsearch-cli/__tests__/manifest.test.ts
+++ b/packages/instantsearch-cli/__tests__/manifest.test.ts
@@ -145,7 +145,6 @@ describe('manifest', () => {
 
     it.each([
       'flavor',
-      'framework',
       'typescript',
       'componentsPath',
       'libPath',
@@ -161,6 +160,24 @@ describe('manifest', () => {
       expect(result).toMatchObject({
         ok: false,
         command: 'init',
+        code: 'invalid_manifest',
+      });
+    });
+
+    it('accepts a manifest without a framework field', () => {
+      const manifest = validManifest();
+      delete (manifest as Record<string, unknown>).framework;
+
+      const result = validateManifest(manifest, { command: 'init' });
+      expect(result).toMatchObject({ ok: true });
+    });
+
+    it('rejects an empty-string framework value', () => {
+      const manifest = validManifest({ framework: '' as unknown as string });
+
+      const result = validateManifest(manifest, { command: 'init' });
+      expect(result).toMatchObject({
+        ok: false,
         code: 'invalid_manifest',
       });
     });

--- a/packages/instantsearch-cli/__tests__/manifest.test.ts
+++ b/packages/instantsearch-cli/__tests__/manifest.test.ts
@@ -3,7 +3,6 @@ import os from 'os';
 import path from 'path';
 
 import {
-  MANIFEST_API_VERSION,
   readManifest,
   serializeManifest,
   validateManifest,
@@ -17,7 +16,6 @@ function makeTempDir(): string {
 
 function validManifest(overrides: Partial<Manifest> = {}): Manifest {
   return {
-    apiVersion: MANIFEST_API_VERSION,
     flavor: 'react',
     framework: 'vite',
     typescript: true,
@@ -86,7 +84,7 @@ describe('manifest', () => {
 
     it('returns invalid_manifest when the schema is violated', () => {
       const filePath = path.join(tempDir, 'instantsearch.json');
-      const bad = { ...validManifest(), apiVersion: 2 };
+      const bad = { ...validManifest(), flavor: undefined };
       fs.writeFileSync(filePath, JSON.stringify(bad), 'utf8');
 
       const result = readManifest(filePath, { command: 'introspect' });
@@ -212,15 +210,5 @@ describe('manifest', () => {
       });
     });
 
-    it('rejects an apiVersion that does not equal 1', () => {
-      const manifest = { ...validManifest(), apiVersion: 2 as unknown as 1 };
-      const result = validateManifest(manifest, { command: 'init' });
-
-      expect(result).toMatchObject({
-        ok: false,
-        code: 'invalid_manifest',
-        message: expect.stringContaining('apiVersion'),
-      });
-    });
   });
 });

--- a/packages/instantsearch-cli/__tests__/manifest.test.ts
+++ b/packages/instantsearch-cli/__tests__/manifest.test.ts
@@ -132,6 +132,19 @@ describe('manifest', () => {
       });
     });
 
+    it('returns write_failed when the parent directory does not exist', () => {
+      const filePath = path.join(tempDir, 'nonexistent', 'instantsearch.json');
+
+      const result = writeManifest(filePath, validManifest(), {
+        command: 'init',
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        command: 'init',
+        code: 'write_failed',
+      });
+    });
   });
 
   describe('validateManifest', () => {
@@ -210,5 +223,21 @@ describe('manifest', () => {
       });
     });
 
+    it.each(['appId', 'searchApiKey'])(
+      'rejects empty-string algolia.%s',
+      (field) => {
+        const manifest = validManifest({
+          algolia: { appId: 'APP', searchApiKey: 'KEY', [field]: '' },
+        });
+
+        const result = validateManifest(manifest, { command: 'init' });
+
+        expect(result).toMatchObject({
+          ok: false,
+          code: 'invalid_manifest',
+          message: expect.stringContaining(`algolia.${field}`),
+        });
+      }
+    );
   });
 });

--- a/packages/instantsearch-cli/__tests__/manifest.test.ts
+++ b/packages/instantsearch-cli/__tests__/manifest.test.ts
@@ -66,7 +66,6 @@ describe('manifest', () => {
       expect(result).toEqual({
         ok: false,
         command: 'add',
-        apiVersion: 1,
         code: 'invalid_manifest',
         message: expect.stringContaining('not valid JSON'),
       });
@@ -80,7 +79,6 @@ describe('manifest', () => {
       expect(result).toEqual({
         ok: false,
         command: 'add',
-        apiVersion: 1,
         code: 'not_found',
         message: expect.stringContaining(filePath),
       });
@@ -131,7 +129,6 @@ describe('manifest', () => {
       expect(result).toEqual({
         ok: false,
         command: 'init',
-        apiVersion: 1,
         code: 'manifest_exists',
         message: expect.stringContaining(filePath),
       });
@@ -164,7 +161,6 @@ describe('manifest', () => {
       expect(result).toMatchObject({
         ok: false,
         command: 'init',
-        apiVersion: 1,
         code: 'invalid_manifest',
       });
     });

--- a/packages/instantsearch-cli/src/manifest.ts
+++ b/packages/instantsearch-cli/src/manifest.ts
@@ -20,7 +20,11 @@ export type Manifest = {
   }>;
 };
 
-type RefusalCode = 'invalid_manifest' | 'not_found' | 'manifest_exists';
+type RefusalCode =
+  | 'invalid_manifest'
+  | 'not_found'
+  | 'manifest_exists'
+  | 'write_failed';
 
 type ManifestFailure = ReturnType<typeof failureEnvelope>;
 
@@ -92,7 +96,13 @@ export function writeManifest(
         `A manifest already exists at ${filePath}.`
       );
     }
-    throw error;
+    return refuse(
+      command,
+      'write_failed',
+      `Could not write manifest to ${filePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
   }
   return { ok: true, path: filePath };
 }
@@ -164,8 +174,9 @@ function checkAlgolia(value: unknown): string | null {
     return 'Manifest "algolia" must be an object.';
   }
   for (const key of ['appId', 'searchApiKey']) {
-    if (typeof value[key] !== 'string') {
-      return `Manifest "algolia.${key}" must be a string.`;
+    const entry = value[key];
+    if (typeof entry !== 'string' || entry.length === 0) {
+      return `Manifest "algolia.${key}" must be a non-empty string.`;
     }
   }
   return null;

--- a/packages/instantsearch-cli/src/manifest.ts
+++ b/packages/instantsearch-cli/src/manifest.ts
@@ -1,0 +1,207 @@
+import fs from 'fs';
+
+import { failureEnvelope } from './envelope';
+
+export const MANIFEST_API_VERSION = 1;
+
+export type Manifest = {
+  apiVersion: typeof MANIFEST_API_VERSION;
+  flavor: string;
+  framework: string;
+  typescript: boolean;
+  componentsPath: string;
+  libPath: string;
+  aliases: Record<string, string[]>;
+  algolia: {
+    appId: string;
+    searchApiKey: string;
+  };
+  features: Array<{
+    name: string;
+    path: string;
+    indexName: string;
+  }>;
+};
+
+type RefusalCode = 'invalid_manifest' | 'not_found' | 'manifest_exists';
+
+type ManifestFailure = ReturnType<typeof failureEnvelope>;
+
+type ReadResult = { ok: true; manifest: Manifest } | ManifestFailure;
+type WriteResult = { ok: true; path: string } | ManifestFailure;
+type ValidateResult = { ok: true; manifest: Manifest } | ManifestFailure;
+
+type Options = { command: string };
+
+function refuse(
+  command: string,
+  code: RefusalCode,
+  message: string
+): ManifestFailure {
+  return failureEnvelope(command, code, message);
+}
+
+export function readManifest(
+  filePath: string,
+  options: Options
+): ReadResult {
+  const { command } = options;
+
+  let contents: string;
+  try {
+    contents = fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    if (errorCode(error) === 'ENOENT') {
+      return refuse(command, 'not_found', `Manifest not found at ${filePath}.`);
+    }
+    return refuse(
+      command,
+      'invalid_manifest',
+      `Failed to read manifest at ${filePath}: ${describeError(error)}`
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (error) {
+    return refuse(
+      command,
+      'invalid_manifest',
+      `Manifest at ${filePath} is not valid JSON: ${describeError(error)}`
+    );
+  }
+
+  return validateManifest(parsed, options);
+}
+
+export function writeManifest(
+  filePath: string,
+  manifest: Manifest,
+  options: Options
+): WriteResult {
+  const { command } = options;
+
+  try {
+    fs.writeFileSync(filePath, serializeManifest(manifest), {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+  } catch (error) {
+    if (errorCode(error) === 'EEXIST') {
+      return refuse(
+        command,
+        'manifest_exists',
+        `A manifest already exists at ${filePath}.`
+      );
+    }
+    throw error;
+  }
+  return { ok: true, path: filePath };
+}
+
+export function validateManifest(
+  value: unknown,
+  options: Options
+): ValidateResult {
+  const error = checkManifest(value);
+  if (error) {
+    return refuse(options.command, 'invalid_manifest', error);
+  }
+  return { ok: true, manifest: value as Manifest };
+}
+
+export function serializeManifest(manifest: Manifest): string {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+function checkManifest(value: unknown): string | null {
+  if (!isPlainObject(value)) {
+    return 'Manifest must be a JSON object.';
+  }
+
+  if (value.apiVersion !== MANIFEST_API_VERSION) {
+    return `Manifest "apiVersion" must equal ${MANIFEST_API_VERSION}.`;
+  }
+
+  for (const key of ['flavor', 'framework', 'componentsPath', 'libPath']) {
+    const entry = value[key];
+    if (typeof entry !== 'string' || entry.length === 0) {
+      return `Manifest "${key}" must be a non-empty string.`;
+    }
+  }
+
+  if (typeof value.typescript !== 'boolean') {
+    return 'Manifest "typescript" must be a boolean.';
+  }
+
+  const aliasesError = checkAliases(value.aliases);
+  if (aliasesError) return aliasesError;
+
+  const algoliaError = checkAlgolia(value.algolia);
+  if (algoliaError) return algoliaError;
+
+  const featuresError = checkFeatures(value.features);
+  if (featuresError) return featuresError;
+
+  return null;
+}
+
+function checkAliases(value: unknown): string | null {
+  if (!isPlainObject(value)) {
+    return 'Manifest "aliases" must be an object mapping aliases to string arrays.';
+  }
+  for (const [key, entries] of Object.entries(value)) {
+    if (!Array.isArray(entries) || !entries.every((e) => typeof e === 'string')) {
+      return `Manifest "aliases.${key}" must be an array of strings.`;
+    }
+  }
+  return null;
+}
+
+function checkAlgolia(value: unknown): string | null {
+  if (!isPlainObject(value)) {
+    return 'Manifest "algolia" must be an object.';
+  }
+  for (const key of ['appId', 'searchApiKey']) {
+    if (typeof value[key] !== 'string') {
+      return `Manifest "algolia.${key}" must be a string.`;
+    }
+  }
+  return null;
+}
+
+function checkFeatures(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return 'Manifest "features" must be an array.';
+  }
+  for (let i = 0; i < value.length; i++) {
+    const feature = value[i];
+    if (!isPlainObject(feature)) {
+      return `Manifest "features[${i}]" must be an object.`;
+    }
+    for (const key of ['name', 'path', 'indexName']) {
+      const entry = feature[key];
+      if (typeof entry !== 'string' || entry.length === 0) {
+        return `Manifest "features[${i}].${key}" must be a non-empty string.`;
+      }
+    }
+  }
+  return null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const code = (error as { code: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  }
+  return undefined;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/instantsearch-cli/src/manifest.ts
+++ b/packages/instantsearch-cli/src/manifest.ts
@@ -2,10 +2,7 @@ import fs from 'fs';
 
 import { failureEnvelope } from './envelope';
 
-export const MANIFEST_API_VERSION = 1;
-
 export type Manifest = {
-  apiVersion: typeof MANIFEST_API_VERSION;
   flavor: string;
   framework?: string;
   typescript: boolean;
@@ -118,10 +115,6 @@ export function serializeManifest(manifest: Manifest): string {
 function checkManifest(value: unknown): string | null {
   if (!isPlainObject(value)) {
     return 'Manifest must be a JSON object.';
-  }
-
-  if (value.apiVersion !== MANIFEST_API_VERSION) {
-    return `Manifest "apiVersion" must equal ${MANIFEST_API_VERSION}.`;
   }
 
   for (const key of ['flavor', 'componentsPath', 'libPath']) {

--- a/packages/instantsearch-cli/src/manifest.ts
+++ b/packages/instantsearch-cli/src/manifest.ts
@@ -7,7 +7,7 @@ export const MANIFEST_API_VERSION = 1;
 export type Manifest = {
   apiVersion: typeof MANIFEST_API_VERSION;
   flavor: string;
-  framework: string;
+  framework?: string;
   typescript: boolean;
   componentsPath: string;
   libPath: string;
@@ -124,11 +124,18 @@ function checkManifest(value: unknown): string | null {
     return `Manifest "apiVersion" must equal ${MANIFEST_API_VERSION}.`;
   }
 
-  for (const key of ['flavor', 'framework', 'componentsPath', 'libPath']) {
+  for (const key of ['flavor', 'componentsPath', 'libPath']) {
     const entry = value[key];
     if (typeof entry !== 'string' || entry.length === 0) {
       return `Manifest "${key}" must be a non-empty string.`;
     }
+  }
+
+  if (
+    value.framework !== undefined &&
+    (typeof value.framework !== 'string' || value.framework.length === 0)
+  ) {
+    return 'Manifest "framework" must be a non-empty string when present.';
   }
 
   if (typeof value.typescript !== 'boolean') {


### PR DESCRIPTION
## Summary

Adds an internal module for reading, writing, and validating `instantsearch.json`, the per-project configuration file the CLI will create and maintain. Not exposed to users in this PR — later PRs (starting with `init`) will call it.

## Manifest shape

```
flavor: string
framework?: string  // optional — only set when special handling is needed (e.g. "next-app")
typescript: boolean
componentsPath: string
libPath: string
aliases: Record<string, string[]>
algolia: { appId, searchApiKey }   // both non-empty strings
features: [{ name, path, indexName }]
```

No schema version field. The package is alpha; if/when we break the shape, we'll add a version signal alongside the migrator.

## Behavior

- Reading a valid manifest returns the parsed object
- Reading malformed JSON → `invalid_manifest`
- Reading a missing file → `not_found`
- Required-field omissions on read → `invalid_manifest`
- Manifests without a `framework` field are accepted; an empty-string `framework` is rejected
- Empty-string `algolia.appId` / `algolia.searchApiKey` → `invalid_manifest`
- Writing then reading produces a byte-identical round-trip
- Trying to write a manifest where one already exists → `manifest_exists` (detected race-free via the `wx` write flag — no separate `existsSync` pre-check)
- Any other write error (missing parent dir, permission denied, no space, …) → `write_failed` envelope. The module never throws on IO errors.

## Checklist

- [x] Read valid manifest → parsed object
- [x] Read malformed JSON → `invalid_manifest`
- [x] Read missing file → `not_found`
- [x] Round-trip writes are byte-identical
- [x] Schema validation rejects missing required fields with `invalid_manifest`
- [x] Re-creating an existing manifest → `manifest_exists`
- [x] Manifest without `framework` is accepted
- [x] Manifest with empty-string `framework` is rejected
- [x] Empty-string `appId` / `searchApiKey` is rejected
- [x] Write into a missing parent directory → `write_failed` (no uncaught throw)