### PR TITLE
fix(refinement-list): expose show more/less state via aria-expanded

### DIFF
--- a/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
+++ b/packages/instantsearch.js/src/components/RefinementList/RefinementList.tsx
@@ -319,6 +319,7 @@ class RefinementList<TTemplates extends Templates> extends Component<
           className: showMoreButtonClassName,
           disabled: !this.props.canToggleShowMore,
           onClick: this.props.toggleShowMore,
+          'aria-expanded': Boolean(this.props.isShowingMore),
         }}
         data={{
           isShowingMore: this.props.isShowingMore,

--- a/packages/instantsearch.js/src/components/RefinementList/__tests__/__snapshots__/RefinementList-test.tsx.snap
+++ b/packages/instantsearch.js/src/components/RefinementList/__tests__/__snapshots__/RefinementList-test.tsx.snap
@@ -43,6 +43,7 @@ exports[`RefinementList rendering with facets and disabled show more 1`] = `
       </li>
     </ul>
     <button
+      aria-expanded="false"
       class="showMore disabledShowMore"
       disabled=""
     >
@@ -72,6 +73,7 @@ exports[`RefinementList rendering with facets and show more 1`] = `
       </li>
     </ul>
     <button
+      aria-expanded="false"
       class="showMore"
     >
       {"isShowingMore":false}

--- a/packages/instantsearch.js/src/widgets/hierarchical-menu/__tests__/hierarchical-menu.test.tsx
+++ b/packages/instantsearch.js/src/widgets/hierarchical-menu/__tests__/hierarchical-menu.test.tsx
@@ -137,64 +137,65 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       await wait(0);
 
       expect(container).toMatchInlineSnapshot(`
-<div>
-  <div
-    class="ais-HierarchicalMenu"
-  >
-    <ul
-      class="ais-HierarchicalMenu-list"
-    >
-      <li
-        class="ais-HierarchicalMenu-item"
-      >
         <div>
-          <a
-            class="ais-HierarchicalMenu-link"
-            href="#"
+          <div
+            class="ais-HierarchicalMenu"
           >
-            <span
-              class="ais-HierarchicalMenu-label"
+            <ul
+              class="ais-HierarchicalMenu-list"
             >
-              Cameras & Camcorders
-            </span>
-            <span
-              class="ais-HierarchicalMenu-count"
+              <li
+                class="ais-HierarchicalMenu-item"
+              >
+                <div>
+                  <a
+                    class="ais-HierarchicalMenu-link"
+                    href="#"
+                  >
+                    <span
+                      class="ais-HierarchicalMenu-label"
+                    >
+                      Cameras & Camcorders
+                    </span>
+                    <span
+                      class="ais-HierarchicalMenu-count"
+                    >
+                      1,369
+                    </span>
+                  </a>
+                </div>
+              </li>
+              <li
+                class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected"
+              >
+                <div>
+                  <a
+                    class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected"
+                    href="#"
+                  >
+                    <span
+                      class="ais-HierarchicalMenu-label"
+                    >
+                      Video Games
+                    </span>
+                    <span
+                      class="ais-HierarchicalMenu-count"
+                    >
+                      505
+                    </span>
+                  </a>
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-expanded="false"
+              class="ais-HierarchicalMenu-showMore"
             >
-              1,369
-            </span>
-          </a>
+              Show more
+            </button>
+          </div>
         </div>
-      </li>
-      <li
-        class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected"
-      >
-        <div>
-          <a
-            class="ais-HierarchicalMenu-link ais-HierarchicalMenu-link--selected"
-            href="#"
-          >
-            <span
-              class="ais-HierarchicalMenu-label"
-            >
-              Video Games
-            </span>
-            <span
-              class="ais-HierarchicalMenu-count"
-            >
-              505
-            </span>
-          </a>
-        </div>
-      </li>
-    </ul>
-    <button
-      class="ais-HierarchicalMenu-showMore"
-    >
-      Show more
-    </button>
-  </div>
-</div>
-`);
+      `);
 
       const showMoreButton = within(container).getByRole('button');
 
@@ -246,56 +247,57 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       await wait(0);
 
       expect(container).toMatchInlineSnapshot(`
-<div>
-  <div
-    class="ais-HierarchicalMenu"
-  >
-    <ul
-      class="ais-HierarchicalMenu-list"
-    >
-      <li
-        class="ais-HierarchicalMenu-item"
-      >
         <div>
-          <a
-            href="#"
-            style="font-weight: normal;"
+          <div
+            class="ais-HierarchicalMenu"
           >
-            <span>
-              Cameras & Camcorders
-               (
-              1369
-              )
-            </span>
-          </a>
+            <ul
+              class="ais-HierarchicalMenu-list"
+            >
+              <li
+                class="ais-HierarchicalMenu-item"
+              >
+                <div>
+                  <a
+                    href="#"
+                    style="font-weight: normal;"
+                  >
+                    <span>
+                      Cameras & Camcorders
+                       (
+                      1369
+                      )
+                    </span>
+                  </a>
+                </div>
+              </li>
+              <li
+                class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected"
+              >
+                <div>
+                  <a
+                    href="#"
+                    style="font-weight: bold;"
+                  >
+                    <span>
+                      Video Games
+                       (
+                      505
+                      )
+                    </span>
+                  </a>
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-expanded="false"
+              class="ais-HierarchicalMenu-showMore"
+            >
+              Show more
+            </button>
+          </div>
         </div>
-      </li>
-      <li
-        class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected"
-      >
-        <div>
-          <a
-            href="#"
-            style="font-weight: bold;"
-          >
-            <span>
-              Video Games
-               (
-              505
-              )
-            </span>
-          </a>
-        </div>
-      </li>
-    </ul>
-    <button
-      class="ais-HierarchicalMenu-showMore"
-    >
-      Show more
-    </button>
-  </div>
-</div>
-`);
+      `);
 
       const showMoreButton = within(container).getByRole('button');
 
@@ -351,56 +353,57 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/hierarchica
       await wait(0);
 
       expect(container).toMatchInlineSnapshot(`
-<div>
-  <div
-    class="ais-HierarchicalMenu"
-  >
-    <ul
-      class="ais-HierarchicalMenu-list"
-    >
-      <li
-        class="ais-HierarchicalMenu-item"
-      >
         <div>
-          <a
-            href="#"
-            style="font-weight: normal;"
+          <div
+            class="ais-HierarchicalMenu"
           >
-            <span>
-              Cameras & Camcorders
-               (
-              1369
-              )
-            </span>
-          </a>
+            <ul
+              class="ais-HierarchicalMenu-list"
+            >
+              <li
+                class="ais-HierarchicalMenu-item"
+              >
+                <div>
+                  <a
+                    href="#"
+                    style="font-weight: normal;"
+                  >
+                    <span>
+                      Cameras & Camcorders
+                       (
+                      1369
+                      )
+                    </span>
+                  </a>
+                </div>
+              </li>
+              <li
+                class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected"
+              >
+                <div>
+                  <a
+                    href="#"
+                    style="font-weight: bold;"
+                  >
+                    <span>
+                      Video Games
+                       (
+                      505
+                      )
+                    </span>
+                  </a>
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-expanded="false"
+              class="ais-HierarchicalMenu-showMore"
+            >
+              Show more
+            </button>
+          </div>
         </div>
-      </li>
-      <li
-        class="ais-HierarchicalMenu-item ais-HierarchicalMenu-item--selected"
-      >
-        <div>
-          <a
-            href="#"
-            style="font-weight: bold;"
-          >
-            <span>
-              Video Games
-               (
-              505
-              )
-            </span>
-          </a>
-        </div>
-      </li>
-    </ul>
-    <button
-      class="ais-HierarchicalMenu-showMore"
-    >
-      Show more
-    </button>
-  </div>
-</div>
-`);
+      `);
 
       const showMoreButton = within(container).getByRole('button');
 

--- a/packages/instantsearch.js/src/widgets/menu/__tests__/menu.test.tsx
+++ b/packages/instantsearch.js/src/widgets/menu/__tests__/menu.test.tsx
@@ -70,97 +70,99 @@ describe('menu', () => {
       await wait(0);
 
       expect(container).toMatchInlineSnapshot(`
-<div>
-  <div
-    class="ais-Menu"
-  >
-    <ul
-      class="ais-Menu-list"
-    >
-      <li
-        class="ais-Menu-item ais-Menu-item--selected"
-      >
         <div>
-          <a
-            class="ais-Menu-link"
-            href="#"
+          <div
+            class="ais-Menu"
           >
-            <span
-              class="ais-Menu-label"
+            <ul
+              class="ais-Menu-list"
             >
-              Apple
-            </span>
-            <span
-              class="ais-Menu-count"
+              <li
+                class="ais-Menu-item ais-Menu-item--selected"
+              >
+                <div>
+                  <a
+                    class="ais-Menu-link"
+                    href="#"
+                  >
+                    <span
+                      class="ais-Menu-label"
+                    >
+                      Apple
+                    </span>
+                    <span
+                      class="ais-Menu-count"
+                    >
+                      442
+                    </span>
+                  </a>
+                </div>
+              </li>
+              <li
+                class="ais-Menu-item"
+              >
+                <div>
+                  <a
+                    class="ais-Menu-link"
+                    href="#"
+                  >
+                    <span
+                      class="ais-Menu-label"
+                    >
+                      Canon
+                    </span>
+                    <span
+                      class="ais-Menu-count"
+                    >
+                      287
+                    </span>
+                  </a>
+                </div>
+              </li>
+              <li
+                class="ais-Menu-item"
+              >
+                <div>
+                  <a
+                    class="ais-Menu-link"
+                    href="#"
+                  >
+                    <span
+                      class="ais-Menu-label"
+                    >
+                      Dell
+                    </span>
+                    <span
+                      class="ais-Menu-count"
+                    >
+                      174
+                    </span>
+                  </a>
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-expanded="false"
+              class="ais-Menu-showMore"
             >
-              442
-            </span>
-          </a>
+              Show more
+            </button>
+          </div>
         </div>
-      </li>
-      <li
-        class="ais-Menu-item"
-      >
-        <div>
-          <a
-            class="ais-Menu-link"
-            href="#"
-          >
-            <span
-              class="ais-Menu-label"
-            >
-              Canon
-            </span>
-            <span
-              class="ais-Menu-count"
-            >
-              287
-            </span>
-          </a>
-        </div>
-      </li>
-      <li
-        class="ais-Menu-item"
-      >
-        <div>
-          <a
-            class="ais-Menu-link"
-            href="#"
-          >
-            <span
-              class="ais-Menu-label"
-            >
-              Dell
-            </span>
-            <span
-              class="ais-Menu-count"
-            >
-              174
-            </span>
-          </a>
-        </div>
-      </li>
-    </ul>
-    <button
-      class="ais-Menu-showMore"
-    >
-      Show more
-    </button>
-  </div>
-</div>
-`);
+      `);
 
       const toggleButton = within(container).getByRole('button');
 
       fireEvent.click(toggleButton);
 
       expect(toggleButton).toMatchInlineSnapshot(`
-<button
-  class="ais-Menu-showMore"
->
-  Show less
-</button>
-`);
+        <button
+          aria-expanded="true"
+          class="ais-Menu-showMore"
+        >
+          Show less
+        </button>
+      `);
     });
 
     test('renders with templates using `html`', async () => {
@@ -207,83 +209,85 @@ describe('menu', () => {
       await wait(0);
 
       expect(container).toMatchInlineSnapshot(`
