### PR TITLE
fix(chat): show loader during gap in tool calls

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -32,7 +32,13 @@ import type {
 } from './ChatMessage';
 import type { ChatMessageErrorProps } from './ChatMessageError';
 import type { ChatMessageLoaderProps } from './ChatMessageLoader';
-import type { ChatEmptyProps, ChatLayoutOwnProps, ChatMessageBase, ChatStatus, ClientSideTools } from './types';
+import type {
+  ChatEmptyProps,
+  ChatLayoutOwnProps,
+  ChatMessageBase,
+  ChatStatus,
+  ClientSideTools,
+} from './types';
 
 export type ChatMessagesTranslations = {
   /**
@@ -539,15 +545,10 @@ const getShowLoader = (
   if (!lastPart) return true;
   if (isPartText(lastPart)) return false;
 
-  if (isPartTool(lastPart)) {
-    if (lastPart.state === 'output-available') return false;
-    if (lastPart.state === 'input-streaming') {
-      const tool = findTool(lastPart.type, tools);
-      return !tool?.streamInput;
-    }
-    return true;
+  if (isPartTool(lastPart) && lastPart.state === 'input-streaming') {
+    const tool = findTool(lastPart.type, tools);
+    return !tool?.streamInput;
   }
 
   return true;
 };
-

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -859,7 +859,7 @@ export function createOptionsTests(
         ).toBeInTheDocument();
       });
 
-      test('does not show loader during streaming when last part is a tool with output', async () => {
+      test('shows loader during streaming when last part is a tool with output (between tool calls or before text)', async () => {
         const searchClient = createSearchClient();
         const chat = new Chat({});
 
@@ -887,6 +887,9 @@ export function createOptionsTests(
             {
               id: '2',
               role: 'assistant',
+              // Status is still streaming so more events are coming after this
+              // tool resolves (another tool call or text); the loader must
+              // bridge the gap between this finish-step and the next start-step.
               parts: [
                 { type: 'text', text: 'Let me search for that.' },
                 {
@@ -895,6 +898,73 @@ export function createOptionsTests(
                   state: 'output-available',
                   input: {},
                   output: { hits: [] },
+                },
+              ],
+            },
+          ] as any;
+          chat._state.status = 'streaming';
+          await wait(0);
+        });
+
+        expect(
+          document.querySelector('.ais-ChatMessageLoader')
+        ).toBeInTheDocument();
+      });
+
+      test('does not show loader during streaming when last part is a tool with streaming input and streamInput is true', async () => {
+        const searchClient = createSearchClient();
+        const chat = new Chat({});
+
+        await setup({
+          instantSearchOptions: {
+            indexName: 'indexName',
+            searchClient,
+          },
+          widgetParams: {
+            javascript: {
+              ...createDefaultWidgetParams(chat),
+              tools: {
+                [SearchIndexToolType]: {
+                  streamInput: true,
+                  templates: {
+                    layout: '<div id="tool-content">streaming...</div>',
+                  },
+                },
+              },
+            },
+            react: {
+              ...createDefaultWidgetParams(chat),
+              tools: {
+                [SearchIndexToolType]: {
+                  streamInput: true,
+                  layoutComponent: () => (
+                    <div id="tool-content">streaming...</div>
+                  ),
+                },
+              },
+            },
+            vue: {},
+          },
+        });
+
+        await openChat(act);
+
+        await act(async () => {
+          chat._state.messages = [
+            {
+              id: '1',
+              role: 'user',
+              parts: [{ type: 'text', text: 'Hello' }],
+            },
+            {
+              id: '2',
+              role: 'assistant',
+              parts: [
+                {
+                  type: `tool-${SearchIndexToolType}`,
+                  toolCallId: '1',
+                  state: 'input-streaming',
+                  input: undefined,
                 },
               ],
             },


### PR DESCRIPTION
This PR fixes the gap in the loader being shown when there are multiple tool calls. The gap was caused by the backend stopping streaming slightly between the tool calls (during the step finish and step start stages).


<details>
<summary>Demo with the display results tool</summary>
<video src="https://github.com/user-attachments/assets/95536c7e-201d-4b9e-bb70-ef12faab9c3b" />
</details>

<details>
<summary>Demo with only search index tool</summary>
<video src="https://github.com/user-attachments/assets/2ff37ded-c316-419e-b125-9017d1c5f44f" />
</details>