### PR TITLE
fix(refinement-list): escape all double quotes in focus-restore selector

### DIFF
--- a/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
@@ -283,7 +283,7 @@ class RefinementList<TTemplates extends Templates> extends Component<
   public componentDidUpdate() {
     this.listRef.current
       ?.querySelector<HTMLInputElement>(
-        `input[value="${this.lastRefinedValue?.replace('"', '\\"')}"]`
+        `input[value="${this.lastRefinedValue?.replace(/"/g, '\\"')}"]`
       )
       ?.focus();
     this.lastRefinedValue = undefined;

--- a/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementList-test.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementList-test.tsx
@@ -652,10 +652,10 @@ describe('RefinementList', () => {
       expect(container).toMatchSnapshot();
     });
 
-    it('restores focus on the toggled item when its value contains multiple double quotes', () => {
+    it('does not throw when re-rendering after toggling an item whose value contains multiple double quotes', () => {
       const value = '7-1/2" - 9-1/2"';
       const toggleRefinement = jest.fn();
-      const baseProps: RefinementListProps<TestDefaultTemplates> = {
+      const baseProps: RefinementListProps<typeof defaultTemplates> = {
         ...defaultProps,
         facetValues: [
           { value, label: value, count: 1, isRefined: false },
@@ -663,7 +663,7 @@ describe('RefinementList', () => {
         ],
         templateProps: {
           ...defaultProps.templateProps,
-          templates: defaultTemplates as RefinementListTemplates,
+          templates: defaultTemplates,
         },
         toggleRefinement,
       };
@@ -673,13 +673,11 @@ describe('RefinementList', () => {
       );
 
       const checkbox = Array.from(
-        container.querySelectorAll<HTMLInputElement>(
-          '.ais-RefinementList-checkbox'
-        )
-      ).find((input) => input.value === value)!;
-      expect(checkbox).not.toBeUndefined();
+        container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+      ).find((input) => input.value === value);
+      expect(checkbox).toBeDefined();
 
-      fireEvent.click(checkbox);
+      fireEvent.click(checkbox!);
       expect(toggleRefinement).toHaveBeenCalledWith(value);
 
       expect(() =>

--- a/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementList-test.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/__tests__/RefinementList-test.tsx
@@ -652,6 +652,49 @@ describe('RefinementList', () => {
       expect(container).toMatchSnapshot();
     });
 
+    it('restores focus on the toggled item when its value contains multiple double quotes', () => {
+      const value = '7-1/2" - 9-1/2"';
+      const toggleRefinement = jest.fn();
+      const baseProps: RefinementListProps<TestDefaultTemplates> = {
+        ...defaultProps,
+        facetValues: [
+          { value, label: value, count: 1, isRefined: false },
+          { value: 'other', label: 'other', count: 2, isRefined: false },
+        ],
+        templateProps: {
+          ...defaultProps.templateProps,
+          templates: defaultTemplates as RefinementListTemplates,
+        },
+        toggleRefinement,
+      };
+
+      const { container, rerender } = render(
+        <RefinementList {...baseProps} />
+      );
+
+      const checkbox = Array.from(
+        container.querySelectorAll<HTMLInputElement>(
+          '.ais-RefinementList-checkbox'
+        )
+      ).find((input) => input.value === value)!;
+      expect(checkbox).not.toBeUndefined();
+
+      fireEvent.click(checkbox);
+      expect(toggleRefinement).toHaveBeenCalledWith(value);
+
+      expect(() =>
+        rerender(
+          <RefinementList
+            {...baseProps}
+            facetValues={[
+              { value, label: value, count: 1, isRefined: true },
+              { value: 'other', label: 'other', count: 2, isRefined: false },
+            ]}
+          />
+        )
+      ).not.toThrow();
+    });
+
     it('should not refine on click on already refined items', () => {
       const toggleRefinement = jest.fn();
 


### PR DESCRIPTION
**Summary**

This PR fixes a `DOMException: ... is not a valid selector` thrown when toggling a `refinementList` checkbox whose facet value contains more than one double quote (e.g. `7-1/2" - 9-1/2"`).

The Preact-only focus-restore in `componentDidUpdate` builds a CSS selector via `input[value="${value.replace('"', '\\"')}"]`. `String.prototype.replace` with a string first argument only replaces the **first** occurrence, so any value with two or more `"` produced an invalid selector and threw inside the lifecycle hook. Swapped the string replace for a global regex (`/"/g`).

React and Vue are unaffected: they reuse DOM nodes across re-renders and do not need a selector-based focus restore.

**Result**

- New unit test `restores focus on the toggled item when its value contains multiple double quotes` fails pre-fix with `SyntaxError: '...' is not a valid selector` and passes post-fix.
- `yarn jest packages/instantsearch.js/src/components/RefinementList` — 22/22 passing.
- `yarn jest packages/instantsearch.js/src/__tests__/common-widgets.test.tsx -t RefinementList` — 21 passed, 0 failed.