### PR TITLE
chore: harden architecture refactor workflow

### DIFF
--- a/.claude/prompts/architecture-refactor/implement.md
+++ b/.claude/prompts/architecture-refactor/implement.md
@@ -43,7 +43,7 @@ Only after choosing an approach should you edit files. Record the chosen approac
 - Preserve shipped public behavior and stable public interfaces unless the chosen approach explicitly requires a migration.
 - Add or update focused tests when the refactor changes behavior or moves validation to a better interface.
 - Remove only imports, variables, or helpers made unused by this change.
-- Leave generated run artifacts in `.claude/refactors/`; they are ignored by git.
+- Leave generated run artifacts in `architecture-refactor-runs/`; they are ignored by git.
 
 ## Validation
 

--- a/.claude/prompts/architecture-refactor/scout.md
+++ b/.claude/prompts/architecture-refactor/scout.md
@@ -2,7 +2,7 @@
 
 You are running the architecture-refactor scout for InstantSearch.
 
-First read `.claude/prompts/architecture-refactor/rubric.md`. Use that vocabulary and rubric exactly. Produce markdown only, except for the required hidden candidate manifest comment. Do not create other HTML.
+First read `.claude/prompts/architecture-refactor/rubric.md`. Use that vocabulary and rubric exactly. Produce markdown only, except for the required hidden candidate manifest comment and the `<details>`/`<summary>` tags around each candidate. Do not create other HTML.
 
 ## Task
 
@@ -59,7 +59,8 @@ List every candidate from the shortlist in the manifest, in the same order. Keep
 
 ## Candidate Shortlist
 
-### candidate-1: Short Title
+<details>
+<summary><strong>candidate-1: Short Title</strong></summary>
 
 - Recommendation strength: `Strong`, `Worth exploring`, or `Speculative`
 - Files: bullet list of involved files/modules
@@ -85,11 +86,21 @@ flowchart LR
   Deep --> Detail[Hidden detail]
 ```
 
-Repeat the same shape for `candidate-2` through at most `candidate-5`.
+</details>
+
+Repeat the same collapsible `<details>` shape for `candidate-2` through at most `candidate-5`. Keep each summary text in the exact form `candidate-N: Short Title`, and keep the title identical to the corresponding hidden manifest entry.
 
 ## Top Recommendation
 
 Name the single candidate you would implement first and explain why in terms of depth, locality, leverage, and likely PR size.
+
+## Next Step
+
+Tell maintainers how to trigger implementation of a selected candidate. Use this exact command shape:
+
+`/implement candidate-1`
+
+Explain that they should replace `candidate-1` with the candidate id they want to implement.
 
 ## Non-Candidates
 

--- a/.github/scripts/architecture-refactor.cjs
+++ b/.github/scripts/architecture-refactor.cjs
@@ -11,7 +11,10 @@ const promptDir = path.join(
   'prompts',
   'architecture-refactor'
 );
-const runsDir = path.join(repoRoot, '.claude', 'refactors', 'runs');
+const runsDir = path.resolve(
+  repoRoot,
+  process.env.ARCHITECTURE_REFACTOR_RUNS_DIR || 'architecture-refactor-runs'
+);
 
 const stageConfig = {
   scout: {
@@ -466,6 +469,12 @@ function runScout(options) {
     optionNumber(options, 'max-turns', stageConfig.scout.maxTurns),
     stageConfig.scout.allowedTools
   );
+
+  if (!existsSync(reportPath)) {
+    fail(`Scout report was not created: ${reportPath}`);
+  }
+
+  candidateManifest(readFileSync(reportPath, 'utf8'));
 
   process.stdout.write(
     `Scout report: ${path.relative(repoRoot, reportPath)}\n`

--- a/.github/workflows/architecture-refactor.yml
+++ b/.github/workflows/architecture-refactor.yml
@@ -175,8 +175,8 @@ jobs:
           title="$(jq -r '.title' "$issue_json")"
           expected_prefix="Architecture refactor scout: "
 
-          if [[ "$author" != "github-actions[bot]" ]]; then
-            echo "::error::Tracking issue must be created by github-actions[bot]."
+          if [[ "$author" != "app/github-actions" ]]; then
+            echo "::error::Tracking issue must be created by GitHub Actions."
             exit 1
           fi
 

--- a/.github/workflows/architecture-refactor.yml
+++ b/.github/workflows/architecture-refactor.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Resolve request
         id: request
@@ -73,7 +73,7 @@ jobs:
           node .github/scripts/architecture-refactor.cjs resolve-request >> "$GITHUB_OUTPUT"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -106,12 +106,15 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RUN_ID: ${{ steps.scout.outputs.run_id }}
           REPORT: ${{ steps.scout.outputs.report }}
+          VISIBILITY_MENTION: '@algolia/frontend-experiences-web'
         run: |
           set -euo pipefail
 
           issue_body="$(mktemp)"
           {
             echo "<!-- architecture-refactor-scout run=${RUN_ID} -->"
+            echo ""
+            echo "cc ${VISIBILITY_MENTION}"
             echo ""
             cat "$REPORT"
           } > "$issue_body"

--- a/.github/workflows/architecture-refactor.yml
+++ b/.github/workflows/architecture-refactor.yml
@@ -93,7 +93,7 @@ jobs:
             --run "$RUN_ID" \
             --max-turns "${{ steps.request.outputs.max_turns }}"
 
-          report=".claude/refactors/runs/${RUN_ID}/scout.md"
+          report="architecture-refactor-runs/${RUN_ID}/scout.md"
 
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "report=${report}" >> "$GITHUB_OUTPUT"
@@ -159,7 +159,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          run_dir=".claude/refactors/runs/${RUN_ID}"
+          run_dir="architecture-refactor-runs/${RUN_ID}"
           mkdir -p "$run_dir"
 
           issue_json="$run_dir/tracking-issue.json"

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build/
 
 # Generated files
 /.claude/refactors/
+/architecture-refactor-runs/
 /docs
 /website/algoliasearch-helper-js/*
 /website/examples/*

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ build/
 !scripts/build/**
 
 # Generated files
-/.claude/refactors/
 /architecture-refactor-runs/
 /docs
 /website/algoliasearch-helper-js/*


### PR DESCRIPTION
## Summary
- Move architecture refactor run artifacts out of `.claude/` to avoid Claude Code sensitive-path write gating in CI.
- Validate scout report creation and the required candidate manifest before later workflow steps consume the report.
- Improve generated scout issues with collapsible candidate sections, implementation instructions, and a team visibility mention.
- Update the workflow to Node 24-based GitHub action majors and accept the `app/github-actions` author returned by `gh issue view` for implement runs.

## Test plan
- `node --check .github/scripts/architecture-refactor.cjs`
- Focused fake-`claude` scout success/failure checks
- Local author-guard check for `app/github-actions`
- `git diff --check`
- `ReadLints` on changed files