### PR TITLE
feat(chat): render guardrail fallback as assistant message

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1061,16 +1061,16 @@ data: [DONE]`,
       });
     });
 
-    it('surfaces a guardrail-violation fallbackResponse via the error state', async () => {
+    it('renders a guardrail-violation fallbackResponse as assistant history', async () => {
       const fallbackResponse =
         "I'm sorry I couldn't respond to that, please try again with another message.";
-      const { widget } = getInitializedWidget({
-        agentId: undefined,
-        transport: {
-          fetch: () =>
-            Promise.resolve(
-              new Response(
-                `data: {"type": "start", "messageId": "test-id"}
+      const onError = jest.fn();
+      const onFinish = jest.fn();
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            `data: {"type": "start", "messageId": "test-id"}
 
 data: {"type": "start-step"}
 
@@ -1083,18 +1083,29 @@ data: {"type": "text-end", "id": "msg-1"}
 data: {"type": "finish-step"}
 
 data: {"type": "data-guardrail-violation", "data": {"category": "product_returns", "guardrailType": "input", "fallbackResponse": ${JSON.stringify(
-                  fallbackResponse
-                )}}}
+              fallbackResponse
+            )}}}
 
 data: {"type": "finish"}
 
 data: [DONE]`,
-                {
-                  headers: { 'Content-Type': 'text/event-stream' },
-                }
-              )
-            ),
+            {
+              headers: { 'Content-Type': 'text/event-stream' },
+            }
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(`data: {"type":"finish"}\n\ndata: [DONE]`, {
+            headers: { 'Content-Type': 'text/event-stream' },
+          })
+        );
+      const { widget } = getInitializedWidget({
+        agentId: undefined,
+        transport: {
+          fetch: fetchMock,
         },
+        onError,
+        onFinish,
       });
 
       const { chatInstance } = widget;
@@ -1107,24 +1118,58 @@ data: [DONE]`,
       });
 
       await waitFor(() => {
-        expect(chatInstance.status).toBe('error');
-        expect(chatInstance.error?.message).toBe(fallbackResponse);
-        // Tagged so the UI can branch on it and render the fallback verbatim
-        // instead of the generic friendly default used for cost-control
-        // errors.
-        expect(chatInstance.error?.name).toBe('GuardrailViolationError');
-        // The in-progress assistant message produced for this request is
-        // stripped so only the user message added by `sendMessage` remains
-        // beyond what was already there. This matches cost-control errors
-        // where no assistant message is appended on failure.
-        expect(chatInstance.messages.length).toBe(messagesBeforeSend + 1);
+        expect(chatInstance.status).toBe('ready');
+        expect(chatInstance.error).toBeUndefined();
+        expect(onError).not.toHaveBeenCalled();
+        expect(chatInstance.messages.length).toBe(messagesBeforeSend + 2);
         expect(
-          chatInstance.messages[chatInstance.messages.length - 1].role
-        ).toBe('user');
+          chatInstance.messages[chatInstance.messages.length - 1]
+        ).toMatchObject({
+          id: 'test-id',
+          role: 'assistant',
+          parts: [{ type: 'text', text: fallbackResponse, state: 'done' }],
+        });
+        expect(JSON.stringify(chatInstance.messages)).not.toContain(
+          'If you need help'
+        );
       });
+
+      const assistant = chatInstance.messages[chatInstance.messages.length - 1];
+
+      expect(onFinish).toHaveBeenCalledWith({
+        message: assistant,
+        messages: chatInstance.messages,
+        isAbort: false,
+        isDisconnect: false,
+        isError: false,
+      });
+
+      await chatInstance.sendMessage({
+        id: 'follow-up-id',
+        role: 'user',
+        parts: [{ type: 'text', text: 'what can you help with?' }],
+      });
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
+
+      const [, secondRequest] = fetchMock.mock.calls[1];
+      const secondRequestBody = JSON.parse(
+        (secondRequest as RequestInit).body as string
+      );
+      expect(secondRequestBody.messages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'test-id',
+            role: 'assistant',
+            parts: [{ type: 'text', text: fallbackResponse, state: 'done' }],
+          }),
+        ])
+      );
     });
 
-    it('falls back to a generic message when fallbackResponse is missing', async () => {
+    it('renders a generic assistant message when fallbackResponse is missing', async () => {
       const { widget } = getInitializedWidget({
         agentId: undefined,
         transport: {
@@ -1157,10 +1202,21 @@ data: [DONE]`,
       });
 
       await waitFor(() => {
-        expect(chatInstance.status).toBe('error');
-        expect(chatInstance.error?.message).toBe(
-          'Sorry, we are not able to generate a response at the moment.'
-        );
+        expect(chatInstance.status).toBe('ready');
+        expect(chatInstance.error).toBeUndefined();
+        expect(
+          chatInstance.messages[chatInstance.messages.length - 1]
+        ).toMatchObject({
+          id: 'test-id',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'text',
+              text: 'Sorry, we are not able to generate a response at the moment.',
+              state: 'done',
+            },
+          ],
+        });
       });
     });
   });

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -5,6 +5,8 @@ import { AbstractChat } from '../abstract-chat';
 import { parseJsonEventStream } from '../stream-parser';
 
 import type {
+  ChatOnErrorCallback,
+  ChatOnFinishCallback,
   ChatState,
   ChatTransport,
   UIMessage,
@@ -94,10 +96,14 @@ function createTestSetup(
     chunks,
     sse,
     onToolCall,
+    onFinish,
+    onError,
   }: {
     chunks?: UIMessageChunk[];
     sse?: string;
     onToolCall?: (options: { toolCall: any }) => void | Promise<void>;
+    onFinish?: ChatOnFinishCallback<UIMessage>;
+    onError?: ChatOnErrorCallback;
   } = { chunks: [] }
 ) {
   const makeStream = (): ReadableStream<UIMessageChunk> =>
@@ -122,6 +128,8 @@ function createTestSetup(
       // eslint-disable-next-line no-plusplus
       return () => `gen-${++i}`;
     })(),
