### PR TITLE
feat(chat): add persistence opt-out

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -16,7 +16,7 @@ import connectChat from '../connectChat';
 
 import type { UIMessage, ChatTransport } from '../../../lib/ai-lite';
 import type { InstantSearch, IndexWidget } from '../../../types';
-import type { ChatConnectorParams } from '../connectChat';
+import type { ChatConnectorParams, ChatCustomInstance } from '../connectChat';
 
 jest.mock('../../../lib/utils/sendChatMessageFeedback', () => ({
   sendChatMessageFeedback: jest.fn(() => Promise.resolve(new Response('{}'))),
@@ -75,6 +75,9 @@ describe('connectChat', () => {
       const assertChatConnectorParams = <TParams extends ChatConnectorParams>(
         params: TParams
       ) => params;
+      const assertChatCustomInstanceParams = (
+        params: ChatCustomInstance<UIMessage>
+      ) => params;
       const customChat = undefined as unknown as Chat<UIMessage>;
 
       const agentParams = assertChatConnectorParams({
@@ -88,6 +91,14 @@ describe('connectChat', () => {
       const legacyAgentWithTransportParams = assertChatConnectorParams({
         agentId: 'agentId',
         transport: { api: 'https://custom.api' },
+      });
+      const agentPersistenceParams = assertChatConnectorParams({
+        agentId: 'agentId',
+        persistence: false,
+      });
+      const transportPersistenceParams = assertChatConnectorParams({
+        transport: { api: 'https://custom.api' },
+        persistence: false,
       });
 
       // @ts-expect-error requestOptions is only valid with agentId
@@ -115,6 +126,12 @@ describe('connectChat', () => {
         },
       });
 
+      assertChatCustomInstanceParams({
+        chat: customChat,
+        // @ts-expect-error persistence is owned by custom chat instances
+        persistence: false,
+      });
+
       expect(agentParams.requestOptions?.queryParameters).toEqual({
         cache: false,
       });
@@ -125,6 +142,8 @@ describe('connectChat', () => {
         agentId: 'agentId',
         transport: { api: 'https://custom.api' },
       });
+      expect(agentPersistenceParams.persistence).toBe(false);
+      expect(transportPersistenceParams.persistence).toBe(false);
     });
   });
 
@@ -574,6 +593,92 @@ describe('connectChat', () => {
   });
 
   describe('default chat instance', () => {
+    const cacheKey = 'instantsearch-chat-initial-messages';
+
+    beforeEach(() => {
+      sessionStorage.clear();
+    });
+
+    it('does not restore messages from sessionStorage when persistence is disabled', () => {
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'previous',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Previous message' }],
+        },
+      ];
+      sessionStorage.setItem(
+        `${cacheKey}-agentId`,
+        JSON.stringify(previousMessages)
+      );
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: 'agentId',
+        persistence: false,
+      });
+
+      expect(getRenderState().messages).toEqual([]);
+    });
+
+    it('does not save messages to sessionStorage when persistence is disabled', () => {
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'previous',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Previous message' }],
+        },
+      ];
+      const storageKey = `${cacheKey}-agentId`;
+      sessionStorage.setItem(storageKey, JSON.stringify(previousMessages));
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: 'agentId',
+        persistence: false,
+      });
+      const nextMessages: UIMessage[] = [
+        {
+          id: 'next',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Next message' }],
+        },
+      ];
+
+      getRenderState().setMessages(nextMessages);
+
+      expect(sessionStorage.getItem(storageKey)).toBe(
+        JSON.stringify(previousMessages)
+      );
+    });
+
+    it('applies initialMessages when persistence is disabled', () => {
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'previous',
+          role: 'user',
+          parts: [{ type: 'text', text: 'Previous message' }],
+        },
+      ];
+      const initialMessages: UIMessage[] = [
+        {
+          id: 'initial',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Welcome' }],
+        },
+      ];
+      sessionStorage.setItem(
+        `${cacheKey}-agentId`,
+        JSON.stringify(previousMessages)
+      );
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: 'agentId',
+        persistence: false,
+        initialMessages,
+      });
+
+      expect(getRenderState().messages).toEqual(initialMessages);
+    });
+
     it('adds a compatibility layer for Algolia MCP Server search tool', async () => {
       const onSearchToolCall = jest.fn();
 

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -112,8 +112,17 @@ export type ChatRenderState<TUiMessage extends UIMessage = UIMessage> = {
 
 export type ChatInitWithoutTransport<TUiMessage extends UIMessage> = Omit<
   ChatInitAi<TUiMessage>,
-  'transport'
+  'transport' | 'persistence'
 >;
+
+export type ChatPersistence = {
+  /**
+   * Whether to persist and restore messages from sessionStorage.
+   *
+   * @default true
+   */
+  persistence?: boolean;
+};
 
 export type ChatAgentRequestOptions = {
   /**
@@ -158,6 +167,7 @@ export type ChatCustomInstance<TUiMessage extends UIMessage> = {
   transport?: ConstructorParameters<typeof DefaultChatTransport>[0];
   feedback?: never;
   requestOptions?: never;
+  persistence?: never;
 };
 
 export type ApplyFiltersParams = {
@@ -166,7 +176,7 @@ export type ApplyFiltersParams = {
 };
 
 export type ChatInit<TUiMessage extends UIMessage> =
-  ChatInitWithoutTransport<TUiMessage> & ChatTransport;
+  ChatInitWithoutTransport<TUiMessage> & ChatTransport & ChatPersistence;
 
 export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
   | ChatCustomInstance<TUiMessage>

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -112,17 +112,8 @@ export type ChatRenderState<TUiMessage extends UIMessage = UIMessage> = {
 
 export type ChatInitWithoutTransport<TUiMessage extends UIMessage> = Omit<
   ChatInitAi<TUiMessage>,
-  'transport' | 'persistence'
+  'transport'
 >;
-
-export type ChatPersistence = {
-  /**
-   * Whether to persist and restore messages from sessionStorage.
-   *
-   * @default true
-   */
-  persistence?: boolean;
-};
 
 export type ChatAgentRequestOptions = {
   /**
@@ -176,7 +167,7 @@ export type ApplyFiltersParams = {
 };
 
 export type ChatInit<TUiMessage extends UIMessage> =
-  ChatInitWithoutTransport<TUiMessage> & ChatTransport & ChatPersistence;
+  ChatInitWithoutTransport<TUiMessage> & ChatTransport;
 
 export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
   | ChatCustomInstance<TUiMessage>

--- a/packages/instantsearch.js/src/lib/chat/__tests__/chat.test.ts
+++ b/packages/instantsearch.js/src/lib/chat/__tests__/chat.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
-import { ChatState, CACHE_KEY } from '../chat';
+import { Chat, ChatState, CACHE_KEY } from '../chat';
 
 describe('ChatState', () => {
   beforeAll(() => {
@@ -18,6 +18,11 @@ describe('ChatState', () => {
         removeItem(key: string) {
           delete store[key];
         },
+        clear() {
+          Object.keys(store).forEach((key) => {
+            delete store[key];
+          });
+        },
       };
     })();
 
@@ -27,12 +32,7 @@ describe('ChatState', () => {
   });
 
   beforeEach(() => {
-    // Clear sessionStorage before each test
-    sessionStorage.removeItem(CACHE_KEY);
-    sessionStorage.removeItem(`${CACHE_KEY}-agentID1`);
-    sessionStorage.removeItem(`${CACHE_KEY}-agentID2`);
-    sessionStorage.removeItem(`${CACHE_KEY}-agentID3`);
-    sessionStorage.removeItem(`${CACHE_KEY}-agentID4`);
+    sessionStorage.clear();
   });
 
   afterAll(() => {
@@ -72,6 +72,48 @@ describe('ChatState', () => {
     expect(chatState.messages).toEqual(initialMessages);
   });
 
+  it('should not load initial messages from sessionStorage when persistence is disabled', () => {
+    const agentId = 'agentID5';
+    const initialMessages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'bot', content: 'Hi there!' },
+    ];
+    sessionStorage.setItem(
+      `${CACHE_KEY}-${agentId}`,
+      JSON.stringify(initialMessages)
+    );
+
+    // eslint-disable-next-line jest/unbound-method
+    const originalGetItem = sessionStorage.getItem;
+    sessionStorage.getItem = () => {
+      throw new Error('unexpected sessionStorage read');
+    };
+
+    try {
+      const chatState = new ChatState(agentId, undefined, false);
+      expect(chatState.messages).toEqual([]);
+    } finally {
+      sessionStorage.getItem = originalGetItem;
+    }
+  });
+
+  it('should use explicit messages when persistence is disabled', () => {
+    const agentId = 'agentID6';
+    const storedMessages = [{ role: 'user', content: 'Stored message' }];
+    const initialMessages = [{ role: 'user', content: 'Explicit message' }];
+    sessionStorage.setItem(
+      `${CACHE_KEY}-${agentId}`,
+      JSON.stringify(storedMessages)
+    );
+
+    const chatState = new ChatState<any>(agentId, initialMessages, false);
+
+    expect(chatState.messages).toEqual(initialMessages);
+    expect(sessionStorage.getItem(`${CACHE_KEY}-${agentId}`)).toBe(
+      JSON.stringify(storedMessages)
+    );
+  });
+
   it('should not save messages to sessionStorage when status is not ready', () => {
     const agentId = 'agentID3';
     const chatState = new ChatState<any>(agentId);
@@ -84,6 +126,36 @@ describe('ChatState', () => {
     expect(sessionStorage.getItem(`${CACHE_KEY}-${agentId}`)).toBe(null);
     chatState.status = 'error';
     expect(sessionStorage.getItem(`${CACHE_KEY}-${agentId}`)).toBe(null);
+  });
+
+  it('should not save messages to sessionStorage when persistence is disabled', () => {
+    const agentId = 'agentID7';
+    const chatState = new ChatState<any>(agentId, undefined, false);
+    const message = { role: 'user', content: 'Hello' };
+
+    chatState.status = 'submitted';
+    chatState.messages = [message];
+    chatState.status = 'ready';
+
+    expect(sessionStorage.getItem(`${CACHE_KEY}-${agentId}`)).toBe(null);
+  });
+
+  it('should not persist messages for Chat when persistence is disabled', () => {
+    const agentId = 'agentID8';
+    const storedMessages = [{ role: 'user', content: 'Stored message' }];
+    const message = { role: 'user', content: 'Hello' };
+    sessionStorage.setItem(
+      `${CACHE_KEY}-${agentId}`,
+      JSON.stringify(storedMessages)
+    );
+
+    const chat = new Chat<any>({ agentId, persistence: false });
+    expect(chat.messages).toEqual([]);
+
+    chat.messages = [message];
+    expect(sessionStorage.getItem(`${CACHE_KEY}-${agentId}`)).toBe(
+      JSON.stringify(storedMessages)
+    );
   });
 
   it('should handle sessionStorage being unavailable', () => {

--- a/packages/instantsearch.js/src/lib/chat/chat.ts
+++ b/packages/instantsearch.js/src/lib/chat/chat.ts
@@ -4,12 +4,22 @@ import type {
   UIMessage,
   ChatState as BaseChatState,
   ChatStatus,
-  ChatInit,
+  ChatInit as BaseChatInit,
 } from '../ai-lite';
 
 export type { UIMessage };
 export { AbstractChat };
-export { ChatInit };
+
+export type ChatInit<TUiMessage extends UIMessage> =
+  BaseChatInit<TUiMessage> & {
+    agentId?: string;
+    /**
+     * Whether to persist and restore messages from sessionStorage.
+     *
+     * @default true
+     */
+    persistence?: boolean;
+  };
 
 export const CACHE_KEY = 'instantsearch-chat-initial-messages';
 
@@ -35,9 +45,21 @@ export class ChatState<TUiMessage extends UIMessage>
 
   constructor(
     id: string | undefined = undefined,
-    initialMessages: TUiMessage[] = getDefaultInitialMessages<TUiMessage>(id)
+    initialMessages: TUiMessage[] | undefined = undefined,
+    persistence = true
   ) {
-    this._messages = initialMessages;
+    if (initialMessages !== undefined) {
+      this._messages = initialMessages;
+    } else if (persistence) {
+      this._messages = getDefaultInitialMessages<TUiMessage>(id);
+    } else {
+      this._messages = [];
+    }
+
+    if (!persistence) {
+      return;
+    }
+
     const saveMessagesInLocalStorage = () => {
       if (this.status === 'ready') {
         try {
@@ -148,9 +170,10 @@ export class Chat<
   constructor({
     messages,
     agentId,
+    persistence = true,
     ...init
-  }: ChatInit<TUiMessage> & { agentId?: string }) {
-    const state = new ChatState(agentId, messages);
+  }: ChatInit<TUiMessage>) {
+    const state = new ChatState(agentId, messages, persistence);
     super({ ...init, state });
     this._state = state;
   }

--- a/tests/common/widgets/chat/index.ts
+++ b/tests/common/widgets/chat/index.ts
@@ -1,6 +1,7 @@
 import { fakeAct, skippableDescribe } from '../../common';
 
 import { createOptionsTests } from './options';
+import { createPersistenceTests } from './persistence';
 import { createStreamingTests } from './streaming';
 import { createTemplatesTests } from './templates';
 import { createTranslationsTests } from './translations';
@@ -45,6 +46,7 @@ export function createChatWidgetTests(
 
   skippableDescribe('Chat widget common tests', skippedTests, () => {
     createOptionsTests(setup, { act, skippedTests, flavor });
+    createPersistenceTests(setup, { act, skippedTests, flavor });
     createStreamingTests(setup, { act, skippedTests, flavor });
     createTemplatesTests(setup, { act, skippedTests, flavor });
     createTranslationsTests(setup, { act, skippedTests, flavor });

--- a/tests/common/widgets/chat/persistence.ts
+++ b/tests/common/widgets/chat/persistence.ts
@@ -1,0 +1,64 @@
+import { createSearchClient } from '@instantsearch/mocks';
+
+import { openChat } from './utils';
+
+import type { ChatWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+import type { UIMessage } from 'instantsearch.js/es/lib/chat';
+
+export function createPersistenceTests(
+  setup: ChatWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('persistence', () => {
+    test('does not restore persisted messages when persistence is disabled', async () => {
+      sessionStorage.clear();
+      const searchClient = createSearchClient();
+      const cacheKey = 'instantsearch-chat-initial-messages';
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'previous',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Previous persisted answer' }],
+        },
+      ];
+      const initialMessages: UIMessage[] = [
+        {
+          id: 'initial',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Fresh greeting' }],
+        },
+      ];
+
+      sessionStorage.setItem(
+        `${cacheKey}-agentId`,
+        JSON.stringify(previousMessages)
+      );
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            agentId: 'agentId',
+            persistence: false,
+            initialMessages,
+          },
+          react: {
+            agentId: 'agentId',
+            persistence: false,
+            initialMessages,
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(document.body).toHaveTextContent('Fresh greeting');
+      expect(document.body).not.toHaveTextContent('Previous persisted answer');
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Adds `persistence?: boolean` to InstantSearch Chat so consumers can opt out of the built-in `sessionStorage` restore/save behavior.

[FX-3871]

## Implementation

- Defaults `persistence` to `true` to preserve existing behavior.
- Skips `sessionStorage` reads and write callbacks when `persistence: false`.
- Keeps explicit `messages` and connector `initialMessages` behavior intact.
- Exposes the option for InstantSearch-created Chat instances.
- Rejects `persistence` on custom `chat` instances, since custom chat owns its state.

## Scope guard

This PR only handles persistence opt-out. It does not change guardrails, `addToolResult`, no-initial-search

## Tests

- `yarn jest packages/instantsearch.js/src/lib/chat/__tests__/chat.test.ts packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts --runInBand`
- `yarn jest common-widgets -t 'Chat widget common tests' --runInBand`
- `yarn prettier --check ...`
- `yarn lint:changed`
- `git diff --cached --check`

## Note

`yarn type-check` currently fails on inherited Chat widget renderer typing errors in untouched files:
- `packages/instantsearch.js/src/widgets/chat/chat.tsx:104`
- `packages/react-instantsearch/src/widgets/Chat.tsx:54`


<!--
**Result**

  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

[FX-3871]: https://algolia.atlassian.net/browse/FX-3871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