### PR TITLE
chore: stop locking architecture refactor issues

### DIFF
--- a/.github/workflows/architecture-refactor.yml
+++ b/.github/workflows/architecture-refactor.yml
@@ -126,14 +126,8 @@ jobs:
           )"
           issue_number="${issue_url##*/}"
 
-          gh api \
-            --method PUT \
-            "repos/${GH_REPO}/issues/${issue_number}/lock" \
-            -f lock_reason=resolved \
-            >/dev/null
-
           echo "issue_url=${issue_url}" >> "$GITHUB_OUTPUT"
-          echo "Created and locked ${issue_url}"
+          echo "Created ${issue_url}"
 
       - name: Comment implementation started
         if: steps.request.outputs.stage == 'implement'


### PR DESCRIPTION
**Summary**

Stop locking architecture refactor scout issues after creation so the workflow can post status comments normally.