### PR TITLE
feat(chat): add request options to agent requests

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "129 kB"
+      "maxSize": "130 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "101.5 kB"
+      "maxSize": "102 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1179,6 +1179,25 @@ data: [DONE]`,
         expect(searchParams.get('userToken')).toBe('user-1');
       });
 
+      it('keeps the built-in compatibility mode on agent requests', async () => {
+        const { widget } = getInitializedWidget({
+          agentId: 'agentId',
+          requestOptions: {
+            queryParameters: {
+              compatibilityMode: 'custom',
+              userToken: 'user-1',
+            },
+          },
+        });
+
+        await widget.chatInstance.sendMessage({ text: 'hello' });
+
+        const { url } = getRequestPayload();
+        const searchParams = new URL(url).searchParams;
+        expect(searchParams.get('compatibilityMode')).toBe('ai-sdk-5');
+        expect(searchParams.get('userToken')).toBe('user-1');
+      });
+
       it('sends persistent headers on agent requests', async () => {
         const { widget } = getInitializedWidget({
           agentId: 'agentId',
@@ -1225,6 +1244,29 @@ data: [DONE]`,
             'x-session-id': 'session-1',
           })
         );
+      });
+
+      it('keeps the x-algolia-agent chat marker even when requestOptions tries to override it', async () => {
+        const { widget } = getInitializedWidget({
+          agentId: 'agentId',
+          requestOptions: {
+            headers: {
+              'x-algolia-application-id': 'spoofed-app',
+              'x-algolia-api-key': 'spoofed-key',
+              'x-algolia-agent': 'spoofed-agent',
+              'x-algolia-referer': 'chat-widget',
+            },
+          },
+        });
+
+        await widget.chatInstance.sendMessage({ text: 'hello' });
+
+        const { headers } = getRequestPayload();
+        expect(headers['x-algolia-application-id']).toBe('appId');
+        expect(headers['x-algolia-api-key']).toBe('apiKey');
+        expect(headers['x-algolia-agent']).toContain('; chat');
+        expect(headers['x-algolia-agent']).not.toBe('spoofed-agent');
+        expect(headers['x-algolia-referer']).toBe('chat-widget');
       });
 
       it('does not register `chat` on the search client user-agent', () => {

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -85,7 +85,7 @@ describe('connectChat', () => {
         },
       });
 
-      assertChatConnectorParams({
+      const legacyAgentWithTransportParams = assertChatConnectorParams({
         agentId: 'agentId',
         transport: { api: 'https://custom.api' },
       });
@@ -120,6 +120,10 @@ describe('connectChat', () => {
       });
       expect(agentParams.requestOptions?.headers).toEqual({
         'x-algolia-referer': 'chat-widget',
+      });
+      expect(legacyAgentWithTransportParams).toEqual({
+        agentId: 'agentId',
+        transport: { api: 'https://custom.api' },
       });
     });
   });

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -72,11 +72,12 @@ describe('connectChat', () => {
     });
 
     it('types requestOptions as agentId-only', () => {
-      const assertChatConnectorParams = (_params: ChatConnectorParams) =>
-        undefined;
+      const assertChatConnectorParams = <TParams extends ChatConnectorParams>(
+        params: TParams
+      ) => params;
       const customChat = undefined as unknown as Chat<UIMessage>;
 
-      assertChatConnectorParams({
+      const agentParams = assertChatConnectorParams({
         agentId: 'agentId',
         requestOptions: {
           queryParameters: { cache: false },
@@ -114,7 +115,12 @@ describe('connectChat', () => {
         },
       });
 
-      expect(true).toBe(true);
+      expect(agentParams.requestOptions?.queryParameters).toEqual({
+        cache: false,
+      });
+      expect(agentParams.requestOptions?.headers).toEqual({
+        'x-algolia-referer': 'chat-widget',
+      });
     });
   });
 
@@ -1466,17 +1472,16 @@ data: [DONE]`,
       return new Chat<UIMessage>({ transport: createMockTransport() });
     }
 
-    function createChatWidgetWithContext(
-      params: Omit<ChatConnectorParams<UIMessage>, 'transport' | 'agentId'> & {
-        chat: Chat<UIMessage>;
-      }
-    ) {
+    function createChatWidgetWithContext(params: {
+      chat: Chat<UIMessage>;
+      context?: ChatConnectorParams<UIMessage>['context'];
+    }) {
       const renderFn = jest.fn();
       const makeWidget = connectChat(renderFn);
       const widget = makeWidget({
         ...params,
         transport: { api: 'http://unused' },
-      } as ChatConnectorParams<UIMessage>);
+      });
       return { widget, renderFn };
     }
 

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -30,7 +30,7 @@ describe('connectChat', () => {
       ...(!('agentId' in widgetParams) ? { agentId: 'agentId' } : {}),
       disableTriggerValidation: true,
       ...widgetParams,
-    });
+    } as ChatConnectorParams);
 
     const helper = algoliasearchHelper(createSearchClient(), '');
 
