### PR TITLE
feat(stats): announce result changes to screen readers

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
-      "maxSize": "275 kB"
+      "maxSize": "280 kB"
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "102.5 kB"
+      "maxSize": "103 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/packages/instantsearch.js/src/components/Stats/Stats.tsx
+++ b/packages/instantsearch.js/src/components/Stats/Stats.tsx
@@ -2,7 +2,9 @@
 
 import { cx } from 'instantsearch-ui-components';
 import { h } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
 
+import { formatNumber } from '../../lib/formatNumber';
 import Template from '../Template/Template';
 
 import type { ComponentCSSClasses } from '../../types';
@@ -31,33 +33,111 @@ type StatsProps = {
   query: string;
 };
 
+// Delay before announcing an update, so that rapid changes (e.g. typing in the
+// search box) settle into a single announcement instead of piling up. Mirrors
+// the debounce used by GOV.UK's accessible-autocomplete.
+const ANNOUNCEMENT_DELAY = 1400;
+
+const visuallyHiddenStyle = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+} as const;
+
+// Result count without the volatile details (such as the processing time) that
+// are part of the visible text, so that only the meaningful count is announced.
+function getAnnouncement(
+  nbHits: number,
+  nbSortedHits: number | undefined,
+  areHitsSorted: boolean
+) {
+  if (areHitsSorted) {
+    const suffix = `sorted out of ${formatNumber(nbHits)}`;
+
+    if (nbSortedHits === 0) {
+      return `No relevant results ${suffix}`;
+    }
+    if (nbSortedHits === 1) {
+      return `1 relevant result ${suffix}`;
+    }
+    return `${formatNumber(nbSortedHits || 0)} relevant results ${suffix}`;
+  }
+
+  if (nbHits === 0) {
+    return 'No results';
+  }
+  if (nbHits === 1) {
+    return '1 result';
+  }
+  return `${formatNumber(nbHits)} results`;
+}
+
 const Stats = ({
   nbHits,
   nbSortedHits,
+  areHitsSorted,
   cssClasses,
   templateProps,
   ...rest
-}: StatsProps) => (
-  <div className={cx(cssClasses.root)}>
-    <Template
-      {...templateProps}
-      templateKey="text"
-      rootTagName="span"
-      rootProps={{ className: cssClasses.text }}
-      data={{
-        hasManySortedResults: nbSortedHits && nbSortedHits > 1,
-        hasNoSortedResults: nbSortedHits === 0,
-        hasOneSortedResults: nbSortedHits === 1,
-        hasManyResults: nbHits > 1,
-        hasNoResults: nbHits === 0,
-        hasOneResult: nbHits === 1,
-        nbHits,
-        nbSortedHits,
-        cssClasses,
-        ...rest,
-      }}
-    />
-  </div>
-);
+}: StatsProps) => {
+  const nextAnnouncement = getAnnouncement(nbHits, nbSortedHits, areHitsSorted);
+  const [announcement, setAnnouncement] = useState('');
+  const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const isInitialRef = useRef(true);
+
+  useEffect(() => {
+    // Don't announce the initial results, only subsequent changes.
+    if (isInitialRef.current) {
+      isInitialRef.current = false;
+      return undefined;
+    }
+
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      setAnnouncement(nextAnnouncement);
+    }, ANNOUNCEMENT_DELAY);
+
+    return () => clearTimeout(timerRef.current);
+  }, [nextAnnouncement]);
+
+  return (
+    <div className={cx(cssClasses.root)}>
+      <Template
+        {...templateProps}
+        templateKey="text"
+        rootTagName="span"
+        rootProps={{ className: cssClasses.text }}
+        data={{
+          hasManySortedResults: nbSortedHits && nbSortedHits > 1,
+          hasNoSortedResults: nbSortedHits === 0,
+          hasOneSortedResults: nbSortedHits === 1,
+          hasManyResults: nbHits > 1,
+          hasNoResults: nbHits === 0,
+          hasOneResult: nbHits === 1,
+          nbHits,
+          nbSortedHits,
+          areHitsSorted,
+          cssClasses,
+          ...rest,
+        }}
+      />
+      <span
+        className="ais-Stats-announcement"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={visuallyHiddenStyle}
+      >
+        {announcement}
+      </span>
+    </div>
+  );
+};
 
 export default Stats;