-<div>
-  <div
-    class="ais-Menu"
-  >
-    <ul
-      class="ais-Menu-list"
-    >
-      <li
-        class="ais-Menu-item ais-Menu-item--selected"
-      >
         <div>
-          <span
-            style="font-weight: bold;"
-            title="Apple"
+          <div
+            class="ais-Menu"
           >
-            Apple
-             - (
-            442
-            )
-          </span>
+            <ul
+              class="ais-Menu-list"
+            >
+              <li
+                class="ais-Menu-item ais-Menu-item--selected"
+              >
+                <div>
+                  <span
+                    style="font-weight: bold;"
+                    title="Apple"
+                  >
+                    Apple
+                     - (
+                    442
+                    )
+                  </span>
+                </div>
+              </li>
+              <li
+                class="ais-Menu-item"
+              >
+                <div>
+                  <span
+                    style="font-weight: normal;"
+                    title="Canon"
+                  >
+                    Canon
+                     - (
+                    287
+                    )
+                  </span>
+                </div>
+              </li>
+              <li
+                class="ais-Menu-item"
+              >
+                <div>
+                  <span
+                    style="font-weight: normal;"
+                    title="Dell"
+                  >
+                    Dell
+                     - (
+                    174
+                    )
+                  </span>
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-expanded="false"
+              class="ais-Menu-showMore"
+            >
+              <span>
+                Show more
+              </span>
+            </button>
+          </div>
         </div>
