### PR TITLE
fix(chat): hydrate full objects in display results tool

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "127 kB"
+      "maxSize": "127.25 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "265 kB"
+      "maxSize": "265.25 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "127.5 kB"
+      "maxSize": "128 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "266.5 kB"
+      "maxSize": "267.5 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "264.25 kB"
+      "maxSize": "265 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "99.5 kB"
+      "maxSize": "99.75 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -128,6 +128,12 @@ export type ChatMessageProps = ComponentProps<'article'> & {
    */
   setIndexUiState: (state: object) => void;
   /**
+   * The full conversation. Forwarded to tool components so those that only
+   * receive object IDs (e.g. display results) can hydrate records from a
+   * preceding search tool's hits.
+   */
+  messages?: ChatMessageBase[];
+  /**
    * Close the chat
    */
   onClose: () => void;
@@ -170,6 +176,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
       tools = {},
       indexUiState,
       setIndexUiState,
+      messages,
       onClose,
       translations: userTranslations,
       suggestionsElement,
@@ -259,10 +266,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
               toolCallId: toolMessage.toolCallId,
             });
 
-          if (
-            toolMessage.state === 'input-streaming' &&
-            !tool.streamInput
-          ) {
+          if (toolMessage.state === 'input-streaming' && !tool.streamInput) {
             return null;
           }
 
@@ -279,6 +283,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
                 message={toolMessage}
                 indexUiState={indexUiState}
                 setIndexUiState={setIndexUiState}
+                messages={messages}
                 addToolResult={boundAddToolResult}
                 applyFilters={tool.applyFilters}
                 sendEvent={tool.sendEvent || (() => {})}

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -32,7 +32,13 @@ import type {
 } from './ChatMessage';
 import type { ChatMessageErrorProps } from './ChatMessageError';
 import type { ChatMessageLoaderProps } from './ChatMessageLoader';
-import type { ChatEmptyProps, ChatLayoutOwnProps, ChatMessageBase, ChatStatus, ClientSideTools } from './types';
+import type {
+  ChatEmptyProps,
+  ChatLayoutOwnProps,
+  ChatMessageBase,
+  ChatStatus,
+  ClientSideTools,
+} from './types';
 
 export type ChatMessagesTranslations = {
   /**
@@ -234,6 +240,7 @@ function createDefaultMessageComponent<
     tools,
     indexUiState,
     setIndexUiState,
+    messages,
     onReload,
     onClose,
     onFeedback,
@@ -251,6 +258,7 @@ function createDefaultMessageComponent<
     assistantMessageProps?: Partial<ChatMessageProps>;
     indexUiState: object;
     setIndexUiState: (state: object) => void;
+    messages?: ChatMessageBase[];
     tools: ClientSideTools;
     onReload: (messageId?: string) => void;
     onClose: () => void;
@@ -337,6 +345,7 @@ function createDefaultMessageComponent<
         tools={tools}
         indexUiState={indexUiState}
         setIndexUiState={setIndexUiState}
+        messages={messages}
         onClose={onClose}
         actions={defaultActions}
         actionsComponent={actionsComponent}
@@ -480,6 +489,7 @@ export function createChatMessagesComponent({
                 tools={tools}
                 indexUiState={indexUiState}
                 setIndexUiState={setIndexUiState}
+                messages={messages}
                 onReload={onReload}
                 onFeedback={onFeedback}
                 feedbackState={feedbackState}
@@ -550,4 +560,3 @@ const getShowLoader = (
 
   return true;
 };
-

--- a/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
@@ -66,10 +66,6 @@ export function createDisplayResultsToolComponent<
       ...userTranslations,
     };
 
-    // The backend only sends object IDs for display results, so we rebuild the
-    // full records from the hits the preceding search tool already fetched.
-    // `getHitsByObjectID` is memoized on the `messages` reference, so this is
-    // not recomputed on unrelated re-renders.
     const hitsByObjectID = messages ? getHitsByObjectID(messages) : undefined;
 
     const output = message?.output as DisplayResultsOutput<TObject> | undefined;

--- a/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
@@ -24,6 +24,17 @@ type DisplayResultsOutput<THit> = {
   groups?: Array<DisplayResultsGroup<THit>>;
 };
 
+/**
+ * An item handed to a group's carousel: the record (hydrated from the search
+ * tool) augmented with the display tool's own result object under a separate
+ * `__displayToolResult` namespace, so the tool's curation fields (e.g. `why`)
+ * can never collide with record fields in either direction.
+ */
+export type DisplayResultsItem<THit extends RecordWithObjectID> =
+  RecordWithObjectID<THit> & {
+    __displayToolResult: RecordWithObjectID<THit>;
+  };
+
 export type DisplayResultsGroupCarouselProps<THit extends RecordWithObjectID> =
   {
     items: Array<RecordWithObjectID<THit>>;
@@ -107,21 +118,20 @@ export function createDisplayResultsToolComponent<
 
           if (results.length === 0) return null;
 
-          const items = results.map((result, idx) => {
-            const hydrated = hitsByObjectID?.[result.objectID] as
-              | RecordWithObjectID<TObject>
-              | undefined;
+          const items: Array<DisplayResultsItem<TObject>> = results.map(
+            (result, idx) => {
+              const hydrated = hitsByObjectID?.[result.objectID] as
+                | RecordWithObjectID<TObject>
+                | undefined;
 
-            return {
-              ...hydrated,
-              ...result,
-              // When hydrated, keep the record's real `objectID` (the
-              // display tool references it by a stripped `id`), so click events
-              // and Insights report the correct objectID.
-              ...(hydrated ? { objectID: hydrated.objectID } : {}),
-              __position: idx + 1,
-            };
-          }) as Array<RecordWithObjectID<TObject>>;
+              return {
+                ...(hydrated as RecordWithObjectID<TObject>),
+                objectID: result.objectID,
+                __position: idx + 1,
+                __displayToolResult: result,
+              };
+            }
+          );
 
           return (
             <div key={groupIndex} className="ais-ChatToolDisplayResults-group">

--- a/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
@@ -1,5 +1,7 @@
 /** @jsx createElement */
 
+import { getHitsByObjectID } from '../../../lib/utils/chat';
+
 import type { RecordWithObjectID, Renderer } from '../../../types';
 import type { ClientSideToolComponentProps } from '../types';
 
@@ -54,15 +56,21 @@ export function createDisplayResultsToolComponent<
   ) {
     const {
       toolProps,
-      groupCarouselComponent: GroupCarousel,
+      groupCarouselComponent: renderGroupCarousel,
       translations: userTranslations,
     } = userProps;
-    const { message, sendEvent } = toolProps;
+    const { message, messages, sendEvent } = toolProps;
 
     const translations: DisplayResultsTranslations = {
       ...DEFAULT_TRANSLATIONS,
       ...userTranslations,
     };
+
+    // The backend only sends object IDs for display results, so we rebuild the
+    // full records from the hits the preceding search tool already fetched.
+    // `getHitsByObjectID` is memoized on the `messages` reference, so this is
+    // not recomputed on unrelated re-renders.
+    const hitsByObjectID = messages ? getHitsByObjectID(messages) : undefined;
 
     const output = message?.output as DisplayResultsOutput<TObject> | undefined;
     const intro = typeof output?.intro === 'string' ? output.intro : undefined;
@@ -94,10 +102,21 @@ export function createDisplayResultsToolComponent<
 
           if (results.length === 0) return null;
 
-          const items = results.map((result, idx) => ({
-            ...result,
-            __position: idx + 1,
-          })) as Array<RecordWithObjectID<TObject>>;
+          const items = results.map((result, idx) => {
+            const hydrated = hitsByObjectID?.[result.objectID] as
+              | RecordWithObjectID<TObject>
+              | undefined;
+
+            return {
+              ...hydrated,
+              ...result,
+              // When hydrated, keep the record's real `objectID` (the
+              // display tool references it by a stripped `id`), so click events
+              // and Insights report the correct objectID.
+              ...(hydrated ? { objectID: hydrated.objectID } : {}),
+              __position: idx + 1,
+            };
+          }) as Array<RecordWithObjectID<TObject>>;
 
           return (
             <div key={groupIndex} className="ais-ChatToolDisplayResults-group">
@@ -111,7 +130,7 @@ export function createDisplayResultsToolComponent<
                   {group.why}
                 </div>
               )}
-              <GroupCarousel items={items} sendEvent={sendEvent} />
+              {renderGroupCarousel({ items, sendEvent })}
             </div>
           );
         })}

