### PR TITLE
fix(chat): collapse empty tool wrapper to prevent extra spacing

### DIFF
--- a/packages/instantsearch.css/src/components/chat/_chat-message.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message.scss
@@ -53,6 +53,10 @@
   overflow-x: auto;
 }
 
+.ais-ChatMessage-tool:empty {
+  display: none;
+}
+
 .ais-ChatMessage--neutral .ais-ChatMessage-message {
   background-color: rgba(var(--ais-muted-color-rgb), 0.1);
   padding: calc(var(--ais-spacing) * 0.75);


### PR DESCRIPTION
## Summary

- When a tool's `layoutComponent` returns `null`, the wrapping `<div class="ais-ChatMessage-tool">` at `packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx:269-283` is still emitted.
- The empty div has no styling itself, but it sits between surrounding markdown blocks and prevents `<p>` margins from collapsing across it — producing visibly extra vertical space in messages whose tool parts intentionally render nothing.
- Adds `.ais-ChatMessage-tool:empty { display: none; }` so empty wrappers are taken out of the flow and stop affecting layout.

A proper fix would skip the wrapper in `ChatMessage.tsx` when the layout component renders nothing, but that requires inspecting a component's render output (can't safely call components as functions) and would likely need a `shouldRender` predicate on the tool definition. This CSS rule is the small, local fix in the meantime.

### Caveat

`:empty` is strict — it matches only when the wrapper contains no nodes at all. Returning `null`, `false`, or `undefined` from the layout component works; returning `<></>` with whitespace inside does not.

## Test plan

- [ ] Register a tool whose `layoutComponent` returns `null`, send a message that triggers it between text parts, confirm the gap matches the gap between two text-only parts
- [ ] Confirm tools that do render are unaffected
- [ ] Visually check chat-min.css regenerates with the new rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)