-      </li>
-      <li
-        class="ais-Menu-item"
-      >
-        <div>
-          <span
-            style="font-weight: normal;"
-            title="Canon"
-          >
-            Canon
-             - (
-            287
-            )
-          </span>
-        </div>
-      </li>
-      <li
-        class="ais-Menu-item"
-      >
-        <div>
-          <span
-            style="font-weight: normal;"
-            title="Dell"
-          >
-            Dell
-             - (
-            174
-            )
-          </span>
-        </div>
-      </li>
-    </ul>
-    <button
-      class="ais-Menu-showMore"
-    >
-      <span>
-        Show more
-      </span>
-    </button>
-  </div>
-</div>
-`);
+      `);
 
       const toggleButton = within(container).getByRole('button');
 
       fireEvent.click(toggleButton);
 
       expect(toggleButton).toMatchInlineSnapshot(`
-<button
-  class="ais-Menu-showMore"
->
-  <span>
-    Show less
-  </span>
-</button>
-`);
+        <button
+          aria-expanded="true"
+          class="ais-Menu-showMore"
+        >
+          <span>
+            Show less
+          </span>
+        </button>
+      `);
     });
 
     test('renders with templates using JSX', async () => {
@@ -331,83 +335,85 @@ describe('menu', () => {
       await wait(0);
 
       expect(container).toMatchInlineSnapshot(`