--- a/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
@@ -47,10 +47,15 @@ const DEFAULT_TRANSLATIONS: DisplayResultsTranslations = {
   streamingLabel: 'Curating results…',
 };
 
+export type UseMemo = <TValue>(
+  factory: () => TValue,
+  deps: readonly unknown[]
+) => TValue;
+
 export function createDisplayResultsToolComponent<
   TObject extends RecordWithObjectID
   // oxlint-disable-next-line no-unused-vars
->({ createElement, Fragment }: Renderer) {
+>({ createElement, Fragment, useMemo }: Renderer & { useMemo: UseMemo }) {
   return function DisplayResultsTool(
     userProps: DisplayResultsToolProps<TObject>
   ) {
@@ -66,7 +71,11 @@ export function createDisplayResultsToolComponent<
       ...userTranslations,
     };
 
-    const hitsByObjectID = messages ? getHitsByObjectID(messages) : undefined;
+    const toolCallId = message?.toolCallId;
+    const hitsByObjectID = useMemo(
+      () => (messages ? getHitsByObjectID(messages, toolCallId) : undefined),
+      [messages, toolCallId]
+    );
 
     const output = message?.output as DisplayResultsOutput<TObject> | undefined;
     const intro = typeof output?.intro === 'string' ? output.intro : undefined;

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -482,6 +482,7 @@ export type ChatLayoutOwnProps<
 
 export type ClientSideToolComponentProps = {
   message: ChatToolMessage;
+  messages?: ChatMessageBase[];
   indexUiState: object;
   setIndexUiState: (state: object) => void;
   onClose: () => void;
@@ -534,4 +535,3 @@ export type ChatEmptyProps = {
    */
   setInput?: (input: string) => void;
 };
-

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -169,6 +169,85 @@ describe('getHitsByObjectID', () => {
     expect(map['84254']).toBe(map['media-sample-data-84254']);
   });
 
+  test('scopes collection to the turn containing `untilToolCallId`, ignoring later searches', () => {
+    const messages: ChatMessageBase[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search-1',
+            state: 'output-available',
+            input: { query: 'shoes' },
+            output: { hits: [{ objectID: '1', name: 'Runner', __queryID: 'q1' }] },
+          },
+          {
+            type: 'tool-algolia_display_results',
+            toolCallId: 'display-1',
+            state: 'output-available',
+            input: {},
+            output: { groups: [{ results: [{ objectID: '1' }] }] },
+          },
+        ],
+      },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search-2',
+            state: 'output-available',
+            input: { query: 'running shoes' },
+            output: {
+              hits: [{ objectID: '1', name: 'Runner Pro', __queryID: 'q2' }],
+            },
+          },
+        ],
+      },
+    ] as ChatMessageBase[];
+
+    // Scoped to the first turn: the later search (with `q2`) must not leak in.
+    expect(getHitsByObjectID(messages, 'display-1')).toEqual({
+      1: { objectID: '1', name: 'Runner', __queryID: 'q1' },
+    });
+
+    // Without a boundary, last write across the whole conversation wins.
+    expect(getHitsByObjectID(messages)).toEqual({
+      1: { objectID: '1', name: 'Runner Pro', __queryID: 'q2' },
+    });
+  });
+
+  test('includes the search in the same message as `untilToolCallId`', () => {
+    const messages: ChatMessageBase[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: { query: 'shoes' },
+            output: { hits: [{ objectID: '1', name: 'Runner' }] },
+          },
+          {
+            type: 'tool-algolia_display_results',
+            toolCallId: 'display',
+            state: 'output-available',
+            input: {},
+            output: { groups: [{ results: [{ objectID: '1' }] }] },
+          },
+        ],
+      },
+    ] as ChatMessageBase[];
+
+    expect(getHitsByObjectID(messages, 'display')).toEqual({
+      1: { objectID: '1', name: 'Runner' },
+    });
+  });
+
   test('returns an empty map when there are no search outputs', () => {
     expect(getHitsByObjectID([])).toEqual({});
   });

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -132,43 +132,6 @@ describe('getHitsByObjectID', () => {
     });
   });
 
