### PR TITLE
fix(refinement-list): ensure focus is maintained on toggled inputs with escaped values

### DIFF
--- a/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
@@ -281,11 +281,13 @@ class RefinementList<TTemplates extends Templates> extends Component<
    * @see https://github.com/preactjs/preact/issues/3242
    */
   public componentDidUpdate() {
-    this.listRef.current
-      ?.querySelector<HTMLInputElement>(
-        `input[value="${this.lastRefinedValue?.replace('"', '\\"')}"]`
-      )
-      ?.focus();
+    const inputs = this.listRef.current?.getElementsByTagName('input') || [];
+    for (let i = 0; i < inputs.length; i++) {
+      if (inputs[i].value === this.lastRefinedValue) {
+        inputs[i].focus();
+        break;
+      }
+    }
     this.lastRefinedValue = undefined;
   }
 

--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -599,6 +599,11 @@ const testOptions = {
   createRefinementListWidgetTests: {
     skippedTests: {
       'selects first item on submitting the search (with searchableSelectOnSubmit: true)': true,
+      // Vue does not have the JS flavor's `componentDidUpdate` focus
+      // restoration; Vue 3 resets `activeElement` to body across re-renders,
+      // so the focus assertion is unreliable there. The bug this test
+      // catches is in the Preact RefinementList component.
+      'keeps focus on toggled input between re-renders (multiple values that should be escaped)': true,
     },
   },
   createHierarchicalMenuWidgetTests: undefined,

--- a/tests/common/widgets/refinement-list/options.ts
+++ b/tests/common/widgets/refinement-list/options.ts
@@ -631,6 +631,52 @@ export function createOptionsTests(
       expect(document.activeElement).toEqual(updatedTargetItem);
     });
 
+    test('keeps focus on toggled input between re-renders (multiple values that should be escaped)', async () => {
+      const searchClient = createMockedSearchClient(
+        {},
+        {
+          Apple: 100,
+          '7-1/2" - 9-1/2"': 200,
+          Samsung: 300,
+        }
+      );
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: { attribute: 'brand' },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const initialTargetItem = document.querySelector(
+        '.ais-RefinementList-checkbox[value="7-1/2\\" - 9-1/2\\""]'
+      )!;
+
+      // Single click: the item's `isRefined` flips, which is part of the
+      // Preact key, so the old <input> unmounts and a fresh one mounts.
+      // The click-focused element is gone; only the post-render focus
+      // restoration in `componentDidUpdate` can put focus on the new input.
+      // If the restoration logic builds a CSS selector with values that
+      // contain `"` but only escapes the first one, `querySelector` throws
+      // and focus drops to body.
+      await act(async () => {
+        userEvent.click(initialTargetItem);
+        await wait(0);
+      });
+
+      const updatedTargetItem = document.querySelector(
+        '.ais-RefinementList-checkbox[value="7-1/2\\" - 9-1/2\\""]'
+      )!;
+
+      expect(updatedTargetItem).toBeChecked();
+      expect(document.activeElement).toEqual(updatedTargetItem);
+    });
+
     test('does not display facets that should be hidden based on the renderingContent', async () => {
       const searchClient = createMockedSearchClient(undefined, undefined, {
         facetOrdering: {

--- a/tests/common/widgets/refinement-list/options.ts
+++ b/tests/common/widgets/refinement-list/options.ts
@@ -631,51 +631,59 @@ export function createOptionsTests(
       expect(document.activeElement).toEqual(updatedTargetItem);
     });
 
-    test('keeps focus on toggled input between re-renders (multiple values that should be escaped)', async () => {
-      const searchClient = createMockedSearchClient(
-        {},
-        {
-          Apple: 100,
-          '7-1/2" - 9-1/2"': 200,
-          Samsung: 300,
-        }
-      );
+    // Unlike the test above, this one uses a single click so the item's
+    // `isRefined` actually flips. Because the Preact key includes
+    // `isRefined`, the old <input> unmounts and a fresh one mounts. The
+    // click-focused element is gone; only the post-render focus
+    // restoration in the JS flavor's `componentDidUpdate` can put focus on
+    // the new input. If the restoration logic builds a CSS selector with
+    // values that contain `"` but only escapes the first one,
+    // `querySelector` throws and focus drops to body.
+    // Vue 3 resets `activeElement` to body across re-renders without an
+    // equivalent restoration mechanism, so this test is skipped there
+    // (see `tests/common-widgets.test.js` in vue-instantsearch).
+    skippableTest(
+      'keeps focus on toggled input between re-renders (multiple values that should be escaped)',
+      skippedTests,
+      async () => {
+        const searchClient = createMockedSearchClient(
+          {},
+          {
+            Apple: 100,
+            '7-1/2" - 9-1/2"': 200,
+            Samsung: 300,
+          }
+        );
 
-      await setup({
-        instantSearchOptions: {
-          indexName: 'indexName',
-          searchClient,
-        },
-        widgetParams: { attribute: 'brand' },
-      });
+        await setup({
+          instantSearchOptions: {
+            indexName: 'indexName',
+            searchClient,
+          },
+          widgetParams: { attribute: 'brand' },
+        });
 
-      await act(async () => {
-        await wait(0);
-      });
+        await act(async () => {
+          await wait(0);
+        });
 
-      const initialTargetItem = document.querySelector(
-        '.ais-RefinementList-checkbox[value="7-1/2\\" - 9-1/2\\""]'
-      )!;
+        const initialTargetItem = document.querySelector(
+          '.ais-RefinementList-checkbox[value="7-1/2\\" - 9-1/2\\""]'
+        )!;
 
-      // Single click: the item's `isRefined` flips, which is part of the
-      // Preact key, so the old <input> unmounts and a fresh one mounts.
-      // The click-focused element is gone; only the post-render focus
-      // restoration in `componentDidUpdate` can put focus on the new input.
-      // If the restoration logic builds a CSS selector with values that
-      // contain `"` but only escapes the first one, `querySelector` throws
-      // and focus drops to body.
-      await act(async () => {
-        userEvent.click(initialTargetItem);
-        await wait(0);
-      });
+        await act(async () => {
+          userEvent.click(initialTargetItem);
+          await wait(0);
+        });
 
-      const updatedTargetItem = document.querySelector(
-        '.ais-RefinementList-checkbox[value="7-1/2\\" - 9-1/2\\""]'
-      )!;
+        const updatedTargetItem = document.querySelector(
+          '.ais-RefinementList-checkbox[value="7-1/2\\" - 9-1/2\\""]'
+        )!;
 
-      expect(updatedTargetItem).toBeChecked();
-      expect(document.activeElement).toEqual(updatedTargetItem);
-    });
+        expect(updatedTargetItem).toBeChecked();
+        expect(document.activeElement).toEqual(updatedTargetItem);
+      }
+    );
 
     test('does not display facets that should be hidden based on the renderingContent', async () => {
       const searchClient = createMockedSearchClient(undefined, undefined, {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

change from a css to a loop solution for re-focusing active elements.

**Result**

Ensure we don't need to rely on escaping for keeping focus.

When there are multiple quotes to escape, the previous approach did not work, because it was relying on then invalid CSS selectors. This is fixed by looping over the inputs and checking its value directly.


<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
