### PR TITLE
fix(highlight): keep separator state when reverse-highlight siblings disagree

### DIFF
--- a/packages/instantsearch.js/src/lib/utils/__tests__/getHighlightFromSiblings-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/getHighlightFromSiblings-test.ts
@@ -21,6 +21,12 @@ const multipleMatches: HighlightedParts[] = [
   { isHighlighted: false, value: 'Black' },
 ];
 
+const siblingsDisagree: HighlightedParts[] = [
+  { isHighlighted: true, value: 'Amazon' },
+  { isHighlighted: false, value: ' - ' },
+  { isHighlighted: false, value: 'Fire' },
+];
+
 describe('getHighlightFromSiblings', () => {
   test('returns the isHighlighted value with a missing sibling', () => {
     expect(getHighlightFromSiblings(oneMatch, 0)).toEqual(true);
@@ -28,5 +34,13 @@ describe('getHighlightFromSiblings', () => {
 
   test('returns the isHighlighted value with both siblings', () => {
     expect(getHighlightFromSiblings(multipleMatches, 1)).toEqual(true);
+  });
+
+  test('keeps the separator state when siblings disagree', () => {
+    // The separator sits between a highlighted and a non-highlighted part, so
+    // it must keep its own state instead of inheriting from siblings. With the
+    // previous `|| true` the neighbors collapsed to `true === true` and the
+    // separator was wrongly reported as highlighted.
+    expect(getHighlightFromSiblings(siblingsDisagree, 1)).toEqual(false);
   });
 });

--- a/packages/instantsearch.js/src/lib/utils/__tests__/reverseHighlightedParts-test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/reverseHighlightedParts-test.ts
@@ -38,7 +38,11 @@ describe('reverseHighlightedParts', () => {
         value: ' - Fire HD8 - 8&quot; - Tablet - 16GB - Wi-',
       },
       { isHighlighted: true, value: 'Fi' },
-      { isHighlighted: false, value: ' - ' },
+      // The separator sits between two non-highlighted parts ('Fi' and
+      // 'Black'), so its siblings agree and it inherits their state — keeping
+      // the reversed "Fi - Black" run contiguously highlighted. Previously the
+      // `|| true` bug broke this run with a gap here.
+      { isHighlighted: true, value: ' - ' },
       { isHighlighted: true, value: 'Black' },
     ]);
   });

--- a/packages/instantsearch.js/src/lib/utils/getHighlightFromSiblings.ts
+++ b/packages/instantsearch.js/src/lib/utils/getHighlightFromSiblings.ts
@@ -6,8 +6,8 @@ const hasAlphanumeric = new RegExp(/\w/i);
 
 export function getHighlightFromSiblings(parts: HighlightedParts[], i: number) {
   const current = parts[i];
-  const isNextHighlighted = parts[i + 1]?.isHighlighted || true;
-  const isPreviousHighlighted = parts[i - 1]?.isHighlighted || true;
+  const isNextHighlighted = parts[i + 1]?.isHighlighted ?? true;
+  const isPreviousHighlighted = parts[i - 1]?.isHighlighted ?? true;
 
   if (
     !hasAlphanumeric.test(unescape(current.value)) &&


### PR DESCRIPTION
## What's broken

`getHighlightFromSiblings` (used by `reverseHighlightedParts` for reverse-highlight / reverse-snippet) computes neighbor highlight state with `||`:

```js
const isNextHighlighted = parts[i + 1]?.isHighlighted || true;
const isPreviousHighlighted = parts[i - 1]?.isHighlighted || true;
```

`X || true` is always `true`, even when the neighbor exists and is genuinely `false`. So the `isPreviousHighlighted === isNextHighlighted` guard is always satisfied, and every separator part is treated as inheriting its siblings' highlight state — even when the siblings disagree. For a value where a separator sits between a highlighted and a non-highlighted segment, the reverse-highlight / reverse-snippet output is wrong.

## Why it happens

`||` was used where a "default only when the neighbor is missing" was intended — the `?.` optional chaining shows the intent. `false || true` collapses a real `false` neighbor to `true`.

## Fix

Use `??` so the `true` default applies only when the neighbor is absent (`undefined`). This changes behavior **only** in the present-and-`false` case (the bug); missing-sibling behavior is preserved byte-for-byte, so no currently-correct case regresses.

`??` is already used throughout `instantsearch.js` source, so the toolchain supports it.

## Test

Added a regression case: a separator between a highlighted and a non-highlighted segment keeps its own state. Fails before, passes after.

## Context

Mirrors [algolia/autocomplete#1348](https://github.com/algolia/autocomplete/pull/1348), which fixes the same bug in the `autocomplete-preset-algolia` port of this sibling strategy. The autocomplete code was a faithful port of this function — including the `|| true` — so the bug exists in both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test update

Updated the existing `reverseHighlightedParts` "multiple matches" expectation: it asserted the buggy output (a separator between two non-highlighted parts reversed to non-highlighted, breaking an otherwise contiguous reverse-highlighted run). With the fix the separator correctly inherits its agreeing siblings, so the reversed "Fi - Black" run is uniformly highlighted. Note: the equivalent autocomplete repo has no test covering this "separator between two present, agreeing neighbors" path, which is why algolia/autocomplete#1348 went green without a test change.