+    onError,
+    onFinish,
     onToolCall,
   });
 
@@ -140,6 +148,106 @@ function assistantPart(state: InMemoryChatState): any {
 }
 
 describe('AbstractChat.processStreamWithCallbacks', () => {
+  describe('guardrail violations', () => {
+    it('replaces partial assistant content with the fallback and finishes ready', async () => {
+      const fallbackResponse =
+        "I can't help with that request, but I can help with product questions.";
+      const onFinish = jest.fn();
+      const onError = jest.fn();
+      const { chat, state } = createTestSetup({
+        chunks: [
+          startChunk(),
+          { type: 'text-start', id: 'text-1' },
+          {
+            type: 'text-delta',
+            id: 'text-1',
+            delta: 'Unsafe partial content',
+          },
+          {
+            type: 'data-guardrail-violation',
+            data: {
+              category: 'blocked',
+              guardrailType: 'output',
+              fallbackResponse,
+            },
+          },
+          finishChunk(),
+        ],
+        onError,
+        onFinish,
+      });
+
+      await chat.sendMessage({ text: 'blocked request' });
+
+      const assistant = state.messages.find((m) => m.role === 'assistant')!;
+
+      expect(state.status).toBe('ready');
+      expect(state.error).toBeUndefined();
+      expect(onError).not.toHaveBeenCalled();
+      expect(assistant).toMatchObject({
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: fallbackResponse, state: 'done' }],
+      });
+      expect(JSON.stringify(assistant.parts)).not.toContain(
+        'Unsafe partial content'
+      );
+      expect(onFinish).toHaveBeenCalledWith({
+        message: assistant,
+        messages: state.messages,
+        isAbort: false,
+        isDisconnect: false,
+        isError: false,
+      });
+    });
+
+    it('creates a fallback assistant message when violation arrives before an assistant message starts', async () => {
+      const onFinish = jest.fn();
+      const onError = jest.fn();
+      const { chat, state } = createTestSetup({
+        chunks: [
+          {
+            type: 'data-guardrail-violation',
+            data: {
+              category: 'blocked',
+              guardrailType: 'input',
+              fallbackResponse: 'I cannot process this request.',
+            },
+          },
+          finishChunk(),
+        ],
+        onError,
+        onFinish,
+      });
+
+      await chat.sendMessage({ text: 'blocked request' });
+
+      const assistant = state.messages.find((m) => m.role === 'assistant')!;
+
+      expect(state.status).toBe('ready');
+      expect(state.error).toBeUndefined();
+      expect(onError).not.toHaveBeenCalled();
+      expect(assistant).toMatchObject({
+        id: 'gen-2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'text',
+            text: 'I cannot process this request.',
+            state: 'done',
+          },
+        ],
+      });
+      expect(onFinish).toHaveBeenCalledWith({
+        message: assistant,
+        messages: state.messages,
+        isAbort: false,
+        isDisconnect: false,
+        isError: false,
+      });
+    });
+  });
+
   describe('tool-input lifecycle (existing chunks)', () => {
     it('tool-input-start, tool-input-delta and tool-input-available drive a part through input-streaming to input-available, repairing partial JSON and triggering onToolCall', async () => {
       const onToolCall = jest.fn();
@@ -397,7 +505,6 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         errorText: 'unbounded whitespace',
       });
     });
