### PR TITLE
feat(autocomplete): defer index registration until first user focus

### DIFF
--- a/packages/instantsearch-ui-components/src/components/autocomplete/createAutocompletePropGetters.ts
+++ b/packages/instantsearch-ui-components/src/components/autocomplete/createAutocompletePropGetters.ts
@@ -78,6 +78,14 @@ export type UsePropGetters<TItem extends BaseHit> = (params: {
    * Whether the input should be focused and the panel open initially.
    */
   autoFocus?: boolean;
+  /**
+   * Externally-supplied id used to prefix every DOM id this hook generates.
+   * Use this when the autocomplete renders across multiple component trees
+   * (e.g., a placeholder shell + a fully-wired version) that must produce
+   * matching ids for `htmlFor`/`aria-*` to stay stable across the swap.
+   * Falls back to an internal `useId()` when omitted.
+   */
+  id?: string;
 }) => {
   getInputProps: GetInputProps;
   getItemProps: GetItemProps;
@@ -115,8 +123,10 @@ export function createAutocompletePropGetters({
     isDetached = false,
     shouldHidePanel = false,
     autoFocus = false,
+    id,
   }: Parameters<UsePropGetters<TItem>>[0]): ReturnType<UsePropGetters<TItem>> {
-    const getElementId = createGetElementId(useId());
+    const internalId = useId();
+    const getElementId = createGetElementId(id ?? internalId);
     const inputRef = useRef<HTMLInputElement | null>(null);
     const rootRef = useRef<HTMLDivElement | null>(null);
     const [isOpen, setIsOpen] = useState(autoFocus);

--- a/packages/instantsearch.js/src/widgets/__tests__/index.test.ts
+++ b/packages/instantsearch.js/src/widgets/__tests__/index.test.ts
@@ -163,9 +163,9 @@ function initiateAllWidgets(): Array<[WidgetNames, Widget | IndexWidget]> {
           widget as Widgets['EXPERIMENTAL_autocomplete'];
 
         const instance = EXPERIMENTAL_autocomplete({ container, indices: [] });
-        const autocomplete = (instance[1] as IndexWidget)
-          .getWidgets()
-          .find((w) => w.$$type === 'ais.autocomplete');
+        const autocomplete = instance.find(
+          (w) => w.$$type === 'ais.autocomplete'
+        );
 
         if (!autocomplete) {
           throw new Error('autocomplete widget not found');

--- a/packages/instantsearch.js/src/widgets/autocomplete/__tests__/autocomplete-test.ts
+++ b/packages/instantsearch.js/src/widgets/autocomplete/__tests__/autocomplete-test.ts
@@ -10,6 +10,7 @@ import {
 import { wait } from '@instantsearch/testutils/wait';
 
 import instantsearch from '../../..';
+import { walkIndex } from '../../../lib/utils';
 import { EXPERIMENTAL_autocomplete } from '../autocomplete';
 
 describe('EXPERIMENTAL_autocomplete()', () => {
@@ -773,6 +774,43 @@ describe('EXPERIMENTAL_autocomplete()', () => {
         'input[type="search"]'
       )!;
       expect(input.value).toBe('macbook');
+    });
+
+    it('uses a namespaced indexId for child indices to avoid collisions with same-named parent indices', async () => {
+      const container = document.body.appendChild(
+        document.createElement('div')
+      );
+      const searchClient = createSearchClient({});
+      const search = instantsearch({
+        searchClient,
+        indexName: 'instant_search',
+      });
+
+      search.addWidgets([
+        EXPERIMENTAL_autocomplete({
+          container,
+          indices: [
+            {
+              indexName: 'instant_search',
+              templates: { item: ({ item }) => String(item.objectID) },
+            },
+          ],
+        }),
+      ]);
+
+      search.start();
+      await flush();
+      focusSearchInput(container);
+      await flush();
+
+      const indexIds: string[] = [];
+      walkIndex(search.mainIndex, (widget) => indexIds.push(widget.getIndexId()));
+
+      const parentMatches = indexIds.filter((id) => id === 'instant_search');
+      expect(parentMatches).toHaveLength(1);
+      expect(
+        indexIds.some((id) => id.startsWith('ais-autocomplete-') && id.endsWith('-instant_search'))
+      ).toBe(true);
     });
 
     it('attaches the isolated tree only once across repeated focuses', async () => {

--- a/packages/instantsearch.js/src/widgets/autocomplete/__tests__/autocomplete-test.ts
+++ b/packages/instantsearch.js/src/widgets/autocomplete/__tests__/autocomplete-test.ts
@@ -894,10 +894,11 @@ describe('EXPERIMENTAL_autocomplete()', () => {
       await flush();
       const callsAfterFocus = searchMock.mock.calls.length;
 
-      // Mount triggers only the parent composition search; the autocomplete's
-      // own search waits for focus.
+      // Mount triggers only the parent composition search; focus triggers
+      // exactly one additional search (the isolated autocomplete's), without
+      // re-running the parent.
       expect(callsBeforeFocus).toBe(1);
-      expect(callsAfterFocus).toBeGreaterThan(callsBeforeFocus);
+      expect(callsAfterFocus).toBe(2);
     });
   });
 });

--- a/packages/instantsearch.js/src/widgets/autocomplete/__tests__/autocomplete-test.ts
+++ b/packages/instantsearch.js/src/widgets/autocomplete/__tests__/autocomplete-test.ts
@@ -123,6 +123,7 @@ describe('EXPERIMENTAL_autocomplete()', () => {
 
     it('normalizes transformItems indices to feed IDs in feeds-mode', async () => {
       const transformItems = jest.fn((items) => items);
+      const container = document.body.appendChild(document.createElement('div'));
       const compositionClient = createCompositionClient({
         search: jest.fn(() =>
           Promise.resolve({
@@ -142,7 +143,7 @@ describe('EXPERIMENTAL_autocomplete()', () => {
 
       search.addWidgets([
         EXPERIMENTAL_autocomplete({
-          container: document.body.appendChild(document.createElement('div')),
+          container,
           feeds: [
             {
               feedID: 'products',
@@ -154,6 +155,8 @@ describe('EXPERIMENTAL_autocomplete()', () => {
       ]);
 
       search.start();
+      await wait(0);
+      container.querySelector<HTMLInputElement>('input[type="search"]')?.focus();
       await wait(0);
       await wait(0);
 
@@ -174,6 +177,7 @@ describe('EXPERIMENTAL_autocomplete()', () => {
 
     it('keeps feedID normalization for declared feeds with mixed feed responses', async () => {
       const transformItems = jest.fn((items) => items);
+      const container = document.body.appendChild(document.createElement('div'));
       const compositionClient = createCompositionClient({
         search: jest.fn(() =>
           Promise.resolve({
@@ -197,7 +201,7 @@ describe('EXPERIMENTAL_autocomplete()', () => {
 
       search.addWidgets([
         EXPERIMENTAL_autocomplete({
-          container: document.body.appendChild(document.createElement('div')),
+          container,
           feeds: [
             {
               feedID: 'products',
@@ -213,6 +217,8 @@ describe('EXPERIMENTAL_autocomplete()', () => {
       ]);
 
       search.start();
+      await wait(0);
+      container.querySelector<HTMLInputElement>('input[type="search"]')?.focus();
       await wait(0);
       await wait(0);
 
@@ -608,6 +614,218 @@ describe('EXPERIMENTAL_autocomplete()', () => {
       expect(container.querySelectorAll('.ais-AutocompleteIndex')).toHaveLength(
         0
       );
+    });
+  });
+
+  describe('lazy activation', () => {
+    function focusSearchInput(container: HTMLElement) {
+      const input = container.querySelector<HTMLInputElement>(
+        'input[type="search"]'
+      );
+      if (!input) {
+        return;
+      }
+      input.focus();
+      input.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+    }
+
+    async function flush() {
+      await wait(0);
+      await wait(0);
+      await wait(0);
+    }
+
+    it('does not search on mount in indices-mode', async () => {
+      const container = document.body.appendChild(
+        document.createElement('div')
+      );
+      const searchClient = createSearchClient({});
+      const search = instantsearch({
+        searchClient,
+        indexName: 'indexName',
+      });
+
+      search.addWidgets([
+        EXPERIMENTAL_autocomplete({
+          container,
+          indices: [
+            {
+              indexName: 'my-index',
+              templates: { item: ({ item }) => String(item.objectID) },
+            },
+          ],
+        }),
+      ]);
+
+      search.start();
+      await flush();
+
+      const requestedIndices = (searchClient.search as jest.Mock).mock.calls
+        .flatMap((call) => call[0] as Array<{ indexName: string }>)
+        .map((request) => request.indexName);
+
+      expect(requestedIndices).not.toContain('my-index');
+    });
+
+    it('searches the autocomplete index on first focus in indices-mode', async () => {
+      const container = document.body.appendChild(
+        document.createElement('div')
+      );
+      const searchClient = createSearchClient({});
+      const search = instantsearch({
+        searchClient,
+        indexName: 'indexName',
+      });
+
+      search.addWidgets([
+        EXPERIMENTAL_autocomplete({
+          container,
+          indices: [
+            {
+              indexName: 'my-index',
+              templates: { item: ({ item }) => String(item.objectID) },
+            },
+          ],
+        }),
+      ]);
+
+      search.start();
+      await flush();
+      focusSearchInput(container);
+      await flush();
+
+      const requestedIndices = (searchClient.search as jest.Mock).mock.calls
+        .flatMap((call) => call[0] as Array<{ indexName: string }>)
+        .map((request) => request.indexName);
+
+      expect(requestedIndices).toContain('my-index');
+    });
+
+    it('propagates the initial query from the parent into the autocomplete search on first focus', async () => {
+      const container = document.body.appendChild(
+        document.createElement('div')
+      );
+      const searchClient = createSearchClient({});
+      const search = instantsearch({
+        searchClient,
+        indexName: 'indexName',
+        initialUiState: {
+          indexName: { query: 'macbook' },
+        },
+      });
+
+      search.addWidgets([
+        EXPERIMENTAL_autocomplete({
+          container,
+          indices: [
+            {
+              indexName: 'my-index',
+              templates: { item: ({ item }) => String(item.objectID) },
+            },
+          ],
+        }),
+      ]);
+
+      search.start();
+      await flush();
+      focusSearchInput(container);
+      await flush();
+
+      const autocompleteRequests = (
+        searchClient.search as jest.Mock
+      ).mock.calls
+        .flatMap((call) => call[0] as Array<{ indexName: string; params: { query?: string } }>)
+        .filter((request) => request.indexName === 'my-index');
+
+      expect(autocompleteRequests).toHaveLength(1);
+      expect(autocompleteRequests[0].params.query).toBe('macbook');
+    });
+
+    it('attaches the isolated tree only once across repeated focuses', async () => {
+      const container = document.body.appendChild(
+        document.createElement('div')
+      );
+      const searchClient = createSearchClient({});
+      const search = instantsearch({
+        searchClient,
+        indexName: 'indexName',
+      });
+
+      search.addWidgets([
+        EXPERIMENTAL_autocomplete({
+          container,
+          indices: [
+            {
+              indexName: 'my-index',
+              templates: { item: ({ item }) => String(item.objectID) },
+            },
+          ],
+        }),
+      ]);
+
+      search.start();
+      await flush();
+      focusSearchInput(container);
+      await flush();
+      const callsAfterFirstFocus = (searchClient.search as jest.Mock).mock.calls
+        .flatMap((call) => call[0] as Array<{ indexName: string }>)
+        .filter((request) => request.indexName === 'my-index').length;
+
+      focusSearchInput(container);
+      await flush();
+      const callsAfterSecondFocus = (
+        searchClient.search as jest.Mock
+      ).mock.calls
+        .flatMap((call) => call[0] as Array<{ indexName: string }>)
+        .filter((request) => request.indexName === 'my-index').length;
+
+      expect(callsAfterSecondFocus).toBe(callsAfterFirstFocus);
+    });
+
+    it('only the parent composition search fires before focus in feeds-mode; focus adds another', async () => {
+      const container = document.body.appendChild(
+        document.createElement('div')
+      );
+      const searchMock = jest.fn(() =>
+        Promise.resolve({
+          results: [
+            createSingleSearchResponse({
+              feedID: 'products',
+              hits: [{ objectID: 'p1' }],
+            } as any),
+          ],
+        })
+      );
+      const compositionClient = createCompositionClient({ search: searchMock });
+      const search = instantsearch({
+        searchClient: compositionClient,
+        compositionID: 'my-comp',
+      });
+
+      search.addWidgets([
+        EXPERIMENTAL_autocomplete({
+          container,
+          feeds: [
+            {
+              feedID: 'products',
+              templates: { item: ({ item }) => String(item.objectID) },
+            },
+          ],
+        }),
+      ]);
+
+      search.start();
+      await flush();
+      const callsBeforeFocus = searchMock.mock.calls.length;
+
+      focusSearchInput(container);
+      await flush();
+      const callsAfterFocus = searchMock.mock.calls.length;
+
+      // Mount triggers only the parent composition search; the autocomplete's
+      // own search waits for focus.
+      expect(callsBeforeFocus).toBe(1);
+      expect(callsAfterFocus).toBeGreaterThan(callsBeforeFocus);
     });
   });
 });

--- a/packages/instantsearch.js/src/widgets/autocomplete/__tests__/autocomplete-test.ts
+++ b/packages/instantsearch.js/src/widgets/autocomplete/__tests__/autocomplete-test.ts
@@ -741,6 +741,40 @@ describe('EXPERIMENTAL_autocomplete()', () => {
       expect(autocompleteRequests[0].params.query).toBe('macbook');
     });
 
+    it('pre-activation shell input reflects the parent query', async () => {
+      const container = document.body.appendChild(
+        document.createElement('div')
+      );
+      const searchClient = createSearchClient({});
+      const search = instantsearch({
+        searchClient,
+        indexName: 'indexName',
+        initialUiState: {
+          indexName: { query: 'macbook' },
+        },
+      });
+
+      search.addWidgets([
+        EXPERIMENTAL_autocomplete({
+          container,
+          indices: [
+            {
+              indexName: 'my-index',
+              templates: { item: ({ item }) => String(item.objectID) },
+            },
+          ],
+        }),
+      ]);
+
+      search.start();
+      await flush();
+
+      const input = container.querySelector<HTMLInputElement>(
+        'input[type="search"]'
+      )!;
+      expect(input.value).toBe('macbook');
+    });
+
     it('attaches the isolated tree only once across repeated focuses', async () => {
       const container = document.body.appendChild(
         document.createElement('div')

--- a/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
+++ b/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
@@ -53,6 +53,7 @@ import type {
   Hit,
   IndexUiState,
   IndexWidget,
+  InstantSearch,
   Renderer,
   RendererOptions,
   Template,
@@ -201,6 +202,7 @@ function getMediaQueryList(mediaQuery: string) {
 type RendererParams<TItem extends BaseHit> = {
   instanceId: number;
   containerNode: HTMLElement;
+  activate: () => void;
   indicesConfig: Array<IndexConfig<TItem>>;
   renderState: {
     indexTemplateProps: Array<
@@ -333,8 +335,6 @@ const createRenderer = <TItem extends BaseHit>(
         hasWarnedMissingPromptSuggestionsChat: false,
       };
 
-      connectorParams.refine(targetIndex.getHelper()?.state.query ?? '');
-      return;
     }
 
     render(
@@ -347,6 +347,7 @@ const createRenderer = <TItem extends BaseHit>(
 type AutocompleteWrapperProps<TItem extends BaseHit> = Pick<
   RendererParams<TItem>,
   | 'indicesConfig'
+  | 'activate'
   | 'getSearchPageURL'
   | 'onSelect'
   | 'cssClasses'
@@ -367,6 +368,7 @@ type AutocompleteWrapperProps<TItem extends BaseHit> = Pick<
 function AutocompleteWrapper<TItem extends BaseHit>({
   indicesConfig,
   indices,
+  activate,
   getSearchPageURL,
   onSelect: userOnSelect,
   refine: refineAutocomplete,
@@ -830,6 +832,12 @@ function AutocompleteWrapper<TItem extends BaseHit>({
       query={localQuery}
       inputProps={{
         ...inputProps,
+        onFocus: (event) => {
+          activate();
+          (inputProps as { onFocus?: (event: unknown) => void }).onFocus?.(
+            event
+          );
+        },
         onInput: (event: { currentTarget: HTMLInputElement }) => {
           const query = event.currentTarget.value;
           setLocalQuery(query);
@@ -1400,9 +1408,27 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
     ...userTranslations,
   };
 
+  let isolatedTree: IndexWidget | null = null;
+  let parentRef: IndexWidget | null | undefined;
+  let activated = false;
+
+  const activate = () => {
+    if (activated || !parentRef || !isolatedTree) return;
+    activated = true;
+    parentRef.addWidgets([isolatedTree]);
+    const parentQuery = parentRef.getHelper()?.state.query;
+    if (parentQuery) {
+      isolatedTree.getHelper()?.setQuery(parentQuery);
+    }
+    // Adding an isolated index to a non-isolated parent schedules main's search,
+    // not the isolated derived helper's. Trigger it explicitly.
+    isolatedTree.scheduleLocalSearch();
+  };
+
   const specializedRenderer = createRenderer({
     instanceId,
     containerNode,
+    activate,
     indicesConfig,
     getSearchPageURL,
     onSelect,
@@ -1466,11 +1492,9 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
       }
     }
 
-    let bootstrappedTree: IndexWidget | null = null;
-    const bootstrap: Widget = {
-      $$type: 'ais.autocomplete',
-      $$widgetType: 'ais.autocomplete',
-      init({ instantSearchInstance, parent }) {
+    return [
+      connectSearchBox(() => null)({}),
+      createBootstrap((instantSearchInstance) => {
         if (!instantSearchInstance.compositionID) {
           throw new Error(
             withUsage(
@@ -1478,15 +1502,15 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
             )
           );
         }
-        bootstrappedTree = index({
+        const tree = index({
           indexName: instantSearchInstance.compositionID,
           indexId: `ais-autocomplete-${instanceId}`,
           EXPERIMENTAL_isolated: true,
         });
         const feedContainers = feedIDs.map((feedID) =>
-          createFeedContainer(feedID, bootstrappedTree!, instantSearchInstance)
+          createFeedContainer(feedID, tree, instantSearchInstance)
         );
-        bootstrappedTree.addWidgets([
+        tree.addWidgets([
           configure(searchParameters),
           // Connector-only registration runs `hydrateFeedsFromInitialResultsIfNeeded`
           // at init for SSR, without triggering the extra search `feeds()` would.
@@ -1502,44 +1526,82 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
             ...(aiMode ? { opensChat: true as const } : {}),
           },
         ]);
-        parent?.addWidgets([bootstrappedTree]);
-      },
-      render() {},
-      dispose({ parent }) {
-        if (bootstrappedTree) {
-          parent?.removeWidgets([bootstrappedTree]);
-          bootstrappedTree = null;
-        }
-        return undefined;
-      },
-    };
-    return [connectSearchBox(() => null)({}), bootstrap];
+        return tree;
+      }),
+    ];
   }
 
   return [
     connectSearchBox(() => null)({}),
-    index({
-      indexId: `ais-autocomplete-${instanceId}`,
-      EXPERIMENTAL_isolated: true,
-    }).addWidgets([
-      configure(searchParameters),
-      ...indicesConfig.map(
-        ({ indexName, searchParameters: indexSearchParameters }) =>
-          index({ indexName, indexId: indexName }).addWidgets([
-            configure(indexSearchParameters || {}),
-          ])
-      ),
-      {
-        ...makeWidget({
-          escapeHTML,
-          transformItems: effectiveTransformItems,
-          future: { undefinedEmptyQuery: true },
-        }),
-        $$widgetType: 'ais.autocomplete',
-        ...(aiMode ? { opensChat: true as const } : {}),
-      },
-    ]),
+    createBootstrap(() =>
+      index({
+        indexId: `ais-autocomplete-${instanceId}`,
+        EXPERIMENTAL_isolated: true,
+      }).addWidgets([
+        configure(searchParameters),
+        ...indicesConfig.map(
+          ({ indexName, searchParameters: indexSearchParameters }) =>
+            index({ indexName, indexId: indexName }).addWidgets([
+              configure(indexSearchParameters || {}),
+            ])
+        ),
+        {
+          ...makeWidget({
+            escapeHTML,
+            transformItems: effectiveTransformItems,
+            future: { undefinedEmptyQuery: true },
+          }),
+          $$widgetType: 'ais.autocomplete',
+          ...(aiMode ? { opensChat: true as const } : {}),
+        },
+      ])
+    ),
   ];
+
+  function createBootstrap(
+    buildTree: (instantSearchInstance: InstantSearch) => IndexWidget
+  ): Widget {
+    return {
+      $$type: 'ais.autocomplete',
+      $$widgetType: 'ais.autocomplete',
+      init({ instantSearchInstance, parent }) {
+        parentRef = parent;
+        isolatedTree = buildTree(instantSearchInstance);
+        renderShell(specializedRenderer, instantSearchInstance);
+      },
+      render() {},
+      dispose({ parent }) {
+        if (activated && isolatedTree) {
+          parent?.removeWidgets([isolatedTree]);
+        }
+        render(null, containerNode);
+        isolatedTree = null;
+        parentRef = undefined;
+        activated = false;
+        return undefined;
+      },
+    };
+  }
+}
+
+function renderShell<TItem extends BaseHit>(
+  renderer: Renderer<
+    AutocompleteRenderState,
+    Partial<AutocompleteWidgetParams<TItem>>
+  >,
+  instantSearchInstance: InstantSearch
+) {
+  renderer(
+    {
+      instantSearchInstance,
+      indices: [],
+      refine: noop,
+      currentRefinement: '',
+      widgetParams: {},
+    } as AutocompleteRenderState &
+      RendererOptions<Partial<AutocompleteWidgetParams<TItem>>>,
+    true
+  );
 }
 
 function ConditionalReverseHighlight<TItem extends { query: string }>({

--- a/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
+++ b/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
@@ -1410,18 +1410,21 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
 
   let isolatedTree: IndexWidget | null = null;
   let parentRef: IndexWidget | null | undefined;
+  let instanceRef: InstantSearch | null = null;
   let activated = false;
 
   const activate = () => {
-    if (activated || !parentRef || !isolatedTree) return;
+    if (activated || !parentRef || !isolatedTree || !instanceRef) return;
     activated = true;
     parentRef.addWidgets([isolatedTree]);
+    // `parentRef.addWidgets` schedules the parent's search even though the
+    // parent's own state hasn't changed; cancel it so only the isolated tree
+    // searches on activation.
+    instanceRef.scheduleSearch.cancel();
     const parentQuery = parentRef.getHelper()?.state.query;
     if (parentQuery) {
       isolatedTree.getHelper()?.setQuery(parentQuery);
     }
-    // Adding an isolated index to a non-isolated parent schedules main's search,
-    // not the isolated derived helper's. Trigger it explicitly.
     isolatedTree.scheduleLocalSearch();
   };
 
@@ -1567,6 +1570,7 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
       $$widgetType: 'ais.autocomplete',
       init({ instantSearchInstance, parent }) {
         parentRef = parent;
+        instanceRef = instantSearchInstance;
         isolatedTree = buildTree(instantSearchInstance);
         renderShell(specializedRenderer, instantSearchInstance);
       },
@@ -1578,6 +1582,7 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
         render(null, containerNode);
         isolatedTree = null;
         parentRef = undefined;
+        instanceRef = null;
         activated = false;
         return undefined;
       },

--- a/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
+++ b/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
@@ -807,7 +807,7 @@ function AutocompleteWrapper<TItem extends BaseHit>({
         NoResultsComponent={noResultsComponent}
         items={hits.map((item) => ({
           ...item,
-          __indexName: indexId,
+          __indexName: indexName,
         }))}
         getItemProps={getItemProps}
         sendEvent={find(indices, (idx) => idx.indexId === indexId)?.sendEvent}
@@ -1541,9 +1541,10 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
         configure(searchParameters),
         ...indicesConfig.map(
           ({ indexName, searchParameters: indexSearchParameters }) =>
-            index({ indexName, indexId: indexName }).addWidgets([
-              configure(indexSearchParameters || {}),
-            ])
+            index({
+              indexName,
+              indexId: `ais-autocomplete-${instanceId}-${indexName}`,
+            }).addWidgets([configure(indexSearchParameters || {})])
         ),
         {
           ...makeWidget({

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -754,6 +754,8 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
     ...forwardedProps
   } = restProps as Record<string, unknown>;
 
+  const instance = useInstantSearchContext();
+
   if (!activated) {
     const {
       indices: _shellUnusedIndices,
@@ -770,7 +772,27 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
             id: `autocomplete${domId}input`,
             role: 'combobox',
             placeholder,
-            onFocus: () => setActivated(true),
+            onFocus: () => {
+              // Routing only fills the parent index's UI state, not the
+              // autocomplete's isolated one, so without this, the autocomplete
+              // would activate with an empty query and fire a useless search.
+              // We copy the parent's query into the autocomplete's slot of
+              // `_initialUiState` right before flipping `activated`: that's the
+              // moment the isolated `<Index>` is about to mount and read it.
+              // Doing this later would mean firing a second search to correct
+              // the first.
+              if (indexUiState.query) {
+                const isoIndexId = `ais-autocomplete-${instanceKey}`;
+                const initial = (
+                  instance as { _initialUiState: Record<string, IndexUiState> }
+                )._initialUiState;
+                initial[isoIndexId] = {
+                  ...initial[isoIndexId],
+                  query: indexUiState.query,
+                };
+              }
+              setActivated(true);
+            },
           }}
           clearQuery={() => {}}
           query={indexUiState.query ?? ''}
@@ -830,7 +852,10 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
   }
 
   return (
-    <Index EXPERIMENTAL_isolated>
+    <Index
+      EXPERIMENTAL_isolated
+      indexId={`ais-autocomplete-${instanceKey}`}
+    >
       <Configure {...searchParameters} />
       {indicesConfig.map((index) => (
         <Index key={index.indexName} indexName={index.indexName}>
@@ -874,15 +899,6 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
     transformItems,
     future: { undefinedEmptyQuery: true },
   });
-
-  // Mirror the parent's query onto the isolated helper so URL-routed and
-  // initialUiState queries reach the autocomplete on first activation.
-  useEffect(() => {
-    if (indexUiState.query && currentRefinement === undefined) {
-      refineAutocomplete(indexUiState.query);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const resolvedQuery =
     currentRefinement !== undefined

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -858,7 +858,11 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
     >
       <Configure {...searchParameters} />
       {indicesConfig.map((index) => (
-        <Index key={index.indexName} indexName={index.indexName}>
+        <Index
+          key={index.indexName}
+          indexName={index.indexName}
+          indexId={`ais-autocomplete-${instanceKey}-${index.indexName}`}
+        >
           <Configure {...index.searchParameters} />
         </Index>
       ))}
@@ -1143,7 +1147,7 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
         NoResultsComponent={currentIndexConfig.noResultsComponent}
         items={hits.map((item) => ({
           ...item,
-          __indexName: indexId,
+          __indexName: indexName,
         }))}
         getItemProps={getItemProps}
         sendEvent={sendEvent}

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -21,6 +21,7 @@ import React, {
   createElement,
   Fragment,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -755,6 +756,21 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
   } = restProps as Record<string, unknown>;
 
   const instance = useInstantSearchContext();
+  // Lazy activation only: when `activated` flips from false to true, the
+  // newly-mounted isolated `<Index>` schedules the parent's search even
+  // though the parent's state hasn't changed. Cancel it so only the
+  // autocomplete's own search fires on activation. Skip when `autoFocus`
+  // mounts the inner eagerly — the parent's legitimate initial search
+  // shares the same defer slot and must not be cancelled.
+  const initialActivatedRef = useRef(activated);
+  useLayoutEffect(() => {
+    if (activated && !initialActivatedRef.current) {
+      initialActivatedRef.current = true;
+      (
+        instance as unknown as { scheduleSearch: { cancel: () => void } }
+      ).scheduleSearch.cancel();
+    }
+  }, [activated, instance]);
 
   if (!activated) {
     const {

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -108,9 +108,12 @@ const AutocompleteDetachedSearchButton =
   });
 
 let id = 0;
-const useAutocompleteInstanceId: () => string = React.useId
-  ? () => React.useId().replace(/:/g, '')
-  : () => React.useState(() => `a${id++}`)[0];
+// Colons (`:r0:`) preserved so concatenations like `autocomplete:r0:input`
+// have a recognisable boundary; callers that need a colon-free variant for
+// InstantSearch's `indexId` strip them at the use site.
+const useAutocompleteId: () => string = React.useId
+  ? () => React.useId()
+  : () => React.useState(() => `:a${id++}:`)[0];
 const usePropGetters = createAutocompletePropGetters({
   useEffect,
   useId: React.useId || (() => React.useState(() => (id++).toString())),
@@ -443,6 +446,7 @@ type InnerAutocompleteProps<TItem extends BaseHit> = Omit<
     itemComponent: typeof AutocompleteRecentSearch;
     classNames: Partial<AutocompleteIndexClassNames>;
   };
+  instanceKey: string;
 };
 
 export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
@@ -461,6 +465,14 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
     transformItems,
     ...restProps
   } = props;
+  const { autoFocus, placeholder, classNames } = restProps as {
+    autoFocus?: boolean;
+    placeholder?: string;
+    classNames?: Partial<AutocompleteClassNames>;
+  };
+  // Eager-mount only when `autoFocus` is set — otherwise wait for first focus
+  // before registering the autocomplete subtree in the search graph.
+  const [activated, setActivated] = useState(autoFocus === true);
   const translations: AutocompleteTranslations = {
     ...DEFAULT_TRANSLATIONS,
     ...userTranslations,
@@ -475,9 +487,8 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
       ...(props.aiMode ? { opensChat: true } : {}),
     }
   );
-  // In feeds-mode, indexId disambiguates multiple Autocomplete instances
-  // sharing the same compositionID. Mirrors the fallback at line 111 for React <18.
-  const instanceKey = useAutocompleteInstanceId();
+  const domId = useAutocompleteId();
+  const instanceKey = domId.replace(/:/g, '');
 
   if (isFeedsMode && indices !== undefined) {
     throw new Error(
@@ -743,6 +754,33 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
     ...forwardedProps
   } = restProps as Record<string, unknown>;
 
+  if (!activated) {
+    const {
+      indices: _shellUnusedIndices,
+      feeds: _shellUnusedFeeds,
+      ...shellRootProps
+    } = restProps as Record<string, unknown>;
+    return (
+      <Autocomplete
+        {...(shellRootProps as React.HTMLAttributes<HTMLDivElement>)}
+        classNames={classNames}
+      >
+        <AutocompleteSearch
+          inputProps={{
+            id: `autocomplete${domId}input`,
+            role: 'combobox',
+            placeholder,
+            onFocus: () => setActivated(true),
+          }}
+          clearQuery={() => {}}
+          query=""
+          isSearchStalled={false}
+          classNames={classNames}
+        />
+      </Autocomplete>
+    );
+  }
+
   const innerAutocomplete = (
     <InnerAutocomplete
       {...(forwardedProps as Omit<
@@ -757,6 +795,8 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
         | 'translations'
         | 'transformItems'
       >)}
+      autoFocus
+      instanceKey={domId}
       indicesConfig={indicesConfig}
       refineSearchBox={refine}
       isSearchStalled={isSearchStalled}
@@ -823,6 +863,7 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
   translations,
   classNames,
   aiMode,
+  instanceKey,
   ...props
 }: InnerAutocompleteProps<TItem>) {
   const {
@@ -833,6 +874,15 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
     transformItems,
     future: { undefinedEmptyQuery: true },
   });
+
+  // Mirror the parent's query onto the isolated helper so URL-routed and
+  // initialUiState queries reach the autocomplete on first activation.
+  useEffect(() => {
+    if (indexUiState.query && currentRefinement === undefined) {
+      refineAutocomplete(indexUiState.query);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const resolvedQuery =
     currentRefinement !== undefined
@@ -937,6 +987,7 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
     setIsOpen,
     focusInput,
   } = usePropGetters<TItem>({
+    id: instanceKey,
     indices: indicesForPropGettersWithPromptSuggestions,
     indicesConfig: indicesConfigForPropGetters,
     onRefine: (query) => {

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -448,6 +448,7 @@ type InnerAutocompleteProps<TItem extends BaseHit> = Omit<
     classNames: Partial<AutocompleteIndexClassNames>;
   };
   domId: string;
+  detached: ReturnType<typeof useDetachedMode>;
 };
 
 export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
@@ -756,6 +757,8 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
   } = restProps as Record<string, unknown>;
 
   const instance = useInstantSearchContext();
+  const detached = useDetachedMode(detachedMediaQuery);
+  const { isDetached, setIsModalOpen } = detached;
   // Lazy activation only: when `activated` flips from false to true, the
   // newly-mounted isolated `<Index>` schedules the parent's search even
   // though the parent's state hasn't changed. Cancel it so only the
@@ -780,46 +783,62 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
       placeholder: _shellUnusedPlaceholder,
       classNames: _shellUnusedClassNames,
       aiMode: _shellUnusedAiMode,
-      recentSearchConfig: _shellUnusedRecentSearchConfig,
+      panelComponent: _shellUnusedPanelComponent,
+      getSearchPageURL: _shellUnusedGetSearchPageURL,
+      onSelect: _shellUnusedOnSelect,
       ...shellRootProps
     } = restProps as Record<string, unknown>;
+    const activateWithQueryMirror = () => {
+      // Routing only fills the parent index's UI state, not the
+      // autocomplete's isolated one, so without this, the autocomplete
+      // would activate with an empty query and fire a useless search.
+      // We copy the parent's query into the autocomplete's slot of
+      // `_initialUiState` right before flipping `activated`: that's the
+      // moment the isolated `<Index>` is about to mount and read it.
+      // Doing this later would mean firing a second search to correct
+      // the first.
+      if (indexUiState.query) {
+        const isoIndexId = `ais-autocomplete-${instanceKey}`;
+        const initial = (
+          instance as { _initialUiState: Record<string, IndexUiState> }
+        )._initialUiState;
+        initial[isoIndexId] = {
+          ...initial[isoIndexId],
+          query: indexUiState.query,
+        };
+      }
+      setActivated(true);
+    };
     return (
       <Autocomplete
         {...(shellRootProps as React.HTMLAttributes<HTMLDivElement>)}
         classNames={classNames}
       >
-        <AutocompleteSearch
-          inputProps={{
-            id: `autocomplete${domId}input`,
-            role: 'combobox',
-            placeholder,
-            onFocus: () => {
-              // Routing only fills the parent index's UI state, not the
-              // autocomplete's isolated one, so without this, the autocomplete
-              // would activate with an empty query and fire a useless search.
-              // We copy the parent's query into the autocomplete's slot of
-              // `_initialUiState` right before flipping `activated`: that's the
-              // moment the isolated `<Index>` is about to mount and read it.
-              // Doing this later would mean firing a second search to correct
-              // the first.
-              if (indexUiState.query) {
-                const isoIndexId = `ais-autocomplete-${instanceKey}`;
-                const initial = (
-                  instance as { _initialUiState: Record<string, IndexUiState> }
-                )._initialUiState;
-                initial[isoIndexId] = {
-                  ...initial[isoIndexId],
-                  query: indexUiState.query,
-                };
-              }
-              setActivated(true);
-            },
-          }}
-          clearQuery={() => {}}
-          query={indexUiState.query ?? ''}
-          isSearchStalled={false}
-          classNames={classNames}
-        />
+        {isDetached ? (
+          <AutocompleteDetachedSearchButton
+            query={indexUiState.query ?? ''}
+            placeholder={placeholder}
+            classNames={classNames}
+            translations={translations}
+            onClick={() => {
+              setIsModalOpen(true);
+              activateWithQueryMirror();
+            }}
+          />
+        ) : (
+          <AutocompleteSearch
+            inputProps={{
+              id: `autocomplete${domId}input`,
+              role: 'combobox',
+              placeholder,
+              onFocus: activateWithQueryMirror,
+            }}
+            clearQuery={() => {}}
+            query={indexUiState.query ?? ''}
+            isSearchStalled={false}
+            classNames={classNames}
+          />
+        )}
       </Autocomplete>
     );
   }
@@ -840,6 +859,7 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
       >)}
       autoFocus
       domId={domId}
+      detached={detached}
       indicesConfig={indicesConfig}
       refineSearchBox={refine}
       isSearchStalled={isSearchStalled}
@@ -848,7 +868,6 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
       showRecent={showRecent}
       recentSearchConfig={recentSearchConfig}
       showQuerySuggestions={normalizedShowQuerySuggestions}
-      detachedMediaQuery={detachedMediaQuery}
       translations={translations}
       showPromptSuggestions={normalizedShowPromptSuggestions}
       transformItems={effectiveTransformItems}
@@ -909,11 +928,11 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
   transformItems,
   placeholder,
   autoFocus,
-  detachedMediaQuery = DEFAULT_DETACHED_MEDIA_QUERY,
   translations,
   classNames,
   aiMode,
   domId,
+  detached,
   ...props
 }: InnerAutocompleteProps<TItem>) {
   const {
@@ -930,8 +949,7 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
       ? currentRefinement
       : indexUiState.query ?? '';
 
-  const { isDetached, isModalDetached, isModalOpen, setIsModalOpen } =
-    useDetachedMode(detachedMediaQuery);
+  const { isDetached, isModalDetached, isModalOpen, setIsModalOpen } = detached;
   const previousIsDetachedRef = useRef(isDetached);
 
   const {

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -446,7 +446,7 @@ type InnerAutocompleteProps<TItem extends BaseHit> = Omit<
     itemComponent: typeof AutocompleteRecentSearch;
     classNames: Partial<AutocompleteIndexClassNames>;
   };
-  instanceKey: string;
+  domId: string;
 };
 
 export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
@@ -818,7 +818,7 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
         | 'transformItems'
       >)}
       autoFocus
-      instanceKey={domId}
+      domId={domId}
       indicesConfig={indicesConfig}
       refineSearchBox={refine}
       isSearchStalled={isSearchStalled}
@@ -892,7 +892,7 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
   translations,
   classNames,
   aiMode,
-  instanceKey,
+  domId,
   ...props
 }: InnerAutocompleteProps<TItem>) {
   const {
@@ -1007,7 +1007,7 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
     setIsOpen,
     focusInput,
   } = usePropGetters<TItem>({
-    id: instanceKey,
+    id: domId,
     indices: indicesForPropGettersWithPromptSuggestions,
     indicesConfig: indicesConfigForPropGetters,
     onRefine: (query) => {

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -773,7 +773,7 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
             onFocus: () => setActivated(true),
           }}
           clearQuery={() => {}}
-          query=""
+          query={indexUiState.query ?? ''}
           isSearchStalled={false}
           classNames={classNames}
         />

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -760,6 +760,11 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
     const {
       indices: _shellUnusedIndices,
       feeds: _shellUnusedFeeds,
+      autoFocus: _shellUnusedAutoFocus,
+      placeholder: _shellUnusedPlaceholder,
+      classNames: _shellUnusedClassNames,
+      aiMode: _shellUnusedAiMode,
+      recentSearchConfig: _shellUnusedRecentSearchConfig,
       ...shellRootProps
     } = restProps as Record<string, unknown>;
     return (

--- a/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
@@ -4,7 +4,8 @@
 
 import { createCompositionClient, createSearchClient } from '@instantsearch/mocks';
 import { InstantSearchTestWrapper } from '@instantsearch/testutils';
-import { render } from '@testing-library/react';
+import { wait } from '@instantsearch/testutils/wait';
+import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 import { EXPERIMENTAL_Autocomplete } from '../Autocomplete';
@@ -110,6 +111,201 @@ describe('EXPERIMENTAL_Autocomplete', () => {
       }).not.toThrow();
 
       consoleError.mockRestore();
+    });
+  });
+
+  describe('lazy activation', () => {
+    test('does not search on mount in indices-mode', async () => {
+      const searchClient = createSearchClient({});
+
+      render(
+        <InstantSearchTestWrapper
+          searchClient={searchClient}
+          indexName="indexName"
+        >
+          <EXPERIMENTAL_Autocomplete
+            indices={[
+              {
+                indexName: 'my-index',
+                itemComponent: ({ item }) =>
+                  React.createElement('div', null, String(item.objectID)),
+              },
+            ]}
+          />
+        </InstantSearchTestWrapper>
+      );
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const requestedIndices = (
+        searchClient.search as jest.Mock
+      ).mock.calls
+        .flatMap((call) => call[0] as Array<{ indexName: string }>)
+        .map((request) => request.indexName);
+      expect(requestedIndices).not.toContain('my-index');
+    });
+
+    test('searches the autocomplete index on first focus in indices-mode', async () => {
+      const searchClient = createSearchClient({});
+
+      const { container } = render(
+        <InstantSearchTestWrapper
+          searchClient={searchClient}
+          indexName="indexName"
+        >
+          <EXPERIMENTAL_Autocomplete
+            indices={[
+              {
+                indexName: 'my-index',
+                itemComponent: ({ item }) =>
+                  React.createElement('div', null, String(item.objectID)),
+              },
+            ]}
+          />
+        </InstantSearchTestWrapper>
+      );
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const input = container.querySelector('input[type="search"]')!;
+      await act(async () => {
+        fireEvent.focus(input);
+        await wait(0);
+      });
+
+      const requestedIndices = (
+        searchClient.search as jest.Mock
+      ).mock.calls
+        .flatMap((call) => call[0] as Array<{ indexName: string }>)
+        .map((request) => request.indexName);
+      expect(requestedIndices).toContain('my-index');
+    });
+
+    test('propagates the initial query from the parent on first focus', async () => {
+      const searchClient = createSearchClient({});
+
+      const { container } = render(
+        <InstantSearchTestWrapper
+          searchClient={searchClient}
+          indexName="indexName"
+          initialUiState={{
+            indexName: { query: 'macbook' },
+          }}
+        >
+          <EXPERIMENTAL_Autocomplete
+            indices={[
+              {
+                indexName: 'my-index',
+                itemComponent: ({ item }) =>
+                  React.createElement('div', null, String(item.objectID)),
+              },
+            ]}
+          />
+        </InstantSearchTestWrapper>
+      );
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const input = container.querySelector('input[type="search"]')!;
+      await act(async () => {
+        fireEvent.focus(input);
+        await wait(0);
+      });
+
+      const autocompleteRequest = (
+        searchClient.search as jest.Mock
+      ).mock.calls
+        .flatMap(
+          (call) =>
+            call[0] as Array<{
+              indexName: string;
+              params: { query?: string };
+            }>
+        )
+        .find(
+          (request) =>
+            request.indexName === 'my-index' && request.params.query
+        );
+
+      expect(autocompleteRequest?.params.query).toBe('macbook');
+    });
+
+    test('eager-activates when autoFocus is set', async () => {
+      const searchClient = createSearchClient({});
+
+      render(
+        <InstantSearchTestWrapper
+          searchClient={searchClient}
+          indexName="indexName"
+        >
+          <EXPERIMENTAL_Autocomplete
+            autoFocus
+            indices={[
+              {
+                indexName: 'my-index',
+                itemComponent: ({ item }) =>
+                  React.createElement('div', null, String(item.objectID)),
+              },
+            ]}
+          />
+        </InstantSearchTestWrapper>
+      );
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const requestedIndices = (
+        searchClient.search as jest.Mock
+      ).mock.calls
+        .flatMap((call) => call[0] as Array<{ indexName: string }>)
+        .map((request) => request.indexName);
+      expect(requestedIndices).toContain('my-index');
+    });
+
+    test('keeps the input id stable across the shell→real transition', async () => {
+      const searchClient = createSearchClient({});
+
+      const { container } = render(
+        <InstantSearchTestWrapper
+          searchClient={searchClient}
+          indexName="indexName"
+        >
+          <EXPERIMENTAL_Autocomplete
+            indices={[
+              {
+                indexName: 'my-index',
+                itemComponent: ({ item }) =>
+                  React.createElement('div', null, String(item.objectID)),
+              },
+            ]}
+          />
+        </InstantSearchTestWrapper>
+      );
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const shellInputId = container.querySelector('input[type="search"]')!.id;
+
+      const input = container.querySelector<HTMLInputElement>(
+        'input[type="search"]'
+      )!;
+      await act(async () => {
+        fireEvent.focus(input);
+        await wait(0);
+      });
+
+      const realInputId = container.querySelector('input[type="search"]')!.id;
+
+      expect(realInputId).toBe(shellInputId);
     });
   });
 });

--- a/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
@@ -8,10 +8,10 @@ import {
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
 import { InstantSearchTestWrapper } from '@instantsearch/testutils';
-import { InstantSearchSSRProvider } from 'react-instantsearch-core';
 import { wait } from '@instantsearch/testutils/wait';
 import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
+import { InstantSearchSSRProvider } from 'react-instantsearch-core';
 
 import { EXPERIMENTAL_Autocomplete } from '../Autocomplete';
 

--- a/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
@@ -236,6 +236,39 @@ describe('EXPERIMENTAL_Autocomplete', () => {
       expect(autocompleteRequest?.params.query).toBe('macbook');
     });
 
+    test('pre-activation shell input reflects the parent query', async () => {
+      const searchClient = createSearchClient({});
+
+      const { container } = render(
+        <InstantSearchTestWrapper
+          searchClient={searchClient}
+          indexName="indexName"
+          initialUiState={{
+            indexName: { query: 'macbook' },
+          }}
+        >
+          <EXPERIMENTAL_Autocomplete
+            indices={[
+              {
+                indexName: 'my-index',
+                itemComponent: ({ item }) =>
+                  React.createElement('div', null, String(item.objectID)),
+              },
+            ]}
+          />
+        </InstantSearchTestWrapper>
+      );
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        'input[type="search"]'
+      )!;
+      expect(input.value).toBe('macbook');
+    });
+
     test('eager-activates when autoFocus is set', async () => {
       const searchClient = createSearchClient({});
 

--- a/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
@@ -407,5 +407,58 @@ describe('EXPERIMENTAL_Autocomplete', () => {
 
       expect(realInputId).toBe(shellInputId);
     });
+
+    test('renders the detached search button in the shell when the detached media query matches, and clicking it opens the detached panel', async () => {
+      const detachedMediaQuery = '(max-width: 9999px)';
+      (window.matchMedia as jest.Mock).mockImplementation((query: string) => ({
+        matches: query === detachedMediaQuery,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+
+      const searchClient = createSearchClient({});
+
+      const { container } = render(
+        <InstantSearchTestWrapper
+          searchClient={searchClient}
+          indexName="indexName"
+        >
+          <EXPERIMENTAL_Autocomplete
+            detachedMediaQuery={detachedMediaQuery}
+            indices={[
+              {
+                indexName: 'my-index',
+                itemComponent: ({ item }) =>
+                  React.createElement('div', null, String(item.objectID)),
+              },
+            ]}
+          />
+        </InstantSearchTestWrapper>
+      );
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const detachedButton = container.querySelector(
+        '.ais-AutocompleteDetachedSearchButton'
+      );
+      expect(detachedButton).not.toBeNull();
+      expect(container.querySelector('input[type="search"]')).toBeNull();
+
+      await act(async () => {
+        fireEvent.click(detachedButton!);
+        await wait(0);
+      });
+
+      expect(
+        document.querySelector('.ais-AutocompleteDetachedOverlay')
+      ).not.toBeNull();
+    });
   });
 });

--- a/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
@@ -218,7 +218,7 @@ describe('EXPERIMENTAL_Autocomplete', () => {
         await wait(0);
       });
 
-      const autocompleteRequest = (
+      const autocompleteRequests = (
         searchClient.search as jest.Mock
       ).mock.calls
         .flatMap(
@@ -228,12 +228,10 @@ describe('EXPERIMENTAL_Autocomplete', () => {
               params: { query?: string };
             }>
         )
-        .find(
-          (request) =>
-            request.indexName === 'my-index' && request.params.query
-        );
+        .filter((request) => request.indexName === 'my-index');
 
-      expect(autocompleteRequest?.params.query).toBe('macbook');
+      expect(autocompleteRequests).toHaveLength(1);
+      expect(autocompleteRequests[0].params.query).toBe('macbook');
     });
 
     test('pre-activation shell input reflects the parent query', async () => {

--- a/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
@@ -2,8 +2,13 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 
-import { createCompositionClient, createSearchClient } from '@instantsearch/mocks';
+import {
+  createCompositionClient,
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import { InstantSearchTestWrapper } from '@instantsearch/testutils';
+import { InstantSearchSSRProvider } from 'react-instantsearch-core';
 import { wait } from '@instantsearch/testutils/wait';
 import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
@@ -265,6 +270,70 @@ describe('EXPERIMENTAL_Autocomplete', () => {
         'input[type="search"]'
       )!;
       expect(input.value).toBe('macbook');
+    });
+
+    test('autocomplete child does not inherit SSR results from same-named parent index', async () => {
+      // Never-resolving search lets us observe the panel before the
+      // autocomplete's own request comes back.
+      const searchClient = {
+        search: jest.fn(() => new Promise(() => {})),
+      };
+
+      const initialResults = {
+        instant_search: {
+          state: {
+            index: 'instant_search',
+            query: '',
+            hitsPerPage: 8,
+          },
+          results: [
+            createSingleSearchResponse({
+              index: 'instant_search',
+              hits: [{ objectID: 'parent-hit', name: 'Parent SSR Hit' }],
+            }),
+          ],
+        },
+      } as Parameters<typeof InstantSearchSSRProvider>[0]['initialResults'];
+
+      const { container } = render(
+        <InstantSearchSSRProvider initialResults={initialResults}>
+          <InstantSearchTestWrapper
+            searchClient={searchClient as never}
+            indexName="instant_search"
+          >
+            <EXPERIMENTAL_Autocomplete
+              indices={[
+                {
+                  indexName: 'instant_search',
+                  itemComponent: ({ item }) =>
+                    React.createElement(
+                      'div',
+                      { 'data-testid': 'ac-item' },
+                      String((item as { name: string }).name)
+                    ),
+                },
+              ]}
+            />
+          </InstantSearchTestWrapper>
+        </InstantSearchSSRProvider>
+      );
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        'input[type="search"]'
+      )!;
+      await act(async () => {
+        fireEvent.focus(input);
+        await wait(0);
+      });
+
+      const renderedItems = container.querySelectorAll(
+        '[data-testid="ac-item"]'
+      );
+      expect(renderedItems).toHaveLength(0);
     });
 
     test('eager-activates when autoFocus is set', async () => {

--- a/packages/react-instantsearch/src/widgets/__tests__/AutocompleteFeedsMode.integration.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/AutocompleteFeedsMode.integration.test.tsx
@@ -289,7 +289,7 @@ describe('EXPERIMENTAL_Autocomplete feeds-mode (integration)', () => {
       ),
     });
 
-    render(
+    const { container } = render(
       <InstantSearch searchClient={searchClient} compositionID="my-comp">
         <Configure hitsPerPage={8} />
         <EXPERIMENTAL_Autocomplete
@@ -304,6 +304,9 @@ describe('EXPERIMENTAL_Autocomplete feeds-mode (integration)', () => {
         />
       </InstantSearch>
     );
+
+    const input = container.querySelector('input[type="search"]')!;
+    fireEvent.focus(input);
 
     await waitFor(() => {
       expect(transformItems).toHaveBeenCalled();

--- a/packages/react-instantsearch/src/widgets/__tests__/all-widgets.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/all-widgets.test.tsx
@@ -6,8 +6,8 @@ describe('widgets', () => {
   const customExpectedLength: Partial<
     Record<typeof widgets[0]['name'], number>
   > = {
-    // searchbox + isolated index
-    EXPERIMENTAL_Autocomplete: 2,
+    // searchbox only (the isolated index attaches lazily on first focus)
+    EXPERIMENTAL_Autocomplete: 1,
   };
 
   test('renders one widget', () => {

--- a/tests/common/widgets/autocomplete/insights.tsx
+++ b/tests/common/widgets/autocomplete/insights.tsx
@@ -4,7 +4,7 @@ import {
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent, screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -88,6 +88,13 @@ export function createInsightsTests(
         await wait(0);
       });
 
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
+        await wait(margin + delay);
+        await wait(0);
+      });
+
       window.aa.mockClear();
 
       const items = document.querySelectorAll('.ais-AutocompleteIndexItem');
@@ -152,6 +159,13 @@ export function createInsightsTests(
 
       // Wait for initial results
       await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
         await wait(margin + delay);
         await wait(0);
       });
@@ -237,6 +251,13 @@ export function createInsightsTests(
 
       // Wait for initial results
       await act(async () => {
+        await wait(margin + delay);
+        await wait(0);
+      });
+
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
         await wait(margin + delay);
         await wait(0);
       });

--- a/tests/common/widgets/autocomplete/options.tsx
+++ b/tests/common/widgets/autocomplete/options.tsx
@@ -22,7 +22,7 @@ function createMockedSearchClient(
 
 export function createOptionsTests(
   setup: AutocompleteWidgetSetup,
-  { act, flavor }: Required<TestOptions>
+  { act }: Required<TestOptions>
 ) {
   describe('options', () => {
     test('renders with default options', async () => {
@@ -79,6 +79,12 @@ export function createOptionsTests(
       });
 
       await act(async () => {
+        await wait(0);
+      });
+
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
         await wait(0);
       });
 
@@ -140,7 +146,13 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(searchClient.search).toHaveBeenCalledTimes(2);
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
+        await wait(0);
+      });
+
+      expect(searchClient.search).toHaveBeenCalledTimes(3);
       expect(searchClient.search).toHaveBeenNthCalledWith(1, [
         {
           indexName: 'query_suggestions',
@@ -214,15 +226,12 @@ export function createOptionsTests(
       await act(async () => {
         await wait(0);
 
-        // JS currently doesn't refine on focus
-        if (flavor === 'javascript') {
-          const input = screen.getByRole('combobox', {
-            name: /submit/i,
-          });
-          userEvent.click(input);
-          userEvent.type(input, 'a');
-          userEvent.clear(input);
-        }
+        const input = screen.getByRole('combobox', {
+          name: /submit/i,
+        });
+        userEvent.click(input);
+        userEvent.type(input, 'a');
+        userEvent.clear(input);
 
         await wait(0);
       });
@@ -324,6 +333,12 @@ export function createOptionsTests(
         await wait(0);
       });
 
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
+        await wait(0);
+      });
+
       // No recent searches yet, so the header should not be rendered
       expect(
         document.querySelector('.ais-AutocompleteRecentSearchesHeader')
@@ -406,6 +421,12 @@ export function createOptionsTests(
       });
 
       await act(async () => {
+        await wait(0);
+      });
+
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
         await wait(0);
       });
 
@@ -494,6 +515,12 @@ export function createOptionsTests(
       });
 
       await act(async () => {
+        await wait(0);
+      });
+
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
         await wait(0);
       });
 
@@ -587,12 +614,16 @@ export function createOptionsTests(
         0
       );
 
-      const input = screen.getByRole('combobox', { name: /submit/i });
+      let input = screen.getByRole('combobox', { name: /submit/i });
 
       await act(async () => {
         userEvent.click(input);
         await wait(0);
+      });
 
+      input = screen.getByRole('combobox', { name: /submit/i });
+
+      await act(async () => {
         userEvent.keyboard('{ArrowDown}');
         await wait(0);
       });
@@ -697,10 +728,16 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      const input = screen.getByRole('combobox', { name: /submit/i });
+      let input = screen.getByRole('combobox', { name: /submit/i });
 
       await act(async () => {
         await userEvent.click(input);
+        await wait(0);
+      });
+
+      input = screen.getByRole('combobox', { name: /submit/i });
+
+      await act(async () => {
         await userEvent.paste(input, 'Item 3');
         await wait(0);
       });
@@ -763,12 +800,17 @@ export function createOptionsTests(
         await wait(0);
       });
 
+      const focusInput = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(focusInput);
+        await wait(0);
+      });
+
       (searchClient.search as jest.Mock).mockClear();
 
       const input = screen.getByRole('combobox', { name: /submit/i });
 
       await act(async () => {
-        await userEvent.click(input);
         await userEvent.paste(input, 'hello');
         await wait(0);
       });
@@ -895,10 +937,16 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      const input = screen.getByRole('combobox', { name: /submit/i });
+      let input = screen.getByRole('combobox', { name: /submit/i });
 
       await act(async () => {
         userEvent.click(input);
+        await wait(0);
+      });
+
+      input = screen.getByRole('combobox', { name: /submit/i });
+
+      await act(async () => {
         userEvent.keyboard('{ArrowDown}');
         await wait(0);
       });
@@ -972,10 +1020,16 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      const input = screen.getByRole('combobox', { name: /submit/i });
+      let input = screen.getByRole('combobox', { name: /submit/i });
 
       await act(async () => {
         userEvent.click(input);
+        await wait(0);
+      });
+
+      input = screen.getByRole('combobox', { name: /submit/i });
+
+      await act(async () => {
         userEvent.keyboard('{ArrowDown}');
         await wait(0);
       });
@@ -1056,10 +1110,16 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      const input = screen.getByRole('combobox', { name: /submit/i });
+      let input = screen.getByRole('combobox', { name: /submit/i });
 
       await act(async () => {
         userEvent.click(input);
+        await wait(0);
+      });
+
+      input = screen.getByRole('combobox', { name: /submit/i });
+
+      await act(async () => {
         userEvent.type(input, 'Item 3');
         userEvent.keyboard('{Enter}');
         await wait(0);
@@ -1131,11 +1191,17 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      const input = screen.getByRole('combobox', { name: /submit/i });
+      let input = screen.getByRole('combobox', { name: /submit/i });
+
+      await act(async () => {
+        userEvent.click(input);
+        await wait(0);
+      });
+
+      input = screen.getByRole('combobox', { name: /submit/i });
 
       // Type and submit a query
       await act(async () => {
-        userEvent.click(input);
         userEvent.type(input, 'hello');
         userEvent.keyboard('{Enter}');
         await wait(0);
@@ -1196,10 +1262,16 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      const input = screen.getByRole('combobox', { name: /submit/i });
+      let input = screen.getByRole('combobox', { name: /submit/i });
 
       await act(async () => {
         userEvent.click(input);
+        await wait(0);
+      });
+
+      input = screen.getByRole('combobox', { name: /submit/i });
+
+      await act(async () => {
         userEvent.type(input, 'Item 3');
         userEvent.keyboard('{Enter}');
         await wait(0);
@@ -1278,7 +1350,9 @@ export function createOptionsTests(
       await act(async () => {
         userEvent.click(input);
         await wait(0);
+      });
 
+      await act(async () => {
         userEvent.keyboard('{ArrowUp}');
         await wait(0);
       });
@@ -1350,6 +1424,12 @@ export function createOptionsTests(
         await wait(0);
       });
 
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
+        await wait(0);
+      });
+
       expect(
         document.querySelector('.ais-ReverseHighlight-nonHighlighted')
       ).toHaveTextContent('hell');
@@ -1405,12 +1485,14 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      const input = screen.getByRole('combobox', { name: /submit/i });
+      let input = screen.getByRole('combobox', { name: /submit/i });
 
       await act(async () => {
         userEvent.click(input);
         await wait(0);
       });
+
+      input = screen.getByRole('combobox', { name: /submit/i });
 
       expect(input).toHaveFocus();
 
@@ -1521,6 +1603,12 @@ export function createOptionsTests(
         await wait(0);
       });
 
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
+        await wait(0);
+      });
+
       const applyButton = screen.getByRole('button', {
         name: /apply hello as search/i,
         hidden: true,
@@ -1538,8 +1626,9 @@ export function createOptionsTests(
         })
       ).toHaveValue('hello');
 
-      // 2 initial calls for the root index + suggestions index, then 1 for the suggestions index only
-      expect(searchClient.search).toHaveBeenCalledTimes(3);
+      // 1 initial call for the root index, 2 calls when focusing the input
+      // (root + suggestions), then 1 for the suggestions index after clicking apply
+      expect(searchClient.search).toHaveBeenCalledTimes(4);
       expect(searchClient.search).toHaveBeenLastCalledWith(
         expect.arrayContaining([
           expect.objectContaining({
@@ -1687,6 +1776,18 @@ export function createOptionsTests(
           await wait(0);
         });
 
+        // For lazy-activation flavors (React), the detached UI only renders
+        // after the input is focused.
+        const preActivationInput = screen.queryByRole('combobox', {
+          name: /submit/i,
+        });
+        if (preActivationInput) {
+          await act(async () => {
+            userEvent.click(preActivationInput);
+            await wait(0);
+          });
+        }
+
         expect(
           document.querySelector('.ais-AutocompleteDetachedSearchButton')
         ).toBeInTheDocument();
@@ -1827,6 +1928,18 @@ export function createOptionsTests(
         await act(async () => {
           await wait(0);
         });
+
+        // For lazy-activation flavors (React), the detached UI only renders
+        // after the input is focused.
+        const preActivationInput = screen.queryByRole('combobox', {
+          name: /submit/i,
+        });
+        if (preActivationInput) {
+          await act(async () => {
+            userEvent.click(preActivationInput);
+            await wait(0);
+          });
+        }
 
         expect(
           document.querySelector('.ais-AutocompleteDetachedSearchButton')
@@ -2051,6 +2164,12 @@ export function createOptionsTests(
           await wait(0);
         });
 
+        const input = screen.getByRole('combobox', { name: /submit/i });
+        await act(async () => {
+          userEvent.click(input);
+          await wait(0);
+        });
+
         const indicesItems = document.querySelectorAll(
           '.ais-AutocompleteIndexItem'
         );
@@ -2145,6 +2264,12 @@ export function createOptionsTests(
           await wait(0);
         });
 
+        const input = screen.getByRole('combobox', { name: /submit/i });
+        await act(async () => {
+          userEvent.click(input);
+          await wait(0);
+        });
+
         const indicesItems = document.querySelectorAll(
           '.ais-AutocompleteIndexItem'
         );
@@ -2218,7 +2343,9 @@ export function createOptionsTests(
         await act(async () => {
           userEvent.click(input);
           await wait(0);
+        });
 
+        await act(async () => {
           userEvent.keyboard('{ArrowDown}');
           await wait(0);
         });
@@ -2311,7 +2438,9 @@ export function createOptionsTests(
         await act(async () => {
           userEvent.click(input);
           await wait(0);
+        });
 
+        await act(async () => {
           userEvent.keyboard('{ArrowDown}');
           await wait(0);
         });
@@ -2373,6 +2502,12 @@ export function createOptionsTests(
           await wait(0);
         });
 
+        const input = screen.getByRole('combobox', { name: /submit/i });
+        await act(async () => {
+          userEvent.click(input);
+          await wait(0);
+        });
+
         expect(
           document.querySelector('.ais-AutocompletePromptSuggestions')
         ).toBeInTheDocument();
@@ -2422,6 +2557,12 @@ export function createOptionsTests(
         });
 
         await act(async () => {
+          await wait(0);
+        });
+
+        const input = screen.getByRole('combobox', { name: /submit/i });
+        await act(async () => {
+          userEvent.click(input);
           await wait(0);
         });
 
@@ -2488,6 +2629,12 @@ export function createOptionsTests(
           await wait(0);
         });
 
+        const input = screen.getByRole('combobox', { name: /submit/i });
+        await act(async () => {
+          userEvent.click(input);
+          await wait(0);
+        });
+
         // Query suggestions should be rendered
         const querySuggestionItems = document.querySelectorAll(
           '.ais-AutocompleteSuggestionsItem'
@@ -2542,6 +2689,12 @@ export function createOptionsTests(
         });
 
         await act(async () => {
+          await wait(0);
+        });
+
+        const input = screen.getByRole('combobox', { name: /submit/i });
+        await act(async () => {
+          userEvent.click(input);
           await wait(0);
         });
 
@@ -2618,6 +2771,12 @@ export function createOptionsTests(
         });
 
         await act(async () => {
+          await wait(0);
+        });
+
+        const input = screen.getByRole('combobox', { name: /submit/i });
+        await act(async () => {
+          userEvent.click(input);
           await wait(0);
         });
 
@@ -2756,6 +2915,12 @@ export function createOptionsTests(
           await wait(0);
         });
 
+        const input = screen.getByRole('combobox', { name: /submit/i });
+        await act(async () => {
+          userEvent.click(input);
+          await wait(0);
+        });
+
         expect(
           document.querySelector('.ais-AutocompleteIndexNoResults')
         ).toBeInTheDocument();
@@ -2808,6 +2973,12 @@ export function createOptionsTests(
         });
 
         await act(async () => {
+          await wait(0);
+        });
+
+        const input = screen.getByRole('combobox', { name: /submit/i });
+        await act(async () => {
+          userEvent.click(input);
           await wait(0);
         });
 

--- a/tests/common/widgets/autocomplete/options.tsx
+++ b/tests/common/widgets/autocomplete/options.tsx
@@ -152,7 +152,9 @@ export function createOptionsTests(
         await wait(0);
       });
 
-      expect(searchClient.search).toHaveBeenCalledTimes(3);
+      // 1 initial call for the root index, 1 call when focusing the input
+      // (the autocomplete's own search; the parent search is cancelled).
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
       expect(searchClient.search).toHaveBeenNthCalledWith(1, [
         {
           indexName: 'query_suggestions',
@@ -1626,9 +1628,10 @@ export function createOptionsTests(
         })
       ).toHaveValue('hello');
 
-      // 1 initial call for the root index, 2 calls when focusing the input
-      // (root + suggestions), then 1 for the suggestions index after clicking apply
-      expect(searchClient.search).toHaveBeenCalledTimes(4);
+      // 1 initial call for the root index, 1 call when focusing the input
+      // (only the suggestions; the parent search is cancelled), then 1 for
+      // the suggestions index after clicking apply
+      expect(searchClient.search).toHaveBeenCalledTimes(3);
       expect(searchClient.search).toHaveBeenLastCalledWith(
         expect.arrayContaining([
           expect.objectContaining({

--- a/tests/common/widgets/autocomplete/templates.tsx
+++ b/tests/common/widgets/autocomplete/templates.tsx
@@ -104,6 +104,12 @@ export function createTemplatesTests(
         await wait(0);
       });
 
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
+        await wait(0);
+      });
+
       const headers = [
         ...document.querySelectorAll('.ais-AutocompleteIndexHeader'),
       ];


### PR DESCRIPTION
**Summary**

`EXPERIMENTAL_autocomplete` registered its isolated index at mount time, dispatching an Algolia search on every page load. Customers are currently paying for an autocomplete request on every visit, regardless of whether the visitor ever interacted with the autocomplete.

The widget now waits until first focus to register (unless they have `autoFocus={true}`, which opts back into eager mounting) which is also consistent with how [Autocomplete](https://github.com/algolia/autocomplete/) historically works.

Connector users (`connectAutocomplete`) keep their existing behaviour. They own their tree and can defer registration themselves if they want.

**Bundled fixes**

Deferring registration also fixes a long-standing SSR hydration mismatch in React (server emitted panel content, client mounted it closed). But it then exposed a flash of the parent index's results on first focus, caused by an `indexId` collision between the autocomplete's child and a same-named parent in the host tree, so the parent's SSR `_initialResults` seeded the autocomplete child. The flash existed before the PR, but was masked by the eager mount-time search. Lazy activation makes it conspicuous, so it has to ship in the same PR.

**Result**

- Land on `/`. Autocomplete input is empty. No network requests for the autocomplete.
- Focus the input. One network request fires, with empty query.
- Land on `/?query=nintendo`. Autocomplete input shows `nintendo`. No network requests for the autocomplete.
- Focus the input. One network request fires, with `query=nintendo`.

| | Before | After |
| --- | --- | --- |
| JS | <video src="https://github.com/user-attachments/assets/c0a281df-b54b-4a18-859d-46d2231e1481" /> | <video src="https://github.com/user-attachments/assets/05c31543-cbf8-4e34-9b20-5c7e4f2a30c2" /> |
| React | <video src="https://github.com/user-attachments/assets/97707c55-c630-4ed3-bb2a-644f2361fd94" /> | <video src="https://github.com/user-attachments/assets/4db2dd72-18a4-446c-9695-b8d6f176e016" /> |
| Next.js | <video src="https://github.com/user-attachments/assets/5e406b82-1381-4843-ae03-3c72a86fa4f0" /> | <video src="https://github.com/user-attachments/assets/0ae4211a-dae8-443f-968f-f86c269a8ff5" /> |