-<div>
-  <div
-    class="ais-Menu"
-  >
-    <ul
-      class="ais-Menu-list"
-    >
-      <li
-        class="ais-Menu-item ais-Menu-item--selected"
-      >
         <div>
-          <span
-            style="font-weight: bold;"
-            title="Apple"
+          <div
+            class="ais-Menu"
           >
-            Apple
-             - (
-            442
-            )
-          </span>
+            <ul
+              class="ais-Menu-list"
+            >
+              <li
+                class="ais-Menu-item ais-Menu-item--selected"
+              >
+                <div>
+                  <span
+                    style="font-weight: bold;"
+                    title="Apple"
+                  >
+                    Apple
+                     - (
+                    442
+                    )
+                  </span>
+                </div>
+              </li>
+              <li
+                class="ais-Menu-item"
+              >
+                <div>
+                  <span
+                    style="font-weight: normal;"
+                    title="Canon"
+                  >
+                    Canon
+                     - (
+                    287
+                    )
+                  </span>
+                </div>
+              </li>
+              <li
+                class="ais-Menu-item"
+              >
+                <div>
+                  <span
+                    style="font-weight: normal;"
+                    title="Dell"
+                  >
+                    Dell
+                     - (
+                    174
+                    )
+                  </span>
+                </div>
+              </li>
+            </ul>
+            <button
+              aria-expanded="false"
+              class="ais-Menu-showMore"
+            >
+              <span>
+                Show more
+              </span>
+            </button>
+          </div>
         </div>
