### PR TITLE
refactor(react-instantsearch-core): share server search execution

### DIFF
--- a/packages/react-instantsearch-core/src/index.ts
+++ b/packages/react-instantsearch-core/src/index.ts
@@ -44,4 +44,7 @@ export * from './lib/useInstantSearchContext';
 export * from './lib/useRSCContext';
 export * from './lib/InstantSearchRSCContext';
 export * from './lib/InstantSearchSSRContext';
+export {
+  createServerSearchExecution as __internal_createServerSearchExecution,
+} from './lib/serverSearchExecution';
 export * from './server';

--- a/packages/react-instantsearch-core/src/lib/serverSearchExecution.ts
+++ b/packages/react-instantsearch-core/src/lib/serverSearchExecution.ts
@@ -1,0 +1,143 @@
+import { getInitialResults as getInstantSearchInitialResults } from 'instantsearch.js/es/lib/server';
+import {
+  isTwoPassWidget,
+  resetWidgetId,
+  walkIndex,
+} from 'instantsearch.js/es/lib/utils';
+
+import type {
+  CompositionClient,
+  InitialResults,
+  InstantSearch,
+  SearchClient,
+  SearchOptions,
+} from 'instantsearch.js';
+
+export type ServerSearchExecutionOptions = {
+  skipRecommend?: boolean;
+};
+
+type InternalInstantSearch = InstantSearch & {
+  _resetScheduleSearch?: () => void;
+};
+
+export function resetServerSearchWidgetIds() {
+  resetWidgetId();
+}
+
+export function createServerSearchExecution(search: InstantSearch) {
+  const helper = search.mainHelper!;
+  const client = helper.getClient();
+
+  let isClientPatched = false;
+  let requestParamsList: SearchOptions[] | undefined;
+
+  function patchSearchClient() {
+    if (isClientPatched) {
+      return;
+    }
+
+    if (search.compositionID) {
+      helper.setClient({
+        ...client,
+        search(query) {
+          requestParamsList = [query.requestBody.params];
+          return (client as CompositionClient).search(query);
+        },
+      } as CompositionClient);
+    } else {
+      helper.setClient({
+        ...client,
+        search(queries) {
+          requestParamsList = queries.map(({ params }) => params);
+          return (client as SearchClient).search(queries);
+        },
+      } as SearchClient);
+    }
+
+    isClientPatched = true;
+  }
+
+  return {
+    resetWidgetIds() {
+      resetServerSearchWidgetIds();
+    },
+
+    prepare({
+      skipRecommend = false,
+    }: ServerSearchExecutionOptions = {}): Promise<
+      SearchOptions[] | undefined
+    > {
+      requestParamsList = undefined;
+      patchSearchClient();
+
+      return new Promise((resolve, reject) => {
+        let searchResultsReceived = false;
+        let recommendResultsReceived = false;
+
+        helper.derivedHelpers[0].once('result', () => {
+          searchResultsReceived = true;
+          if (
+            !search._hasRecommendWidget ||
+            skipRecommend ||
+            recommendResultsReceived
+          ) {
+            resolve(requestParamsList);
+          }
+        });
+
+        helper.derivedHelpers[0].once('recommend:result', () => {
+          recommendResultsReceived = true;
+          if (!search._hasSearchWidget || searchResultsReceived) {
+            resolve(requestParamsList);
+          }
+        });
+
+        helper.once('error', reject);
+        search.once('error', reject);
+        helper.derivedHelpers.forEach((derivedHelper) =>
+          derivedHelper.once('error', reject)
+        );
+      });
+    },
+
+    trigger({ skipRecommend = false }: ServerSearchExecutionOptions = {}) {
+      if (search._hasSearchWidget) {
+        if (search.compositionID) {
+          helper.searchWithComposition();
+        } else {
+          helper.searchOnlyWithDerivedHelpers();
+        }
+      }
+
+      if (!skipRecommend && search._hasRecommendWidget) {
+        helper.recommend();
+      }
+    },
+
+    hasSearchOrRecommendWidgets() {
+      return search._hasSearchWidget || search._hasRecommendWidget;
+    },
+
+    hasTwoPassWidgets() {
+      let hasTwoPassWidgets = false;
+
+      walkIndex(search.mainIndex, (index) => {
+        hasTwoPassWidgets =
+          hasTwoPassWidgets || index.getWidgets().some(isTwoPassWidget);
+      });
+
+      return hasTwoPassWidgets;
+    },
+
+    resetScheduleSearch() {
+      (search as InternalInstantSearch)._resetScheduleSearch?.();
+    },
+
+    getInitialResults(
+      paramsList?: SearchOptions[] | undefined
+    ): InitialResults {
+      return getInstantSearchInitialResults(search.mainIndex, paramsList);
+    },
+  };
+}

