### PR TITLE
refactor(instantsearch.js): share widget search parameter collection

### DIFF
--- a/packages/instantsearch.js/src/connectors/feeds/FeedContainer.ts
+++ b/packages/instantsearch.js/src/connectors/feeds/FeedContainer.ts
@@ -1,6 +1,7 @@
 import algoliasearchHelper from 'algoliasearch-helper';
 
 import {
+  collectWidgetSearchParameters,
   createInitArgs,
   createRenderArgs,
   storeRenderState,
@@ -288,13 +289,11 @@ export function createFeedContainer(
       searchParameters: SearchParameters,
       { uiState }: { uiState: IndexUiState }
     ) {
-      return localWidgets.reduce(
-        (params, widget) =>
-          widget.getWidgetSearchParameters
-            ? widget.getWidgetSearchParameters(params, { uiState })
-            : params,
-        searchParameters
-      );
+      return collectWidgetSearchParameters(localWidgets, {
+        uiState,
+        initialSearchParameters: searchParameters,
+        useWidgetParameters: false,
+      });
     },
 
     refreshUiState() {

--- a/packages/instantsearch.js/src/connectors/feeds/__tests__/FeedContainer-test.ts
+++ b/packages/instantsearch.js/src/connectors/feeds/__tests__/FeedContainer-test.ts
@@ -300,10 +300,11 @@ describe('FeedContainer', () => {
         instantSearchInstance
       );
 
-      const cleanedState = instantSearchInstance.helper!.state.setQueryParameter(
-        'disjunctiveFacets',
-        []
-      );
+      const cleanedState =
+        instantSearchInstance.helper!.state.setQueryParameter(
+          'disjunctiveFacets',
+          []
+        );
       const widget = createWidget({
         dispose: jest.fn(() => cleanedState),
       });
@@ -343,6 +344,36 @@ describe('FeedContainer', () => {
       const widget2 = createWidget();
       container.addWidgets([widget2]);
       expect(widget2.init).toHaveBeenCalled();
+    });
+
+    it('addWidgets after init applies child search parameters to the parent helper', () => {
+      const instantSearchInstance = createInstantSearch({
+        started: true,
+      } as any);
+      const parent = index({ indexName: 'test' });
+      parent.getHelper = () => instantSearchInstance.helper!;
+      const container = createFeedContainer(
+        'products',
+        parent,
+        instantSearchInstance
+      );
+      const initialState = instantSearchInstance.helper!.state;
+      const expectedState = initialState.addDisjunctiveFacet('brand');
+      const widget = createWidget({
+        getWidgetSearchParameters: jest.fn((searchParameters) =>
+          searchParameters.addDisjunctiveFacet('brand')
+        ),
+      });
+      const setStateSpy = jest.spyOn(instantSearchInstance.helper!, 'setState');
+
+      container.init({} as any);
+      container.addWidgets([widget]);
+
+      expect(widget.getWidgetSearchParameters).toHaveBeenCalledWith(
+        initialState,
+        { uiState: {} }
+      );
+      expect(setStateSpy).toHaveBeenCalledWith(expectedState);
     });
 
     it('addWidgets flattens nested widget arrays', () => {

--- a/packages/instantsearch.js/src/lib/utils/__tests__/collectWidgetSearchParameters-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/collectWidgetSearchParameters-test.ts
@@ -1,0 +1,115 @@
+import algoliasearchHelper from 'algoliasearch-helper';
+
+import { createWidget } from '../../../../test/createWidget';
+import { index } from '../../../widgets';
+import { collectWidgetSearchParameters } from '../collectWidgetSearchParameters';
+import { isIndexWidget } from '../isIndexWidget';
+
+describe('collectWidgetSearchParameters', () => {
+  it('collects search parameters from widgets in order', () => {
+    const initialSearchParameters = new algoliasearchHelper.SearchParameters({
+      index: 'products',
+    });
+    const searchBox = createWidget({
+      getWidgetSearchParameters: jest.fn((searchParameters, { uiState }) =>
+        searchParameters.setQueryParameter('query', uiState.query)
+      ),
+    });
+    const pagination = createWidget({
+      getWidgetSearchParameters: jest.fn((searchParameters, { uiState }) =>
+        searchParameters.setQueryParameter('page', uiState.page)
+      ),
+    });
+
+    const actual = collectWidgetSearchParameters([searchBox, pagination], {
+      uiState: { query: 'iphone', page: 2 },
+      initialSearchParameters,
+    });
+
+    expect(actual.query).toBe('iphone');
+    expect(actual.page).toBe(2);
+  });
+
+  it('preserves the initial search parameters when no widget changes them', () => {
+    const initialSearchParameters = new algoliasearchHelper.SearchParameters({
+      index: 'products',
+    });
+    const widget = createWidget();
+
+    const actual = collectWidgetSearchParameters([widget], {
+      uiState: {},
+      initialSearchParameters,
+    });
+
+    expect(actual).toBe(initialSearchParameters);
+  });
+
+  it('can skip widgets selected by the caller', () => {
+    const initialSearchParameters = new algoliasearchHelper.SearchParameters({
+      index: 'products',
+    });
+    const nestedIndex = index({ indexName: 'related' });
+    const getWidgetSearchParameters = jest.spyOn(
+      nestedIndex,
+      'getWidgetSearchParameters'
+    );
+
+    const actual = collectWidgetSearchParameters([nestedIndex], {
+      uiState: {},
+      initialSearchParameters,
+      skipWidget: isIndexWidget,
+    });
+
+    expect(actual).toBe(initialSearchParameters);
+    expect(getWidgetSearchParameters).not.toHaveBeenCalled();
+  });
+
+  it('uses getWidgetParameters for search-dependent widgets by default', () => {
+    const initialSearchParameters = new algoliasearchHelper.SearchParameters({
+      index: 'products',
+    });
+    const widget = createWidget({
+      dependsOn: 'search',
+      getWidgetParameters: jest.fn((searchParameters) =>
+        searchParameters.setQueryParameter('query', 'iphone')
+      ),
+      getWidgetSearchParameters: jest.fn((searchParameters) =>
+        searchParameters.setQueryParameter('query', 'wrong')
+      ),
+    });
+
+    const actual = collectWidgetSearchParameters([widget], {
+      uiState: {},
+      initialSearchParameters,
+    });
+
+    expect(actual.query).toBe('iphone');
+    expect(widget.getWidgetParameters).toHaveBeenCalledTimes(1);
+    expect(widget.getWidgetSearchParameters).not.toHaveBeenCalled();
+  });
+
+  it('can keep using getWidgetSearchParameters for search-dependent widgets', () => {
+    const initialSearchParameters = new algoliasearchHelper.SearchParameters({
+      index: 'products',
+    });
+    const widget = createWidget({
+      dependsOn: 'search',
+      getWidgetParameters: jest.fn((searchParameters) =>
+        searchParameters.setQueryParameter('query', 'wrong')
+      ),
+      getWidgetSearchParameters: jest.fn((searchParameters) =>
+        searchParameters.setQueryParameter('query', 'iphone')
+      ),
+    });
+
+    const actual = collectWidgetSearchParameters([widget], {
+      uiState: {},
+      initialSearchParameters,
+      useWidgetParameters: false,
+    });
+
+    expect(actual.query).toBe('iphone');
+    expect(widget.getWidgetParameters).not.toHaveBeenCalled();
+    expect(widget.getWidgetSearchParameters).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/instantsearch.js/src/lib/utils/collectWidgetSearchParameters.ts
+++ b/packages/instantsearch.js/src/lib/utils/collectWidgetSearchParameters.ts
@@ -1,0 +1,50 @@
+import type { IndexWidget, Widget } from '../../types';
+import type { SearchParameters } from 'algoliasearch-helper';
+
+type WidgetSearchParametersOptions = Parameters<
+  NonNullable<Widget['getWidgetSearchParameters']>
+>[1];
+type SearchDependentWidget = Widget & {
+  dependsOn?: 'search';
+  getWidgetParameters?: (
+    state: SearchParameters,
+    widgetParametersOptions: WidgetSearchParametersOptions
+  ) => SearchParameters;
+};
+
+export type CollectWidgetSearchParametersOptions =
+  WidgetSearchParametersOptions & {
+    initialSearchParameters: SearchParameters;
+    skipWidget?: (widget: Widget | IndexWidget) => boolean;
+    useWidgetParameters?: boolean;
+  };
+
+export function collectWidgetSearchParameters(
+  widgets: Array<Widget | IndexWidget>,
+  widgetSearchParametersOptions: CollectWidgetSearchParametersOptions
+): SearchParameters {
+  const {
+    initialSearchParameters,
+    skipWidget = () => false,
+    useWidgetParameters = true,
+    ...rest
+  } = widgetSearchParametersOptions;
+
+  return widgets.reduce<SearchParameters>((state, widget) => {
+    if (skipWidget(widget) || !widget.getWidgetSearchParameters) {
+      return state;
+    }
+
+    const searchWidget = widget as SearchDependentWidget;
+
+    if (
+      useWidgetParameters &&
+      searchWidget.dependsOn === 'search' &&
+      searchWidget.getWidgetParameters
+    ) {
+      return searchWidget.getWidgetParameters(state, rest);
+    }
+
+    return widget.getWidgetSearchParameters(state, rest);
+  }, initialSearchParameters);
+}

--- a/packages/instantsearch.js/src/lib/utils/index.ts
+++ b/packages/instantsearch.js/src/lib/utils/index.ts
@@ -3,6 +3,7 @@ export * from './capitalize';
 export * from './checkIndexUiState';
 export * from './checkRendering';
 export * from './clearRefinements';
+export * from './collectWidgetSearchParameters';
 export * from './concatHighlightedParts';
 export * from './createConcurrentSafePromise';
 export * from './createSendEventForFacet';

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -2,6 +2,7 @@ import algoliasearchHelper from 'algoliasearch-helper';
 
 import {
   checkIndexUiState,
+  collectWidgetSearchParameters,
   createDocumentationMessageGenerator,
   resolveSearchParameters,
   mergeSearchParameters,
@@ -96,9 +97,6 @@ export type IndexRenderOptions = {
 type WidgetSearchParametersOptions = Parameters<
   NonNullable<Widget['getWidgetSearchParameters']>
 >[1];
-type LocalWidgetSearchParametersOptions = WidgetSearchParametersOptions & {
-  initialSearchParameters: SearchParameters;
-};
 type LocalWidgetRecommendParametersOptions = WidgetSearchParametersOptions & {
   initialRecommendParameters: RecommendParameters;
 };
@@ -238,25 +236,6 @@ function getLocalWidgetsUiState(
 
     return widget.getWidgetState!(uiState, widgetStateOptions);
   }, initialUiState);
-}
-
-function getLocalWidgetsSearchParameters(
-  widgets: Array<Widget | IndexWidget>,
-  widgetSearchParametersOptions: LocalWidgetSearchParametersOptions
-): SearchParameters {
-  const { initialSearchParameters, ...rest } = widgetSearchParametersOptions;
-
-  return widgets.reduce<SearchParameters>((state, widget) => {
-    if (!widget.getWidgetSearchParameters || isIndexWidget(widget)) {
-      return state;
-    }
-
-    if (widget.dependsOn === 'search' && widget.getWidgetParameters) {
-      return widget.getWidgetParameters(state, rest);
-    }
-
-    return widget.getWidgetSearchParameters(state, rest);
-  }, initialSearchParameters);
 }
 
 function getLocalWidgetsRecommendParameters(
@@ -489,9 +468,10 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       localWidgets = localWidgets.concat(flatWidgets);
       if (localInstantSearchInstance && Boolean(flatWidgets.length)) {
         privateHelperSetState(helper!, {
-          state: getLocalWidgetsSearchParameters(localWidgets, {
+          state: collectWidgetSearchParameters(localWidgets, {
             uiState: localUiState,
             initialSearchParameters: helper!.state,
+            skipWidget: isIndexWidget,
           }),
           recommendState: getLocalWidgetsRecommendParameters(localWidgets, {
             uiState: localUiState,
@@ -610,20 +590,22 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
 
         const newState = localInstantSearchInstance.future
           .preserveSharedStateOnUnmount
-          ? getLocalWidgetsSearchParameters(localWidgets, {
+          ? collectWidgetSearchParameters(localWidgets, {
               uiState: localUiState,
               initialSearchParameters: new algoliasearchHelper.SearchParameters(
                 {
                   index: this.getIndexName(),
                 }
               ),
+              skipWidget: isIndexWidget,
             })
-          : getLocalWidgetsSearchParameters(localWidgets, {
+          : collectWidgetSearchParameters(localWidgets, {
               uiState: getLocalWidgetsUiState(localWidgets, {
                 searchParameters: cleanedSearchState,
                 helper: helper!,
               }),
               initialSearchParameters: cleanedSearchState,
+              skipWidget: isIndexWidget,
             });
 
         localUiState = getLocalWidgetsUiState(localWidgets, {
@@ -661,11 +643,12 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       // inside InstantSearch at the `start` method, which occurs before the `init`
       // step.
       const mainHelper = instantSearchInstance.mainHelper!;
-      const parameters = getLocalWidgetsSearchParameters(localWidgets, {
+      const parameters = collectWidgetSearchParameters(localWidgets, {
         uiState: localUiState,
         initialSearchParameters: new algoliasearchHelper.SearchParameters({
           index: indexName,
         }),
+        skipWidget: isIndexWidget,
       });
       const recommendParameters = getLocalWidgetsRecommendParameters(
         localWidgets,
@@ -1025,9 +1008,10 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
     },
 
     getWidgetSearchParameters(searchParameters, { uiState }) {
-      return getLocalWidgetsSearchParameters(localWidgets, {
+      return collectWidgetSearchParameters(localWidgets, {
         uiState,
         initialSearchParameters: searchParameters,
+        skipWidget: isIndexWidget,
       });
     },
 


### PR DESCRIPTION
## Summary
- Extract widget search-parameter collection into a shared InstantSearch.js utility.
- Reuse the collector from the index widget and FeedContainer while preserving their existing caller policies.
- Add focused coverage for collector behavior and FeedContainer child-parameter merging after init.

## Test plan
- `yarn jest --runTestsByPath packages/instantsearch.js/src/lib/utils/__tests__/collectWidgetSearchParameters-test.ts packages/instantsearch.js/src/connectors/feeds/__tests__/FeedContainer-test.ts packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts --runInBand`
- `yarn workspace instantsearch.js build:types`
- `yarn lint:changed`