--- a/packages/instantsearch.js/src/components/Stats/__tests__/Stats-test.tsx
+++ b/packages/instantsearch.js/src/components/Stats/__tests__/Stats-test.tsx
@@ -4,7 +4,7 @@
 /** @jsx h */
 
 import { mount } from '@instantsearch/testutils/enzyme';
-import { render } from '@testing-library/preact';
+import { act, render } from '@testing-library/preact';
 import { h } from 'preact';
 
 import createHelpers from '../../../lib/createHelpers';
@@ -39,6 +39,25 @@ describe('Stats', () => {
           dangerouslySetInnerHTML={
             {
               "__html": "1,234 results found in 42ms",
+            }
+          }
+        />
+        <span
+          aria-atomic="true"
+          aria-live="polite"
+          className="ais-Stats-announcement"
+          role="status"
+          style={
+            {
+              "border": 0,
+              "clip": "rect(0, 0, 0, 0)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": 0,
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
             }
           }
         />
@@ -125,6 +144,40 @@ describe('Stats', () => {
         No relevant results sorted out of 1,234 found in 42ms
       </span>
     `);
+  });
+
+  it('announces the trimmed count after a debounce when results change', () => {
+    jest.useFakeTimers();
+
+    try {
+      const { container, rerender } = render(
+        <Stats {...getProps()} templateProps={{ templates: defaultTemplates }} />
+      );
+
+      const region = container.querySelector('.ais-Stats-announcement');
+
+      // Initial results are not announced.
+      expect(region).toHaveTextContent('');
+      expect(region!.textContent).toBe('');
+
+      rerender(
+        <Stats
+          {...getProps({ nbHits: 5 })}
+          templateProps={{ templates: defaultTemplates }}
+        />
+      );
+
+      // Still empty before the debounce elapses.
+      expect(region!.textContent).toBe('');
+
+      act(() => {
+        jest.advanceTimersByTime(1400);
+      });
+
+      expect(region).toHaveTextContent('5 results');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   function getProps(extraProps = {}) {

--- a/packages/instantsearch.js/src/widgets/panel/__tests__/panel.test.tsx
+++ b/packages/instantsearch.js/src/widgets/panel/__tests__/panel.test.tsx
@@ -64,6 +64,15 @@ describe('panel', () => {
                   >
                     10 results found in 0ms
                   </span>
+                  <span
+                    aria-atomic="true"
+                    aria-live="polite"
+                    class="ais-Stats-announcement"
+                    role="status"
+                    style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+                  >
+                    
+                  </span>
                 </div>
               </div>
             </div>
@@ -142,6 +151,15 @@ describe('panel', () => {
                     class="ais-Stats-text"
                   >
                     10 results found in 0ms
+                  </span>
+                  <span
+                    aria-atomic="true"
+                    aria-live="polite"
+                    class="ais-Stats-announcement"
+                    role="status"
+                    style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+                  >
+                    
                   </span>
                 </div>
               </div>
@@ -233,6 +251,15 @@ describe('panel', () => {
                     class="ais-Stats-text"
                   >
                     10 results found in 0ms
+                  </span>
+                  <span
+                    aria-atomic="true"
+                    aria-live="polite"
+                    class="ais-Stats-announcement"
+                    role="status"
+                    style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+                  >
+                    
                   </span>
                 </div>
               </div>

--- a/packages/instantsearch.js/src/widgets/stats/__tests__/stats.test.tsx
+++ b/packages/instantsearch.js/src/widgets/stats/__tests__/stats.test.tsx
@@ -98,6 +98,15 @@ describe('stats', () => {
             >
               2 results found in 0ms
             </span>
+            <span
+              aria-atomic="true"
+              aria-live="polite"
+              class="ais-Stats-announcement"
+              role="status"
+              style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+            >
+              
+            </span>
           </div>
         </div>
       `);
@@ -117,6 +126,15 @@ describe('stats', () => {
               class="ais-Stats-text"
             >
               No results found in 0ms
+            </span>
+            <span
+              aria-atomic="true"
+              aria-live="polite"
+              class="ais-Stats-announcement"
+              role="status"
+              style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+            >
+              
             </span>
           </div>
         </div>
@@ -178,6 +196,15 @@ describe('stats', () => {
                 ms
               </span>
             </span>
+            <span
+              aria-atomic="true"
+              aria-live="polite"
+              class="ais-Stats-announcement"
+              role="status"
+              style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+            >
+              
+            </span>
           </div>
         </div>
       `);
@@ -199,6 +226,15 @@ describe('stats', () => {
               <span>
                 No results
               </span>
+            </span>
+            <span
+              aria-atomic="true"
+              aria-live="polite"
+              class="ais-Stats-announcement"
+              role="status"
+              style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+            >
+              
             </span>
           </div>
         </div>
@@ -262,6 +298,15 @@ describe('stats', () => {
                 ms
               </span>
             </span>
+            <span
+              aria-atomic="true"
+              aria-live="polite"
+              class="ais-Stats-announcement"
+              role="status"
+              style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+            >
+              
+            </span>
           </div>
         </div>
       `);
@@ -283,6 +328,15 @@ describe('stats', () => {
               <span>
                 No results
               </span>
+            </span>
+            <span
+              aria-atomic="true"
+              aria-live="polite"
+              class="ais-Stats-announcement"
+              role="status"
+              style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+            >
+              
             </span>
           </div>
         </div>

--- a/packages/react-instantsearch/src/ui/Stats.tsx
+++ b/packages/react-instantsearch/src/ui/Stats.tsx
@@ -1,5 +1,5 @@
 import { cx } from 'instantsearch-ui-components';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 export type StatsProps = React.ComponentProps<'div'> & {
   nbHits: number;
@@ -9,6 +9,12 @@ export type StatsProps = React.ComponentProps<'div'> & {
   classNames?: Partial<StatsClassNames>;
   translations: {
     rootElementText: StatsTranslations;
+    /**
+     * Text announced to assistive technologies when the results change. It
+     * omits volatile details (such as the processing time) so that only the
+     * meaningful result count is spoken.
+     */
+    announcementText?: StatsTranslations;
   };
 };
 
@@ -24,6 +30,23 @@ export type StatsClassNames = {
    * Class names to apply to the root element
    */
   root: string;
+};
+
+// Delay before announcing an update, so that rapid changes (e.g. typing in the
+// search box) settle into a single announcement instead of piling up. Mirrors
+// the debounce used by GOV.UK's accessible-autocomplete.
+const ANNOUNCEMENT_DELAY = 1400;
+
+const visuallyHiddenStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
 };
 
 export function Stats({
@@ -42,6 +65,28 @@ export function Stats({
     areHitsSorted,
   };
 
+  const nextAnnouncement = translations.announcementText
+    ? translations.announcementText(translationOptions)
+    : '';
+  const [announcement, setAnnouncement] = useState('');
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const isInitialRef = useRef(true);
+
+  useEffect(() => {
+    // Don't announce the initial results, only subsequent changes.
+    if (isInitialRef.current) {
+      isInitialRef.current = false;
+      return undefined;
+    }
+
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      setAnnouncement(nextAnnouncement);
+    }, ANNOUNCEMENT_DELAY);
+
+    return () => clearTimeout(timerRef.current);
+  }, [nextAnnouncement]);
+
   return (
     <div
       {...props}
@@ -49,6 +94,15 @@ export function Stats({
     >
       <span className="ais-Stats-text">
         {translations.rootElementText(translationOptions)}
+      </span>
+      <span
+        className="ais-Stats-announcement"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={visuallyHiddenStyle}
+      >
+        {announcement}
       </span>
     </div>
   );

--- a/packages/react-instantsearch/src/ui/__tests__/Stats.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/Stats.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import React from 'react';
 
 import { Stats } from '../Stats';
@@ -36,17 +36,24 @@ describe('Stats', () => {
     const { container } = render(<Stats {...props} />);
 
     expect(container).toMatchInlineSnapshot(`
-    <div>
-      <div
-        class="ais-Stats"
-      >
-        <span
-          class="ais-Stats-text"
+      <div>
+        <div
+          class="ais-Stats"
         >
-          100 results found in 10ms
-        </span>
+          <span
+            class="ais-Stats-text"
+          >
+            100 results found in 10ms
+          </span>
+          <span
+            aria-atomic="true"
+            aria-live="polite"
+            class="ais-Stats-announcement"
+            role="status"
+            style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+          />
+        </div>
       </div>
-    </div>
     `);
   });
 
@@ -61,17 +68,24 @@ describe('Stats', () => {
     );
 
     expect(container).toMatchInlineSnapshot(`
-    <div>
-      <div
-        class="ais-Stats ROOT MyCustomStats"
-      >
-        <span
-          class="ais-Stats-text"
+      <div>
+        <div
+          class="ais-Stats ROOT MyCustomStats"
         >
-          100 results found in 10ms
-        </span>
+          <span
+            class="ais-Stats-text"
+          >
+            100 results found in 10ms
+          </span>
+          <span
+            aria-atomic="true"
+            aria-live="polite"
+            class="ais-Stats-announcement"
+            role="status"
+            style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+          />
+        </div>
       </div>
-    </div>
     `);
   });
 
@@ -82,17 +96,24 @@ describe('Stats', () => {
     );
 
     expect(container).toMatchInlineSnapshot(`
-    <div>
-      <div
-        class="ais-Stats MyCustomStats"
-      >
-        <span
-          class="ais-Stats-text"
+      <div>
+        <div
+          class="ais-Stats MyCustomStats"
         >
-          100 results found in 10ms
-        </span>
+          <span
+            class="ais-Stats-text"
+          >
+            100 results found in 10ms
+          </span>
+          <span
+            aria-atomic="true"
+            aria-live="polite"
+            class="ais-Stats-announcement"
+            role="status"
+            style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+          />
+        </div>
       </div>
-    </div>
     `);
   });
 
@@ -101,17 +122,24 @@ describe('Stats', () => {
     const { container } = render(<Stats {...props} />);
 
     expect(container).toMatchInlineSnapshot(`
-    <div>
-      <div
-        class="ais-Stats"
-      >
-        <span
-          class="ais-Stats-text"
+      <div>
+        <div
+          class="ais-Stats"
         >
-          50 relevant results sorted out of 100 found in 10ms
-        </span>
+          <span
+            class="ais-Stats-text"
+          >
+            50 relevant results sorted out of 100 found in 10ms
+          </span>
+          <span
+            aria-atomic="true"
+            aria-live="polite"
+            class="ais-Stats-announcement"
+            role="status"
+            style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+          />
+        </div>
       </div>
-    </div>
     `);
   });
 
@@ -135,6 +163,13 @@ describe('Stats', () => {
           >
             100 results found in 10ms
           </span>
+          <span
+            aria-atomic="true"
+            aria-live="polite"
+            class="ais-Stats-announcement"
+            role="status"
+            style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+          />
         </div>
       </div>
     `);
@@ -171,5 +206,39 @@ describe('Stats', () => {
     rerender(<Stats {...props} />);
 
     expect(getByText('Sorted')).toBeInTheDocument();
+  });
+
+  test('announces the trimmed count after a debounce when results change', () => {
+    jest.useFakeTimers();
+
+    try {
+      const translations = {
+        rootElementText: ({ nbHits }: StatsTranslationOptions) =>
+          `${nbHits} results found`,
+        announcementText: ({ nbHits }: StatsTranslationOptions) =>
+          `${nbHits} results`,
+      };
+
+      const props = createProps({ nbHits: 100, translations });
+      const { container, rerender } = render(<Stats {...props} />);
+
+      const region = container.querySelector('.ais-Stats-announcement');
+
+      // Initial results are not announced.
+      expect(region).toBeEmptyDOMElement();
+
+      rerender(<Stats {...createProps({ nbHits: 5, translations })} />);
+
+      // Still empty before the debounce elapses.
+      expect(region).toBeEmptyDOMElement();
+
+      act(() => {
+        jest.advanceTimersByTime(1400);
+      });
+
+      expect(region).toHaveTextContent('5 results');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/packages/react-instantsearch/src/widgets/Stats.tsx
+++ b/packages/react-instantsearch/src/widgets/Stats.tsx
@@ -40,6 +40,11 @@ export function Stats({ translations, ...props }: StatsProps) {
             : getResultsSentence(options)
         } found in ${options.processingTimeMS.toLocaleString()}ms`;
       },
+      announcementText(options: StatsTranslationOptions) {
+        return options.areHitsSorted
+          ? getSortedResultsSentence(options)
+          : getResultsSentence(options);
+      },
       ...translations,
     },
   };

--- a/packages/react-instantsearch/src/widgets/__tests__/Stats.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Stats.test.tsx
@@ -28,15 +28,22 @@ describe('Stats', () => {
 
     await waitFor(() => {
       expect(container.querySelector('.ais-Stats')).toMatchInlineSnapshot(`
-      <div
-        class="ais-Stats"
-      >
-        <span
-          class="ais-Stats-text"
+        <div
+          class="ais-Stats"
         >
-          Nice stats
-        </span>
-      </div>
+          <span
+            class="ais-Stats-text"
+          >
+            Nice stats
+          </span>
+          <span
+            aria-atomic="true"
+            aria-live="polite"
+            class="ais-Stats-announcement"
+            role="status"
+            style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+          />
+        </div>
       `);
     });
   });

--- a/packages/vue-instantsearch/src/components/Stats.vue
+++ b/packages/vue-instantsearch/src/components/Stats.vue
@@ -12,6 +12,14 @@
         > found in {{ state.processingTimeMS.toLocaleString() }}ms</span
       >
     </slot>
+    <span
+      :class="suit('announcement')"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      :style="visuallyHiddenStyle"
+      >{{ announcement }}</span
+    >
   </div>
 </template>
 
@@ -20,6 +28,12 @@ import { connectStats } from 'instantsearch.js/es/connectors/index';
 
 import { createSuitMixin } from '../mixins/suit';
 import { createWidgetMixin } from '../mixins/widget';
+import { isVue3 } from '../util/vue-compat';
+
+// Delay before announcing an update, so that rapid changes (e.g. typing in the
+// search box) settle into a single announcement instead of piling up. Mirrors
+// the debounce used by GOV.UK's accessible-autocomplete.
+const ANNOUNCEMENT_DELAY = 1400;
 
 export default {
   name: 'AisStats',
@@ -32,7 +46,54 @@ export default {
     ),
     createSuitMixin({ name: 'Stats' }),
   ],
+  data() {
+    return {
+      announcement: '',
+      announcementTimer: undefined,
+      isInitialAnnouncement: true,
+      visuallyHiddenStyle: {
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        padding: 0,
+        margin: '-1px',
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        border: 0,
+      },
+    };
+  },
+  [isVue3 ? 'beforeUnmount' : 'beforeDestroy']() {
+    clearTimeout(this.announcementTimer);
+  },
+  watch: {
+    announcementText(next) {
+      // Don't announce the initial results, only subsequent changes.
+      if (this.isInitialAnnouncement) {
+        this.isInitialAnnouncement = false;
+        return;
+      }
+
+      clearTimeout(this.announcementTimer);
+      this.announcementTimer = setTimeout(() => {
+        this.announcement = next;
+      }, ANNOUNCEMENT_DELAY);
+    },
+  },
   computed: {
+    // Result count without the volatile details (such as the processing time)
+    // that are part of the visible text, so that only the meaningful count is
+    // announced.
+    announcementText() {
+      if (!this.state) {
+        return '';
+      }
+
+      return this.state.areHitsSorted
+        ? this.sortedResultsSentence
+        : this.resultsSentence;
+    },
     sortedResultsSentence() {
       const { nbHits, nbSortedHits } = this.state;
 

--- a/packages/vue-instantsearch/src/components/__tests__/Stats.js
+++ b/packages/vue-instantsearch/src/components/__tests__/Stats.js
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { mount, nextTick } from '../../../test/utils';
+import { __setState } from '../../mixins/widget';
+import Stats from '../Stats.vue';
+
+jest.mock('../../mixins/widget');
+
+const makeState = (nbHits) => ({
+  nbHits,
+  nbSortedHits: nbHits,
+  areHitsSorted: false,
+  processingTimeMS: 10,
+  instantSearchInstance: { helper: { lastResults: {} } },
+});
+
+describe('AisStats', () => {
+  beforeEach(() => {
+    __setState(null);
+  });
+
+  it('announces the trimmed count after a debounce when results change', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const wrapper = mount(Stats);
+
+      // The initial results (first population of `state`) are not announced.
+      wrapper.vm.state = makeState(100);
+      await nextTick();
+
+      const region = wrapper.find('.ais-Stats-announcement');
+      expect(region.text()).toBe('');
+
+      // A subsequent change to the results should be announced.
+      wrapper.vm.state = makeState(5);
+      await nextTick();
+
+      // Still empty before the debounce elapses.
+      expect(region.text()).toBe('');
+
+      jest.advanceTimersByTime(1400);
+      await nextTick();
+
+      expect(region.text()).toBe('5 results');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/tests/common/widgets/stats/options.ts
+++ b/tests/common/widgets/stats/options.ts
@@ -85,6 +85,13 @@ export function createOptionsTests(
           >
             No results found in 0ms
           </span>
+          <span
+            aria-atomic="true"
+            aria-live="polite"
+            class="ais-Stats-announcement"
+            role="status"
+            style="position: absolute; width: 1px; height: 1px; padding: 0px; margin: -1px; overflow: hidden; clip: rect(0px, 0px, 0px, 0px); white-space: nowrap; border: 0px;"
+          />
         </div>
       `
       );


### PR DESCRIPTION
## Summary

Addresses **item 1** of #7098.

The `Stats` widget renders the result count as static text, so screen reader users get no signal when a query or filter changes the number of results (**WCAG 4.1.3 Status Messages, AA**).

## Why not just put `role="status"` on `.ais-Stats`

The obvious fix — making the visible text a live region — has real downsides, confirmed by [Scott O'Hara's "Are we live?"](https://www.scottohara.me/blog/2022/02/05/dynamic-results.html) and by checking what shipping libraries actually do:

- It re-announces **noise** like "…found in 5ms" (a `role=status` is atomic).
- It fires on **every keystroke** (the default SearchBox searches as-you-type).
- It can even announce when **only the processing time changed** and the count did not.

I verified real implementations: **GOV.UK accessible-autocomplete** and **Downshift** both use a *separate visually-hidden* `polite`/`role=status` region announcing a *trimmed* count, debounced; **React Aria** does the same (assertive `role=log`). None make a visible element the live region. (Algolia's own `autocomplete-js`/DocSearch ship no announcement at all.)

## What this does (the GDS pattern)

A dedicated **visually-hidden** live region inside `.ais-Stats`:

```html
<span class="ais-Stats-announcement" role="status" aria-live="polite" aria-atomic="true" style="…sr-only…"></span>
```

- Announces **only the trimmed count** — "1,234 results" / "1 result" / "No results" (and the relevant-sort variants) — never the processing time.
- **Debounced 1400ms** (same as accessible-autocomplete), so typing settles into one announcement instead of piling up.
- **Silent on initial load** — only subsequent changes are announced.
- The visible `.ais-Stats-text` is **unchanged**.

Implemented in all three flavors (instantsearch.js, react-instantsearch, vue-instantsearch), with a shared common-suite snapshot plus a per-flavor behavior test (initial-empty → change → debounce → announces trimmed count).

## Non-breaking

Additive markup only; no public API or class-name changes to existing elements (adds the `.ais-Stats-announcement` element). Snapshots updated.

### Notes / possible follow-ups
- The article also recommends `aria-describedby` on the search input ("results update as you type") and an assertive announcement reserved for "no results". Those are SearchBox-level concerns, out of scope here — could be a follow-up.
- The announced string uses a sensible default phrasing; in React it's overridable via `translations.announcementText`. JS/Vue use the default (customizing the visible text template/slot doesn't change the announcement).

Refs #7098

🤖 Generated with [Claude Code](https://claude.com/claude-code)