### PR TITLE
feat(refinement-list): allow a custom accessible name for the show more button

### DIFF
--- a/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
@@ -66,6 +66,7 @@ export type RefinementListProps<TTemplates extends Templates> = {
   templateProps: PreparedTemplateProps<TTemplates>;
   toggleRefinement: (value: string) => void;
   showMore?: boolean;
+  showMoreButtonLabel?: string;
   toggleShowMore?: () => void;
   isShowingMore?: boolean;
   hasExhaustiveItems?: boolean;
@@ -320,6 +321,7 @@ class RefinementList<TTemplates extends Templates> extends Component<
           disabled: !this.props.canToggleShowMore,
           onClick: this.props.toggleShowMore,
           'aria-expanded': Boolean(this.props.isShowingMore),
+          'aria-label': this.props.showMoreButtonLabel,
         }}
         data={{
           isShowingMore: this.props.isShowingMore,

--- a/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
@@ -1165,6 +1165,37 @@ describe('refinementList', () => {
       `);
     });
   });
+
+  describe('showMoreButtonLabel', () => {
+    test('sets the aria-label on the show more button', async () => {
+      const container = document.createElement('div');
+      const searchClient = createMockedSearchClient();
+
+      const search = instantsearch({
+        indexName: 'indexName',
+        searchClient,
+      });
+
+      search.addWidgets([
+        refinementList({
+          container,
+          attribute: 'brand',
+          showMore: true,
+          showMoreButtonLabel: 'Show more brands',
+        }),
+      ]);
+
+      search.start();
+
+      await wait(0);
+
+      expect(
+        container
+          .querySelector('.ais-RefinementList-showMore')
+          ?.getAttribute('aria-label')
+      ).toEqual('Show more brands');
+    });
+  });
 });
 
 function createMockedSearchClient() {

--- a/packages/instantsearch.js/src/widgets/refinement-list/refinement-list.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/refinement-list.tsx
@@ -204,6 +204,10 @@ export type RefinementListWidgetParams = {
    */
   searchableSelectOnSubmit?: boolean;
   /**
+   * Accessible name (aria-label) for the "Show more"/"Show less" toggle button.
+   */
+  showMoreButtonLabel?: string;
+  /**
    * Templates to use for the widget.
    */
   templates?: RefinementListTemplates;
@@ -221,6 +225,7 @@ const renderer =
     searchBoxTemplates,
     renderState,
     showMore,
+    showMoreButtonLabel,
     searchable,
     searchablePlaceholder,
     searchableIsAlwaysActive,
@@ -235,6 +240,7 @@ const renderer =
     templates: RefinementListOwnTemplates;
     searchBoxTemplates: SearchBoxTemplates;
     showMore?: boolean;
+    showMoreButtonLabel?: string;
     searchable?: boolean;
     searchablePlaceholder?: string;
     searchableIsAlwaysActive?: boolean;
@@ -282,6 +288,7 @@ const renderer =
         searchIsAlwaysActive={searchableIsAlwaysActive}
         isFromSearch={isFromSearch}
         showMore={showMore && !isFromSearch && items.length > 0}
+        showMoreButtonLabel={showMoreButtonLabel}
         toggleShowMore={toggleShowMore}
         isShowingMore={isShowingMore}
         hasExhaustiveItems={hasExhaustiveItems}
@@ -328,6 +335,7 @@ const refinementList: RefinementListWidget = function refinementList(
     limit,
     showMore,
     showMoreLimit,
+    showMoreButtonLabel,
     searchable = false,
     searchablePlaceholder = 'Search...',
     searchableEscapeFacetValues = true,
@@ -431,6 +439,7 @@ const refinementList: RefinementListWidget = function refinementList(
     searchableIsAlwaysActive,
     searchableSelectOnSubmit,
     showMore,
+    showMoreButtonLabel,
   });
 
   const makeWidget = connectRefinementList(specializedRenderer, () =>

--- a/packages/react-instantsearch/src/ui/ShowMoreButton.tsx
+++ b/packages/react-instantsearch/src/ui/ShowMoreButton.tsx
@@ -17,6 +17,10 @@ export type ShowMoreButtonTranslations = {
    * Alternative text for the "Show more" button.
    */
   showMoreButtonText: (options: ShowMoreButtonTextOptions) => string;
+  /**
+   * Accessible name (aria-label) for the show more button.
+   */
+  showMoreButtonLabel?: string;
 };
 
 export function ShowMoreButton({
@@ -25,7 +29,11 @@ export function ShowMoreButton({
   ...props
 }: ShowMoreButtonProps) {
   return (
-    <button {...props} aria-expanded={isShowingMore}>
+    <button
+      {...props}
+      aria-expanded={isShowingMore}
+      aria-label={translations.showMoreButtonLabel}
+    >
       {translations.showMoreButtonText({ isShowingMore })}
     </button>
   );

--- a/packages/react-instantsearch/src/widgets/RefinementList.tsx
+++ b/packages/react-instantsearch/src/widgets/RefinementList.tsx
@@ -123,7 +123,9 @@ export function RefinementList({
     }
   }
 
-  const mergedTranslations: Required<RefinementListProps['translations']> = {
+  const mergedTranslations: Required<
+    Omit<NonNullable<RefinementListProps['translations']>, 'showMoreButtonLabel'>
+  > = {
     resetButtonTitle: 'Clear the search query',
     submitButtonTitle: 'Submit the search query',
     noResultsText: 'No results.',
@@ -163,6 +165,7 @@ export function RefinementList({
     isShowingMore,
     translations: {
       showMoreButtonText: mergedTranslations.showMoreButtonText,
+      showMoreButtonLabel: translations?.showMoreButtonLabel,
     },
   };
 

--- a/packages/react-instantsearch/src/widgets/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/RefinementList.test.tsx
@@ -196,4 +196,25 @@ describe('RefinementList', () => {
       ).toHaveTextContent('Zero results');
     });
   });
+
+  test('sets the aria-label on the show more button', async () => {
+    const searchClient = createMockedSearchClient();
+    const { container } = render(
+      <InstantSearchTestWrapper searchClient={searchClient}>
+        <RefinementList
+          attribute="brand"
+          showMore
+          translations={{ showMoreButtonLabel: 'Show more brands' }}
+        />
+      </InstantSearchTestWrapper>
+    );
+
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => {
+      expect(
+        container.querySelector('.ais-RefinementList-showMore')
+      ).toHaveAttribute('aria-label', 'Show more brands');
+    });
+  });
 });

--- a/packages/vue-instantsearch/src/components/RefinementList.vue
+++ b/packages/vue-instantsearch/src/components/RefinementList.vue
@@ -71,6 +71,7 @@
         v-if="showMore"
         :disabled="!state.canToggleShowMore"
         :aria-expanded="state.isShowingMore ? 'true' : 'false'"
+        :aria-label="showMoreButtonLabel"
       >
         <slot name="showMoreLabel" :is-showing-more="state.isShowingMore">
           Show {{ state.isShowingMore ? 'less' : 'more' }}
@@ -142,6 +143,11 @@ export default {
       type: Boolean,
       required: false,
       default: false,
+    },
+    showMoreButtonLabel: {
+      type: String,
+      required: false,
+      default: undefined,
     },
     sortBy: {
       type: [Array, Function],

--- a/packages/vue-instantsearch/src/components/__tests__/RefinementList.js
+++ b/packages/vue-instantsearch/src/components/__tests__/RefinementList.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { mount } from '../../../test/utils';
+import { __setState } from '../../mixins/widget';
+import RefinementList from '../RefinementList.vue';
+import '../../../test/utils/sortedHtmlSerializer';
+
+jest.mock('../../mixins/widget');
+jest.mock('../../mixins/panel');
+
+const defaultState = {
+  items: [
+    { value: 'Apple', label: 'Apple', highlighted: 'Apple', count: 746, isRefined: false },
+    { value: 'Samsung', label: 'Samsung', highlighted: 'Samsung', count: 633, isRefined: false },
+  ],
+  canRefine: true,
+  canToggleShowMore: true,
+  isShowingMore: false,
+  refine: () => {},
+  createURL: () => {},
+  toggleShowMore: () => {},
+  searchForItems: () => {},
+  isFromSearch: false,
+  sendEvent: () => {},
+};
+
+const defaultProps = {
+  attribute: 'brand',
+};
+
+it('sets the aria-label on the show more button', () => {
+  __setState({ ...defaultState });
+
+  const wrapper = mount(RefinementList, {
+    propsData: {
+      ...defaultProps,
+      showMore: true,
+      showMoreButtonLabel: 'Show more brands',
+    },
+  });
+
+  expect(
+    wrapper.find('.ais-RefinementList-showMore').attributes('aria-label')
+  ).toBe('Show more brands');
+});


### PR DESCRIPTION
## Summary

Addresses **item 3** of #7098.

With several RefinementLists on a page (e.g. working group, author, status), every show-more toggle renders the same accessible name:

```html
<button class="ais-RefinementList-showMore">Show more</button>
```

A screen reader user navigating by buttons cannot tell which list a given "Show more" belongs to. The existing show-more text customization (`showMoreText` template / `showMoreButtonText` translation / `showMoreLabel` slot) only changes the **visible** label, not a distinct accessible name.

## Change

Add an optional `showMoreButtonLabel`. When set, it is applied as the `aria-label` of the toggle button:

- `instantsearch.js` — `showMoreButtonLabel` widget option
- `react-instantsearch` — `translations.showMoreButtonLabel`
- `vue-instantsearch` — `show-more-button-label` prop

```jsx
<RefinementList attribute="brand" showMore translations={{ showMoreButtonLabel: 'Show more brands' }} />
```

The API is intentionally idiomatic per flavor (JS/Vue expose it top-level like other options; React uses `translations`, consistent with `noResultsText`). One focused test per flavor verifies the attribute renders when the option is set.

## Non-breaking

The option defaults to `undefined`, so no `aria-label` is rendered by default and existing markup/snapshots are unchanged.

## Notes / open for discussion

- The value is a **static string** (it doesn't vary with expand state). State is better conveyed by `aria-expanded` — see the companion PR for item 4.
- The OP cited **WCAG 2.4.6 Headings and Labels (AA)**. That's arguably a stretch — "Show more" *does* describe purpose and 2.4.6 doesn't strictly mandate *unique* labels — but the underlying UX concern is real, and an integrator-supplied accessible name is the most direct remedy. An alternative worth considering is documenting `Panel` + `aria-labelledby` instead of adding an option. Happy to adjust the API shape.

Refs #7098

🤖 Generated with [Claude Code](https://claude.com/claude-code)