-      </li>
-      <li
-        class="ais-Menu-item"
-      >
-        <div>
-          <span
-            style="font-weight: normal;"
-            title="Canon"
-          >
-            Canon
-             - (
-            287
-            )
-          </span>
-        </div>
-      </li>
-      <li
-        class="ais-Menu-item"
-      >
-        <div>
-          <span
-            style="font-weight: normal;"
-            title="Dell"
-          >
-            Dell
-             - (
-            174
-            )
-          </span>
-        </div>
-      </li>
-    </ul>
-    <button
-      class="ais-Menu-showMore"
-    >
-      <span>
-        Show more
-      </span>
-    </button>
-  </div>
-</div>
-`);
+      `);
 
       const toggleButton = within(container).getByRole('button');
 
       fireEvent.click(toggleButton);
 
       expect(toggleButton).toMatchInlineSnapshot(`
-<button
-  class="ais-Menu-showMore"
->
-  <span>
-    Show less
-  </span>
-</button>
-`);
+        <button
+          aria-expanded="true"
+          class="ais-Menu-showMore"
+        >
+          <span>
+            Show less
+          </span>
+        </button>
+      `);
     });
 
     function createMockedSearchClient() {

--- a/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
+++ b/packages/instantsearch.js/src/widgets/refinement-list/__tests__/refinement-list.test.tsx
@@ -301,6 +301,7 @@ describe('refinementList', () => {
               </li>
             </ul>
             <button
+              aria-expanded="false"
               class="ais-RefinementList-showMore SHOW-MORE ais-RefinementList-showMore--disabled DISABLED-SHOW-MORE"
               disabled=""
             >
@@ -525,6 +526,7 @@ describe('refinementList', () => {
               </li>
             </ul>
             <button
+              aria-expanded="false"
               class="ais-RefinementList-showMore"
             >
               Show more
@@ -819,6 +821,7 @@ describe('refinementList', () => {
               </li>
             </ul>
             <button
+              aria-expanded="false"
               class="ais-RefinementList-showMore"
             >
               <span>
@@ -1068,6 +1071,7 @@ describe('refinementList', () => {
               </li>
             </ul>
             <button
+              aria-expanded="false"
               class="ais-RefinementList-showMore"
             >
               <span>

--- a/packages/react-instantsearch/src/ui/ShowMoreButton.tsx
+++ b/packages/react-instantsearch/src/ui/ShowMoreButton.tsx
@@ -25,7 +25,7 @@ export function ShowMoreButton({
   ...props
 }: ShowMoreButtonProps) {
   return (
-    <button {...props}>
+    <button {...props} aria-expanded={isShowingMore}>
       {translations.showMoreButtonText({ isShowingMore })}
     </button>
   );

--- a/packages/react-instantsearch/src/ui/__tests__/HierarchicalMenu.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/HierarchicalMenu.test.tsx
@@ -310,6 +310,7 @@ describe('HierarchicalMenu', () => {
               </li>
             </ul>
             <button
+              aria-expanded="false"
               class="ais-HierarchicalMenu-showMore"
             >
               Show more
@@ -467,6 +468,7 @@ describe('HierarchicalMenu', () => {
             </li>
           </ul>
           <button
+            aria-expanded="false"
             class="ais-HierarchicalMenu-showMore SHOWMORE ais-HierarchicalMenu-showMore--disabled DISABLEDSHOWMORE"
             disabled=""
           >

--- a/packages/react-instantsearch/src/ui/__tests__/Menu.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/Menu.test.tsx
@@ -164,6 +164,7 @@ describe('Menu', () => {
               </li>
             </ul>
             <button
+              aria-expanded="false"
               class="ais-Menu-showMore"
             >
               Show more
@@ -254,6 +255,7 @@ describe('Menu', () => {
             </li>
           </ul>
           <button
+            aria-expanded="false"
             class="ais-Menu-showMore SHOWMORE ais-Menu-showMore--disabled DISABLEDSHOWMORE"
             disabled=""
           >

--- a/packages/react-instantsearch/src/ui/__tests__/RefinementList.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/RefinementList.test.tsx
@@ -135,69 +135,70 @@ describe('RefinementList', () => {
       const { container } = render(<RefinementList {...props} />);
 
       expect(container).toMatchInlineSnapshot(`
-              <div>
-                <div
-                  class="ais-RefinementList"
+        <div>
+          <div
+            class="ais-RefinementList"
+          >
+            <ul
+              class="ais-RefinementList-list"
+            >
+              <li
+                class="ais-RefinementList-item ais-RefinementList-item--selected"
+              >
+                <label
+                  class="ais-RefinementList-label"
                 >
-                  <ul
-                    class="ais-RefinementList-list"
+                  <input
+                    checked=""
+                    class="ais-RefinementList-checkbox"
+                    type="checkbox"
+                    value="Insignia™"
+                  />
+                  <span
+                    class="ais-RefinementList-labelText"
                   >
-                    <li
-                      class="ais-RefinementList-item ais-RefinementList-item--selected"
-                    >
-                      <label
-                        class="ais-RefinementList-label"
-                      >
-                        <input
-                          checked=""
-                          class="ais-RefinementList-checkbox"
-                          type="checkbox"
-                          value="Insignia™"
-                        />
-                        <span
-                          class="ais-RefinementList-labelText"
-                        >
-                          Insignia™
-                        </span>
-                        <span
-                          class="ais-RefinementList-count"
-                        >
-                          746
-                        </span>
-                      </label>
-                    </li>
-                    <li
-                      class="ais-RefinementList-item"
-                    >
-                      <label
-                        class="ais-RefinementList-label"
-                      >
-                        <input
-                          class="ais-RefinementList-checkbox"
-                          type="checkbox"
-                          value="Samsung"
-                        />
-                        <span
-                          class="ais-RefinementList-labelText"
-                        >
-                          Samsung
-                        </span>
-                        <span
-                          class="ais-RefinementList-count"
-                        >
-                          633
-                        </span>
-                      </label>
-                    </li>
-                  </ul>
-                  <button
-                    class="ais-RefinementList-showMore"
+                    Insignia™
+                  </span>
+                  <span
+                    class="ais-RefinementList-count"
                   >
