### PR TITLE
fix(chat): update carousel view all button handler for mcp search tool

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "267.5 kB"
+      "maxSize": "268 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,11 +10,11 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "127.5 kB"
+      "maxSize": "127.75 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "266.5 kB"
+      "maxSize": "267 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -453,6 +453,7 @@ export type SearchToolInput = {
   query: string;
   number_of_results?: number;
   facet_filters?: string[][];
+  [facetKey: `facet_${string}`]: string[] | string[][] | undefined;
 };
 
 export type ApplyFiltersParams = {
@@ -536,4 +537,3 @@ export type ChatEmptyProps = {
    */
   setInput?: (input: string) => void;
 };
-

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -449,12 +449,21 @@ export type AddToolResultWithOutput = (
   params: Pick<Parameters<AddToolResult>[0], 'output'>
 ) => ReturnType<AddToolResult>;
 
-export type SearchToolInput = {
+type SearchToolInputBase = {
   query: string;
   number_of_results?: number;
-  facet_filters?: string[][];
-  [facetKey: `facet_${string}`]: string[] | string[][] | undefined;
 };
+
+type DefaultSearchToolInput = SearchToolInputBase & {
+  facet_filters?: string[][];
+};
+
+type McpSearchToolInput = SearchToolInputBase & {
+  facet_filters?: undefined;
+  [facetKey: `facet_${string}`]: string[] | undefined;
+};
+
+export type SearchToolInput = DefaultSearchToolInput | McpSearchToolInput;
 
 export type ApplyFiltersParams = {
   query?: string;

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -1,0 +1,75 @@
+import { getFacetFiltersFromToolInput } from '../chat';
+
+describe('getFacetFiltersFromToolInput', () => {
+  test('returns undefined when input is undefined', () => {
+    expect(getFacetFiltersFromToolInput(undefined)).toBeUndefined();
+  });
+
+  test('returns the standard `facet_filters` array when present', () => {
+    const facetFilters = [['brand:Apple'], ['type:book']];
+
+    expect(
+      getFacetFiltersFromToolInput({
+        query: 'phone',
+        facet_filters: facetFilters,
+      })
+    ).toBe(facetFilters);
+  });
+
+  test('builds facet filters from MCP `facet_<attribute>` keys', () => {
+    expect(
+      getFacetFiltersFromToolInput({
+        query: '',
+        clickAnalytics: true,
+        facet_type: ['book'],
+        facet_brand: [],
+        facet_title: [],
+        facet_author: [],
+        facet_categories: [
+          'Literature & Fiction',
+          'Mystery, Thriller & Suspense',
+          'Teen & Young Adult',
+        ],
+        facet__collections: [],
+        facet_price: [],
+        userIntent: 'irrelevant',
+      } as Parameters<typeof getFacetFiltersFromToolInput>[0])
+    ).toEqual([
+      ['type:book'],
+      [
+        'categories:Literature & Fiction',
+        'categories:Mystery, Thriller & Suspense',
+        'categories:Teen & Young Adult',
+      ],
+    ]);
+  });
+
+  test('preserves the attribute name including leading underscores', () => {
+    expect(
+      getFacetFiltersFromToolInput({
+        query: '',
+        facet__collections: ['summer'],
+      } as Parameters<typeof getFacetFiltersFromToolInput>[0])
+    ).toEqual([['_collections:summer']]);
+  });
+
+  test('ignores non-string and empty facet values', () => {
+    expect(
+      getFacetFiltersFromToolInput({
+        query: '',
+        facet_brand: [],
+        facet_type: [42, 'book', null] as unknown as string[],
+      } as Parameters<typeof getFacetFiltersFromToolInput>[0])
+    ).toEqual([['type:book']]);
+  });
+
+  test('returns undefined when there are no facet refinements', () => {
+    expect(
+      getFacetFiltersFromToolInput({
+        query: 'phone',
+        facet_brand: [],
+        facet_type: [],
+      } as Parameters<typeof getFacetFiltersFromToolInput>[0])
+    ).toBeUndefined();
+  });
+});

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -5,6 +5,7 @@ import type {
   ChatToolMessage,
   ClientSideTool,
   ClientSideTools,
+  SearchToolInput,
 } from '../../components/chat/types';
 
 export const getTextContent = (message: ChatMessageBase) => {
@@ -41,4 +42,49 @@ export const findTool = (
     )?.[1];
   }
   return tool;
+};
+
+const FACET_KEY_PREFIX = 'facet_';
+
+/**
+ * Extracts the `facetFilters` from a search tool input.
+ *
+ * The default search tool provides a ready-to-use `facet_filters` array. The
+ * Algolia MCP Server search tool instead expresses refinements as individual
+ * `facet_<attribute>` keys (e.g. `facet_categories: ['Books', 'Toys']`), which
+ * are converted here into the `[['attribute:value']]` shape `applyFilters`
+ * expects.
+ */
+export const getFacetFiltersFromToolInput = (
+  input: SearchToolInput | undefined
+): string[][] | undefined => {
+  if (!input) {
+    return undefined;
+  }
+
+  if (Array.isArray(input.facet_filters)) {
+    return input.facet_filters;
+  }
+
+  const facetFilters = Object.entries(input).reduce<string[][]>(
+    (acc, [key, value]) => {
+      if (!startsWith(key, FACET_KEY_PREFIX) || !Array.isArray(value)) {
+        return acc;
+      }
+
+      const attribute = key.slice(FACET_KEY_PREFIX.length);
+      const values = value.filter(
+        (item): item is string => typeof item === 'string'
+      );
+
+      if (attribute && values.length > 0) {
+        acc.push(values.map((item) => `${attribute}:${item}`));
+      }
+
+      return acc;
+    },
+    []
+  );
+
+  return facetFilters.length > 0 ? facetFilters : undefined;
 };

--- a/packages/instantsearch-ui-components/src/lib/utils/index.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/index.ts
@@ -1,3 +1,4 @@
+export { getFacetFiltersFromToolInput } from './chat';
 export * from './find';
 export * from './promptSuggestions';
 export * from './startsWith';

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRightIcon,
   createButtonComponent,
   createChatComponent,
+  getFacetFiltersFromToolInput,
 } from 'instantsearch-ui-components';
 import { Fragment, h, render } from 'preact';
 import { useMemo } from 'preact/hooks';
@@ -102,12 +103,7 @@ function createCarouselTool<
     onClose,
     sendEvent,
   }: ClientSideToolTemplateData) {
-    const input = message?.input as
-      | {
-          query: string;
-          number_of_results?: number;
-        }
-      | undefined;
+    const input = message?.input as SearchToolInput | undefined;
 
     const output = message?.output as
       | {
@@ -210,7 +206,7 @@ function createCarouselTool<
                 if (!input || !applyFilters) return;
                 const params = applyFilters({
                   query: input.query,
-                  facetFilters: input.facet_filters,
+                  facetFilters: getFacetFiltersFromToolInput(input),
                 });
 
                 if (

--- a/packages/react-instantsearch/src/widgets/chat/tools/SearchIndexTool.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/SearchIndexTool.tsx
@@ -3,11 +3,9 @@ import {
   ChevronRightIcon,
   ArrowRightIcon,
   createButtonComponent,
+  getFacetFiltersFromToolInput,
 } from 'instantsearch-ui-components';
-import {
-  addAbsolutePosition,
-  addQueryID,
-} from 'instantsearch.js/es/lib/utils';
+import { addAbsolutePosition, addQueryID } from 'instantsearch.js/es/lib/utils';
 import React, { createElement } from 'react';
 
 import { Carousel } from '../../../components';
@@ -18,17 +16,12 @@ import type {
   Pragma,
   RecommendComponentProps,
   RecordWithObjectID,
+  SearchToolInput,
   UserClientSideTool,
 } from 'instantsearch-ui-components';
 import type { ComponentProps } from 'react';
 
 type ItemComponent<TObject> = RecommendComponentProps<TObject>['itemComponent'];
-
-type SearchToolInput = {
-  query: string;
-  number_of_results?: number;
-  facet_filters?: string[][];
-};
 
 function createCarouselTool<TObject extends RecordWithObjectID>(
   showViewAll: boolean,
@@ -45,13 +38,7 @@ function createCarouselTool<TObject extends RecordWithObjectID>(
     onClose,
     sendEvent,
   }: ClientSideToolComponentProps) {
-    const input = message?.input as
-      | {
-          query: string;
-          number_of_results?: number;
-          facet_filters?: string[][];
-        }
-      | undefined;
+    const input = message?.input as SearchToolInput | undefined;
 
     const output = message?.output as
       | {
@@ -146,7 +133,7 @@ function createCarouselTool<TObject extends RecordWithObjectID>(
                 if (!input || !applyFilters) return;
                 const params = applyFilters({
                   query: input.query,
-                  facetFilters: input.facet_filters,
+                  facetFilters: getFacetFiltersFromToolInput(input),
                 });
 
                 if (

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/SearchIndexTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/SearchIndexTool.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { createCarouselTool } from '../SearchIndexTool';
@@ -87,6 +88,51 @@ describe('createCarouselTool', () => {
 
       expect(screen.getByText('MCP Product 1')).toBeInTheDocument();
       expect(screen.getByText('MCP Product 2')).toBeInTheDocument();
+    });
+
+    test('converts MCP `facet_<name>` input into `facetFilters` on "View all"', async () => {
+      const applyFilters = jest.fn().mockReturnValue({});
+      const tool = createCarouselTool<TestHit>(true, mockItemComponent);
+      const LayoutComponent = tool.layoutComponent!;
+
+      const message: ClientSideToolComponentProps['message'] = {
+        type: 'tool-algolia_search_index_products',
+        state: 'output-available',
+        toolCallId: 'test-call-id',
+        input: {
+          query: '',
+          facet_type: ['book'],
+          facet_brand: [],
+          facet_categories: ['Literature & Fiction', 'Teen & Young Adult'],
+          facet__collections: [],
+        },
+        output: {
+          hits: [{ objectID: '1', name: 'MCP Product 1', __position: 1 }],
+          nbHits: 50,
+        },
+      };
+
+      render(
+        <LayoutComponent
+          message={message}
+          applyFilters={applyFilters}
+          onClose={jest.fn()}
+          indexUiState={{}}
+          addToolResult={jest.fn()}
+          setIndexUiState={jest.fn()}
+          sendEvent={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByText('View all'));
+
+      expect(applyFilters).toHaveBeenCalledWith({
+        query: '',
+        facetFilters: [
+          ['type:book'],
+          ['categories:Literature & Fiction', 'categories:Teen & Young Adult'],
+        ],
+      });
     });
   });
 });

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -1293,6 +1293,93 @@ export function createOptionsTests(
         );
       });
 
+      test('applies filters from the MCP search tool `facet_<name>` view all button', async () => {
+        const searchClient = createSearchClient();
+
+        const chat = new Chat({
+          messages: [
+            {
+              id: '1',
+              role: 'assistant',
+              parts: [
+                {
+                  type: `tool-${SearchIndexToolType}`,
+                  toolCallId: '1',
+                  input: {
+                    query: 'test',
+                    facet_brand: ['Apple'],
+                    facet_category: ['Laptops', 'Tablets'],
+                    facet_color: [],
+                  },
+                  state: 'output-available',
+                  output: {
+                    hits: [
+                      {
+                        objectID: '123',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+          id: 'chat-id',
+        });
+
+        await setup({
+          instantSearchOptions: {
+            indexName: 'indexName',
+            searchClient,
+            initialUiState: {
+              indexName: {
+                refinementList: {
+                  brand: ['Samsung', 'Apple'],
+                  category: ['Laptops'],
+                },
+              },
+            },
+          },
+          widgetParams: {
+            javascript: {
+              ...createDefaultWidgetParams(chat),
+              renderRefinements: true,
+            },
+            react: {
+              ...createDefaultWidgetParams(chat),
+              renderRefinements: true,
+            },
+            vue: {},
+          },
+        });
+
+        await openChat(act);
+
+        userEvent.click(
+          document.querySelector(
+            '.ais-ChatToolSearchIndexCarouselHeaderViewAll'
+          )!
+        );
+
+        await act(async () => {
+          await wait(0);
+        });
+
+        expect(searchClient.search).toHaveBeenCalledTimes(2);
+        expect(searchClient.search).toHaveBeenLastCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              params: expect.objectContaining({
+                query: 'test',
+                facetFilters: [
+                  ['brand:Apple'],
+                  ['category:Laptops', 'category:Tablets'],
+                ],
+              }),
+            }),
+          ])
+        );
+      });
+
       test('applies filters for custom tools', async () => {
         const searchClient = createSearchClient();
 


### PR DESCRIPTION
The MCP search tool sends any facets it uses for search in the `facet_${facet-name}` format rather than in the  `facet_filters` array in a non MCP tool.

This PR updates the handler to cater for both types of tools.

[FX-3829]

[FX-3829]: https://algolia.atlassian.net/browse/FX-3829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