### PR TITLE
feat(structured-output): generic structured-outputs connector + onPageSuggestions widget (PoC)

### DIFF
--- a/examples/js/showcase/src/components/widgets/WidgetOnPageSuggestions.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetOnPageSuggestions.tsx
@@ -1,0 +1,191 @@
+import { onPageSuggestions } from "instantsearch.js/es/widgets";
+import { useEffect, useState } from "preact/hooks";
+
+import { useWidget } from "../../hooks/useWidget";
+import { useSearch } from "../../context/search";
+
+// The generic `structured-outputs` endpoint only exists on the local backend
+// for now (see the PoC handoff), so we point the widget at it through the Vite
+// dev proxy (`/agent-backend` -> http://localhost:8000) to avoid CORS. Swap
+// `transport` for `agentId` once the endpoint ships to the Algolia API.
+const AGENT_ID = "deefd3da-ef9a-4cc6-969a-cc6fbb220bb7";
+const APP_ID = "F4T6CUV2AH";
+// Search-only key (safe to expose client-side, like the latency key in AgenticView).
+const API_KEY = "f33fd36eb0c251c553e3cd7684a6ba33";
+
+interface ProductHit {
+  objectID: string;
+  name: string;
+  brand?: string;
+  categories?: string[];
+  price?: number;
+  description?: string;
+  image?: string;
+}
+
+const suggestionItem = (suggestion: unknown) =>
+  typeof suggestion === "string"
+    ? suggestion
+    : (suggestion as { label?: string; title?: string })?.label ??
+      (suggestion as { title?: string })?.title ??
+      JSON.stringify(suggestion);
+
+// The PDP "context" sent to the task: the meaningful record fields, without the
+// search metadata (`_highlightResult`, `__position`, …) that the index returns.
+function toContextProduct(hit: ProductHit) {
+  return {
+    objectID: hit.objectID,
+    name: hit.name,
+    brand: hit.brand,
+    categories: hit.categories,
+    price: hit.price,
+    description: hit.description,
+  };
+}
+
+// Mounts the widget for a single product. Re-mounted (via `key`) when the
+// selected product changes, which re-runs the initial generation.
+function ProductSuggestions({ product }: { product: ProductHit }) {
+  const ref = useWidget((el) =>
+    onPageSuggestions({
+      container: el,
+      contextType: "pdp",
+      context: { product: toContextProduct(product) },
+      maxSuggestions: 3,
+      // Stream NDJSON snapshots so the list fills in progressively. The
+      // connector reads the body as NDJSON when `stream` is true, so the
+      // `?stream=true` query param must match.
+      stream: true,
+      transport: {
+        api: `/agent-backend/1/agents/${AGENT_ID}/structured-outputs?stream=true`,
+        headers: {
+          "x-algolia-application-id": APP_ID,
+          "x-algolia-api-key": API_KEY,
+        },
+      },
+      templates: { item: suggestionItem },
+      cssClasses: {
+        root: "flex flex-col gap-2",
+        refresh:
+          "self-start rounded-md border border-neutral-300 px-2.5 py-1 text-xs font-medium text-neutral-600 transition-colors hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:text-neutral-300 dark:hover:bg-neutral-800",
+        list: "flex flex-col gap-1.5",
+        item: "rounded-md bg-neutral-50 px-3 py-2 text-sm text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200",
+        loading: "text-xs text-neutral-500 dark:text-neutral-400",
+        empty: "text-xs text-neutral-500 dark:text-neutral-400",
+      },
+    })
+  );
+
+  return <div ref={ref} />;
+}
+
+export function WidgetOnPageSuggestions() {
+  const search = useSearch();
+  const [products, setProducts] = useState<ProductHit[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    // `search.client` is typed as a search/composition union, so narrow it to
+    // the plain multi-query `search` shape we use here.
+    const client = search.client as unknown as {
+      search: (
+        requests: Array<{
+          indexName: string;
+          params: { query?: string; hitsPerPage?: number };
+        }>
+      ) => Promise<{ results: Array<{ hits?: ProductHit[] }> }>;
+    };
+
+    client
+      .search([
+        { indexName: search.indexName, params: { query: "", hitsPerPage: 6 } },
+      ])
+      .then((response) => {
+        if (!active) return;
+        const hits = response.results[0]?.hits ?? [];
+        setProducts(hits);
+        setSelectedId(hits[0]?.objectID ?? null);
+      })
+      .catch(() => {
+        /* leave the loading state; nothing actionable for the demo */
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const selected =
+    products.find((product) => product.objectID === selectedId) ?? null;
+
+  if (!selected) {
+    return (
+      <p class="text-xs text-neutral-500 dark:text-neutral-400">
+        Loading products from the index…
+      </p>
+    );
+  }
+
+  return (
+    <div class="flex flex-col gap-3">
+      {/* Record picker (records come from the index) */}
+      <div class="flex flex-wrap gap-2">
+        {products.map((product) => {
+          const isSelected = product.objectID === selected.objectID;
+          return (
+            <button
+              key={product.objectID}
+              type="button"
+              class={`max-w-[16rem] cursor-pointer truncate rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                isSelected
+                  ? "border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-950/40 dark:text-blue-300"
+                  : "border-neutral-200 text-neutral-600 hover:border-neutral-300 hover:bg-neutral-50 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+              }`}
+              onClick={() => setSelectedId(product.objectID)}
+            >
+              {product.name}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Selected record (the "PDP") */}
+      <div class="flex gap-4 rounded-xl border border-neutral-200 bg-white p-4 dark:border-neutral-700 dark:bg-neutral-800">
+        {selected.image ? (
+          <img
+            src={selected.image}
+            alt={selected.name}
+            class="h-16 w-16 shrink-0 rounded-lg object-contain"
+          />
+        ) : (
+          <div class="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg bg-neutral-100 text-2xl font-semibold text-neutral-400 dark:bg-neutral-700 dark:text-neutral-500">
+            {(selected.brand ?? selected.name).charAt(0)}
+          </div>
+        )}
+        <div class="flex min-w-0 flex-col gap-1">
+          <h3 class="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+            {selected.name}
+          </h3>
+          <p class="text-xs text-neutral-500 dark:text-neutral-400">
+            {[selected.brand, selected.price && `$${selected.price.toLocaleString()}`]
+              .filter(Boolean)
+              .join(" · ")}
+          </p>
+          {selected.description && (
+            <p class="line-clamp-3 text-xs leading-relaxed text-neutral-600 dark:text-neutral-300">
+              {selected.description}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Suggestions for the selected record */}
+      <div class="flex flex-col gap-2">
+        <p class="text-xs font-semibold uppercase tracking-wide text-neutral-400 dark:text-neutral-500">
+          On-page suggestions
+        </p>
+        <ProductSuggestions key={selected.objectID} product={selected} />
+      </div>
+    </div>
+  );
+}

--- a/examples/js/showcase/src/views/AgenticView.tsx
+++ b/examples/js/showcase/src/views/AgenticView.tsx
@@ -9,6 +9,7 @@ import { WidgetChatTrigger } from "../components/widgets/WidgetChatTrigger";
 // TODO: re-enable once the `filterSuggestions` widget works properly.
 // import { WidgetFilterSuggestions } from "../components/widgets/WidgetFilterSuggestions";
 import { WidgetHits } from "../components/widgets/WidgetHits";
+import { WidgetOnPageSuggestions } from "../components/widgets/WidgetOnPageSuggestions";
 import { WidgetSwitcher } from "../components/WidgetSwitcher";
 import { ChatLayoutContext } from "../context/chatLayout";
 import { SearchContext } from "../context/search";
@@ -76,7 +77,14 @@ export function AgenticView() {
             </ChatLayoutSwitcher>
           </div>
 
-          {/* Row 3: Hits */}
+          {/* Row 3: On-page suggestions (generic structured-outputs endpoint) */}
+          <WidgetSwitcher
+            widgets={[
+              { title: "onPageSuggestions (PDP)", body: WidgetOnPageSuggestions },
+            ]}
+          />
+
+          {/* Row 4: Hits */}
           <WidgetSwitcher widgets={[{ title: "hits", body: WidgetHits }]} />
         </div>
       </ChatLayoutContext.Provider>

--- a/examples/js/showcase/vite.config.mjs
+++ b/examples/js/showcase/vite.config.mjs
@@ -5,6 +5,17 @@ import commonjs from 'vite-plugin-commonjs';
 
 export default defineConfig({
   plugins: [commonjs(), tailwindcss(), preact()],
+  server: {
+    // Proxy the local `structured-outputs` backend so the browser stays
+    // same-origin (no CORS). Override the target with STRUCTURED_OUTPUTS_API.
+    proxy: {
+      '/agent-backend': {
+        target: process.env.STRUCTURED_OUTPUTS_API || 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/agent-backend/, ''),
+      },
+    },
+  },
   build: {
     commonjsOptions: {
       requireReturnsDefault: 'preferred',

--- a/packages/instantsearch.js/src/connectors/index.ts
+++ b/packages/instantsearch.js/src/connectors/index.ts
@@ -59,3 +59,4 @@ export { default as connectChat } from './chat/connectChat';
 export { default as connectFeeds } from './feeds/connectFeeds';
 export { default as connectChatTrigger } from './chat/connectChatTrigger';
 export { default as connectFilterSuggestions } from './filter-suggestions/connectFilterSuggestions';
+export { default as connectStructuredOutput } from './structured-output/connectStructuredOutput';

--- a/packages/instantsearch.js/src/connectors/structured-output/__tests__/connectStructuredOutput-test.ts
+++ b/packages/instantsearch.js/src/connectors/structured-output/__tests__/connectStructuredOutput-test.ts
@@ -1,0 +1,224 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+import algoliasearchHelper from 'algoliasearch-helper';
+
+import { createInitOptions } from '../../../../test/createWidget';
+import connectStructuredOutput from '../connectStructuredOutput';
+
+import type {
+  StructuredOutputConnectorParams,
+  StructuredOutputRenderState,
+} from '../connectStructuredOutput';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const stringToUint8Array = (str: string): Uint8Array => {
+  const arr = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; i++) {
+    arr[i] = str.charCodeAt(i);
+  }
+  return arr;
+};
+
+const createMockStream = (lines: string[]): ReadableStream<Uint8Array> => {
+  let index = 0;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return {
+    getReader: () => ({
+      read: () =>
+        index < lines.length
+          ? Promise.resolve({
+              done: false,
+              value: stringToUint8Array(lines[index++]),
+            })
+          : Promise.resolve({ done: true, value: undefined }),
+      releaseLock: () => {},
+    }),
+  } as ReadableStream<Uint8Array>;
+};
+
+describe('connectStructuredOutput', () => {
+  const getInitializedWidget = (
+    widgetParams: Partial<StructuredOutputConnectorParams> = {}
+  ) => {
+    const renderFn = jest.fn();
+    const unmountFn = jest.fn();
+    const makeWidget = connectStructuredOutput(renderFn, unmountFn);
+    const widget = makeWidget({
+      agentId: 'agentId',
+      task: 'on_page_suggestions',
+      ...widgetParams,
+    });
+
+    const helper = algoliasearchHelper(createSearchClient(), 'indexName');
+    widget.init(createInitOptions({ helper }));
+
+    const getRenderState = (): StructuredOutputRenderState =>
+      renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+
+    return { widget, helper, renderFn, unmountFn, getRenderState };
+  };
+
+  describe('Usage', () => {
+    it('throws without render function', () => {
+      expect(() => {
+        // @ts-expect-error
+        connectStructuredOutput()({ task: 'x' });
+      }).toThrow(/The render function is not valid/);
+    });
+
+    it('throws without task', () => {
+      expect(() => {
+        connectStructuredOutput(jest.fn())({} as StructuredOutputConnectorParams);
+      }).toThrow('The `task` option is required.');
+    });
+
+    it('throws without agentId or transport', () => {
+      expect(() => {
+        connectStructuredOutput(jest.fn())({ task: 'on_page_suggestions' });
+      }).toThrow(
+        'The `agentId` option is required unless a custom `transport` is provided.'
+      );
+    });
+
+    it('is a widget', () => {
+      const widget = connectStructuredOutput(jest.fn())({
+        agentId: 'agentId',
+        task: 'on_page_suggestions',
+      });
+
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.structuredOutput',
+          init: expect.any(Function),
+          render: expect.any(Function),
+          dispose: expect.any(Function),
+        })
+      );
+    });
+  });
+
+  describe('submit (non-streaming)', () => {
+    it('posts { task, variables } to the structured-outputs endpoint', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ output: { suggestions: ['a'] } }),
+        })
+      ) as jest.Mock;
+
+      const { getRenderState } = getInitializedWidget();
+      getRenderState().submit({ contextType: 'pdp', objectID: '1' });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '/agent-studio/1/agents/agentId/structured-outputs?stream=false'
+        ),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            task: 'on_page_suggestions',
+            variables: { contextType: 'pdp', objectID: '1' },
+          }),
+        })
+      );
+
+      await flush();
+
+      expect(getRenderState().output).toEqual({ suggestions: ['a'] });
+      expect(getRenderState().isLoading).toBe(false);
+      expect(getRenderState().error).toBeNull();
+    });
+
+    it('exposes the error on failure', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({ ok: false, status: 502 })
+      ) as jest.Mock;
+
+      const { getRenderState } = getInitializedWidget();
+      getRenderState().submit({});
+
+      await flush();
+
+      expect(getRenderState().output).toBeNull();
+      expect(getRenderState().error).toEqual(new Error('HTTP error 502'));
+      expect(getRenderState().isLoading).toBe(false);
+    });
+  });
+
+  describe('submit (streaming)', () => {
+    it('replaces output with each NDJSON snapshot', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          body: createMockStream([
+            '{"suggestions":["a"]}\n',
+            '{"suggestions":["a","b"]}\n',
+          ]),
+        })
+      ) as jest.Mock;
+
+      const { getRenderState } = getInitializedWidget({ stream: true });
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      getRenderState().submit({});
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('structured-outputs?stream=true'),
+        expect.anything()
+      );
+
+      await flush();
+
+      expect(getRenderState().output).toEqual({ suggestions: ['a', 'b'] });
+      expect(getRenderState().isLoading).toBe(false);
+    });
+  });
+
+  describe('custom transport', () => {
+    it('uses the transport api and prepareRequest', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ output: {} }),
+        })
+      ) as jest.Mock;
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: undefined,
+        transport: {
+          api: 'https://example.test/structured',
+          headers: { 'x-custom': '1' },
+          prepareRequest: (body) => ({ body: { ...body, extra: true } }),
+        },
+      });
+
+      getRenderState().submit({ a: 1 });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://example.test/structured',
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'x-custom': '1' }),
+          body: JSON.stringify({
+            task: 'on_page_suggestions',
+            variables: { a: 1 },
+            extra: true,
+          }),
+        })
+      );
+
+      await flush();
+    });
+  });
+
+  describe('dispose', () => {
+    it('calls the unmount function', () => {
+      const { widget, unmountFn } = getInitializedWidget();
+      widget.dispose!();
+      expect(unmountFn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/instantsearch.js/src/connectors/structured-output/__tests__/connectStructuredOutput-test.ts
+++ b/packages/instantsearch.js/src/connectors/structured-output/__tests__/connectStructuredOutput-test.ts
@@ -150,13 +150,16 @@ describe('connectStructuredOutput', () => {
   });
 
   describe('submit (streaming)', () => {
-    it('replaces output with each NDJSON snapshot', async () => {
+    it('replaces output with each AI SDK structured-output data part', async () => {
       global.fetch = jest.fn(() =>
         Promise.resolve({
           ok: true,
           body: createMockStream([
-            '{"suggestions":["a"]}\n',
-            '{"suggestions":["a","b"]}\n',
+            'data: {"type":"start","messageId":"message-id"}\n\n',
+            'data: {"type":"data-structured-output","id":"on_page_suggestions","data":{"suggestions":["a"]}}\n\n',
+            'data: {"type":"data-structured-output","id":"on_page_suggestions","data":{"suggestions":["a","b"]}}\n\n',
+            'data: {"type":"finish"}\n\n',
+            'data: [DONE]\n\n',
           ]),
         })
       ) as jest.Mock;
@@ -174,6 +177,30 @@ describe('connectStructuredOutput', () => {
       await flush();
 
       expect(getRenderState().output).toEqual({ suggestions: ['a', 'b'] });
+      expect(getRenderState().isLoading).toBe(false);
+    });
+
+    it('exposes AI SDK stream errors', async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          body: createMockStream([
+            'data: {"type":"start","messageId":"message-id"}\n\n',
+            'data: {"type":"error","errorText":"Structured generation failed"}\n\n',
+            'data: [DONE]\n\n',
+          ]),
+        })
+      ) as jest.Mock;
+
+      const { getRenderState } = getInitializedWidget({ stream: true });
+      getRenderState().submit({});
+
+      await flush();
+
+      expect(getRenderState().output).toBeNull();
+      expect(getRenderState().error).toEqual(
+        new Error('Structured generation failed')
+      );
       expect(getRenderState().isLoading).toBe(false);
     });
   });
@@ -217,7 +244,7 @@ describe('connectStructuredOutput', () => {
   describe('dispose', () => {
     it('calls the unmount function', () => {
       const { widget, unmountFn } = getInitializedWidget();
-      widget.dispose!();
+      widget.dispose();
       expect(unmountFn).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/instantsearch.js/src/connectors/structured-output/connectStructuredOutput.ts
+++ b/packages/instantsearch.js/src/connectors/structured-output/connectStructuredOutput.ts
@@ -1,0 +1,297 @@
+import { parseJsonEventStream, processStream } from '../../lib/ai-lite';
+import {
+  checkRendering,
+  createDocumentationMessageGenerator,
+  getAlgoliaAgent,
+  getAppIdAndApiKey,
+  noop,
+} from '../../lib/utils';
+
+import type {
+  Connector,
+  IndexRenderState,
+  InitOptions,
+  Renderer,
+  Unmounter,
+  UnknownWidgetParams,
+  WidgetRenderState,
+} from '../../types';
+
+const withUsage = createDocumentationMessageGenerator({
+  name: 'structured-output',
+  connector: true,
+});
+
+export type StructuredOutputTransport = {
+  /**
+   * The custom API endpoint URL.
+   */
+  api: string;
+  /**
+   * Custom headers to send with the request.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Function to prepare the request body before sending.
+   * Receives the default `{ task, variables }` body and returns the body to send.
+   */
+  prepareRequest?: (body: Record<string, unknown>) => {
+    body: Record<string, unknown>;
+  };
+};
+
+export type StructuredOutputRenderState<TOutput = Record<string, unknown>> = {
+  /**
+   * The latest structured output. During streaming this is a progressively
+   * completed snapshot; `null` before the first response and after an error.
+   */
+  output: TOutput | null;
+  /**
+   * Whether a generation is currently in flight (including while streaming).
+   */
+  isLoading: boolean;
+  /**
+   * The error from the last failed generation, if any.
+   */
+  error: Error | null;
+  /**
+   * Runs the configured task with the given variables. Cancels any in-flight
+   * generation before starting a new one.
+   */
+  submit: (variables: Record<string, unknown>) => void;
+};
+
+export type StructuredOutputConnectorParams = {
+  /**
+   * The ID of the agent configured in the Algolia dashboard.
+   * Required unless a custom `transport` is provided.
+   */
+  agentId?: string;
+  /**
+   * The structured task to run (an enabled `structuredTasks.<task>` on the agent).
+   */
+  task: string;
+  /**
+   * Whether to stream the output as NDJSON snapshots instead of waiting for the
+   * full object.
+   * @default false
+   */
+  stream?: boolean;
+  /**
+   * Custom transport configuration for the API requests.
+   * When provided, allows using a custom endpoint, headers, and request body.
+   */
+  transport?: StructuredOutputTransport;
+  /**
+   * Identifier used as the key in `indexRenderState`, so several structured-output
+   * widgets can coexist on the same index.
+   * @default 'structuredOutput'
+   */
+  type?: string;
+};
+
+export type StructuredOutputWidgetDescription<
+  TOutput = Record<string, unknown>
+> = {
+  $$type: 'ais.structuredOutput';
+  renderState: StructuredOutputRenderState<TOutput>;
+  indexRenderState: {
+    structuredOutput: WidgetRenderState<
+      StructuredOutputRenderState<TOutput>,
+      StructuredOutputConnectorParams
+    >;
+  };
+};
+
+export type StructuredOutputConnector = Connector<
+  StructuredOutputWidgetDescription,
+  StructuredOutputConnectorParams
+>;
+
+export default (function connectStructuredOutput<
+  TWidgetParams extends UnknownWidgetParams
+>(
+  renderFn: Renderer<
+    StructuredOutputRenderState,
+    TWidgetParams & StructuredOutputConnectorParams
+  >,
+  unmountFn: Unmounter = noop
+) {
+  checkRendering(renderFn, withUsage());
+
+  return <TOutput extends Record<string, unknown> = Record<string, unknown>>(
+    widgetParams: TWidgetParams & StructuredOutputConnectorParams
+  ) => {
+    const {
+      agentId,
+      task,
+      stream = false,
+      transport,
+      type = 'structuredOutput',
+    } = widgetParams || {};
+
+    if (!task) {
+      throw new Error(withUsage('The `task` option is required.'));
+    }
+
+    if (!agentId && !transport) {
+      throw new Error(
+        withUsage(
+          'The `agentId` option is required unless a custom `transport` is provided.'
+        )
+      );
+    }
+
+    let endpoint: string;
+    let headers: Record<string, string>;
+    let output: TOutput | null = null;
+    let isLoading = false;
+    let error: Error | null = null;
+    let abortController: AbortController | undefined;
+    let render: () => void = noop;
+
+    const buildBody = (variables: Record<string, unknown>) => {
+      const body: Record<string, unknown> = { task, variables };
+      return transport?.prepareRequest ? transport.prepareRequest(body).body : body;
+    };
+
+    const readStream = (response: Response): Promise<void> => {
+      if (!response.body) {
+        return Promise.reject(new Error('The streaming response has no body.'));
+      }
+
+      // Each NDJSON line is a complete snapshot of the output object, so we
+      // simply replace the current output on every chunk.
+      const snapshots = parseJsonEventStream(
+        response.body
+      ) as unknown as ReadableStream<TOutput>;
+
+      return new Promise<void>((resolve, reject) => {
+        processStream<TOutput>(
+          snapshots,
+          (snapshot) => {
+            output = snapshot;
+            render();
+          },
+          resolve,
+          reject
+        );
+      });
+    };
+
+    const submit = (variables: Record<string, unknown>) => {
+      abortController?.abort();
+      abortController = new AbortController();
+      const { signal } = abortController;
+
+      isLoading = true;
+      error = null;
+      output = null;
+      render();
+
+      fetch(endpoint, {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildBody(variables)),
+        signal,
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`HTTP error ${response.status}`);
+          }
+
+          if (stream) {
+            return readStream(response);
+          }
+
+          return response.json().then((data) => {
+            output = (data?.output ?? null) as TOutput | null;
+          });
+        })
+        .then(() => {
+          if (signal.aborted) {
+            return;
+          }
+          isLoading = false;
+          render();
+        })
+        .catch((err) => {
+          if (signal.aborted) {
+            return;
+          }
+          error = err as Error;
+          output = null;
+          isLoading = false;
+          render();
+        });
+    };
+
+    const getWidgetRenderState = () => ({
+      output,
+      isLoading,
+      error,
+      submit,
+      widgetParams,
+    });
+
+    return {
+      $$type: 'ais.structuredOutput',
+
+      init(initOptions: InitOptions) {
+        const { instantSearchInstance } = initOptions;
+
+        if (transport) {
+          endpoint = transport.api;
+          headers = transport.headers || {};
+        } else {
+          const [appId, apiKey] = getAppIdAndApiKey(instantSearchInstance.client);
+
+          if (!appId || !apiKey) {
+            throw new Error(
+              withUsage(
+                'Could not extract Algolia credentials from the search client.'
+              )
+            );
+          }
+
+          endpoint = `https://${appId}.algolia.net/agent-studio/1/agents/${agentId}/structured-outputs?stream=${stream}`;
+          headers = {
+            'x-algolia-application-id': appId,
+            'x-algolia-api-key': apiKey,
+            'x-algolia-agent': getAlgoliaAgent(instantSearchInstance.client),
+          };
+        }
+
+        render = () => {
+          renderFn(
+            { ...getWidgetRenderState(), instantSearchInstance },
+            false
+          );
+        };
+
+        renderFn({ ...getWidgetRenderState(), instantSearchInstance }, true);
+      },
+
+      render({ instantSearchInstance }) {
+        renderFn({ ...getWidgetRenderState(), instantSearchInstance }, false);
+      },
+
+      dispose() {
+        abortController?.abort();
+        unmountFn();
+      },
+
+      getRenderState(renderState): IndexRenderState &
+        StructuredOutputWidgetDescription['indexRenderState'] {
+        return {
+          ...renderState,
+          [type as 'structuredOutput']: getWidgetRenderState(),
+        };
+      },
+
+      getWidgetRenderState() {
+        return getWidgetRenderState();
+      },
+    };
+  };
+} satisfies StructuredOutputConnector);

--- a/packages/instantsearch.js/src/connectors/structured-output/connectStructuredOutput.ts
+++ b/packages/instantsearch.js/src/connectors/structured-output/connectStructuredOutput.ts
@@ -7,6 +7,7 @@ import {
   noop,
 } from '../../lib/utils';
 
+import type { UIMessageChunk } from '../../lib/ai-lite';
 import type {
   Connector,
   IndexRenderState,
@@ -72,8 +73,8 @@ export type StructuredOutputConnectorParams = {
    */
   task: string;
   /**
-   * Whether to stream the output as NDJSON snapshots instead of waiting for the
-   * full object.
+   * Whether to stream the output as AI SDK structured-output data parts instead
+   * of waiting for the full object.
    * @default false
    */
   stream?: boolean;
@@ -160,18 +161,19 @@ export default (function connectStructuredOutput<
         return Promise.reject(new Error('The streaming response has no body.'));
       }
 
-      // Each NDJSON line is a complete snapshot of the output object, so we
-      // simply replace the current output on every chunk.
-      const snapshots = parseJsonEventStream(
-        response.body
-      ) as unknown as ReadableStream<TOutput>;
+      const chunks = parseJsonEventStream(response.body);
 
       return new Promise<void>((resolve, reject) => {
-        processStream<TOutput>(
-          snapshots,
-          (snapshot) => {
-            output = snapshot;
-            render();
+        processStream<UIMessageChunk>(
+          chunks,
+          (chunk) => {
+            if (chunk.type === 'data-structured-output') {
+              output = chunk.data as TOutput;
+              render();
+            }
+            if (chunk.type === 'error') {
+              reject(new Error(chunk.errorText));
+            }
           },
           resolve,
           reject

--- a/packages/instantsearch.js/src/widgets/__tests__/index.test.ts
+++ b/packages/instantsearch.js/src/widgets/__tests__/index.test.ts
@@ -181,6 +181,14 @@ function initiateAllWidgets(): Array<[WidgetNames, Widget | IndexWidget]> {
           attributes: ['attr'],
         });
       }
+      case 'onPageSuggestions': {
+        const onPageSuggestions = widget as Widgets['onPageSuggestions'];
+        return onPageSuggestions({
+          container,
+          agentId: 'test-agent-id',
+          contextType: 'pdp',
+        });
+      }
       case 'chatTrigger': {
         const chatTriggerWidget = widget as Widgets['chatTrigger'];
         return chatTriggerWidget({

--- a/packages/instantsearch.js/src/widgets/index.ts
+++ b/packages/instantsearch.js/src/widgets/index.ts
@@ -64,3 +64,4 @@ export { default as lookingSimilar } from './looking-similar/looking-similar';
 export { default as chat } from './chat/chat';
 export { default as chatTrigger } from './chat-trigger/chat-trigger';
 export { default as filterSuggestions } from './filter-suggestions/filter-suggestions';
+export { default as onPageSuggestions } from './on-page-suggestions/on-page-suggestions';

--- a/packages/instantsearch.js/src/widgets/on-page-suggestions/on-page-suggestions.tsx
+++ b/packages/instantsearch.js/src/widgets/on-page-suggestions/on-page-suggestions.tsx
@@ -1,0 +1,250 @@
+/** @jsx h */
+
+import { h, render } from 'preact';
+
+import connectStructuredOutput from '../../connectors/structured-output/connectStructuredOutput';
+import {
+  getContainerNode,
+  createDocumentationMessageGenerator,
+} from '../../lib/utils';
+
+import type {
+  StructuredOutputConnectorParams,
+  StructuredOutputRenderState,
+  StructuredOutputWidgetDescription,
+} from '../../connectors/structured-output/connectStructuredOutput';
+import type { Renderer, WidgetFactory } from '../../types';
+import type { ComponentChildren } from 'preact';
+
+const withUsage = createDocumentationMessageGenerator({
+  name: 'on-page-suggestions',
+});
+
+/**
+ * The shape returned by the `on_page_suggestions` task. The individual
+ * suggestion shape is defined by the agent's output schema, so it stays
+ * `unknown` here and is resolved by the `item` template.
+ */
+export type OnPageSuggestionsOutput = {
+  suggestions?: unknown[];
+};
+
+export type OnPageSuggestionsContextType = 'pdp' | 'plp' | 'custom';
+
+export type OnPageSuggestionsTemplates = Partial<{
+  /**
+   * Renders a single suggestion. Defaults to the suggestion's `label`/`title`/`text`
+   * field, the string itself, or its JSON representation.
+   */
+  item: (suggestion: unknown, index: number) => ComponentChildren;
+  /**
+   * Renders the loading state.
+   */
+  loading: () => ComponentChildren;
+  /**
+   * Renders when there are no suggestions (or generation failed).
+   */
+  empty: () => ComponentChildren;
+}>;
+
+export type OnPageSuggestionsCSSClasses = Partial<{
+  root: string;
+  refresh: string;
+  list: string;
+  item: string;
+  loading: string;
+  empty: string;
+}>;
+
+type OnPageSuggestionsWidgetParams = {
+  /**
+   * CSS Selector or HTMLElement to insert the widget.
+   */
+  container: string | HTMLElement;
+  /**
+   * The structured task to run.
+   * @default 'on_page_suggestions'
+   */
+  task?: string;
+  /**
+   * The kind of page the suggestions are generated for. Selects how `context`
+   * is mapped to the task `variables`.
+   */
+  contextType: OnPageSuggestionsContextType;
+  /**
+   * The page data to send (e.g. the product record for `pdp`). Merged with
+   * `contextType` into the task `variables`. Ignored when `getVariables` is set.
+   */
+  context?: Record<string, unknown>;
+  /**
+   * Full control over the task `variables`. Overrides `contextType`/`context`.
+   */
+  getVariables?: () => Record<string, unknown>;
+  /**
+   * Hard cap on the number of rendered suggestions.
+   * @default 3
+   */
+  maxSuggestions?: number;
+  /**
+   * Templates to use for the widget.
+   */
+  templates?: OnPageSuggestionsTemplates;
+  /**
+   * CSS classes to add.
+   */
+  cssClasses?: OnPageSuggestionsCSSClasses;
+};
+
+export type OnPageSuggestionsWidget = WidgetFactory<
+  StructuredOutputWidgetDescription<OnPageSuggestionsOutput> & {
+    $$widgetType: 'ais.onPageSuggestions';
+  },
+  Omit<StructuredOutputConnectorParams, 'task'>,
+  OnPageSuggestionsWidgetParams
+>;
+
+function defaultItem(suggestion: unknown): ComponentChildren {
+  if (typeof suggestion === 'string') {
+    return suggestion;
+  }
+  if (suggestion && typeof suggestion === 'object') {
+    const record = suggestion as Record<string, unknown>;
+    const label = record.label ?? record.title ?? record.text;
+    if (typeof label === 'string') {
+      return label;
+    }
+  }
+  return JSON.stringify(suggestion);
+}
+
+const createRenderer =
+  ({
+    containerNode,
+    cssClasses,
+    templates,
+    maxSuggestions,
+    getVariables,
+  }: {
+    containerNode: HTMLElement;
+    cssClasses: OnPageSuggestionsCSSClasses;
+    templates: OnPageSuggestionsTemplates;
+    maxSuggestions: number;
+    getVariables: () => Record<string, unknown>;
+  }): Renderer<
+    StructuredOutputRenderState<OnPageSuggestionsOutput>,
+    Partial<OnPageSuggestionsWidgetParams>
+  > =>
+  ({ output, isLoading, error, submit }, isFirstRendering) => {
+    if (isFirstRendering) {
+      // On-page suggestions are page-context driven, not search driven: kick off
+      // a single generation as soon as the widget mounts.
+      submit(getVariables());
+      return;
+    }
+
+    const suggestions = (output?.suggestions ?? []).slice(0, maxSuggestions);
+    const itemTemplate = templates.item || defaultItem;
+
+    let children: ComponentChildren;
+    if (isLoading && suggestions.length === 0) {
+      children = templates.loading ? (
+        templates.loading()
+      ) : (
+        <div className={cssClasses.loading}>Loading suggestions…</div>
+      );
+    } else if (suggestions.length === 0) {
+      children = templates.empty ? (
+        templates.empty()
+      ) : (
+        <div className={cssClasses.empty}>
+          {error ? 'Could not load suggestions.' : 'No suggestions.'}
+        </div>
+      );
+    } else {
+      children = (
+        <ul className={cssClasses.list}>
+          {suggestions.map((suggestion, index) => (
+            <li key={index} className={cssClasses.item}>
+              {itemTemplate(suggestion, index)}
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    render(
+      <div className={cssClasses.root}>
+        <button
+          type="button"
+          className={cssClasses.refresh}
+          disabled={isLoading}
+          onClick={() => submit(getVariables())}
+        >
+          {isLoading ? 'Refreshing…' : 'Refresh'}
+        </button>
+        {children}
+      </div>,
+      containerNode
+    );
+  };
+
+const onPageSuggestions: OnPageSuggestionsWidget = function onPageSuggestions(
+  widgetParams
+) {
+  const {
+    container,
+    contextType,
+    context,
+    getVariables,
+    maxSuggestions = 3,
+    templates = {},
+    cssClasses = {},
+    task = 'on_page_suggestions',
+    agentId,
+    stream,
+    transport,
+    type,
+  } = widgetParams || {};
+
+  if (!container) {
+    throw new Error(withUsage('The `container` option is required.'));
+  }
+
+  const containerNode = getContainerNode(container);
+
+  const resolveVariables = (): Record<string, unknown> =>
+    getVariables ? getVariables() : { contextType, ...context };
+
+  const specializedRenderer = createRenderer({
+    containerNode,
+    cssClasses: {
+      root: 'ais-OnPageSuggestions',
+      refresh: 'ais-OnPageSuggestions-refresh',
+      list: 'ais-OnPageSuggestions-list',
+      item: 'ais-OnPageSuggestions-item',
+      loading: 'ais-OnPageSuggestions-loading',
+      empty: 'ais-OnPageSuggestions-empty',
+      ...cssClasses,
+    },
+    templates,
+    maxSuggestions,
+    getVariables: resolveVariables,
+  });
+
+  const makeWidget = connectStructuredOutput(specializedRenderer, () =>
+    render(null, containerNode)
+  );
+
+  return {
+    ...makeWidget<OnPageSuggestionsOutput>({
+      agentId,
+      task,
+      stream,
+      transport,
+      type,
+    }),
+    $$widgetType: 'ais.onPageSuggestions',
+  };
+};
+
+export default onPageSuggestions;


### PR DESCRIPTION
## Summary

Frontend PoC for the generic `structured-outputs` endpoint (structured JSON in → structured JSON out, optional streaming). Adds one generic connector and a first thin widget on top of it, plus a PDP demo in the showcase.

- **`connectStructuredOutput`** — generic transport + `submit(variables)`. Builds the endpoint from the search client (`/agent-studio/1/agents/{agentId}/structured-outputs`) or a custom `transport`. Non-stream reads `{ output }`; stream parses NDJSON object snapshots (reusing `ai-lite`'s `parseJsonEventStream`/`processStream`) and replaces `output` progressively. Cancels in-flight requests via `AbortController`. Exposes `{ output, isLoading, error, submit }`.
- **`onPageSuggestions`** — thin widget parameterized by `contextType` (`pdp`/`plp`/`custom`); maps context → task `variables`, auto-submits on mount, renders the suggestions list (capped at `maxSuggestions`) with overridable templates and a **Refresh** button.
- **Showcase** — `WidgetOnPageSuggestions` in the Agentic view: a PDP-style demo that pulls records from the index, lets you select one, and streams its on-page suggestions underneath. Uses a Vite dev proxy (`/agent-backend`) to reach the local backend.

## Notes

- The endpoint currently only exists on the local backend branch, so the showcase uses a custom `transport` (swap for `agentId` once it ships to the Algolia API).
- Scope: core `instantsearch.js` only (no React/Vue bindings); no UI-components package, debounce, or common-test-suite parity tests — deferred PoC scope.
- The task `variables` shape (`{ contextType, product }`) must align with the agent's `on_page_suggestions` system prompt.

## Test plan

- [ ] `connectStructuredOutput` unit tests pass (non-stream, streaming snapshots, custom transport, errors, usage guards)
- [ ] Widget discovery test passes (`widgets/__tests__/index.test.ts`)
- [ ] `instantsearch.js` typecheck clean for the new files
- [ ] Showcase: Agentic → onPageSuggestions (PDP) renders, select a record, suggestions stream in, Refresh regenerates (requires local backend on `:8000`)