-
   });
 
   describe('tool-output-error', () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -2,7 +2,6 @@
 import { processStream } from './stream-parser';
 import {
   generateId as defaultGenerateId,
-  GuardrailViolationError,
   SerialJobExecutor,
   tryParseErrorMessage,
 } from './utils';
@@ -122,6 +121,9 @@ const parseToolInputDelta = (
 
   return fallbackInput;
 };
+
+const defaultGuardrailFallbackResponse =
+  'Sorry, we are not able to generate a response at the moment.';
 
 /**
  * Abstract base class for chat implementations.
@@ -1160,37 +1162,42 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               break;
             }
 
-            // Surface guardrail violations through the error state, but
-            // distinct from generic cost-control / 4xx errors: throw a
-            // `GuardrailViolationError` so the UI can render the
-            // service-provided `fallbackResponse` verbatim (it's authored for
-            // end-user display) instead of the friendly default used for
-            // opaque transport errors. Also discard any in-progress assistant
-            // message so no partial text lingers above the fallback, and
-            // clear the local cursor so the `onFinish` callback doesn't
-            // receive a `currentMessage` that no longer exists in state.
             case 'data-guardrail-violation': {
-              isError = true;
-
-              if (currentMessageIndex >= 0) {
-                this.state.messages = this.state.messages.slice(
-                  0,
-                  currentMessageIndex
-                );
-                currentMessage = undefined;
-                currentMessageIndex = -1;
-              }
-
               // `chunk.data` widens to `unknown` here: the chunk union also
               // carries a generic `data-${string}` member, and the literal
               // matches both, so narrowing can't pick the specific shape.
               const { fallbackResponse } = chunk.data as {
                 fallbackResponse?: string;
               };
-              throw new GuardrailViolationError(
-                fallbackResponse ||
-                  'Sorry, we are not able to generate a response at the moment.'
-              );
+              const fallbackText =
+                fallbackResponse || defaultGuardrailFallbackResponse;
+
+              // The stream closes after a guardrail violation; keep the
+              // fallback as the current message so the normal finish path runs.
+              currentMessage = {
+                id: currentMessage?.id || currentMessageId || this.generateId(),
+                role: 'assistant',
+                metadata: currentMessage?.metadata,
+                parts: [
+                  {
+                    type: 'text',
+                    text: fallbackText,
+                    state: 'done',
+                  },
+                ],
+              } as unknown as TUIMessage;
+
+              if (currentMessageIndex >= 0) {
+                this.state.replaceMessage(currentMessageIndex, currentMessage);
+              } else {
+                this.state.pushMessage(currentMessage);
+                currentMessageIndex = this.state.messages.length - 1;
+              }
+
+              currentMessageId = currentMessage.id;
+              currentTextPartId = undefined;
+              currentReasoningPartId = undefined;
+              break;
             }
 
             default: {

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -368,8 +368,7 @@ export type UIMessageChunk<
   | {
       // Emitted by the agent when a guardrail intercepts the request or the
       // response. The `fallbackResponse` is authored for end-user display and
-      // is surfaced verbatim by the chat error UI (see
-      // `GuardrailViolationError`).
+      // is surfaced as the assistant message for the blocked turn.
       type: 'data-guardrail-violation';
       data: {
         fallbackResponse?: string;

--- a/packages/instantsearch.js/src/lib/ai-lite/utils.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/utils.ts
@@ -94,11 +94,10 @@ export function resolveValue<T>(
 }
 
 /**
- * Error raised when the upstream stream emits a `data-guardrail-violation`
- * chunk. The `message` carries the service-provided `fallbackResponse`, which
- * is intentionally surfaced verbatim through the chat error UI (unlike
- * generic cost-control / 4xx errors, where the raw API message is hidden
- * behind a friendly default).
+ * Error shape for custom chat implementations that still surface a
+ * `data-guardrail-violation` chunk through the error UI. The `message` carries
+ * the service-provided `fallbackResponse`, which is authored for end-user
+ * display.
  *
  * Detection across package boundaries should rely on `error.name` rather than
  * `instanceof` to avoid issues with mixed module copies in bundled apps.

--- a/tests/common/widgets/chat/guardrails.tsx
+++ b/tests/common/widgets/chat/guardrails.tsx
@@ -1,0 +1,98 @@
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import userEvent from '@testing-library/user-event';
+import { Chat } from 'instantsearch.js/es/lib/chat';
+
+import { createDefaultWidgetParams, openChat } from './utils';
+
+import type { ChatWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+import type { UIMessageChunk } from 'instantsearch.js/es/lib/ai-lite';
+
+function chunksToStream(
+  chunks: UIMessageChunk[]
+): ReadableStream<UIMessageChunk> {
+  return new ReadableStream({
+    start(controller) {
+      chunks.forEach((chunk) => controller.enqueue(chunk));
+      controller.close();
+    },
+  });
+}
+
+export function createGuardrailsTests(
+  setup: ChatWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('guardrails', () => {
+    test('renders guardrail fallback as an assistant message', async () => {
+      const searchClient = createSearchClient();
+      const fallbackResponse =
+        "I can't help with that request, but I can help with product questions.";
+
+      const chat = new Chat({
+        persistence: false,
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([
+                { type: 'start', messageId: 'assistant-1' },
+                { type: 'text-start', id: 'text-1' },
+                {
+                  type: 'text-delta',
+                  id: 'text-1',
+                  delta: 'Unsafe partial content',
+                },
+                {
+                  type: 'data-guardrail-violation',
+                  data: {
+                    category: 'blocked',
+                    guardrailType: 'output',
+                    fallbackResponse,
+                  },
+                },
+                { type: 'finish' },
+              ])
+            )
+          ),
+          reconnectToStream: jest.fn(() => Promise.resolve(null)),
+        },
+      });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: createDefaultWidgetParams(chat),
+          react: createDefaultWidgetParams(chat),
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      userEvent.type(
+        document.querySelector('.ais-ChatPrompt-textarea')!,
+        'blocked request'
+      );
+      userEvent.click(document.querySelector('.ais-ChatPrompt-submit')!);
+
+      await act(async () => {
+        await wait(0);
+        await wait(0);
+      });
+
+      const messagesContainer = document.querySelector('.ais-ChatMessages');
+      expect(messagesContainer).toBeInTheDocument();
+      expect(messagesContainer!.textContent).toContain(fallbackResponse);
+      expect(messagesContainer!.textContent).not.toContain(
+        'Unsafe partial content'
+      );
+      expect(
+        document.querySelector('.ais-ChatMessageError')
+      ).not.toBeInTheDocument();
+    });
+  });
+}

--- a/tests/common/widgets/chat/index.ts
+++ b/tests/common/widgets/chat/index.ts
@@ -1,5 +1,6 @@
 import { fakeAct, skippableDescribe } from '../../common';
 
+import { createGuardrailsTests } from './guardrails';
 import { createOptionsTests } from './options';
 import { createPersistenceTests } from './persistence';
 import { createStreamingTests } from './streaming';
@@ -45,6 +46,7 @@ export function createChatWidgetTests(
   });
 
   skippableDescribe('Chat widget common tests', skippedTests, () => {
+    createGuardrailsTests(setup, { act, skippedTests, flavor });
     createOptionsTests(setup, { act, skippedTests, flavor });
     createPersistenceTests(setup, { act, skippedTests, flavor });
     createStreamingTests(setup, { act, skippedTests, flavor });


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

## Summary

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

Renders `data-guardrail-violation` fallbacks as normal assistant messages instead of routing them through Chat error UI.

FX-3872

## Implementation

- Replaces any partial streamed assistant content with the guardrail `fallbackResponse`.
- Creates a fallback assistant message when a violation arrives before an assistant message starts.
- Keeps the fallback in message history so follow-up requests include it.
- Lets the stream finish as `ready`, without setting `chat.error` or calling `onError`.
- Keeps generic transport/API failures on the existing error UI path.

## Scope guard

This PR only changes guardrail-violation rendering/history behavior.

It does not add a public render-mode option, change `data-guardrail-error` 

A future onGuardrailViolation/metadata callback can be added if consumers need telemetry or custom handling, this PR intentionally keeps that out of scope.

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

## Validation

- Focused ai-lite + connector Jest
- Common Chat widget tests
- Prettier check
- lint:changed
- git diff --cached --check
- Local showcase with deterministic guardrail stream
- Dashboard draft preview with real guardrail backend fallback
