### PR TITLE
chore: improve architecture refactor PR metadata

### DIFF
--- a/.claude/prompts/architecture-refactor/implement.md
+++ b/.claude/prompts/architecture-refactor/implement.md
@@ -47,7 +47,17 @@ Only after choosing an approach should you edit files. Record the chosen approac
 
 ## Validation
 
-Do not run lint, tests, or type-checks in this workflow. The draft PR's normal validation is the source of truth. In the implementation report, list the targeted checks and PR validation you expect reviewers to rely on.
+After editing, run a bounded generic validation loop before writing the final report:
+
+- If dependencies are unavailable, run `yarn install --frozen-lockfile` once.
+- Run `yarn lint:changed`.
+- For changed JavaScript, TypeScript, TSX, JSX, CJS, or Vue source files, run `yarn jest --findRelatedTests <changed source files> --ci --runInBand --passWithNoTests`.
+- Run `yarn type-check` only when the candidate changes shared TypeScript contracts, generated declarations, public exports, or cross-package APIs. Otherwise, leave full type-checking to PR CI and say so in the report.
+- If a check fails because of your implementation, fix the issue and rerun the same check.
+- Do not run the full CI suite (`yarn test:ci`, `yarn test:ci:v4`, package builds, bundle-size checks, examples, or e2e tests) unless the selected candidate specifically requires one of them.
+- If a check cannot run in this workflow, explain why in the implementation report instead of guessing.
+
+In the implementation report, list the exact commands you ran and their outcomes. Also list any important PR validation that still needs to run in CI.
 
 ## Required Final Artifact
 

--- a/.github/scripts/architecture-refactor.cjs
+++ b/.github/scripts/architecture-refactor.cjs
@@ -41,6 +41,10 @@ const stageConfig = {
       'Write',
       'Bash(git status *)',
       'Bash(git diff *)',
+      'Bash(yarn install --frozen-lockfile)',
+      'Bash(yarn lint:changed)',
+      'Bash(yarn type-check)',
+      'Bash(yarn jest --findRelatedTests *)',
     ],
   },
 };

--- a/.github/scripts/architecture-refactor.cjs
+++ b/.github/scripts/architecture-refactor.cjs
@@ -50,6 +50,7 @@ function printUsage() {
   node .github/scripts/architecture-refactor.cjs resolve-request
   node .github/scripts/architecture-refactor.cjs scout --run <run-id> [--max-turns <n>]
   node .github/scripts/architecture-refactor.cjs implement <candidate-id> --run <run-id> --scout-report <path> [--max-turns <n>]
+  node .github/scripts/architecture-refactor.cjs candidate-title <candidate-id> --scout-report <path>
   node .github/scripts/architecture-refactor.cjs validate-implementation --report <path>
 `);
 }
@@ -523,6 +524,27 @@ function runImplement(candidateId, options) {
   );
 }
 
+function printCandidateTitle(candidateId, options) {
+  if (!candidateId) {
+    printUsage();
+    process.exit(1);
+  }
+
+  if (!options['scout-report'] || options['scout-report'] === true) {
+    fail('Missing required option: --scout-report <path>');
+  }
+
+  const scoutReportPath = resolveInputPath(options['scout-report']);
+
+  if (!existsSync(scoutReportPath)) {
+    fail(`Scout report does not exist: ${scoutReportPath}`);
+  }
+
+  process.stdout.write(
+    `${candidateTitle(candidateId, readFileSync(scoutReportPath, 'utf8'))}\n`
+  );
+}
+
 function validateImplementation(options) {
   if (!options.report || options.report === true) {
     fail('Missing required option: --report <path>');
@@ -568,6 +590,11 @@ function main() {
 
   if (command === 'implement') {
     runImplement(positionals[0], options);
+    return;
+  }
+
+  if (command === 'candidate-title') {
+    printCandidateTitle(positionals[0], options);
     return;
   }
 

--- a/.github/workflows/architecture-refactor.yml
+++ b/.github/workflows/architecture-refactor.yml
@@ -124,9 +124,16 @@ jobs:
               --title "Architecture refactor scout: ${RUN_ID}" \
               --body-file "$issue_body"
           )"
+          issue_number="${issue_url##*/}"
+
+          gh api \
+            --method PUT \
+            "repos/${GH_REPO}/issues/${issue_number}/lock" \
+            -f lock_reason=resolved \
+            >/dev/null
 
           echo "issue_url=${issue_url}" >> "$GITHUB_OUTPUT"
-          echo "Created ${issue_url}"
+          echo "Created and locked ${issue_url}"
 
       - name: Comment implementation started
         if: steps.request.outputs.stage == 'implement'

--- a/.github/workflows/architecture-refactor.yml
+++ b/.github/workflows/architecture-refactor.yml
@@ -206,10 +206,15 @@ jobs:
 
           branch="$(git branch --show-current)"
           report="$run_dir/implementation-${CANDIDATE_ID}.md"
+          candidate_title="$(
+            node .github/scripts/architecture-refactor.cjs candidate-title "$CANDIDATE_ID" \
+              --scout-report "$run_dir/scout-from-issue.md"
+          )"
 
           echo "branch=${branch}" >> "$GITHUB_OUTPUT"
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "report=${report}" >> "$GITHUB_OUTPUT"
+          echo "pr_title=refactor: ${candidate_title}" >> "$GITHUB_OUTPUT"
 
       - name: Create draft pull request
         id: pull_request
@@ -220,7 +225,9 @@ jobs:
           ISSUE_NUMBER: ${{ steps.request.outputs.issue_number }}
           CANDIDATE_ID: ${{ steps.request.outputs.candidate_id }}
           BRANCH: ${{ steps.implement.outputs.branch }}
+          PR_TITLE: ${{ steps.implement.outputs.pr_title }}
           REPORT: ${{ steps.implement.outputs.report }}
+          REVIEWER_TEAM_SLUG: frontend-experiences-web
         run: |
           set -euo pipefail
 
@@ -257,9 +264,17 @@ jobs:
           pr_url="$(
             gh pr create \
               --draft \
-              --title "refactor: ${CANDIDATE_ID}" \
+              --title "$PR_TITLE" \
               --body-file "$pr_body"
           )"
+          pr_number="${pr_url##*/}"
+
+          gh api \
+            --method POST \
+            "repos/${GH_REPO}/pulls/${pr_number}/requested_reviewers" \
+            -f "team_reviewers[]=${REVIEWER_TEAM_SLUG}" \
+            >/dev/null \
+            || echo "::warning::Could not assign ${REVIEWER_TEAM_SLUG} as a team reviewer; please add it manually."
 
           gh issue comment "$ISSUE_NUMBER" --body "Draft PR created: ${pr_url}"
           echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
**Summary**

Make the architecture refactor workflow create clearer draft PRs by deriving the PR title from the selected scout candidate title instead of the raw candidate id. Also request the `frontend-experiences-web` team as a reviewer for generated draft PRs.

**Result**

Validated locally with:

- `node --check .github/scripts/architecture-refactor.cjs`
- `node .github/scripts/architecture-refactor.cjs candidate-title candidate-1 --scout-report <sample manifest>`
- `git diff --check -- .github/scripts/architecture-refactor.cjs .github/workflows/architecture-refactor.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/architecture-refactor.yml"); puts "yaml-ok"'`

`actionlint` was not installed locally.