@@ -69,6 +69,52 @@ describe('connectChat', () => {
           dispose: expect.any(Function),
         })
       );
+    });
+
+    it('types requestOptions as agentId-only', () => {
+      const assertChatConnectorParams = (_params: ChatConnectorParams) =>
+        undefined;
+      const customChat = undefined as unknown as Chat<UIMessage>;
+
+      assertChatConnectorParams({
+        agentId: 'agentId',
+        requestOptions: {
+          queryParameters: { cache: false },
+          headers: { 'x-algolia-referer': 'chat-widget' },
+        },
+      });
+
+      assertChatConnectorParams({
+        agentId: 'agentId',
+        transport: { api: 'https://custom.api' },
+      });
+
+      // @ts-expect-error requestOptions is only valid with agentId
+      assertChatConnectorParams({
+        transport: { api: 'https://custom.api' },
+        requestOptions: {
+          queryParameters: { cache: false },
+        },
+      });
+
+      // @ts-expect-error requestOptions is not valid when a custom transport is provided
+      assertChatConnectorParams({
+        agentId: 'agentId',
+        transport: { api: 'https://custom.api' },
+        requestOptions: {
+          queryParameters: { cache: false },
+        },
+      });
+
+      assertChatConnectorParams({
+        // @ts-expect-error requestOptions is not valid with a custom chat instance
+        chat: customChat,
+        requestOptions: {
+          queryParameters: { cache: false },
+        },
+      });
+
+      expect(true).toBe(true);
     });
   });
 
@@ -1060,8 +1106,9 @@ data: [DONE]`,
       });
 
       function getRequestPayload() {
-        const [, init] = fetchMock.mock.calls[0];
+        const [url, init] = fetchMock.mock.calls[0];
         return {
+          url: String(url),
           headers: init.headers as Record<string, string>,
           body: JSON.parse(init.body as string),
         };
@@ -1108,6 +1155,78 @@ data: [DONE]`,
         );
       });
 
