### PR TITLE
feat(chat): add parseMarkdown opt-out to render message text as plain…

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -74,7 +74,7 @@
     },
     {
       "path": "./packages/instantsearch.css/components/chat.css",
-      "maxSize": "6 kB"
+      "maxSize": "6.25 kB"
     },
     {
       "path": "./packages/instantsearch.css/components/chat-min.css",

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -153,6 +153,17 @@ export type ChatMessageProps = ComponentProps<'article'> & {
    * Optional translations
    */
   translations?: Partial<ChatMessageTranslations>;
+  /**
+   * Whether to render text parts as markdown.
+   *
+   * When `true` (default), text parts are compiled with `markdown-to-jsx`
+   * (links, code blocks, emphasis, …). When `false`, text parts render as
+   * plain text with newlines preserved — useful for user messages where the
+   * source is the human's literal input and incidental markdown syntax (`*`,
+   * `_`, …) shouldn't be transformed. Note that opting out means links in the
+   * output are no longer clickable.
+   */
+  parseMarkdown?: boolean;
 };
 
 // Keep in sync with packages/instantsearch.js/src/lib/chat/index.ts
@@ -180,6 +191,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
       onClose,
       translations: userTranslations,
       suggestionsElement,
+      parseMarkdown = true,
       ...props
     } = userProps;
 