--- a/packages/react-instantsearch-core/src/server/getServerState.tsx
+++ b/packages/react-instantsearch-core/src/server/getServerState.tsx
@@ -1,16 +1,11 @@
-import {
-  getInitialResults,
-  waitForResults,
-} from 'instantsearch.js/es/lib/server';
-import {
-  isTwoPassWidget,
-  walkIndex,
-  resetWidgetId,
-} from 'instantsearch.js/es/lib/utils';
 import React from 'react';
 
 import { InstantSearchServerContext } from '../components/InstantSearchServerContext';
 import { InstantSearchSSRProvider } from '../components/InstantSearchSSRProvider';
+import {
+  createServerSearchExecution,
+  resetServerSearchWidgetIds,
+} from '../lib/serverSearchExecution';
 
 import type { InstantSearchServerContextApi } from '../components/InstantSearchServerContext';
 import type { InstantSearchServerState } from '../components/InstantSearchSSRProvider';
@@ -36,7 +31,7 @@ export function getServerState(
     current: undefined,
   };
 
-  resetWidgetId();
+  resetServerSearchWidgetIds();
 
   const createNotifyServer = () => {
     let hasBeenNotified = false;
@@ -63,16 +58,11 @@ export function getServerState(
     searchRef,
     notifyServer: createNotifyServer(),
   }).then((serverState) => {
-    let shouldRefetch = false;
-
-    // Two-pass widgets require another query to discover and mount child widgets.
-    walkIndex(searchRef.current!.mainIndex, (index) => {
-      shouldRefetch =
-        shouldRefetch || index.getWidgets().some(isTwoPassWidget);
-    });
+    const execution = createServerSearchExecution(searchRef.current!);
+    const shouldRefetch = execution.hasTwoPassWidgets();
 
     if (shouldRefetch) {
-      resetWidgetId();
+      resetServerSearchWidgetIds();
 
       return execute({
         children: (
@@ -133,14 +123,19 @@ function execute({
         );
       }
 
-      return waitForResults(searchRef.current, skipRecommend);
+      const execution = createServerSearchExecution(searchRef.current);
+      const requestParamsList = execution.prepare({ skipRecommend });
+
+      execution.trigger({ skipRecommend });
+
+      return requestParamsList.then((paramsList) => ({
+        execution,
+        paramsList,
+      }));
     })
-    .then((requestParamsList) => {
+    .then(({ execution, paramsList }) => {
       return {
-        initialResults: getInitialResults(
-          searchRef.current!.mainIndex,
-          requestParamsList
-        ),
+        initialResults: execution.getInitialResults(paramsList),
       };
     });
 }

--- a/packages/react-instantsearch-nextjs/src/InitializePromise.ts
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.ts
@@ -1,12 +1,7 @@
-import { getInitialResults } from 'instantsearch.js/es/lib/server';
-import {
-  isTwoPassWidget,
-  walkIndex,
-  resetWidgetId,
-} from 'instantsearch.js/es/lib/utils';
 import { ServerInsertedHTMLContext } from 'next/navigation';
 import { useContext } from 'react';
 import {
+  __internal_createServerSearchExecution,
   useInstantSearchContext,
   useRSCContext,
   wrapPromiseWithState,
@@ -14,11 +9,7 @@ import {
 
 import { createInsertHTML } from './createInsertHTML';
 
-import type {
-  SearchOptions,
-  CompositionClient,
-  SearchClient,
-} from 'instantsearch.js';
+import type { SearchOptions } from 'instantsearch.js';
 
 type InitializePromiseProps = {
   /**
@@ -37,79 +28,37 @@ export function InitializePromise({ nonce }: InitializePromiseProps) {
     (() => {
       throw new Error('Missing ServerInsertedHTMLContext');
     });
+  const execution = __internal_createServerSearchExecution(search);
 
-  // Extract search parameters from the search client to use them
-  // later during hydration.
-  let requestParamsList: SearchOptions[];
+  execution.resetWidgetIds();
 
-  if (search.compositionID) {
-    search.mainHelper!.setClient({
-      ...search.mainHelper!.getClient(),
-      search(query) {
-        requestParamsList = [query.requestBody.params];
-        return (search.client as CompositionClient).search(query);
-      },
-    } as CompositionClient);
-  } else {
-    search.mainHelper!.setClient({
-      ...search.mainHelper!.getClient(),
-      search(queries) {
-        requestParamsList = queries.map(({ params }) => params);
-        return (search.client as SearchClient).search(queries);
-      },
-    } as SearchClient);
-  }
-
-  resetWidgetId();
-
-  const waitForResults = () =>
-    new Promise<void>((resolve) => {
-      let searchReceived = false;
-      let recommendReceived = false;
-      search.mainHelper!.derivedHelpers[0].once('result', () => {
-        searchReceived = true;
-        if (!search._hasRecommendWidget || recommendReceived) {
-          resolve();
-        }
-      });
-      search.mainHelper!.derivedHelpers[0].once('recommend:result', () => {
-        recommendReceived = true;
-        if (!search._hasSearchWidget || searchReceived) {
-          resolve();
-        }
-      });
-    });
-
-  const injectInitialResults = () => {
+  const injectInitialResults = (requestParamsList?: SearchOptions[]) => {
     const options = { inserted: false };
-    const results = getInitialResults(search.mainIndex, requestParamsList);
+    const results = execution.getInitialResults(requestParamsList);
     insertHTML(createInsertHTML({ options, results, nonce }));
   };
 
   if (waitForResultsRef?.current === null) {
     waitForResultsRef.current = wrapPromiseWithState(
-      waitForResults()
-        .then(() => {
-          let shouldRefetch = false;
-          walkIndex(search.mainIndex, (index) => {
-            shouldRefetch =
-              shouldRefetch || index.getWidgets().some(isTwoPassWidget);
-          });
+      execution
+        .prepare()
+        .then((requestParamsList) => {
+          const shouldRefetch = execution.hasTwoPassWidgets();
 
           if (shouldRefetch) {
-            search._resetScheduleSearch?.();
+            execution.resetScheduleSearch();
             waitForResultsRef.current = wrapPromiseWithState(
-              waitForResults().then(injectInitialResults)
+              execution.prepare().then(injectInitialResults)
             );
           }
 
-          return shouldRefetch;
+          return { requestParamsList, shouldRefetch };
         })
-        .then((shouldRefetch) => {
+        .then(({ requestParamsList, shouldRefetch }) => {
           if (shouldRefetch) {
             return;
           }
-          injectInitialResults();
+          injectInitialResults(requestParamsList);
         })
     );
   }

--- a/packages/react-instantsearch-nextjs/src/TriggerSearch.ts
+++ b/packages/react-instantsearch-nextjs/src/TriggerSearch.ts
@@ -1,6 +1,7 @@
 import { ServerInsertedHTMLContext } from 'next/navigation';
 import { useContext } from 'react';
 import {
+  __internal_createServerSearchExecution,
   useInstantSearchContext,
   useRSCContext,
 } from 'react-instantsearch-core';
@@ -17,17 +18,12 @@ export function TriggerSearch({ nonce }: { nonce?: string }) {
     });
 
   if (waitForResultsRef?.current?.status === 'pending') {
-    if (instantsearch._hasSearchWidget) {
-      if (instantsearch.compositionID) {
-        instantsearch.mainHelper?.searchWithComposition();
-      } else {
-        instantsearch.mainHelper?.searchOnlyWithDerivedHelpers();
-      }
-    }
-    instantsearch._hasRecommendWidget && instantsearch.mainHelper?.recommend();
+    const execution = __internal_createServerSearchExecution(instantsearch);
+
+    execution.trigger();
 
     // If there are no widgets, we inject empty initial results instantly
-    if (!instantsearch._hasSearchWidget && !instantsearch._hasRecommendWidget) {
+    if (!execution.hasSearchOrRecommendWidgets()) {
       const options = { inserted: false };
       insertHTML(createInsertHTML({ options, results: {}, nonce }));
     }

--- a/packages/react-instantsearch-nextjs/src/__tests__/InitializePromise.test.tsx
+++ b/packages/react-instantsearch-nextjs/src/__tests__/InitializePromise.test.tsx
@@ -11,6 +11,7 @@ import * as utils from 'instantsearch.js/es/lib/utils';
 import { ServerInsertedHTMLContext } from 'next/navigation';
 import React from 'react';
 import { SearchBox, TrendingItems } from 'react-instantsearch';
+import * as ReactInstantSearchCore from 'react-instantsearch-core';
 import {
   InstantSearch,
   InstantSearchRSCContext,
@@ -26,6 +27,17 @@ jest.mock('instantsearch.js/es/lib/utils', () => ({
   ...jest.requireActual('instantsearch.js/es/lib/utils'),
   resetWidgetId: jest.fn(),
 }));
+
+jest.mock('react-instantsearch-core', () => {
+  const actual = jest.requireActual('react-instantsearch-core');
+
+  return {
+    ...actual,
+    __internal_createServerSearchExecution: jest.fn(
+      actual.__internal_createServerSearchExecution
+    ),
+  };
+});
 
 const renderComponent = async ({
   children,
@@ -132,6 +144,51 @@ test('it waits for search only if there are only search widgets', async () => {
     expect.objectContaining({ indexName: 'indexName' }),
   ]);
   expect(client.getRecommendations).not.toHaveBeenCalled();
+});
+
+test('it prepares a second pass for two-pass widgets', async () => {
+  const ref: { current: PromiseWithState<void> | null } = { current: null };
+  const insertedHTML = jest.fn();
+  const execution = {
+    resetWidgetIds: jest.fn(),
+    prepare: jest
+      .fn()
+      .mockResolvedValueOnce([{ query: 'first-pass' }])
+      .mockResolvedValueOnce([{ query: 'second-pass' }]),
+    trigger: jest.fn(),
+    hasSearchOrRecommendWidgets: jest.fn(() => true),
+    hasTwoPassWidgets: jest.fn(() => true),
+    resetScheduleSearch: jest.fn(),
+    getInitialResults: jest.fn(() => ({})),
+  };
+  const createServerSearchExecution =
+    ReactInstantSearchCore.__internal_createServerSearchExecution as jest.Mock;
+  const originalImplementation =
+    createServerSearchExecution.getMockImplementation();
+  createServerSearchExecution.mockReturnValue(execution);
+
+  try {
+    await renderComponent({
+      ref,
+      children: <SearchBox />,
+      insertedHTML,
+    });
+
+    if (ref.current?.status === 'pending') {
+      await act(async () => {
+        await ref.current;
+      });
+    }
+
+    expect(execution.prepare).toHaveBeenCalledTimes(2);
+    expect(execution.resetScheduleSearch).toHaveBeenCalledTimes(1);
+    expect(execution.getInitialResults).toHaveBeenCalledWith([
+      { query: 'second-pass' },
+    ]);
+    expect(insertedHTML).toHaveBeenCalledTimes(1);
+  } finally {
+    createServerSearchExecution.mockImplementation(originalImplementation);
+  }
 });
 
 test('it waits for recommend only if there are only recommend widgets', async () => {


### PR DESCRIPTION
## Summary
- Extract shared server search execution logic in React InstantSearch Core.
- Reuse the shared execution path from `getServerState` and the Next.js App Router SSR adapters.
- Add App Router coverage for the two-pass widget refetch branch.

## Test plan
- `yarn jest packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx packages/react-instantsearch-nextjs/src/__tests__/InitializePromise.test.tsx packages/react-instantsearch-nextjs/src/__tests__/InitializePromise-composition.test.tsx packages/react-instantsearch-nextjs/src/__tests__/InstantSearchNext.test.tsx --runInBand`
- `yarn workspace react-instantsearch-core build:types && yarn workspace react-instantsearch-nextjs build:types`
- `yarn lint:changed`