+      it('sends persistent query parameters on agent requests', async () => {
+        const { widget } = getInitializedWidget({
+          agentId: 'agentId',
+          requestOptions: {
+            queryParameters: {
+              cache: false,
+              hitsPerPage: 4,
+              explain: true,
+              userToken: 'user-1',
+            },
+          },
+        });
+
+        await widget.chatInstance.sendMessage({ text: 'hello' });
+
+        const { url } = getRequestPayload();
+        const searchParams = new URL(url).searchParams;
+        expect(searchParams.get('compatibilityMode')).toBe('ai-sdk-5');
+        expect(searchParams.get('cache')).toBe('false');
+        expect(searchParams.get('hitsPerPage')).toBe('4');
+        expect(searchParams.get('explain')).toBe('true');
+        expect(searchParams.get('userToken')).toBe('user-1');
+      });
+
+      it('sends persistent headers on agent requests', async () => {
+        const { widget } = getInitializedWidget({
+          agentId: 'agentId',
+          requestOptions: {
+            headers: {
+              'x-algolia-referer': 'chat-widget',
+              'x-session-id': 'session-1',
+            },
+          },
+        });
+
+        await widget.chatInstance.sendMessage({ text: 'hello' });
+
+        const { headers } = getRequestPayload();
+        expect(headers).toEqual(
+          expect.objectContaining({
+            'x-algolia-application-id': 'appId',
+            'x-algolia-api-key': 'apiKey',
+            'x-algolia-referer': 'chat-widget',
+            'x-session-id': 'session-1',
+          })
+        );
+      });
+
+      it('sends persistent Headers instance on agent requests', async () => {
+        const { widget } = getInitializedWidget({
+          agentId: 'agentId',
+          requestOptions: {
+            headers: new Headers({
+              'x-algolia-referer': 'chat-widget',
+              'x-session-id': 'session-1',
+            }),
+          },
+        });
+
+        await widget.chatInstance.sendMessage({ text: 'hello' });
+
+        const { headers } = getRequestPayload();
+        expect(headers).toEqual(
+          expect.objectContaining({
+            'x-algolia-application-id': 'appId',
+            'x-algolia-api-key': 'apiKey',
+            'x-algolia-referer': 'chat-widget',
+            'x-session-id': 'session-1',
+          })
+        );
+      });
+
       it('does not register `chat` on the search client user-agent', () => {
         const addAlgoliaAgent = jest.fn();
         const client = Object.assign(createSearchClient(), {
@@ -1147,6 +1266,41 @@ data: [DONE]`,
         });
       });
 
+      it('lets per-call headers override persistent headers for one request', async () => {
+        const { widget } = getInitializedWidget({
+          agentId: 'agentId',
+          requestOptions: {
+            headers: {
+              'x-algolia-referer': 'chat-widget',
+            },
+          },
+        });
+
+        await widget.chatInstance.sendMessage(
+          { text: 'hello' },
+          { headers: { 'x-algolia-referer': 'prompt-suggestions' } }
+        );
+        await widget.chatInstance.sendMessage({ text: 'follow-up' });
+
+        const firstHeaders = fetchMock.mock.calls[0][1].headers as Record<
+          string,
+          string
+        >;
+        const secondHeaders = fetchMock.mock.calls[1][1].headers as Record<
+          string,
+          string
+        >;
+
+        expect(firstHeaders).toHaveProperty(
+          'x-algolia-referer',
+          'prompt-suggestions'
+        );
+        expect(secondHeaders).toHaveProperty(
+          'x-algolia-referer',
+          'chat-widget'
+        );
+      });
+
       it('does not carry over the x-algolia-referer to follow-up messages', async () => {
         const { widget } = getInitializedWidget({ agentId: 'agentId' });
 
@@ -1172,13 +1326,33 @@ data: [DONE]`,
         expect(secondHeaders).not.toHaveProperty('x-algolia-referer');
       });
 
+      it('forces cache=false when regenerating with persistent cache query parameter', async () => {
+        const { widget } = getInitializedWidget({
+          agentId: 'agentId',
+          requestOptions: {
+            queryParameters: {
+              cache: true,
+            },
+          },
+        });
+
+        await widget.chatInstance.regenerate();
+
+        const { url } = getRequestPayload();
+        expect(new URL(url).searchParams.get('cache')).toBe('false');
+      });
+
       it('does not duplicate transport metadata in the request body', async () => {
         const { widget } = getInitializedWidget({ agentId: 'agentId' });
 
         await widget.chatInstance.sendMessage({ text: 'hello' });
 
         const { body } = getRequestPayload();
-        expect(Object.keys(body).sort()).toEqual(['id', 'messageId', 'messages']);
+        expect(Object.keys(body).sort()).toEqual([
+          'id',
+          'messageId',
+          'messages',
+        ]);
         expect(body).not.toHaveProperty('headers');
         expect(body).not.toHaveProperty('api');
         expect(body).not.toHaveProperty('credentials');
@@ -1260,7 +1434,7 @@ data: [DONE]`,
       const widget = makeWidget({
         ...params,
         transport: { api: 'http://unused' },
-      });
+      } as ChatConnectorParams<UIMessage>);
       return { widget, renderFn };
     }
 

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -509,12 +509,14 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           const api = new URL(
             `https://${appId}.algolia.net/agent-studio/1/agents/${agentId}/completions`
           );
+          const queryParameters: Record<string, string | number | boolean> = {
+            ...options.requestOptions?.queryParameters,
+            compatibilityMode: 'ai-sdk-5',
+            ...(bypassCache ? { cache: false } : {}),
+          };
+
           api.search = new URLSearchParams(
-            Object.entries({
-              ...options.requestOptions?.queryParameters,
-              compatibilityMode: 'ai-sdk-5',
-              ...(bypassCache ? { cache: false } : {}),
-            }).map(([key, value]) => [key, String(value)])
+            queryParameters as Record<string, string>
           ).toString();
           return api.toString();
         };

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -122,18 +122,41 @@ export type ChatInitWithoutTransport<TUiMessage extends UIMessage> = Omit<
   'transport'
 >;
 
-export type ChatTransport = {
-  transport?: ConstructorParameters<typeof DefaultChatTransport>[0];
-} & (
+export type ChatAgentRequestOptions = {
+  queryParameters?: Record<string, string | number | boolean>;
+  headers?: Record<string, string> | Headers;
+};
+
+export type ChatTransport =
   | {
       agentId: string;
+      transport?: never;
+      requestOptions?: ChatAgentRequestOptions;
       /**
        * Whether to enable feedback (thumbs up/down) on assistant messages.
        */
       feedback?: boolean;
     }
-  | { agentId?: undefined; feedback?: never }
-);
+  | {
+      agentId: string;
+      transport?: ConstructorParameters<typeof DefaultChatTransport>[0];
+      feedback?: boolean;
+      requestOptions?: never;
+    }
+  | {
+      agentId?: undefined;
+      transport?: ConstructorParameters<typeof DefaultChatTransport>[0];
+      feedback?: never;
+      requestOptions?: never;
+    };
+
+export type ChatCustomInstance<TUiMessage extends UIMessage> = {
+  chat: Chat<TUiMessage>;
+  agentId?: undefined;
+  transport?: ConstructorParameters<typeof DefaultChatTransport>[0];
+  feedback?: never;
+  requestOptions?: never;
+};
 
 export type ApplyFiltersParams = {
   query?: string;
@@ -144,7 +167,7 @@ export type ChatInit<TUiMessage extends UIMessage> =
   ChatInitWithoutTransport<TUiMessage> & ChatTransport;
 
 export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
-  | { chat: Chat<TUiMessage> }
+  | ChatCustomInstance<TUiMessage>
   | ChatInit<TUiMessage>
 ) & {
   /**
@@ -473,20 +496,43 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           );
         }
 
-        const baseApi = `https://${appId}.algolia.net/agent-studio/1/agents/${agentId}/completions?compatibilityMode=ai-sdk-5`;
+        const createApi = ({ bypassCache = false } = {}) => {
+          const api = new URL(
+            `https://${appId}.algolia.net/agent-studio/1/agents/${agentId}/completions`
+          );
+          api.searchParams.set('compatibilityMode', 'ai-sdk-5');
+          Object.entries(options.requestOptions?.queryParameters || {}).forEach(
+            ([key, value]) => {
+              api.searchParams.set(key, String(value));
+            }
+          );
+          if (bypassCache) {
+            api.searchParams.set('cache', 'false');
+          }
+          return api.toString();
+        };
+        const baseApi = createApi();
         transport = new DefaultChatTransport({
           api: baseApi,
           headers: {
             'x-algolia-application-id': appId,
             'x-algolia-api-key': apiKey,
             'x-algolia-agent': `${getAlgoliaAgent(client)}; chat`,
+            ...(options.requestOptions?.headers instanceof Headers
+              ? Object.fromEntries(options.requestOptions.headers.entries())
+              : options.requestOptions?.headers),
           },
-          prepareSendMessagesRequest: ({ id, messages, trigger, messageId }) => {
+          prepareSendMessagesRequest: ({
+            id,
+            messages,
+            trigger,
+            messageId,
+          }) => {
             return {
               // Bypass cache when regenerating to ensure fresh responses
               api:
                 trigger === 'regenerate-message'
-                  ? `${baseApi}&cache=false`
+                  ? createApi({ bypassCache: true })
                   : baseApi,
               body: {
                 id,

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -505,19 +505,17 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           );
         }
 
-        const createApi = ({ bypassCache = false } = {}) => {
+        const createApi = (bypassCache = false) => {
           const api = new URL(
             `https://${appId}.algolia.net/agent-studio/1/agents/${agentId}/completions`
           );
-          Object.entries(options.requestOptions?.queryParameters || {}).forEach(
-            ([key, value]) => {
-              api.searchParams.set(key, String(value));
-            }
-          );
-          api.searchParams.set('compatibilityMode', 'ai-sdk-5');
-          if (bypassCache) {
-            api.searchParams.set('cache', 'false');
-          }
+          api.search = new URLSearchParams(
+            Object.entries({
+              ...options.requestOptions?.queryParameters,
+              compatibilityMode: 'ai-sdk-5',
+              ...(bypassCache ? { cache: false } : {}),
+            }).map(([key, value]) => [key, String(value)])
+          ).toString();
           return api.toString();
         };
         const baseApi = createApi();
@@ -541,10 +539,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           }) => {
             return {
               // Bypass cache when regenerating to ensure fresh responses
-              api:
-                trigger === 'regenerate-message'
-                  ? createApi({ bypassCache: true })
-                  : baseApi,
+              api: trigger === 'regenerate-message' ? createApi(true) : baseApi,
               body: {
                 id,
                 messageId,

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -123,7 +123,13 @@ export type ChatInitWithoutTransport<TUiMessage extends UIMessage> = Omit<
 >;
 
 export type ChatAgentRequestOptions = {
+  /**
+   * Query parameters to send with built-in Agent Studio completion requests.
+   */
   queryParameters?: Record<string, string | number | boolean>;
+  /**
+   * Headers to send with built-in Agent Studio completion requests.
+   */
   headers?: Record<string, string> | Headers;
 };
 
@@ -131,6 +137,9 @@ export type ChatTransport =
   | {
       agentId: string;
       transport?: never;
+      /**
+       * Request options to send with built-in Agent Studio completion requests.
+       */
       requestOptions?: ChatAgentRequestOptions;
       /**
        * Whether to enable feedback (thumbs up/down) on assistant messages.
@@ -500,12 +509,12 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           const api = new URL(
             `https://${appId}.algolia.net/agent-studio/1/agents/${agentId}/completions`
           );
-          api.searchParams.set('compatibilityMode', 'ai-sdk-5');
           Object.entries(options.requestOptions?.queryParameters || {}).forEach(
             ([key, value]) => {
               api.searchParams.set(key, String(value));
             }
           );
+          api.searchParams.set('compatibilityMode', 'ai-sdk-5');
           if (bypassCache) {
             api.searchParams.set('cache', 'false');
           }
@@ -515,12 +524,14 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
         transport = new DefaultChatTransport({
           api: baseApi,
           headers: {
-            'x-algolia-application-id': appId,
-            'x-algolia-api-key': apiKey,
-            'x-algolia-agent': `${getAlgoliaAgent(client)}; chat`,
             ...(options.requestOptions?.headers instanceof Headers
               ? Object.fromEntries(options.requestOptions.headers.entries())
               : options.requestOptions?.headers),
+            // Preserve the required Algolia identity headers and chat agent
+            // marker, even when requestOptions.headers contains the same keys.
+            'x-algolia-application-id': appId,
+            'x-algolia-api-key': apiKey,
+            'x-algolia-agent': `${getAlgoliaAgent(client)}; chat`,
           },
           prepareSendMessagesRequest: ({
             id,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->


**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

[FX-3833](https://algolia.atlassian.net/browse/FX-3833)

Adds `requestOptions` for built-in `agentId` chat requests so consumers can pass persistent query parameters and headers to Agent Studio completion requests.

This is scoped to the built-in Agent Studio path only:
- supports `queryParameters`
- supports `headers`
- rejects `requestOptions` with custom `transport` or custom `chat`
- keeps body, metadata, resume/reconnect and custom transport behavior out of scope

Regenerate still forces `cache=false`.

**Documentation**

FX-3833 also includes a documentation update. The documentation source lives in `algolia/docs-new`, so this InstantSearch PR keeps the implementation scoped and the docs-new follow-up should verify/update the generated chat widget API docs for `requestOptions`.

**Test plan**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

- [x] Focused connector tests for persistent query parameters
- [x] Focused connector tests for object headers and `Headers`
- [x] Per-call headers override persistent headers for one request
- [x] Regenerate keeps `cache=false`
- [x] `yarn jest packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts --runInBand`
- [x] Prettier check
- [x] `git diff --check`
- [x] `yarn lint:changed`


[FX-3833]: https://algolia.atlassian.net/browse/FX-3833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