@@ -227,6 +239,22 @@ export function createChatMessageComponent({ createElement }: Renderer) {
           part.text.endsWith('</context>')
         ) {
           return null;
+        }
+        if (!parseMarkdown) {
+          // Render the literal text. The `ais-ChatMessage-text` class applies
+          // `white-space: pre-wrap` to preserve the newlines that markdown
+          // would otherwise collapse, and streaming deltas append cleanly
+          // because there's no parser state to get into a half-parsed entity.
+          // Wrapped in a `<p>` to keep some structure for screen readers
+          // (markdown produces semantic elements; a bare text node would not).
+          return (
+            <p
+              key={`${message.id}-${index}`}
+              className="ais-ChatMessage-text"
+            >
+              {part.text}
+            </p>
+          );
         }
         const markdown = compiler(part.text, {
           createElement: createElement as any,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -206,6 +206,148 @@ describe('ChatMessage', () => {
     `);
   });
 
+  test('parses text parts as markdown by default', () => {
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'user',
+          id: '1',
+          parts: [{ type: 'text', text: 'a *b* c' }],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+      />
+    );
+
+    // markdown-to-jsx turns `*b*` into an <em>, so the literal asterisks are
+    // gone from the output.
+    expect(container.querySelector('em')).not.toBeNull();
+    expect(container.querySelector('em')!.textContent).toBe('b');
+    expect(container.querySelector('.ais-ChatMessage-text')).toBeNull();
+  });
+
+  test('renders text parts as plain text when parseMarkdown is false', () => {
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'user',
+          id: '1',
+          parts: [{ type: 'text', text: 'a *b* c' }],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        parseMarkdown={false}
+      />
+    );
+
+    const text = container.querySelector('.ais-ChatMessage-text');
+    expect(text).not.toBeNull();
+    // The literal asterisks survive: no markdown transformation happened.
+    expect(text!.textContent).toBe('a *b* c');
+    expect(container.querySelector('em')).toBeNull();
+  });
+
+  test('plain-text mode renders the expected DOM structure', () => {
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'user',
+          id: '1',
+          parts: [{ type: 'text', text: 'Use * and _ literally' }],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        parseMarkdown={false}
+      />
+    );
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <article
+          aria-label="Message"
+          class="ais-ChatMessage ais-ChatMessage--left ais-ChatMessage--subtle"
+        >
+          <div
+            class="ais-ChatMessage-container"
+          >
+            <div
+              class="ais-ChatMessage-content"
+            >
+              <div
+                class="ais-ChatMessage-message"
+              >
+                <p
+                  class="ais-ChatMessage-text"
+                >
+                  Use * and _ literally
+                </p>
+              </div>
+            </div>
+          </div>
+        </article>
+      </div>
+    `);
+  });
+
+  test('preserves newlines in plain-text mode', () => {
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'user',
+          id: '1',
+          parts: [{ type: 'text', text: 'line one\nline two' }],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        parseMarkdown={false}
+      />
+    );
+
+    expect(container.querySelector('.ais-ChatMessage-text')!.textContent).toBe(
+      'line one\nline two'
+    );
+  });
+
+  test('still hides legacy `<context>` parts when parseMarkdown is false', () => {
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'user',
+          id: '1',
+          parts: [
+            {
+              type: 'text',
+              text: '<context>{"currentPage":"https://example.com/products"}</context>',
+            },
+            { type: 'text', text: 'Hello' },
+          ],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        parseMarkdown={false}
+      />
+    );
+
+    expect(container.textContent).toBe('Hello');
+    expect(container.textContent).not.toContain('example.com');
+    expect(container.textContent).not.toContain('context');
+  });
+
   test('does not render legacy `<context>` text parts (back-compat)', () => {
     // Pre-migration sessions persisted a `<context>{...}</context>` text part.
     // The shim in `ChatMessage` keeps those out of the rendered transcript

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -143,6 +143,91 @@ describe('ChatMessages', () => {
     `);
   });
 
+  describe('parseMarkdown', () => {
+    test('parses user message text as markdown by default', () => {
+      const { container } = render(
+        <ChatMessages
+          messages={[
+            {
+              role: 'user',
+              id: '1',
+              parts: [{ type: 'text', text: 'a *b* c' }],
+            },
+          ]}
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          tools={{}}
+          onReload={jest.fn()}
+          onClose={jest.fn()}
+        />
+      );
+
+      expect(container.querySelector('em')).not.toBeNull();
+      expect(container.querySelector('.ais-ChatMessage-text')).toBeNull();
+    });
+
+    test('renders user message text as plain text via userMessageProps', () => {
+      const { container } = render(
+        <ChatMessages
+          messages={[
+            {
+              role: 'user',
+              id: '1',
+              parts: [{ type: 'text', text: 'a *b* c\nsecond line' }],
+            },
+          ]}
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          tools={{}}
+          onReload={jest.fn()}
+          onClose={jest.fn()}
+          userMessageProps={{ parseMarkdown: false }}
+        />
+      );
+
+      const text = container.querySelector('.ais-ChatMessage-text');
+      expect(text).not.toBeNull();
+      // No markdown transformation, and the newline is preserved.
+      expect(text!.textContent).toBe('a *b* c\nsecond line');
+      expect(container.querySelector('em')).toBeNull();
+    });
+
+    test('only affects the targeted role', () => {
+      const { container } = render(
+        <ChatMessages
+          messages={[
+            {
+              role: 'user',
+              id: '1',
+              parts: [{ type: 'text', text: 'user *text*' }],
+            },
+            {
+              role: 'assistant',
+              id: '2',
+              parts: [{ type: 'text', text: 'assistant *text*' }],
+            },
+          ]}
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          tools={{}}
+          onReload={jest.fn()}
+          onClose={jest.fn()}
+          userMessageProps={{ parseMarkdown: false }}
+        />
+      );
+
+      const messages = container.querySelectorAll('.ais-ChatMessage-message');
+      // User message: plain text, no emphasis.
+      expect(
+        messages[0].querySelector('.ais-ChatMessage-text')
+      ).not.toBeNull();
+      expect(messages[0].querySelector('em')).toBeNull();
+      // Assistant message: still parsed as markdown.
+      expect(messages[1].querySelector('em')).not.toBeNull();
+      expect(messages[1].querySelector('.ais-ChatMessage-text')).toBeNull();
+    });
+  });
+
   describe('feedback', () => {
     const assistantMessage = {
       role: 'assistant' as const,

--- a/packages/instantsearch.css/src/components/chat/_chat-message.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message.scss
@@ -49,6 +49,13 @@
   }
 }
 
+.ais-ChatMessage-text {
+  margin: 0;
+  // Preserve the author's newlines when markdown parsing is disabled
+  // (`parseMarkdown: false`); markdown would otherwise collapse them.
+  white-space: pre-wrap;
+}
+
 .ais-ChatMessage-code {
   overflow-x: auto;
 }


### PR DESCRIPTION
ChatMessage always ran every text part through markdown-to-jsx, so a user's literal input (`*`, `_`, …) was silently transformed and there was no way to opt out per role. Add `parseMarkdown?: boolean` to `ChatMessageProps` (default `true`, current behaviour preserved). When `false`, text parts render as plain text inside a `<p class="ais-ChatMessage-text">` instead of being compiled.
`
This threads through the existing `userMessageProps`/`assistantMessageProps` plumbing on `ChatMessages` with no extra wiring, so callers disable markdown per role:
  <Chat userMessageProps={{ parseMarkdown: false }} />
Notes:
- The `<context>…</context>` short-circuit stays above the branch, so injected context blocks remain hidden in both modes.
- Newlines are preserved via `white-space: pre-wrap` on `.ais-ChatMessage-text` (markdown would otherwise collapse single newlines).
- The plain-text branch returns `part.text` directly, so streaming deltas append cleanly with no half-parsed entities or flicker.
- Wrapped in a `<p>` to keep some structure for screen readers, since markdown produces semantic elements and a bare text node would not.
- Behaviour change when disabled: links and code blocks are no longer rendered(that's the point of opting out). markdown-to-jsx is still imported, so there is no bundle-size win.
Adds unit and snapshot tests covering both modes, newline preservation, the `<context>` short-circuit in plain-text mode, and that the opt-out only affects the targeted role.