-                    Show more
-                  </button>
-                </div>
-              </div>
-          `);
+                    746
+                  </span>
+                </label>
+              </li>
+              <li
+                class="ais-RefinementList-item"
+              >
+                <label
+                  class="ais-RefinementList-label"
+                >
+                  <input
+                    class="ais-RefinementList-checkbox"
+                    type="checkbox"
+                    value="Samsung"
+                  />
+                  <span
+                    class="ais-RefinementList-labelText"
+                  >
+                    Samsung
+                  </span>
+                  <span
+                    class="ais-RefinementList-count"
+                  >
+                    633
+                  </span>
+                </label>
+              </li>
+            </ul>
+            <button
+              aria-expanded="false"
+              class="ais-RefinementList-showMore"
+            >
+              Show more
+            </button>
+          </div>
+        </div>
+      `);
     });
 
     test('calls onToggleShowMore', () => {
@@ -612,6 +613,7 @@ describe('RefinementList', () => {
             </li>
           </ul>
           <button
+            aria-expanded="false"
             class="ais-RefinementList-showMore SHOWMORE ais-RefinementList-showMore--disabled DISABLEDSHOWMORE"
             disabled=""
           >

--- a/packages/react-instantsearch/src/ui/__tests__/ShowMoreButton.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/ShowMoreButton.test.tsx
@@ -25,7 +25,9 @@ describe('ShowMoreButton', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <button>
+        <button
+          aria-expanded="false"
+        >
           Show more
         </button>
       </div>
@@ -39,7 +41,9 @@ describe('ShowMoreButton', () => {
 
     expect(container).toMatchInlineSnapshot(`
       <div>
-        <button>
+        <button
+          aria-expanded="true"
+        >
           Show less
         </button>
       </div>
@@ -75,6 +79,7 @@ describe('ShowMoreButton', () => {
     expect(container).toMatchInlineSnapshot(`
       <div>
         <button
+          aria-expanded="false"
           disabled=""
         >
           Show more

--- a/packages/vue-instantsearch/src/components/HierarchicalMenu.vue
+++ b/packages/vue-instantsearch/src/components/HierarchicalMenu.vue
@@ -28,6 +28,7 @@
           !state.canToggleShowMore && suit('showMore', 'disabled'),
         ]"
         :disabled="!state.canToggleShowMore"
+        :aria-expanded="state.isShowingMore ? 'true' : 'false'"
         @click.prevent="state.toggleShowMore"
       >
         <slot name="showMoreLabel" :is-showing-more="state.isShowingMore">

--- a/packages/vue-instantsearch/src/components/Menu.vue
+++ b/packages/vue-instantsearch/src/components/Menu.vue
@@ -37,6 +37,7 @@
           !state.canToggleShowMore && suit('showMore', 'disabled'),
         ]"
         :disabled="!state.canToggleShowMore"
+        :aria-expanded="state.isShowingMore ? 'true' : 'false'"
         @click.prevent="state.toggleShowMore"
       >
         <slot name="showMoreLabel" :is-showing-more="state.isShowingMore">

--- a/packages/vue-instantsearch/src/components/RefinementList.vue
+++ b/packages/vue-instantsearch/src/components/RefinementList.vue
@@ -70,6 +70,7 @@
         @click="toggleShowMore"
         v-if="showMore"
         :disabled="!state.canToggleShowMore"
+        :aria-expanded="state.isShowingMore ? 'true' : 'false'"
       >
         <slot name="showMoreLabel" :is-showing-more="state.isShowingMore">
           Show {{ state.isShowingMore ? 'less' : 'more' }}

--- a/packages/vue-instantsearch/src/components/__tests__/__snapshots__/HierarchicalMenu.js.snap
+++ b/packages/vue-instantsearch/src/components/__tests__/__snapshots__/HierarchicalMenu.js.snap
@@ -520,7 +520,9 @@ exports[`custom showMoreLabel render renders correctly with a custom show more l
       </a>
     </li>
   </ul>
-  <button class="ais-HierarchicalMenu-showMore">
+  <button aria-expanded="false"
+          class="ais-HierarchicalMenu-showMore"
+  >
     <span>
       Voir plus
     </span>
@@ -658,7 +660,9 @@ exports[`custom showMoreLabel render renders correctly with a custom show more l
       </a>
     </li>
   </ul>
-  <button class="ais-HierarchicalMenu-showMore">
+  <button aria-expanded="true"
+          class="ais-HierarchicalMenu-showMore"
+  >
     <span>
       Voir moins
     </span>

--- a/tests/common/widgets/hierarchical-menu/options.ts
+++ b/tests/common/widgets/hierarchical-menu/options.ts
@@ -847,6 +847,7 @@ export function createOptionsTests(
               </li>
             </ul>
             <button
+              aria-expanded="false"
               class="ais-HierarchicalMenu-showMore"
             >
               Show more

--- a/tests/common/widgets/menu/options.ts
+++ b/tests/common/widgets/menu/options.ts
@@ -528,6 +528,7 @@ export function createOptionsTests(
               </li>
             </ul>
             <button
+              aria-expanded="false"
               class="ais-Menu-showMore"
             >
               Show more

--- a/tests/common/widgets/refinement-list/options.ts
+++ b/tests/common/widgets/refinement-list/options.ts
@@ -1483,6 +1483,7 @@ export function createOptionsTests(
         ) as HTMLButtonElement;
 
         expect(showMoreButton).toHaveTextContent('Show more');
+        expect(showMoreButton).toHaveAttribute('aria-expanded', 'false');
 
         expect(
           document.querySelector('.ais-RefinementList')
@@ -1727,6 +1728,7 @@ export function createOptionsTests(
               </li>
             </ul>
             <button
+              aria-expanded="false"
               class="ais-RefinementList-showMore"
             >
               Show more
@@ -1742,6 +1744,7 @@ export function createOptionsTests(
         });
 
         expect(showMoreButton).toHaveTextContent('Show less');
+        expect(showMoreButton).toHaveAttribute('aria-expanded', 'true');
         expect(
           document.querySelectorAll('.ais-RefinementList-item')
         ).toHaveLength(20);


### PR DESCRIPTION
## Summary

Addresses **item 4** of #7098 — but not the way the issue proposes. See the reasoning below.

## What the issue asked for vs. what this does

The issue asks that activating "Show more" **move focus** to the first newly-revealed option, and that the control be split into separate "Show more" / "Show less" buttons.

I'd push back on that approach:

- Keeping focus on the toggle after activation is exactly the [WAI-ARIA APG **disclosure** pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/). It is correct, not a bug.
- **WCAG 2.4.3 Focus Order (A)** requires that focus order *preserve meaning and operability* — it does **not** require moving focus into revealed content. Programmatically relocating focus is frequently *surprising* and can be a regression for many users.
- Splitting one toggle into two controls and hijacking focus is a **behavior change** that risks breaking existing customizations (slots/templates/CSS that target the single toggle).

The genuine, standards-aligned gap is that the toggle's **expanded state** is only conveyed visually (via the label flipping between "Show more"/"Show less"), never programmatically.

## Change

Add `aria-expanded` (reflecting `isShowingMore`) to the show-more toggle button. Because the button is shared, this covers **RefinementList, Menu, and HierarchicalMenu** in all three flavors:

- `instantsearch.js` — the shared `RefinementList` component (the Menu and HierarchicalMenu widgets reuse it)
- `react-instantsearch` — the shared `ShowMoreButton` component
- `vue-instantsearch` — `RefinementList.vue`, `Menu.vue`, `HierarchicalMenu.vue`

A cross-flavor common-suite test asserts `aria-expanded` is `"false"` initially and flips to `"true"` after clicking the toggle.

## Non-breaking

Additive attribute only; focus behavior is unchanged. Snapshots updated.

> Note: `aria-expanded` can optionally be paired with `aria-controls` pointing at the list, which would require generating a unique id for the `<ul>`. Left out here to keep the change minimal and non-breaking; happy to add it as a follow-up.

Refs #7098

🤖 Generated with [Claude Code](https://claude.com/claude-code)