-  test('keys hits by their bare `id` so display results can hydrate by stripped objectID', () => {
-    const messages: ChatMessageBase[] = [
-      {
-        id: '1',
-        role: 'assistant',
-        parts: [
-          {
-            type: 'tool-algolia_search_index',
-            toolCallId: 'search',
-            state: 'output-available',
-            input: { query: 'sherlock' },
-            output: {
-              hits: [
-                {
-                  objectID: 'media-sample-data-84254',
-                  id: 84254,
-                  name: 'Hound',
-                },
-              ],
-            },
-          },
-        ],
-      },
-    ] as ChatMessageBase[];
-
-    // The display results tool references this record as `"84254"` (the
-    // backend strips the `media-sample-data-` prefix), so both keys resolve
-    // to the same hit.
-    const map = getHitsByObjectID(messages);
-    expect(map['media-sample-data-84254']).toEqual({
-      objectID: 'media-sample-data-84254',
-      id: 84254,
-      name: 'Hound',
-    });
-    expect(map['84254']).toBe(map['media-sample-data-84254']);
-  });
-
   test('scopes collection to the turn containing `untilToolCallId`, ignoring later searches', () => {
     const messages: ChatMessageBase[] = [
       {
@@ -180,7 +143,9 @@ describe('getHitsByObjectID', () => {
             toolCallId: 'search-1',
             state: 'output-available',
             input: { query: 'shoes' },
-            output: { hits: [{ objectID: '1', name: 'Runner', __queryID: 'q1' }] },
+            output: {
+              hits: [{ objectID: '1', name: 'Runner', __queryID: 'q1' }],
+            },
           },
           {
             type: 'tool-algolia_display_results',

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -1,0 +1,175 @@
+import { getHitsByObjectID } from '../chat';
+
+import type { ChatMessageBase } from '../../../components';
+
+describe('getHitsByObjectID', () => {
+  test('collects hits from a search tool output keyed by objectID', () => {
+    const messages: ChatMessageBase[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: { query: 'shoes' },
+            output: {
+              hits: [
+                { objectID: '1', name: 'Runner' },
+                { objectID: '2', name: 'Sneaker' },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(getHitsByObjectID(messages)).toEqual({
+      1: { objectID: '1', name: 'Runner' },
+      2: { objectID: '2', name: 'Sneaker' },
+    });
+  });
+
+  test('supports the MCP server search tool name shim', () => {
+    const messages: ChatMessageBase[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index_products',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: { query: 'shoes' },
+            output: { hits: [{ objectID: '1', name: 'Runner' }] },
+          },
+        ],
+      },
+    ];
+
+    expect(getHitsByObjectID(messages)).toEqual({
+      1: { objectID: '1', name: 'Runner' },
+    });
+  });
+
+  test('merges hits across several messages, last write wins per objectID', () => {
+    const messages: ChatMessageBase[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search-1',
+            state: 'output-available',
+            input: { query: 'shoes' },
+            output: { hits: [{ objectID: '1', name: 'Runner' }] },
+          },
+        ],
+      },
+      {
+        id: '2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search-2',
+            state: 'output-available',
+            input: { query: 'running shoes' },
+            output: {
+              hits: [
+                { objectID: '1', name: 'Runner Pro' },
+                { objectID: '3', name: 'Trail' },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(getHitsByObjectID(messages)).toEqual({
+      1: { objectID: '1', name: 'Runner Pro' },
+      3: { objectID: '3', name: 'Trail' },
+    });
+  });
+
+  test('ignores non-search tools, pending states, and invalid hits', () => {
+    const messages: ChatMessageBase[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'Here you go' },
+          {
+            type: 'tool-algolia_display_results',
+            toolCallId: 'display',
+            state: 'output-available',
+            input: {},
+            output: { groups: [{ results: [{ objectID: '9' }] }] },
+          },
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'streaming',
+            state: 'input-available',
+            input: { query: 'shoes' },
+          },
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: { query: 'shoes' },
+            output: {
+              hits: [{ objectID: '1', name: 'Runner' }, { objectID: '' }, null],
+            },
+          },
+        ],
+      },
+    ] as ChatMessageBase[];
+
+    expect(getHitsByObjectID(messages)).toEqual({
+      1: { objectID: '1', name: 'Runner' },
+    });
+  });
+
+  test('keys hits by their bare `id` so display results can hydrate by stripped objectID', () => {
+    const messages: ChatMessageBase[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: { query: 'sherlock' },
+            output: {
+              hits: [
+                {
+                  objectID: 'media-sample-data-84254',
+                  id: 84254,
+                  name: 'Hound',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ] as ChatMessageBase[];
+
+    // The display results tool references this record as `"84254"` (the
+    // backend strips the `media-sample-data-` prefix), so both keys resolve
+    // to the same hit.
+    const map = getHitsByObjectID(messages);
+    expect(map['media-sample-data-84254']).toEqual({
+      objectID: 'media-sample-data-84254',
+      id: 84254,
+      name: 'Hound',
+    });
+    expect(map['84254']).toBe(map['media-sample-data-84254']);
+  });
+
+  test('returns an empty map when there are no search outputs', () => {
+    expect(getHitsByObjectID([])).toEqual({});
+  });
+});

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -105,8 +105,8 @@ export const getHitsByObjectID = (
         }
 
         // The display results tool references records by their bare `id` (the
-        // backend strips the index prefix from `objectID`, e.g. it sends
-        // `"84254"` for a hit whose `objectID` is `"media-sample-data-84254"`),
+        // backend strips the prefix from `objectID`, e.g. it sends `"84254"`
+        // for a hit whose `objectID` is `"media-sample-data-84254"`),
         // so index by `id` as well to hydrate those too.
         const id = (hit as { id?: string | number }).id;
         if (id !== undefined && id !== null && id !== '') {

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -6,6 +6,10 @@ import type {
   ClientSideTool,
   ClientSideTools,
 } from '../../components/chat/types';
+import type { RecordWithObjectID } from '../../types';
+
+// Keep in sync with packages/instantsearch.js/src/lib/chat/index.ts
+const SearchIndexToolType = 'algolia_search_index';
 
 export const getTextContent = (message: ChatMessageBase) => {
   return message.parts
@@ -41,4 +45,78 @@ export const findTool = (
     )?.[1];
   }
   return tool;
+};
+
+const isSearchToolPart = (part: ChatToolMessage) =>
+  part.type === `tool-${SearchIndexToolType}` ||
+  // Compatibility shim with Algolia MCP Server search tool
+  startsWith(part.type, `tool-${SearchIndexToolType}_`);
+
+// Memoize the map per `messages` array reference. The chat connector hands out
+// a new array only when the conversation actually changes, so this rebuilds on
+// real updates (e.g. streaming) and returns the cached map on every unrelated
+// re-render — the display tool can call this freely without recomputing.
+const hitsByObjectIDCache = new WeakMap<
+  object,
+  Record<string, RecordWithObjectID>
+>();
+
+/**
+ * Builds a map of `objectID` -> full record by collecting the hits from every
+ * search tool output across the conversation.
+ *
+ * The display results tool only receives object IDs from the backend, so it
+ * relies on this map to hydrate each result with the full record that the
+ * preceding search tool already fetched.
+ */
+export const getHitsByObjectID = (
+  messages: ChatMessageBase[]
+): Record<string, RecordWithObjectID> => {
+  const cached = hitsByObjectIDCache.get(messages);
+  if (cached) {
+    return cached;
+  }
+
+  const hitsByObjectID: Record<string, RecordWithObjectID> = {};
+
+  messages.forEach((message) => {
+    message.parts.forEach((part) => {
+      if (!isPartTool(part) || !isSearchToolPart(part)) {
+        return;
+      }
+
+      const output =
+        part.state === 'output-available'
+          ? (part.output as { hits?: RecordWithObjectID[] } | undefined)
+          : undefined;
+      const hits = output?.hits;
+
+      if (!Array.isArray(hits)) {
+        return;
+      }
+
+      hits.forEach((hit) => {
+        if (!hit) {
+          return;
+        }
+
+        if (typeof hit.objectID === 'string' && hit.objectID !== '') {
+          hitsByObjectID[hit.objectID] = hit;
+        }
+
+        // The display results tool references records by their bare `id` (the
+        // backend strips the index prefix from `objectID`, e.g. it sends
+        // `"84254"` for a hit whose `objectID` is `"media-sample-data-84254"`),
+        // so index by `id` as well to hydrate those too.
+        const id = (hit as { id?: string | number }).id;
+        if (id !== undefined && id !== null && id !== '') {
+          hitsByObjectID[String(id)] = hit;
+        }
+      });
+    });
+  });
+
+  hitsByObjectIDCache.set(messages, hitsByObjectID);
+
+  return hitsByObjectID;
 };

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -52,71 +52,82 @@ const isSearchToolPart = (part: ChatToolMessage) =>
   // Compatibility shim with Algolia MCP Server search tool
   startsWith(part.type, `tool-${SearchIndexToolType}_`);
 
-// Memoize the map per `messages` array reference. The chat connector hands out
-// a new array only when the conversation actually changes, so this rebuilds on
-// real updates (e.g. streaming) and returns the cached map on every unrelated
-// re-render — the display tool can call this freely without recomputing.
-const hitsByObjectIDCache = new WeakMap<
-  object,
-  Record<string, RecordWithObjectID>
->();
+const collectHitsFromPart = (
+  part: ChatToolMessage,
+  hitsByObjectID: Record<string, RecordWithObjectID>
+) => {
+  const output =
+    part.state === 'output-available'
+      ? (part.output as { hits?: RecordWithObjectID[] } | undefined)
+      : undefined;
+  const hits = output?.hits;
+
+  if (!Array.isArray(hits)) {
+    return;
+  }
+
+  hits.forEach((hit) => {
+    if (!hit) {
+      return;
+    }
+
+    if (typeof hit.objectID === 'string' && hit.objectID !== '') {
+      hitsByObjectID[hit.objectID] = hit;
+    }
+
+    // The display results tool references records by their bare `id` (the
+    // backend strips the prefix from `objectID`, e.g. it sends `"84254"`
+    // for a hit whose `objectID` is `"media-sample-data-84254"`),
+    // so index by `id` as well to hydrate those too.
+    const id = (hit as { id?: string | number }).id;
+    if (id !== undefined && id !== null && id !== '') {
+      hitsByObjectID[String(id)] = hit;
+    }
+  });
+};
 
 /**
- * Builds a map of `objectID` -> full record by collecting the hits from every
- * search tool output across the conversation.
+ * Builds a map of `objectID` -> full record by collecting the hits from search
+ * tool outputs across the conversation.
  *
  * The display results tool only receives object IDs from the backend, so it
  * relies on this map to hydrate each result with the full record that the
  * preceding search tool already fetched.
+ *
+ * Pass `untilToolCallId` (the display tool's own `toolCallId`) to scope
+ * collection to the turn that produced it: hits are only gathered up to and
+ * including the message that contains that tool call. This prevents a later
+ * turn's search from overwriting an earlier display tool's records (and their
+ * per-query metadata like `__queryID`).
  */
 export const getHitsByObjectID = (
-  messages: ChatMessageBase[]
+  messages: ChatMessageBase[],
+  untilToolCallId?: string
 ): Record<string, RecordWithObjectID> => {
-  const cached = hitsByObjectIDCache.get(messages);
-  if (cached) {
-    return cached;
-  }
-
   const hitsByObjectID: Record<string, RecordWithObjectID> = {};
 
-  messages.forEach((message) => {
+  for (const message of messages) {
+    let reachedBoundary = false;
+
     message.parts.forEach((part) => {
-      if (!isPartTool(part) || !isSearchToolPart(part)) {
+      if (!isPartTool(part)) {
         return;
       }
-
-      const output =
-        part.state === 'output-available'
-          ? (part.output as { hits?: RecordWithObjectID[] } | undefined)
-          : undefined;
-      const hits = output?.hits;
-
-      if (!Array.isArray(hits)) {
-        return;
+      // Note the boundary but keep processing the rest of this message's parts:
+      // the search tool that fed this display tool lives in the same message,
+      // so its hits must still be collected before we stop.
+      if (untilToolCallId && part.toolCallId === untilToolCallId) {
+        reachedBoundary = true;
       }
-
-      hits.forEach((hit) => {
-        if (!hit) {
-          return;
-        }
-
-        if (typeof hit.objectID === 'string' && hit.objectID !== '') {
-          hitsByObjectID[hit.objectID] = hit;
-        }
-
-        // The display results tool references records by their bare `id` (the
-        // backend strips the prefix from `objectID`, e.g. it sends `"84254"`
-        // for a hit whose `objectID` is `"media-sample-data-84254"`),
-        // so index by `id` as well to hydrate those too.
-        const id = (hit as { id?: string | number }).id;
-        if (id !== undefined && id !== null && id !== '') {
-          hitsByObjectID[String(id)] = hit;
-        }
-      });
+      if (isSearchToolPart(part)) {
+        collectHitsFromPart(part, hitsByObjectID);
+      }
     });
-  });
 
-  hitsByObjectIDCache.set(messages, hitsByObjectID);
+    if (reachedBoundary) {
+      break;
+    }
+  }
 
   return hitsByObjectID;
 };

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -74,15 +74,6 @@ const collectHitsFromPart = (
     if (typeof hit.objectID === 'string' && hit.objectID !== '') {
       hitsByObjectID[hit.objectID] = hit;
     }
-
-    // The display results tool references records by their bare `id` (the
-    // backend strips the prefix from `objectID`, e.g. it sends `"84254"`
-    // for a hit whose `objectID` is `"media-sample-data-84254"`),
-    // so index by `id` as well to hydrate those too.
-    const id = (hit as { id?: string | number }).id;
-    if (id !== undefined && id !== null && id !== '') {
-      hitsByObjectID[String(id)] = hit;
-    }
   });
 };
 

--- a/packages/instantsearch.js/src/widgets/chat/display-results-tool.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/display-results-tool.tsx
@@ -7,6 +7,7 @@ import {
   createDisplayResultsToolComponent,
 } from 'instantsearch-ui-components';
 import { Fragment, h } from 'preact';
+import { useMemo } from 'preact/hooks';
 
 import TemplateComponent from '../../components/Template/Template';
 import { carousel } from '../../templates';
@@ -26,6 +27,7 @@ export function createDisplayResultsTool<
   >({
     createElement: h,
     Fragment,
+    useMemo,
   });
 
   const Button = createButtonComponent({ createElement: h });

--- a/packages/react-instantsearch/src/widgets/chat/tools/DisplayResultsTool.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/DisplayResultsTool.tsx
@@ -4,7 +4,7 @@ import {
   createButtonComponent,
   createDisplayResultsToolComponent,
 } from 'instantsearch-ui-components';
-import React, { createElement, Fragment } from 'react';
+import React, { createElement, Fragment, useMemo } from 'react';
 
 import { Carousel } from '../../../components';
 
@@ -24,6 +24,7 @@ function createDisplayResultsTool<TObject extends RecordWithObjectID>(
   const DisplayResultsUIComponent = createDisplayResultsToolComponent<TObject>({
     createElement: createElement as Pragma,
     Fragment,
+    useMemo,
   });
 
   const Button = createButtonComponent({ createElement: createElement as Pragma });

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
@@ -12,12 +12,16 @@ import type { ClientSideToolComponentProps } from 'instantsearch-ui-components';
 type TestResult = {
   objectID: string;
   why?: string;
+  name?: string;
   __position: number;
 };
 
 const mockItemComponent = ({ item }: { item: TestResult }) => (
   <div data-testid={`item-${item.objectID}`}>
     <span>{item.objectID}</span>
+    {item.name && (
+      <strong data-testid={`name-${item.objectID}`}>{item.name}</strong>
+    )}
     {item.why && <small data-testid={`why-${item.objectID}`}>{item.why}</small>}
   </div>
 );
@@ -68,6 +72,195 @@ describe('createDisplayResultsTool', () => {
     expect(screen.getByTestId('why-2')).toHaveTextContent('everyday classic');
   });
 
+  test('hydrates results from the preceding search tool, keeping display fields', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+
+    const message: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {},
+      output: {
+        groups: [
+          {
+            title: 'Runners',
+            // Backend only sends the objectID (and an optional `why`).
+            results: [{ objectID: '1', why: 'iconic' }, { objectID: '2' }],
+          },
+        ],
+      },
+    };
+
+    // The preceding search tool (same assistant message) carries the full
+    // records; the display tool hydrates from them.
+    const messages: ClientSideToolComponentProps['messages'] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: {},
+            output: {
+              hits: [
+                { objectID: '1', name: 'Air Runner', why: 'from search' },
+                { objectID: '2', name: 'Trail Runner' },
+              ],
+            },
+          },
+          message,
+        ],
+      },
+    ] as ClientSideToolComponentProps['messages'];
+
+    render(
+      <LayoutComponent
+        message={message}
+        messages={messages}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    // Full record fields are hydrated from the search hits…
+    expect(screen.getByTestId('name-1')).toHaveTextContent('Air Runner');
+    expect(screen.getByTestId('name-2')).toHaveTextContent('Trail Runner');
+    // …while display-provided fields take precedence over the hydrated record.
+    expect(screen.getByTestId('why-1')).toHaveTextContent('iconic');
+  });
+
+  test('hydrates by bare `id` and keeps the real Algolia objectID', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+
+    const message: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {},
+      output: {
+        groups: [
+          {
+            title: 'Mystery',
+            // Backend references the record by its stripped id, not the
+            // prefixed Algolia objectID.
+            results: [{ objectID: '84254', why: 'iconic' }],
+          },
+        ],
+      },
+    };
+
+    const messages: ClientSideToolComponentProps['messages'] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: {},
+            output: {
+              hits: [
+                {
+                  objectID: 'media-sample-data-84254',
+                  id: 84254,
+                  name: 'Hound',
+                  why: 'from search',
+                },
+              ],
+            },
+          },
+          message,
+        ],
+      },
+    ] as ClientSideToolComponentProps['messages'];
+
+    render(
+      <LayoutComponent
+        message={message}
+        messages={messages}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    // The full record is hydrated from the search hit it matched by `id`…
+    expect(
+      screen.getByTestId('name-media-sample-data-84254')
+    ).toHaveTextContent('Hound');
+    // …the real Algolia objectID replaces the stripped one (for Insights)…
+    expect(
+      screen.getByTestId('item-media-sample-data-84254')
+    ).toBeInTheDocument();
+    // …and display-provided fields still win over hydrated ones.
+    expect(screen.getByTestId('why-media-sample-data-84254')).toHaveTextContent(
+      'iconic'
+    );
+  });
+
+  test('renders results untouched when no matching hit is available', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+
+    const message: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {},
+      output: {
+        groups: [
+          { title: 'Runners', results: [{ objectID: '1', why: 'iconic' }] },
+        ],
+      },
+    };
+
+    const messages: ClientSideToolComponentProps['messages'] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: {},
+            output: { hits: [{ objectID: '99', name: 'Unrelated' }] },
+          },
+          message,
+        ],
+      },
+    ] as ClientSideToolComponentProps['messages'];
+
+    render(
+      <LayoutComponent
+        message={message}
+        messages={messages}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('item-1')).toBeInTheDocument();
+    expect(screen.getByTestId('why-1')).toHaveTextContent('iconic');
+    expect(screen.queryByTestId('name-1')).not.toBeInTheDocument();
+  });
+
   test('shows streaming caption while preliminary flag is true', () => {
     const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
     const LayoutComponent = tool.layoutComponent!;
@@ -82,9 +275,7 @@ describe('createDisplayResultsTool', () => {
             input: {},
             output: {
               intro: 'Curating',
-              groups: [
-                { title: 'Runners', results: [{ objectID: '1' }] },
-              ],
+              groups: [{ title: 'Runners', results: [{ objectID: '1' }] }],
             },
             preliminary: true,
           } as ClientSideToolComponentProps['message']

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
@@ -11,9 +11,10 @@ import type { ClientSideToolComponentProps } from 'instantsearch-ui-components';
 
 type TestResult = {
   objectID: string;
-  why?: string;
   name?: string;
   __position: number;
+  // Curation payload from the display tool, kept separate from record fields.
+  __displayToolResult?: { objectID: string; why?: string };
 };
 
 const mockItemComponent = ({ item }: { item: TestResult }) => (
@@ -22,7 +23,11 @@ const mockItemComponent = ({ item }: { item: TestResult }) => (
     {item.name && (
       <strong data-testid={`name-${item.objectID}`}>{item.name}</strong>
     )}
-    {item.why && <small data-testid={`why-${item.objectID}`}>{item.why}</small>}
+    {item.__displayToolResult?.why && (
+      <small data-testid={`why-${item.objectID}`}>
+        {item.__displayToolResult.why}
+      </small>
+    )}
   </div>
 );
 
@@ -132,82 +137,9 @@ describe('createDisplayResultsTool', () => {
     // Full record fields are hydrated from the search hits…
     expect(screen.getByTestId('name-1')).toHaveTextContent('Air Runner');
     expect(screen.getByTestId('name-2')).toHaveTextContent('Trail Runner');
-    // …while display-provided fields take precedence over the hydrated record.
+    // …while the display tool's curation payload stays in its own namespace,
+    // so a record field named `why` ("from search") can't clobber it.
     expect(screen.getByTestId('why-1')).toHaveTextContent('iconic');
-  });
-
-  test('hydrates by bare `id` and keeps the real Algolia objectID', () => {
-    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
-    const LayoutComponent = tool.layoutComponent!;
-
-    const message: ClientSideToolComponentProps['message'] = {
-      type: 'tool-algolia_display_results',
-      state: 'output-available',
-      toolCallId: 'display',
-      input: {},
-      output: {
-        groups: [
-          {
-            title: 'Mystery',
-            // Backend references the record by its stripped id, not the
-            // prefixed Algolia objectID.
-            results: [{ objectID: '84254', why: 'iconic' }],
-          },
-        ],
-      },
-    };
-
-    const messages: ClientSideToolComponentProps['messages'] = [
-      {
-        id: '1',
-        role: 'assistant',
-        parts: [
-          {
-            type: 'tool-algolia_search_index',
-            toolCallId: 'search',
-            state: 'output-available',
-            input: {},
-            output: {
-              hits: [
-                {
-                  objectID: 'media-sample-data-84254',
-                  id: 84254,
-                  name: 'Hound',
-                  why: 'from search',
-                },
-              ],
-            },
-          },
-          message,
-        ],
-      },
-    ] as ClientSideToolComponentProps['messages'];
-
-    render(
-      <LayoutComponent
-        message={message}
-        messages={messages}
-        applyFilters={jest.fn()}
-        onClose={jest.fn()}
-        indexUiState={{}}
-        addToolResult={jest.fn()}
-        setIndexUiState={jest.fn()}
-        sendEvent={jest.fn()}
-      />
-    );
-
-    // The full record is hydrated from the search hit it matched by `id`…
-    expect(
-      screen.getByTestId('name-media-sample-data-84254')
-    ).toHaveTextContent('Hound');
-    // …the real Algolia objectID replaces the stripped one (for Insights)…
-    expect(
-      screen.getByTestId('item-media-sample-data-84254')
-    ).toBeInTheDocument();
-    // …and display-provided fields still win over hydrated ones.
-    expect(screen.getByTestId('why-media-sample-data-84254')).toHaveTextContent(
-      'iconic'
-    );
   });
 
   test('renders results untouched when no matching hit is available', () => {


### PR DESCRIPTION
This PR hydrates the display results tool output results with the entire object body. The output from backend for the display results only contains objectIDs, we already have these entire object body from the preceding search index tool.

A map for the objects is created and used in the default display results layout component.

<img width="375" height="565" alt="image" src="https://github.com/user-attachments/assets/bbe5e1d9-8313-41f7-ac41-1abc391856ea" />