### PR TITLE
fix(pagination): mark the current page with aria-current

### DIFF
--- a/packages/algolia-experiences/src/__tests__/render.test.ts
+++ b/packages/algolia-experiences/src/__tests__/render.test.ts
@@ -578,6 +578,7 @@ describe('configToIndex', () => {
               <li class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected">
                 <a class="ais-Pagination-link"
                    aria-label="Page 1"
+                   aria-current="page"
                    href="#"
                 >
                   1

--- a/packages/instantsearch.js/src/components/Pagination/Pagination.tsx
+++ b/packages/instantsearch.js/src/components/Pagination/Pagination.tsx
@@ -182,6 +182,7 @@ function PaginationLink({
           rootProps={{
             className: cssClasses.link,
             'aria-label': ariaLabel,
+            'aria-current': isSelected ? 'page' : undefined,
             href: createURL(pageNumber),
             onClick: createClickHandler(pageNumber),
           }}

--- a/packages/react-instantsearch/src/ui/Pagination.tsx
+++ b/packages/react-instantsearch/src/ui/Pagination.tsx
@@ -204,6 +204,7 @@ export function Pagination({
                 currentPage: page + 1,
                 nbPages,
               })}
+              aria-current={page === currentPage ? 'page' : undefined}
               href={createURL(page)}
               onClick={() => onNavigate(page)}
             >

--- a/packages/react-instantsearch/src/ui/__tests__/Pagination.test.tsx
+++ b/packages/react-instantsearch/src/ui/__tests__/Pagination.test.tsx
@@ -126,6 +126,7 @@ describe('Pagination', () => {
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 2"
                 class="ais-Pagination-link"
                 href="/?page=2"
@@ -212,6 +213,7 @@ describe('Pagination', () => {
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page number 1 of 2"
                 class="ais-Pagination-link"
                 href="/?page=1"
@@ -441,6 +443,7 @@ describe('Pagination', () => {
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="/?page=1"
@@ -519,6 +522,7 @@ describe('Pagination', () => {
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="/?page=1"
@@ -605,6 +609,7 @@ describe('Pagination', () => {
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="/?page=1"
@@ -680,6 +685,7 @@ describe('Pagination', () => {
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="/?page=1"
@@ -767,6 +773,7 @@ describe('Pagination', () => {
               class="ais-Pagination-item ITEM ais-Pagination-item--page PAGEITEM ais-Pagination-item--selected SELECTEDITEM"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link LINK"
                 href="/?page=1"

--- a/packages/vue-instantsearch/src/components/Pagination.vue
+++ b/packages/vue-instantsearch/src/components/Pagination.vue
@@ -92,6 +92,9 @@
               :class="suit('link')"
               :href="state.createURL(page)"
               :aria-label="`Page ${page + 1}`"
+              :aria-current="
+                state.currentRefinement === page ? 'page' : undefined
+              "
               @click.exact.left.prevent="refine(page)"
               >{{ page + 1 }}</a
             >

--- a/tests/common/widgets/pagination/options.ts
+++ b/tests/common/widgets/pagination/options.ts
@@ -54,6 +54,16 @@ export function createOptionsTests(
         document.querySelectorAll('.ais-Pagination-item--page')[0]
       ).toHaveClass('ais-Pagination-item--selected');
       expect(
+        document
+          .querySelectorAll('.ais-Pagination-item--page')[0]
+          .querySelector('.ais-Pagination-link')
+      ).toHaveAttribute('aria-current', 'page');
+      expect(
+        document
+          .querySelectorAll('.ais-Pagination-item--page')[1]
+          .querySelector('.ais-Pagination-link')
+      ).not.toHaveAttribute('aria-current');
+      expect(
         document.querySelector('.ais-Pagination-item--firstPage')
       ).toHaveClass('ais-Pagination-item--disabled');
       expect(
@@ -101,6 +111,7 @@ export function createOptionsTests(
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="#"
@@ -258,6 +269,7 @@ export function createOptionsTests(
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="#"
@@ -655,6 +667,7 @@ export function createOptionsTests(
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="#"
@@ -832,6 +845,7 @@ export function createOptionsTests(
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="#"
@@ -1034,6 +1048,7 @@ export function createOptionsTests(
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="#"
@@ -1146,6 +1161,7 @@ export function createOptionsTests(
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="#"
@@ -1223,6 +1239,7 @@ export function createOptionsTests(
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="#"
@@ -1310,6 +1327,7 @@ export function createOptionsTests(
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="#"
@@ -1387,6 +1405,7 @@ export function createOptionsTests(
               class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
             >
               <a
+                aria-current="page"
                 aria-label="Page 1"
                 class="ais-Pagination-link"
                 href="#"


### PR DESCRIPTION
## Summary

Addresses **item 5** of #7098.

The selected page is marked with a modifier class only:

```html
<li class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected">
  <a class="ais-Pagination-link" href="#" aria-label="Page 1">1</a>
</li>
```

There is no `aria-current` anywhere, so the current page is conveyed visually (via the class + styling) but not programmatically (**WCAG 4.1.2 Name, Role, Value, A**; also **1.3.1 Info and Relationships**).

## Change

Add `aria-current="page"` to the current page's link across all three flavors:

- `instantsearch.js` — `components/Pagination/Pagination.tsx`
- `react-instantsearch` — `ui/Pagination.tsx`
- `vue-instantsearch` — `components/Pagination.vue`

Only the currently-selected page link gets the attribute; first/previous/next/last and the other page links do not. A common-suite assertion verifies the selected link has `aria-current="page"` and a non-selected one does not.

## Non-breaking

Additive attribute only. Snapshots updated.

Refs #7098

🤖 Generated with [Claude Code](https://claude.com/claude-code)