### PR TITLE
feat: allow chat and autocomplete to opt out of main search

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
@@ -656,7 +656,11 @@ const testSetups: TestSetupsMap<TestSuites, 'javascript'> = {
       .start();
   },
   createChatWidgetTests({ instantSearchOptions, widgetParams }) {
-    const { renderRefinements, ...chatWidgetParams } = widgetParams;
+    const {
+      renderChat = true,
+      renderRefinements,
+      ...chatWidgetParams
+    } = widgetParams;
 
     const refinementsWidgets = [];
     if (renderRefinements) {
@@ -690,10 +694,16 @@ const testSetups: TestSetupsMap<TestSuites, 'javascript'> = {
         chatTrigger({
           container: document.body.appendChild(document.createElement('div')),
         }),
-        chat({
-          container: document.body.appendChild(document.createElement('div')),
-          ...chatWidgetParams,
-        }),
+        ...(renderChat
+          ? [
+              chat({
+                container: document.body.appendChild(
+                  document.createElement('div')
+                ),
+                ...chatWidgetParams,
+              }),
+            ]
+          : []),
       ])
       .on('error', () => {
         /*

--- a/packages/instantsearch.js/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
+++ b/packages/instantsearch.js/src/connectors/autocomplete/__tests__/connectAutocomplete-test.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../../test/createWidget';
 import instantsearch from '../../../index.es';
 import { TAG_PLACEHOLDER } from '../../../lib/utils';
+import connectConfigure from '../../configure/connectConfigure';
 import connectAutocomplete from '../connectAutocomplete';
 
 import type { SearchClient, SearchResponse } from '../../../types';
@@ -105,6 +106,100 @@ search.addWidgets([
         dispose: expect.any(Function),
       })
     );
+  });
+
+  it('depends on search by default', () => {
+    const customAutocomplete = connectAutocomplete(jest.fn());
+    const widget = customAutocomplete({});
+
+    expect(widget.dependsOn).toBe('search');
+  });
+
+  it('can be configured to depend on no backend request', () => {
+    const customAutocomplete = connectAutocomplete(jest.fn());
+    const widget = customAutocomplete({ requiresSearch: false });
+
+    expect(widget.dependsOn).toBe('none');
+  });
+
+  it('does not trigger a search on its own when it requires no search', async () => {
+    const searchClient = createSearchClient();
+    const autocomplete = connectAutocomplete(jest.fn());
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    search.addWidgets([autocomplete({ requiresSearch: false })]);
+    search.start();
+
+    await wait(0);
+
+    expect(searchClient.search).not.toHaveBeenCalled();
+  });
+
+  it('keeps rendering refinements when it requires no search', async () => {
+    const searchClient = createSearchClient();
+    const render = jest.fn();
+    const autocomplete = connectAutocomplete(render);
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    search.addWidgets([autocomplete({ requiresSearch: false })]);
+    search.start();
+    await wait(0);
+
+    expect(render).toHaveBeenLastCalledWith(
+      expect.objectContaining({ currentRefinement: '' }),
+      false
+    );
+
+    const { refine } = render.mock.calls.at(-1)![0];
+    refine('hello');
+    await wait(0);
+
+    expect(render).toHaveBeenLastCalledWith(
+      expect.objectContaining({ currentRefinement: 'hello' }),
+      false
+    );
+    expect(searchClient.search).not.toHaveBeenCalled();
+  });
+
+  it('still contributes search parameters when another widget triggers search', async () => {
+    const searchClient = createSearchClient();
+    const autocomplete = connectAutocomplete(jest.fn());
+    const configure = connectConfigure(jest.fn());
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient,
+      initialUiState: {
+        indexName: {
+          query: 'apple',
+        },
+      },
+    });
+
+    search.addWidgets([
+      autocomplete({ requiresSearch: false }),
+      configure({ searchParameters: { hitsPerPage: 2 } }),
+    ]);
+    search.start();
+
+    await wait(0);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+    expect(searchClient.search).toHaveBeenCalledWith([
+      {
+        indexName: 'indexName',
+        params: expect.objectContaining({
+          hitsPerPage: 2,
+          query: 'apple',
+          ...TAG_PLACEHOLDER,
+        }),
+      },
+    ]);
   });
 
   it('renders during init and render', () => {

--- a/packages/instantsearch.js/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/packages/instantsearch.js/src/connectors/autocomplete/connectAutocomplete.ts
@@ -11,7 +11,14 @@ import {
 } from '../../lib/utils';
 
 import type { SendEventForHits } from '../../lib/utils';
-import type { Hit, Connector, WidgetRenderState } from '../../types';
+import type {
+  Hit,
+  Connector,
+  IndexRenderState,
+  InitOptions,
+  RenderOptions,
+  WidgetRenderState,
+} from '../../types';
 import type { SearchResults } from 'algoliasearch-helper';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -39,6 +46,12 @@ export type AutocompleteConnectorParams = {
   transformItems?: (
     indices: TransformItemsIndicesConfig[]
   ) => TransformItemsIndicesConfig[];
+  /**
+   * Whether this widget should make InstantSearch require a main search request.
+   *
+   * @default true
+   */
+  requiresSearch?: boolean;
   /**
    * Enable usage of future Autocomplete behavior.
    */
@@ -128,6 +141,7 @@ const connectAutocomplete: AutocompleteConnector = function connectAutocomplete(
       transformItems = ((indices) => indices) as NonNullable<
         AutocompleteConnectorParams['transformItems']
       >,
+      requiresSearch = true,
       future: { undefinedEmptyQuery = false } = {},
     } = widgetParams || {};
 
@@ -164,6 +178,8 @@ search.addWidgets([
 
     return {
       $$type: 'ais.autocomplete',
+      dependsOn: requiresSearch ? ('search' as const) : ('none' as const),
+      shouldRender: requiresSearch ? undefined : () => true,
 
       init(initOptions) {
         const { instantSearchInstance } = initOptions;
@@ -195,7 +211,10 @@ search.addWidgets([
         );
       },
 
-      getRenderState(renderState, renderOptions) {
+      getRenderState(
+        renderState: IndexRenderState,
+        renderOptions: InitOptions | RenderOptions
+      ): IndexRenderState & AutocompleteWidgetDescription['indexRenderState'] {
         return {
           ...renderState,
           autocomplete: this.getWidgetRenderState(renderOptions),
@@ -207,7 +226,7 @@ search.addWidgets([
         state,
         scopedResults,
         instantSearchInstance,
-      }) {
+      }: InitOptions | RenderOptions) {
         if (!connectorState.refine) {
           connectorState.refine = (query: string) => {
             helper.setQuery(query).search();

--- a/packages/instantsearch.js/src/connectors/autocomplete/connectAutocomplete.ts
+++ b/packages/instantsearch.js/src/connectors/autocomplete/connectAutocomplete.ts
@@ -48,6 +48,7 @@ export type AutocompleteConnectorParams = {
   ) => TransformItemsIndicesConfig[];
   /**
    * Whether this widget should make InstantSearch require a main search request.
+   * If this is the only widget, and you mark `requiresSearch: false`, no search request will happen.
    *
    * @default true
    */

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -71,6 +71,27 @@ describe('connectChat', () => {
       );
     });
 
+    it('depends on search by default', () => {
+      const customChat = connectChat(jest.fn());
+      const widget = customChat({
+        agentId: 'agentId',
+        disableTriggerValidation: true,
+      });
+
+      expect(widget.dependsOn).toBe('search');
+    });
+
+    it('can be configured to depend on no backend request', () => {
+      const customChat = connectChat(jest.fn());
+      const widget = customChat({
+        agentId: 'agentId',
+        disableTriggerValidation: true,
+        requiresSearch: false,
+      });
+
+      expect(widget.dependsOn).toBe('none');
+    });
+
     it('types requestOptions as agentId-only', () => {
       const assertChatConnectorParams = <TParams extends ChatConnectorParams>(
         params: TParams

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -33,6 +33,8 @@ import type {
   InstantSearch,
   IndexUiState,
   IndexWidget,
+  InitOptions,
+  RenderOptions,
   WidgetRenderState,
   IndexRenderState,
 } from '../../types';
@@ -181,6 +183,12 @@ export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
    * Whether to resume an ongoing chat generation stream.
    */
   resume?: boolean;
+  /**
+   * Whether this widget should make InstantSearch require a main search request.
+   *
+   * @default true
+   */
+  requiresSearch?: boolean;
   /**
    * Configuration for client-side tools.
    */
@@ -331,6 +339,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       initialUserMessage,
       initialMessages,
       disableTriggerValidation = false,
+      requiresSearch = true,
       ...options
     } = widgetParams || {};
 
@@ -606,6 +615,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
 
     return {
       $$type: 'ais.chat',
+      dependsOn: requiresSearch ? ('search' as const) : ('none' as const),
 
       init(initOptions) {
         const { instantSearchInstance } = initOptions;
@@ -721,8 +731,8 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       },
 
       getRenderState(
-        renderState,
-        renderOptions
+        renderState: IndexRenderState,
+        renderOptions: InitOptions | RenderOptions
         // Type is explicitly redefined, to avoid having the TWidgetParams type in the definition
       ): IndexRenderState & ChatWidgetDescription['indexRenderState'] {
         return {
@@ -732,7 +742,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
         };
       },
 
-      getWidgetRenderState(renderOptions) {
+      getWidgetRenderState(renderOptions: InitOptions | RenderOptions) {
         const { instantSearchInstance, parent, helper } = renderOptions;
         if (!_chatInstance) {
           this.init!({ ...renderOptions, uiState: {}, results: undefined });

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -185,6 +185,7 @@ export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
   resume?: boolean;
   /**
    * Whether this widget should make InstantSearch require a main search request.
+   * If this is the only widget, and you mark `requiresSearch: false`, no search request will happen.
    *
    * @default true
    */

--- a/packages/instantsearch.js/src/connectors/chat/connectChatTrigger.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChatTrigger.ts
@@ -7,6 +7,7 @@ import {
 
 import type {
   Connector,
+  IndexRenderState,
   InitOptions,
   RenderOptions,
   WidgetRenderState,
@@ -93,6 +94,7 @@ const connectChatTrigger: ChatTriggerConnector = function connectChatTrigger(
     return {
       $$type: 'ais.chatTrigger',
       opensChat: true as const,
+      dependsOn: 'none' as const,
 
       init(initOptions) {
         lastOptions = initOptions;
@@ -120,7 +122,7 @@ const connectChatTrigger: ChatTriggerConnector = function connectChatTrigger(
         unmountFn();
       },
 
-      getWidgetRenderState(renderOptions) {
+      getWidgetRenderState(renderOptions: InitOptions | RenderOptions) {
         const chatState = getChatRenderState(renderOptions);
         return {
           open: chatState?.open ?? false,
@@ -129,11 +131,18 @@ const connectChatTrigger: ChatTriggerConnector = function connectChatTrigger(
         };
       },
 
-      getRenderState(renderState, renderOptions) {
+      getRenderState(
+        renderState: IndexRenderState,
+        renderOptions: InitOptions | RenderOptions
+      ) {
         return {
           ...renderState,
           chatTrigger: this.getWidgetRenderState(renderOptions),
         };
+      },
+
+      shouldRender() {
+        return true;
       },
     };
   };

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -595,7 +595,9 @@ See documentation: ${createDocumentationLink({
     }
 
     mainHelper.search = () => {
-      this.status = 'loading';
+      if (this._hasSearchWidget || this._hasRecommendWidget) {
+        this.status = 'loading';
+      }
       this.scheduleRender(false);
 
       warning(

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -595,13 +595,17 @@ See documentation: ${createDocumentationLink({
     }
 
     mainHelper.search = () => {
-      if (this._hasSearchWidget || this._hasRecommendWidget) {
+      const hasSearchOrRecommendWidget =
+        this._hasSearchWidget || this._hasRecommendWidget;
+
+      if (hasSearchOrRecommendWidget) {
         this.status = 'loading';
       }
-      this.scheduleRender(false);
+      this.scheduleRender(!hasSearchOrRecommendWidget);
 
       warning(
-        Boolean(this.indexName) ||
+        !hasSearchOrRecommendWidget ||
+          Boolean(this.indexName) ||
           Boolean(this.compositionID) ||
           this.mainIndex.getWidgets().some(isIndexWidget),
         'No indexName provided, nor an explicit index widget in the widgets tree. This is required to be able to display results.'
@@ -674,7 +678,7 @@ See documentation: ${createDocumentationLink({
       (error as any).error = error;
       this.error = error;
       this.status = 'error';
-      this.scheduleRender(false);
+      this.scheduleRender(!this._hasSearchWidget && !this._hasRecommendWidget);
 
       // This needs to execute last because it throws the error.
       this.emit('error', error);

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -15,7 +15,11 @@ import originalHelper from 'algoliasearch-helper';
 import { h, render, createRef } from 'preact';
 
 import { createRenderOptions, createWidget } from '../../../test/createWidget';
-import { connectSearchBox, connectPagination } from '../../connectors';
+import {
+  connectAutocomplete,
+  connectSearchBox,
+  connectPagination,
+} from '../../connectors';
 import { createInsightsMiddleware } from '../../middlewares';
 import { index } from '../../widgets';
 import InstantSearch from '../InstantSearch';
@@ -70,6 +74,7 @@ jest.mock('algoliasearch-helper', () => {
 });
 
 const virtualSearchBox = connectSearchBox(() => {});
+const virtualAutocomplete = connectAutocomplete(() => {});
 
 beforeEach(() => {
   algoliasearchHelper.mockClear();
@@ -266,6 +271,21 @@ describe('Usage', () => {
 
       See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
     `);
+  });
+
+  it('recomputes search widget flags when widgets are removed before start', () => {
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+    });
+    const searchBox = virtualSearchBox({});
+
+    search.addWidgets([searchBox]);
+    search.removeWidgets([searchBox]);
+    search.start();
+
+    expect(search.mainIndex.getWidgets()).toHaveLength(0);
+    expect(search._hasSearchWidget).toBe(false);
   });
 
   it('throws if createURL is called before start', () => {
@@ -522,6 +542,47 @@ See https://www.algolia.com/doc/api-reference/widgets/configure/js/`);
       await wait(0);
 
       expect(mapMiddlewares(search.middleware)).toEqual([]);
+    });
+
+    test('does not add automatic insights when no widget requires a search', async () => {
+      const searchClient = createSearchClientWithAutomaticInsightsOptedIn();
+      const search = new InstantSearch({
+        indexName: 'indexNameWithAutomaticInsights',
+        searchClient,
+      });
+
+      search.addWidgets([virtualAutocomplete({ requiresSearch: false })]);
+      search.start();
+
+      await wait(0);
+
+      expect(searchClient.search).not.toHaveBeenCalled();
+      expect(mapMiddlewares(search.middleware)).toEqual([]);
+    });
+
+    test('keeps automatic insights when another widget requires a search', async () => {
+      const searchClient = createSearchClientWithAutomaticInsightsOptedIn();
+      const search = new InstantSearch({
+        indexName: 'indexNameWithAutomaticInsights',
+        searchClient,
+      });
+
+      search.addWidgets([
+        virtualAutocomplete({ requiresSearch: false }),
+        virtualSearchBox({}),
+      ]);
+      search.start();
+
+      await wait(0);
+
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+      expect(mapMiddlewares(search.middleware)).toEqual([
+        {
+          $$type: 'ais.insights',
+          $$internal: true,
+          $$automatic: true,
+        },
+      ]);
     });
 
     test('insights: undefined adds the insights middleware if `_automaticInsights: true` is found in at least one index in initial response', async () => {

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -151,6 +151,20 @@ describe('Usage', () => {
       );
     });
 
+    it('does not warn if no widget requires a search or recommend request', async () => {
+      await expect(async () => {
+        const search = new InstantSearch({
+          searchClient: createSearchClient(),
+        });
+
+        search.addWidgets([virtualAutocomplete({ requiresSearch: false })]);
+        search.start();
+        await wait(0);
+      }).not.toWarnDev(
+        '[InstantSearch.js]: No indexName provided, nor an explicit index widget in the widgets tree. This is required to be able to display results.'
+      );
+    });
+
     it('does not warn if index widget is provided', async () => {
       await expect(async () => {
         const search = new InstantSearch({
@@ -1261,6 +1275,67 @@ describe('start', () => {
       expect(event.error).toEqual(new Error('SERVER_ERROR'));
       done();
     });
+  });
+
+  it('clears a search error when the final search widget is removed', async () => {
+    const { searches, searchClient } = createControlledSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+    const searchBox = virtualSearchBox({});
+    const errorEvent = new Promise<void>((resolve) => {
+      search.on('error', () => resolve());
+    });
+
+    search.addWidgets([
+      virtualAutocomplete({ requiresSearch: false }),
+      searchBox,
+    ]);
+    search.start();
+    await wait(0);
+
+    searches[0].rejecter(new Error('SERVER_ERROR'));
+    await errorEvent;
+
+    expect(search.status).toBe('error');
+    expect(search.error).toEqual(new Error('SERVER_ERROR'));
+
+    search.removeWidgets([searchBox]);
+    await wait(0);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+    expect(search.status).toBe('idle');
+    expect(search.error).toBeUndefined();
+  });
+
+  it('clears a late search error after the final search widget is removed', async () => {
+    const { searches, searchClient } = createControlledSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+    const searchBox = virtualSearchBox({});
+    const errorEvent = new Promise<void>((resolve) => {
+      search.on('error', () => resolve());
+    });
+
+    search.addWidgets([
+      virtualAutocomplete({ requiresSearch: false }),
+      searchBox,
+    ]);
+    search.start();
+    await wait(0);
+
+    search.removeWidgets([searchBox]);
+    await wait(0);
+    searches[0].rejecter(new Error('SERVER_ERROR'));
+    await errorEvent;
+    await wait(0);
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+    expect(search.status).toBe('idle');
+    expect(search.error).toBeUndefined();
   });
 
   it('does not trigger a search with initial results', async () => {

--- a/packages/instantsearch.js/src/lib/__tests__/server.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/server.test.ts
@@ -4,6 +4,7 @@ import {
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
+import { SearchParameters } from 'algoliasearch-helper';
 
 import {
   connectConfigure,
@@ -15,6 +16,26 @@ import { index } from '../../widgets';
 import { getInitialResults, waitForResults } from '../server';
 
 describe('waitForResults', () => {
+  test('resolves when no search or recommend request is pending', async () => {
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+    });
+
+    search.addWidgets([
+      {
+        $$type: 'ais.noop',
+        dependsOn: 'none',
+        init() {},
+        render() {},
+        dispose() {},
+      },
+    ]);
+    search.start();
+
+    await expect(waitForResults(search)).resolves.toEqual([]);
+  });
+
   test('waits for the results from the search instance', async () => {
     const { searchClient, searches } = createControlledSearchClient();
     const search = instantsearch({
@@ -88,6 +109,50 @@ describe('waitForResults', () => {
 });
 
 describe('getInitialResults', () => {
+  test('returns empty results when no requests were made', () => {
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient: createSearchClient(),
+    });
+
+    expect(getInitialResults(search.mainIndex, [])).toEqual({});
+  });
+
+  test('excludes isolated index trees without consuming request params', () => {
+    const search = instantsearch({
+      indexName: 'root',
+      searchClient: createSearchClient(),
+    });
+    search._initialResults = Object.fromEntries(
+      ['root', 'suggestions', 'nested'].map((indexName) => [
+        indexName,
+        {
+          state: new SearchParameters({ index: indexName }),
+          results: [createSingleSearchResponse()],
+        },
+      ])
+    );
+    search.addWidgets([
+      index({ EXPERIMENTAL_isolated: true, indexId: 'isolated' }).addWidgets([
+        index({ indexName: 'suggestions' }),
+      ]),
+      index({ indexName: 'nested' }),
+    ]);
+    search.start();
+
+    const rootParams = { hitsPerPage: 3 };
+    const nestedParams = { hitsPerPage: 7 };
+    const initialResults = getInitialResults(search.mainIndex, [
+      rootParams,
+      nestedParams,
+    ]);
+
+    expect(initialResults).not.toHaveProperty('isolated');
+    expect(initialResults).not.toHaveProperty('suggestions');
+    expect(initialResults.root?.requestParams).toEqual([rootParams]);
+    expect(initialResults.nested?.requestParams).toEqual([nestedParams]);
+  });
+
   test('errors if results are not available', () => {
     const search = instantsearch({
       indexName: 'indexName',

--- a/packages/instantsearch.js/src/lib/__tests__/status.test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/status.test.ts
@@ -5,7 +5,7 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
 
-import { connectSearchBox } from '../../connectors';
+import { connectAutocomplete, connectSearchBox } from '../../connectors';
 import instantsearch from '../../index.es';
 
 import type InstantSearch from '../InstantSearch';
@@ -19,6 +19,7 @@ function createDelayedSearchClient(timeout: number) {
 }
 
 const virtualSearchBox = connectSearchBox(() => {});
+const virtualAutocomplete = connectAutocomplete(() => {});
 
 describe('status', () => {
   test('is initially "idle"', () => {
@@ -41,6 +42,25 @@ describe('status', () => {
     await wait(0);
 
     expect(search.status).toBe('idle');
+  });
+
+  test('stays "idle" when no widget requires a request', async () => {
+    const searchClient = createSearchClient();
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+    const render = jest.fn();
+
+    search.on('render', render);
+    search.addWidgets([virtualAutocomplete({ requiresSearch: false })]);
+    search.start();
+
+    await wait(0);
+
+    expect(search.status).toBe('idle');
+    expect(searchClient.search).not.toHaveBeenCalled();
+    expect(render).toHaveBeenCalled();
   });
 
   test('becomes "loading" after calling `start()` when there are widgets', async () => {
@@ -144,6 +164,29 @@ describe('status', () => {
     await wait(20);
 
     expect(search.status).toBe('idle');
+  });
+
+  test('stays "idle" when removing the last widget that requires a request', async () => {
+    const searchClient = createSearchClient();
+    const search = instantsearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+    const searchBox = virtualSearchBox({});
+    const requestFreeWidget = virtualAutocomplete({ requiresSearch: false });
+
+    search.addWidgets([searchBox, requestFreeWidget]);
+    search.start();
+    await wait(0);
+
+    expect(search.status).toBe('idle');
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+
+    search.removeWidgets([searchBox]);
+    await wait(0);
+
+    expect(search.status).toBe('idle');
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
   });
 
   test('becomes "stalled" when the API takes longer than the `stalledSearchDelay` to respond', async () => {

--- a/packages/instantsearch.js/src/lib/server.ts
+++ b/packages/instantsearch.js/src/lib/server.ts
@@ -23,6 +23,9 @@ export function waitForResults(
   // later during hydration.
   let requestParamsList: SearchOptions[];
   const client = helper.getClient();
+  const waitsForSearch = search._hasSearchWidget;
+  const waitsForRecommend = !skipRecommend && search._hasRecommendWidget;
+
   if (search.compositionID) {
     helper.setClient({
       ...client,
@@ -41,18 +44,24 @@ export function waitForResults(
     } as SearchClient);
   }
 
-  if (search._hasSearchWidget) {
+  if (waitsForSearch) {
     if (search.compositionID) {
       helper.searchWithComposition();
     } else {
       helper.searchOnlyWithDerivedHelpers();
     }
   }
-  !skipRecommend && search._hasRecommendWidget && helper.recommend();
+  if (waitsForRecommend) {
+    helper.recommend();
+  }
 
-  return new Promise((resolve, reject) => {
-    let searchResultsReceived = !search._hasSearchWidget;
-    let recommendResultsReceived = !search._hasRecommendWidget || skipRecommend;
+  if (!waitsForSearch && !waitsForRecommend) {
+    return Promise.resolve([]);
+  }
+
+  return new Promise<SearchOptions[]>((resolve, reject) => {
+    let searchResultsReceived = !waitsForSearch;
+    let recommendResultsReceived = !waitsForRecommend;
     // All derived helpers resolve in the same tick so we're safe only relying
     // on the first one.
     helper.derivedHelpers[0].on('result', () => {
@@ -99,6 +108,14 @@ export function getInitialResults(
 
   let requestParamsIndex = 0;
   walkIndex(rootIndex, (widget) => {
+    let currentIndex: IndexWidget | null = widget;
+    while (currentIndex) {
+      if (currentIndex._isolated) {
+        return;
+      }
+      currentIndex = currentIndex.getParent();
+    }
+
     const searchResults = widget.getResults();
     const recommendResults = widget.getHelper()?.lastRecommendResults;
     if (searchResults || recommendResults) {
@@ -140,7 +157,10 @@ export function getInitialResults(
     }
   });
 
-  if (Object.keys(initialResults).length === 0) {
+  if (
+    Object.keys(initialResults).length === 0 &&
+    requestParamsList?.length !== 0
+  ) {
     throw new Error(
       'The root index does not have any results. Make sure you have at least one widget that provides results.'
     );

--- a/packages/instantsearch.js/src/types/widget.ts
+++ b/packages/instantsearch.js/src/types/widget.ts
@@ -56,7 +56,7 @@ export type DisposeOptions = {
 };
 
 export const indexWidgetTypes = ['ais.index', 'ais.feedContainer'] as const;
-export type IndexWidgetType = (typeof indexWidgetTypes)[number];
+export type IndexWidgetType = typeof indexWidgetTypes[number];
 
 // @MAJOR: Remove these exported types if we don't need them
 export type BuiltinTypes =
@@ -160,7 +160,7 @@ export type WidgetDescription = {
 };
 
 type SearchWidget<TWidgetDescription extends WidgetDescription> = {
-  dependsOn?: 'search';
+  dependsOn?: 'search' | 'none';
   getWidgetParameters?: (
     state: SearchParameters,
     widgetParametersOptions: {

--- a/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
+++ b/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
@@ -1079,6 +1079,7 @@ type BaseAutocompleteWidgetParams<TItem extends BaseHit> = {
 
   /**
    * Whether this widget should make InstantSearch require a main search request.
+   * If this is the only widget, and you mark `requiresSearch: false`, no search request will happen.
    *
    * @default true
    */

--- a/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
+++ b/packages/instantsearch.js/src/widgets/autocomplete/autocomplete.tsx
@@ -334,7 +334,6 @@ const createRenderer = <TItem extends BaseHit>(
         recentSearchHeaderComponent,
         hasWarnedMissingPromptSuggestionsChat: false,
       };
-
     }
 
     render(
@@ -832,7 +831,7 @@ function AutocompleteWrapper<TItem extends BaseHit>({
       query={localQuery}
       inputProps={{
         ...inputProps,
-        onFocus: (event) => {
+        onFocus: (event: unknown) => {
           activate();
           (inputProps as { onFocus?: (event: unknown) => void }).onFocus?.(
             event
@@ -938,9 +937,7 @@ function AutocompleteWrapper<TItem extends BaseHit>({
             <AutocompleteDetachedContainer
               classNames={detachedContainerCssClasses}
             >
-              <AutocompleteDetachedFormContainer
-                classNames={cssClasses}
-              >
+              <AutocompleteDetachedFormContainer classNames={cssClasses}>
                 {searchBoxContent}
               </AutocompleteDetachedFormContainer>
               {panelContent}
@@ -1081,6 +1078,13 @@ type BaseAutocompleteWidgetParams<TItem extends BaseHit> = {
   ) => TransformItemsIndicesConfig[];
 
   /**
+   * Whether this widget should make InstantSearch require a main search request.
+   *
+   * @default true
+   */
+  requiresSearch?: boolean;
+
+  /**
    * Search parameters to apply to the autocomplete indices.
    */
   searchParameters?: AutocompleteSearchParameters;
@@ -1188,6 +1192,7 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
     showPromptSuggestions,
     showRecent,
     searchParameters: userSearchParameters,
+    requiresSearch = true,
     getSearchPageURL,
     onSelect,
     templates = {},
@@ -1202,9 +1207,7 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
 
   if (isFeedsMode && indices !== undefined) {
     throw new Error(
-      withUsage(
-        'The `feeds` and `indices` options are mutually exclusive.'
-      )
+      withUsage('The `feeds` and `indices` options are mutually exclusive.')
     );
   }
   if (!container) {
@@ -1226,8 +1229,11 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
   // (section building, dedupe in createAutocompleteStorage) treats feeds
   // like indices without changes to the renderer / storage.
   const querySuggestionsKey = isFeedsMode
-    ? (showQuerySuggestions as FeedsShowQuerySuggestionsWidgetParams | undefined)
-        ?.feedID
+    ? (
+        showQuerySuggestions as
+          | FeedsShowQuerySuggestionsWidgetParams
+          | undefined
+      )?.feedID
     : (
         showQuerySuggestions as
           | IndicesShowQuerySuggestionsWidgetParams
@@ -1235,7 +1241,9 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
       )?.indexName;
   const promptSuggestionsKey = isFeedsMode
     ? (
-        showPromptSuggestions as FeedsShowPromptSuggestionsWidgetParams | undefined
+        showPromptSuggestions as
+          | FeedsShowPromptSuggestionsWidgetParams
+          | undefined
       )?.feedID
     : (
         showPromptSuggestions as
@@ -1306,8 +1314,8 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
       },
       searchParameters: querySuggestionsSearchParameters,
       getQuery: (item) => item.query,
-      getURL:
-        showQuerySuggestions!.getURL as unknown as IndexConfig<TItem>['getURL'],
+      getURL: showQuerySuggestions!
+        .getURL as unknown as IndexConfig<TItem>['getURL'],
     });
   }
   if (promptSuggestionsKey) {
@@ -1361,8 +1369,8 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
       },
       searchParameters: promptSuggestionsSearchParameters,
       getQuery: (item) => item.prompt,
-      getURL:
-        showPromptSuggestions!.getURL as unknown as IndexConfig<TItem>['getURL'],
+      getURL: showPromptSuggestions!
+        .getURL as unknown as IndexConfig<TItem>['getURL'],
     });
   }
 
@@ -1399,6 +1407,12 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
     : transformItems;
 
   const instanceId = ++autocompleteInstanceId;
+  const dependsOn = requiresSearch ? ('search' as const) : ('none' as const);
+  const createSearchBoxCompanion = (): Widget =>
+    ({
+      ...connectSearchBox(() => null)({}),
+      dependsOn,
+    } as Widget);
   const shouldShowRecent = showRecent || undefined;
   const showRecentOptions =
     typeof shouldShowRecent === 'boolean' ? {} : shouldShowRecent;
@@ -1496,7 +1510,7 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
     }
 
     return [
-      connectSearchBox(() => null)({}),
+      createSearchBoxCompanion(),
       createBootstrap((instantSearchInstance) => {
         if (!instantSearchInstance.compositionID) {
           throw new Error(
@@ -1535,7 +1549,7 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
   }
 
   return [
-    connectSearchBox(() => null)({}),
+    createSearchBoxCompanion(),
     createBootstrap(() =>
       index({
         indexId: `ais-autocomplete-${instanceId}`,
@@ -1568,6 +1582,7 @@ export function EXPERIMENTAL_autocomplete<TItem extends BaseHit = BaseHit>(
     return {
       $$type: 'ais.autocomplete',
       $$widgetType: 'ais.autocomplete',
+      dependsOn,
       init({ instantSearchInstance, parent }) {
         parentRef = parent;
         instanceRef = instantSearchInstance;

--- a/packages/instantsearch.js/src/widgets/chat/__tests__/chat.test.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/__tests__/chat.test.tsx
@@ -63,9 +63,7 @@ describe('chat', () => {
       }).not.toThrow();
 
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'The `chat` widget has no way to be opened.'
-        )
+        expect.stringContaining('The `chat` widget has no way to be opened.')
       );
 
       warnSpy.mockRestore();
@@ -99,9 +97,7 @@ describe('chat', () => {
       }).not.toThrow();
 
       expect(warnSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining(
-          'The `chat` widget has no way to be opened.'
-        )
+        expect.stringContaining('The `chat` widget has no way to be opened.')
       );
 
       warnSpy.mockRestore();
@@ -131,12 +127,59 @@ describe('chat', () => {
       }).not.toThrow();
 
       expect(warnSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining(
-          'The `chat` widget has no way to be opened.'
-        )
+        expect.stringContaining('The `chat` widget has no way to be opened.')
       );
 
       warnSpy.mockRestore();
+    });
+
+    test('triggers the main search by default', async () => {
+      const container = document.createElement('div');
+      const searchClient = createSearchClient();
+      document.body.appendChild(container);
+
+      const search = instantsearch({
+        indexName: 'indexName',
+        searchClient,
+      });
+
+      search.addWidgets([
+        chat({
+          container,
+          agentId: 'test-agent-id',
+          disableTriggerValidation: true,
+        }),
+      ]);
+      search.start();
+
+      await wait(0);
+
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not trigger the main search when requiresSearch is false', async () => {
+      const container = document.createElement('div');
+      const searchClient = createSearchClient();
+      document.body.appendChild(container);
+
+      const search = instantsearch({
+        indexName: 'indexName',
+        searchClient,
+      });
+
+      search.addWidgets([
+        chat({
+          container,
+          agentId: 'test-agent-id',
+          disableTriggerValidation: true,
+          requiresSearch: false,
+        }),
+      ]);
+      search.start();
+
+      await wait(0);
+
+      expect(searchClient.search).not.toHaveBeenCalled();
     });
   });
 
@@ -286,9 +329,7 @@ describe('chat', () => {
       fireEvent.input(textareaBefore!, { target: { value: 'hel' } });
       await wait(0);
 
-      const textareaAfter = container.querySelector(
-        '.ais-ChatPrompt-textarea'
-      );
+      const textareaAfter = container.querySelector('.ais-ChatPrompt-textarea');
 
       expect(textareaAfter).toBe(textareaBefore);
       expect(document.activeElement).toBe(textareaAfter);

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -3934,6 +3934,8 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       search.start();
 
       await wait(0);
+      expect(search._hasSearchWidget).toBe(false);
+      expect(search.status).toBe('idle');
       expect(search.client.search).toHaveBeenCalledTimes(0);
     });
 
@@ -4010,7 +4012,7 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       expect(search.client.search).toHaveBeenCalledTimes(1);
     });
 
-    it('triggers composition when root has a compositionId', async () => {
+    it('does not trigger the root composition for an isolated index', async () => {
       const search = instantsearch({
         searchClient: createCompositionClient(),
         compositionID: 'composition-id',
@@ -4022,13 +4024,12 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       search.start();
 
       await wait(0);
-      // Now called for the root, as a compositionId is set
-      expect(search.client.search).toHaveBeenCalledTimes(1);
+      expect(search.client.search).not.toHaveBeenCalled();
 
       search.renderState.a.searchBox?.refine('please search now');
 
-      expect(search.client.search).toHaveBeenCalledTimes(2);
-      expect(castToJestMock(search.client.search).mock.calls[1][0])
+      expect(search.client.search).toHaveBeenCalledTimes(1);
+      expect(castToJestMock(search.client.search).mock.calls[0][0])
         .toMatchInlineSnapshot(`
         {
           "compositionID": "a",
@@ -4039,6 +4040,39 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
           },
         }
       `);
+    });
+
+    it('does not trigger composition for an empty isolated index', async () => {
+      const search = instantsearch({
+        searchClient: createCompositionClient(),
+        compositionID: 'composition-id',
+      }).addWidgets([index({ EXPERIMENTAL_isolated: true })]);
+      search.start();
+
+      await wait(0);
+      expect(search._hasSearchWidget).toBe(false);
+      expect(search.status).toBe('idle');
+      expect(search.client.search).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger composition when a root widget requires no request', async () => {
+      const search = instantsearch({
+        searchClient: createCompositionClient(),
+        compositionID: 'composition-id',
+      }).addWidgets([
+        createWidget({ dependsOn: 'none' }),
+        index({ EXPERIMENTAL_isolated: true, indexName: 'a' }).addWidgets([
+          virtualSearchBox({}),
+        ]),
+      ]);
+      search.start();
+
+      await wait(0);
+      expect(search.client.search).not.toHaveBeenCalled();
+
+      search.renderState.a.searchBox?.refine('please search now');
+
+      expect(search.client.search).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -315,6 +315,61 @@ function resolveScopedResultsFromWidgets(
   }, []);
 }
 
+function getWidgetsRequestDependencies(widgets: Array<Widget | IndexWidget>): {
+  hasSearchWidget: boolean;
+  hasRecommendWidget: boolean;
+} {
+  return widgets.reduce<{
+    hasSearchWidget: boolean;
+    hasRecommendWidget: boolean;
+  }>(
+    (dependencies, widget) => {
+      if (isIndexWidget(widget)) {
+        if (widget._isolated) {
+          return dependencies;
+        }
+
+        const childDependencies = getWidgetsRequestDependencies(
+          widget.getWidgets()
+        );
+
+        return {
+          hasSearchWidget:
+            dependencies.hasSearchWidget || childDependencies.hasSearchWidget,
+          hasRecommendWidget:
+            dependencies.hasRecommendWidget ||
+            childDependencies.hasRecommendWidget,
+        };
+      }
+
+      if (widget.dependsOn === 'recommend') {
+        return { ...dependencies, hasRecommendWidget: true };
+      }
+
+      if (widget.dependsOn === 'none') {
+        return dependencies;
+      }
+
+      return { ...dependencies, hasSearchWidget: true };
+    },
+    {
+      hasSearchWidget: false,
+      hasRecommendWidget: false,
+    }
+  );
+}
+
+function recomputeInstantSearchRequestDependencies(
+  instantSearchInstance: InstantSearch
+) {
+  const { hasSearchWidget, hasRecommendWidget } = getWidgetsRequestDependencies(
+    instantSearchInstance.mainIndex.getWidgets()
+  );
+
+  instantSearchInstance._hasSearchWidget = hasSearchWidget;
+  instantSearchInstance._hasRecommendWidget = hasRecommendWidget;
+}
+
 const index = (widgetParams: IndexWidgetParams): IndexWidget => {
   if (
     widgetParams === undefined ||
@@ -339,8 +394,12 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
   let helper: Helper | null = null;
   let derivedHelper: DerivedHelper | null = null;
   let lastValidSearchParameters: SearchParameters | null = null;
-  let hasRecommendWidget: boolean = false;
-  let hasSearchWidget: boolean = false;
+
+  const recomputeLocalRequestDependencies = () => {
+    if (localInstantSearchInstance) {
+      recomputeInstantSearchRequestDependencies(localInstantSearchInstance);
+    }
+  };
 
   return {
     $$type: 'ais.index',
@@ -469,24 +528,14 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
 
       flatWidgets.forEach((widget) => {
         widget.parent = this;
-        if (isIndexWidget(widget)) {
-          return;
+        if (!isIndexWidget(widget)) {
+          addWidgetId(widget);
         }
-
-        if (localInstantSearchInstance && widget.dependsOn === 'recommend') {
-          localInstantSearchInstance._hasRecommendWidget = true;
-        } else if (localInstantSearchInstance) {
-          localInstantSearchInstance._hasSearchWidget = true;
-        } else if (widget.dependsOn === 'recommend') {
-          hasRecommendWidget = true;
-        } else {
-          hasSearchWidget = true;
-        }
-
-        addWidgetId(widget);
       });
 
       localWidgets = localWidgets.concat(flatWidgets);
+      recomputeLocalRequestDependencies();
+
       if (localInstantSearchInstance && Boolean(flatWidgets.length)) {
         privateHelperSetState(helper!, {
           state: getLocalWidgetsSearchParameters(localWidgets, {
@@ -567,20 +616,8 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
 
       localWidgets.forEach((widget) => {
         widget.parent = undefined;
-        if (isIndexWidget(widget)) {
-          return;
-        }
-
-        if (localInstantSearchInstance && widget.dependsOn === 'recommend') {
-          localInstantSearchInstance._hasRecommendWidget = true;
-        } else if (localInstantSearchInstance) {
-          localInstantSearchInstance._hasSearchWidget = true;
-        } else if (widget.dependsOn === 'recommend') {
-          hasRecommendWidget = true;
-        } else {
-          hasSearchWidget = true;
-        }
       });
+      recomputeLocalRequestDependencies();
 
       if (localInstantSearchInstance && Boolean(flatWidgets.length)) {
         const { cleanedSearchState, cleanedRecommendState } =
@@ -894,12 +931,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         instantSearchInstance.scheduleRender();
       }
 
-      if (hasRecommendWidget) {
-        instantSearchInstance._hasRecommendWidget = true;
-      }
-      if (hasSearchWidget) {
-        instantSearchInstance._hasSearchWidget = true;
-      }
+      recomputeLocalRequestDependencies();
     },
 
     render({ instantSearchInstance }: IndexRenderOptions) {

--- a/packages/instantsearch.js/src/widgets/panel/panel.tsx
+++ b/packages/instantsearch.js/src/widgets/panel/panel.tsx
@@ -180,12 +180,11 @@ const renderer =
 
 type AugmentedWidget<
   TWidgetFactory extends AnyWidgetFactory,
-  TOverriddenKeys extends keyof Widget = 'init' | 'render' | 'dispose'
-> = Omit<
-  ReturnType<TWidgetFactory>,
-  TOverriddenKeys | 'dependsOn' | 'getWidgetParameters'
-> &
-  Pick<Required<Widget>, TOverriddenKeys>;
+  TOverriddenKeys extends keyof Widget = 'init' | 'render' | 'dispose',
+  TWidget extends Widget = ReturnType<TWidgetFactory>
+> = TWidget extends Widget
+  ? Omit<TWidget, TOverriddenKeys> & Pick<Required<TWidget>, TOverriddenKeys>
+  : never;
 
 export type PanelWidget = <TWidgetFactory extends AnyWidgetFactory>(
   panelWidgetParams?: PanelWidgetParams<TWidgetFactory>

--- a/packages/react-instantsearch-core/src/components/__tests__/InstantSearch.test.tsx
+++ b/packages/react-instantsearch-core/src/components/__tests__/InstantSearch.test.tsx
@@ -882,6 +882,47 @@ describe('InstantSearch', () => {
       return (
         <StrictMode>
           <InstantSearch indexName="instant_search" searchClient={searchClient}>
+            <SearchBox />
+            {children}
+          </InstantSearch>
+        </StrictMode>
+      );
+    }
+
+    const { rerender } = render(
+      <App>
+        <RefinementList attribute="brand" />
+        <RefinementList attribute="category" />
+        <RefinementList attribute="color" />
+        <RefinementList attribute="price" />
+      </App>
+    );
+
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+
+    rerender(<App />);
+
+    await act(async () => {
+      await wait(0);
+      await wait(0);
+    });
+
+    // If the timing is wrong, the search will be called once for every removed
+    // widget instead of coalescing them into one search.
+    expect(searchClient.search).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not search when all search widgets are removed', async () => {
+    const searchClient = createAlgoliaSearchClient({});
+
+    function App({ children }: { children?: React.ReactNode }) {
+      return (
+        <StrictMode>
+          <InstantSearch indexName="instant_search" searchClient={searchClient}>
             {children}
           </InstantSearch>
         </StrictMode>
@@ -910,9 +951,7 @@ describe('InstantSearch', () => {
       await wait(0);
     });
 
-    // if the timing is wrong, the search will be called once for every removed widget
-    // except the final one (as there's no search if there are no widgets)
-    expect(searchClient.search).toHaveBeenCalledTimes(2);
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
   });
 
   describe('warn about Next.js router', () => {

--- a/packages/react-instantsearch-core/src/hooks/__tests__/useConnector.test.tsx
+++ b/packages/react-instantsearch-core/src/hooks/__tests__/useConnector.test.tsx
@@ -646,6 +646,44 @@ describe('useConnector', () => {
     expect(getByTestId('attribute')).toHaveTextContent('categories');
   });
 
+  test('replaces the widget when additional widget properties change', async () => {
+    const searchClient = createSearchClient({});
+    const { InstantSearchSpy, indexContext } = createInstantSearchSpy();
+
+    function CustomWidgetWithDependency({
+      dependsOn,
+    }: {
+      dependsOn: 'search' | 'none';
+    }) {
+      useConnector(connectCustomWidget, { attribute: 'brands' }, { dependsOn });
+
+      return null;
+    }
+
+    function App({ dependsOn }: { dependsOn: 'search' | 'none' }) {
+      return (
+        <InstantSearchSpy searchClient={searchClient} indexName="indexName">
+          <CustomWidgetWithDependency dependsOn={dependsOn} />
+        </InstantSearchSpy>
+      );
+    }
+
+    const { rerender } = render(<App dependsOn="search" />);
+
+    expect(indexContext.current!.addWidgets).toHaveBeenLastCalledWith([
+      expect.objectContaining({ dependsOn: 'search' }),
+    ]);
+
+    rerender(<App dependsOn="none" />);
+
+    await waitFor(() =>
+      expect(indexContext.current!.removeWidgets).toHaveBeenCalledTimes(1)
+    );
+    expect(indexContext.current!.addWidgets).toHaveBeenLastCalledWith([
+      expect.objectContaining({ dependsOn: 'none' }),
+    ]);
+  });
+
   test('rerenders the widget on state change', async () => {
     const searchClient = createSearchClient({});
     const { InstantSearchSpy, indexContext } = createInstantSearchSpy();

--- a/packages/react-instantsearch-core/src/hooks/useConnector.ts
+++ b/packages/react-instantsearch-core/src/hooks/useConnector.ts
@@ -153,7 +153,7 @@ export function useConnector<
   useWidget({
     widget,
     parentIndex,
-    props: stableProps,
+    props: [stableProps, stableAdditionalWidgetProperties],
     shouldSsr: Boolean(serverContext),
     skipSuspense,
   });

--- a/packages/react-instantsearch-core/src/lib/InstantSearchRSCContext.ts
+++ b/packages/react-instantsearch-core/src/lib/InstantSearchRSCContext.ts
@@ -5,6 +5,7 @@ import type { RefObject } from 'react';
 
 export type InstantSearchRSCContextApi = {
   waitForResultsRef: RefObject<PromiseWithState<void> | null> | null;
+  resolveWaitForResultsRef?: RefObject<(() => void) | null>;
   countRef: RefObject<number>;
   ignoreMultipleHooksWarning: boolean;
 };
@@ -13,5 +14,6 @@ export const InstantSearchRSCContext =
   createContext<InstantSearchRSCContextApi>({
     countRef: { current: 0 },
     waitForResultsRef: null,
+    resolveWaitForResultsRef: { current: null },
     ignoreMultipleHooksWarning: false,
   });

--- a/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
+++ b/packages/react-instantsearch-core/src/server/__tests__/getServerState.test.tsx
@@ -1,4 +1,5 @@
 import {
+  createControlledSearchClient,
   createMultiSearchResponse,
   createSearchClient,
   createAlgoliaSearchClient,
@@ -6,9 +7,15 @@ import {
   createSingleSearchResponse,
   defaultRenderingContent,
 } from '@instantsearch/mocks';
+import connectAutocomplete from 'instantsearch.js/es/connectors/autocomplete/connectAutocomplete';
 import React, { version as ReactVersion } from 'react';
 import { renderToString } from 'react-dom/server';
-import { Hits, RefinementList, TrendingItems } from 'react-instantsearch';
+import {
+  EXPERIMENTAL_Autocomplete,
+  Hits,
+  RefinementList,
+  TrendingItems,
+} from 'react-instantsearch';
 import {
   InstantSearch,
   InstantSearchSSRProvider,
@@ -16,6 +23,7 @@ import {
   DynamicWidgets,
   Feeds,
   version,
+  useConnector,
   useSearchBox,
 } from 'react-instantsearch-core';
 
@@ -37,6 +45,42 @@ function SearchBox() {
         <input className="ais-SearchBox-input" defaultValue={query} />
       </form>
     </div>
+  );
+}
+
+function AutocompleteWithoutSearch() {
+  useConnector(connectAutocomplete, { requiresSearch: false });
+
+  return null;
+}
+
+function RequestFreeAutocomplete() {
+  return (
+    <EXPERIMENTAL_Autocomplete
+      autoFocus
+      requiresSearch={false}
+      indices={[
+        {
+          indexName: 'suggestions',
+          itemComponent: ({ item }) => <>{item.objectID}</>,
+        },
+      ]}
+    />
+  );
+}
+
+function RequestFreeFeedsAutocomplete() {
+  return (
+    <EXPERIMENTAL_Autocomplete
+      autoFocus
+      requiresSearch={false}
+      feeds={[
+        {
+          feedID: 'products',
+          itemComponent: ({ item }) => <>{item.objectID}</>,
+        },
+      ]}
+    />
   );
 }
 
@@ -335,6 +379,78 @@ describe('getServerState', () => {
 
     expect(Object.keys(serverState.initialResults)).toHaveLength(4);
     expect(serverState.initialResults).toMatchSnapshot();
+  });
+
+  test('returns empty results when no widget requires a search', async () => {
+    const searchClient = createSearchClient({});
+
+    const serverState = await getServerState(
+      <InstantSearchSSRProvider>
+        <InstantSearch searchClient={searchClient} indexName="indexName">
+          <AutocompleteWithoutSearch />
+        </InstantSearch>
+      </InstantSearchSSRProvider>,
+      { renderToString }
+    );
+
+    expect(serverState).toEqual({ initialResults: {} });
+    expect(searchClient.search).not.toHaveBeenCalled();
+  });
+
+  test('excludes isolated autocomplete results when no widget requires a search', async () => {
+    const searchClient = createSearchClient({});
+
+    const serverState = await getServerState(
+      <InstantSearchSSRProvider>
+        <InstantSearch searchClient={searchClient} indexName="indexName">
+          <RequestFreeAutocomplete />
+        </InstantSearch>
+      </InstantSearchSSRProvider>,
+      { renderToString }
+    );
+
+    expect(searchClient.search).toHaveBeenCalledWith([
+      expect.objectContaining({ indexName: 'suggestions' }),
+    ]);
+    expect(serverState).toEqual({ initialResults: {} });
+  });
+
+  test('does not repeat isolated feeds when no widget requires a search', async () => {
+    const searchClient = createCompositionClient();
+
+    const serverState = await getServerState(
+      <InstantSearchSSRProvider>
+        <InstantSearch
+          searchClient={searchClient}
+          compositionID="my-composition"
+        >
+          <RequestFreeFeedsAutocomplete />
+        </InstantSearch>
+      </InstantSearchSSRProvider>,
+      { renderToString }
+    );
+
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+    expect(serverState).toEqual({ initialResults: {} });
+  });
+
+  test('does not wait for pending isolated autocomplete results', async () => {
+    const { searchClient, searches } = createControlledSearchClient();
+
+    const serverState = await getServerState(
+      <InstantSearchSSRProvider>
+        <InstantSearch searchClient={searchClient} indexName="indexName">
+          <RequestFreeAutocomplete />
+        </InstantSearch>
+      </InstantSearchSSRProvider>,
+      { renderToString }
+    );
+
+    expect(searches).toHaveLength(1);
+    expect(serverState).toEqual({ initialResults: {} });
+
+    searches[0].resolver();
+    await searches[0].promise;
   });
 
   test('searches twice (cached) with dynamic widgets', async () => {

--- a/packages/react-instantsearch-core/src/server/getServerState.tsx
+++ b/packages/react-instantsearch-core/src/server/getServerState.tsx
@@ -67,8 +67,15 @@ export function getServerState(
 
     // Two-pass widgets require another query to discover and mount child widgets.
     walkIndex(searchRef.current!.mainIndex, (index) => {
-      shouldRefetch =
-        shouldRefetch || index.getWidgets().some(isTwoPassWidget);
+      let current: typeof index | null = index;
+      while (current) {
+        if (current._isolated) {
+          return;
+        }
+        current = current.getParent();
+      }
+
+      shouldRefetch = shouldRefetch || index.getWidgets().some(isTwoPassWidget);
     });
 
     if (shouldRefetch) {

--- a/packages/react-instantsearch-nextjs/src/InitializePromise.ts
+++ b/packages/react-instantsearch-nextjs/src/InitializePromise.ts
@@ -15,6 +15,7 @@ import {
 import { createInsertHTML } from './createInsertHTML';
 
 import type {
+  IndexWidget,
   SearchOptions,
   CompositionClient,
   SearchClient,
@@ -29,9 +30,22 @@ type InitializePromiseProps = {
   nonce?: string;
 };
 
+function isWithinIsolatedIndex(index: IndexWidget): boolean {
+  let current: IndexWidget | null = index;
+
+  while (current) {
+    if (current._isolated) {
+      return true;
+    }
+    current = current.getParent();
+  }
+
+  return false;
+}
+
 export function InitializePromise({ nonce }: InitializePromiseProps) {
   const search = useInstantSearchContext();
-  const { waitForResultsRef } = useRSCContext();
+  const { waitForResultsRef, resolveWaitForResultsRef } = useRSCContext();
   const insertHTML =
     useContext(ServerInsertedHTMLContext) ||
     (() => {
@@ -66,23 +80,49 @@ export function InitializePromise({ nonce }: InitializePromiseProps) {
     new Promise<void>((resolve) => {
       let searchReceived = false;
       let recommendReceived = false;
-      search.mainHelper!.derivedHelpers[0].once('result', () => {
+      let settled = false;
+      const derivedHelper = search.mainHelper!.derivedHelpers[0];
+      const settle = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (resolveWaitForResultsRef) {
+          resolveWaitForResultsRef.current = null;
+        }
+        resolve();
+      };
+      const onResult = () => {
         searchReceived = true;
         if (!search._hasRecommendWidget || recommendReceived) {
-          resolve();
+          settle();
         }
-      });
-      search.mainHelper!.derivedHelpers[0].once('recommend:result', () => {
+      };
+      const onRecommendResult = () => {
         recommendReceived = true;
         if (!search._hasSearchWidget || searchReceived) {
-          resolve();
+          settle();
         }
-      });
+      };
+
+      if (resolveWaitForResultsRef) {
+        resolveWaitForResultsRef.current = () => {
+          derivedHelper.removeListener('result', onResult);
+          derivedHelper.removeListener('recommend:result', onRecommendResult);
+          settle();
+        };
+      }
+
+      derivedHelper.once('result', onResult);
+      derivedHelper.once('recommend:result', onRecommendResult);
     });
 
   const injectInitialResults = () => {
     const options = { inserted: false };
-    const results = getInitialResults(search.mainIndex, requestParamsList);
+    const results = getInitialResults(
+      search.mainIndex,
+      search._hasSearchWidget ? requestParamsList || [] : []
+    );
     insertHTML(createInsertHTML({ options, results, nonce }));
   };
 
@@ -92,6 +132,9 @@ export function InitializePromise({ nonce }: InitializePromiseProps) {
         .then(() => {
           let shouldRefetch = false;
           walkIndex(search.mainIndex, (index) => {
+            if (isWithinIsolatedIndex(index)) {
+              return;
+            }
             shouldRefetch =
               shouldRefetch || index.getWidgets().some(isTwoPassWidget);
           });

--- a/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
+++ b/packages/react-instantsearch-nextjs/src/InstantSearchNext.tsx
@@ -84,7 +84,7 @@ export function InstantSearchNext<
       <InstantSearch {...instantSearchProps} routing={routing!}>
         {isServer && <InitializePromise nonce={nonce} />}
         {children}
-        {isServer && <TriggerSearch nonce={nonce} />}
+        {isServer && <TriggerSearch />}
       </InstantSearch>
     </ServerOrHydrationProvider>
   );
@@ -102,6 +102,7 @@ function ServerOrHydrationProvider({
   ignoreMultipleHooksWarning: boolean;
 }) {
   const promiseRef = useRef<PromiseWithState<void> | null>(null);
+  const resolvePromiseRef = useRef<(() => void) | null>(null);
   const countRef = useRef(0);
   // Capture once on first render. Side-effect-free read keeps hydration
   // deterministic across StrictMode double-invocation and React 19 / Next.js
@@ -128,6 +129,7 @@ function ServerOrHydrationProvider({
     <InstantSearchRSCContext.Provider
       value={{
         waitForResultsRef: rscWaitRef,
+        resolveWaitForResultsRef: resolvePromiseRef,
         countRef,
         ignoreMultipleHooksWarning,
       }}

--- a/packages/react-instantsearch-nextjs/src/TriggerSearch.ts
+++ b/packages/react-instantsearch-nextjs/src/TriggerSearch.ts
@@ -1,20 +1,11 @@
-import { ServerInsertedHTMLContext } from 'next/navigation';
-import { useContext } from 'react';
 import {
   useInstantSearchContext,
   useRSCContext,
 } from 'react-instantsearch-core';
 
-import { createInsertHTML } from './createInsertHTML';
-
-export function TriggerSearch({ nonce }: { nonce?: string }) {
+export function TriggerSearch() {
   const instantsearch = useInstantSearchContext();
-  const { waitForResultsRef } = useRSCContext();
-  const insertHTML =
-    useContext(ServerInsertedHTMLContext) ||
-    (() => {
-      throw new Error('Missing ServerInsertedHTMLContext');
-    });
+  const { waitForResultsRef, resolveWaitForResultsRef } = useRSCContext();
 
   if (waitForResultsRef?.current?.status === 'pending') {
     if (instantsearch._hasSearchWidget) {
@@ -26,10 +17,8 @@ export function TriggerSearch({ nonce }: { nonce?: string }) {
     }
     instantsearch._hasRecommendWidget && instantsearch.mainHelper?.recommend();
 
-    // If there are no widgets, we inject empty initial results instantly
     if (!instantsearch._hasSearchWidget && !instantsearch._hasRecommendWidget) {
-      const options = { inserted: false };
-      insertHTML(createInsertHTML({ options, results: {}, nonce }));
+      resolveWaitForResultsRef?.current?.();
     }
   }
 

--- a/packages/react-instantsearch-nextjs/src/__tests__/InitializePromise-composition.test.tsx
+++ b/packages/react-instantsearch-nextjs/src/__tests__/InitializePromise-composition.test.tsx
@@ -6,7 +6,7 @@ import { createCompositionClient } from '@instantsearch/mocks';
 import { act, render } from '@testing-library/react';
 import { ServerInsertedHTMLContext } from 'next/navigation';
 import React from 'react';
-import { SearchBox } from 'react-instantsearch';
+import { EXPERIMENTAL_Autocomplete, SearchBox } from 'react-instantsearch';
 import {
   InstantSearch,
   InstantSearchRSCContext,
@@ -43,6 +43,7 @@ const renderComponent = async ({
       <InstantSearchRSCContext.Provider
         value={{
           waitForResultsRef: ref,
+          resolveWaitForResultsRef: { current: null },
           countRef: { current: 0 },
           ignoreMultipleHooksWarning: false,
         }}
@@ -87,6 +88,41 @@ test('it waits for composition-based search', async () => {
     1,
     expect.objectContaining({ compositionID })
   );
+});
+
+test('it ignores isolated feeds when deciding whether to run a second pass', async () => {
+  const ref: { current: PromiseWithState<void> | null } = { current: null };
+  const insertedHTML = jest.fn();
+
+  const client = await renderComponent({
+    ref,
+    insertedHTML,
+    children: (
+      <>
+        <EXPERIMENTAL_Autocomplete
+          autoFocus
+          requiresSearch={false}
+          feeds={[
+            {
+              feedID: 'products',
+              itemComponent: ({ item }) => <>{item.objectID}</>,
+            },
+          ]}
+        />
+        <SearchBox />
+      </>
+    ),
+  });
+
+  await act(async () => {
+    await ref.current;
+  });
+
+  expect(ref.current!.status).toBe('fulfilled');
+  // One isolated feeds request and one main request. Opting the Autocomplete
+  // out of the main search must not repeat its isolated request.
+  expect(client.search).toHaveBeenCalledTimes(2);
+  expect(insertedHTML).toHaveBeenCalledTimes(1);
 });
 
 afterAll(() => {

--- a/packages/react-instantsearch-nextjs/src/__tests__/InitializePromise.test.tsx
+++ b/packages/react-instantsearch-nextjs/src/__tests__/InitializePromise.test.tsx
@@ -7,14 +7,21 @@ import {
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
 import { render, act } from '@testing-library/react';
+import connectAutocomplete from 'instantsearch.js/es/connectors/autocomplete/connectAutocomplete';
 import * as utils from 'instantsearch.js/es/lib/utils';
 import { ServerInsertedHTMLContext } from 'next/navigation';
 import React from 'react';
-import { SearchBox, TrendingItems } from 'react-instantsearch';
+import {
+  Configure,
+  EXPERIMENTAL_Autocomplete,
+  SearchBox,
+  TrendingItems,
+} from 'react-instantsearch';
 import {
   InstantSearch,
   InstantSearchRSCContext,
   InstantSearchSSRProvider,
+  useConnector,
 } from 'react-instantsearch-core';
 
 import { InitializePromise } from '../InitializePromise';
@@ -27,28 +34,55 @@ jest.mock('instantsearch.js/es/lib/utils', () => ({
   resetWidgetId: jest.fn(),
 }));
 
+function AutocompleteWithoutSearch() {
+  useConnector(connectAutocomplete, { requiresSearch: false });
+
+  return null;
+}
+
+function RequestFreeAutocomplete() {
+  return (
+    <EXPERIMENTAL_Autocomplete
+      autoFocus
+      requiresSearch={false}
+      searchParameters={{ hitsPerPage: 3 }}
+      indices={[
+        {
+          indexName: 'suggestions',
+          itemComponent: ({ item }) => <>{item.objectID}</>,
+        },
+      ]}
+    />
+  );
+}
+
 const renderComponent = async ({
   children,
   ref = { current: null },
   nonce,
   insertedHTML,
+  searchClient,
 }: {
   children?: React.ReactNode;
   ref?: { current: PromiseWithState<void> | null };
   nonce?: string;
   insertedHTML?: jest.Mock;
+  searchClient?: ReturnType<typeof createSearchClient>;
 } = {}) => {
-  const client = createSearchClient({
-    getRecommendations: jest.fn().mockResolvedValue({
-      results: [createSingleSearchResponse()],
-    }),
-  });
+  const client =
+    searchClient ||
+    createSearchClient({
+      getRecommendations: jest.fn().mockResolvedValue({
+        results: [createSingleSearchResponse()],
+      }),
+    });
 
   await act(() =>
     render(
       <InstantSearchRSCContext.Provider
         value={{
           waitForResultsRef: ref,
+          resolveWaitForResultsRef: { current: null },
           countRef: { current: 0 },
           ignoreMultipleHooksWarning: false,
         }}
@@ -134,6 +168,23 @@ test('it waits for search only if there are only search widgets', async () => {
   expect(client.getRecommendations).not.toHaveBeenCalled();
 });
 
+test('it searches when an opt-out widget precedes a search widget', async () => {
+  const ref: { current: PromiseWithState<void> | null } = { current: null };
+
+  const client = await renderComponent({
+    ref,
+    children: (
+      <>
+        <AutocompleteWithoutSearch />
+        <SearchBox />
+      </>
+    ),
+  });
+
+  expect(ref.current!.status).toBe('fulfilled');
+  expect(client.search).toHaveBeenCalledTimes(1);
+});
+
 test('it waits for recommend only if there are only recommend widgets', async () => {
   const ref: { current: PromiseWithState<void> | null } = { current: null };
 
@@ -149,6 +200,70 @@ test('it waits for recommend only if there are only recommend widgets', async ()
   expect(ref.current!.status).toBe('fulfilled');
   expect(client.search).not.toHaveBeenCalled();
   expect(client.getRecommendations).toHaveBeenCalledTimes(1);
+});
+
+test('it resolves without a request when no widget requires a search', async () => {
+  const ref: { current: PromiseWithState<void> | null } = { current: null };
+  const insertedHTML = jest.fn();
+
+  const client = await renderComponent({
+    ref,
+    insertedHTML,
+    children: <AutocompleteWithoutSearch />,
+  });
+
+  expect(ref.current!.status).toBe('fulfilled');
+  expect(client.search).not.toHaveBeenCalled();
+  expect(client.getRecommendations).not.toHaveBeenCalled();
+  expect(insertedHTML).toHaveBeenCalledTimes(1);
+  expect(
+    insertedHTML.mock.calls[0][0].props.dangerouslySetInnerHTML.__html
+  ).toContain(' = {}');
+});
+
+test('it inserts empty SSR state when only an isolated autocomplete searches', async () => {
+  const ref: { current: PromiseWithState<void> | null } = { current: null };
+  const insertedHTML = jest.fn();
+
+  const client = await renderComponent({
+    ref,
+    insertedHTML,
+    children: <RequestFreeAutocomplete />,
+  });
+
+  expect(ref.current!.status).toBe('fulfilled');
+  expect(client.search).toHaveBeenCalledWith([
+    expect.objectContaining({ indexName: 'suggestions' }),
+  ]);
+  expect(client.search).not.toHaveBeenCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({ indexName: 'indexName' }),
+    ])
+  );
+  expect(insertedHTML).toHaveBeenCalledTimes(1);
+  expect(
+    insertedHTML.mock.calls[0][0].props.dangerouslySetInnerHTML.__html
+  ).toBe('window[Symbol.for("InstantSearchInitialResults")] = {}');
+});
+
+test('it serializes main request parameters when isolated autocomplete also searches', async () => {
+  const insertedHTML = jest.fn();
+
+  await renderComponent({
+    insertedHTML,
+    children: (
+      <>
+        <RequestFreeAutocomplete />
+        <SearchBox />
+        <Configure hitsPerPage={7} />
+      </>
+    ),
+  });
+
+  const html =
+    insertedHTML.mock.calls[0][0].props.dangerouslySetInnerHTML.__html;
+  expect(html).toContain('"hitsPerPage":7');
+  expect(html).not.toContain('"hitsPerPage":3');
 });
 
 afterAll(() => {

--- a/packages/react-instantsearch/src/__tests__/common-widgets.test.tsx
+++ b/packages/react-instantsearch/src/__tests__/common-widgets.test.tsx
@@ -409,7 +409,11 @@ const testSetups: TestSetupsMap<TestSuites, 'react'> = {
     );
   },
   createChatWidgetTests({ instantSearchOptions, widgetParams }) {
-    const { renderRefinements, ...chatWidgetParams } = widgetParams;
+    const {
+      renderChat = true,
+      renderRefinements,
+      ...chatWidgetParams
+    } = widgetParams;
     render(
       <InstantSearch {...instantSearchOptions}>
         {renderRefinements && (
@@ -427,7 +431,7 @@ const testSetups: TestSetupsMap<TestSuites, 'react'> = {
           </>
         )}
         <ChatTrigger />
-        <Chat {...chatWidgetParams} />
+        {renderChat && <Chat {...chatWidgetParams} />}
         <GlobalErrorSwallower />
       </InstantSearch>
     );

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -386,6 +386,7 @@ type AutocompleteCommonProps<TItem extends BaseHit> = ComponentProps<'div'> & {
   ) => TransformItemsIndicesConfig[];
   /**
    * Whether this widget should make InstantSearch require a main search request.
+   * If this is the only widget, and you mark `requiresSearch: false`, no search request will happen.
    *
    * @default true
    */

--- a/packages/react-instantsearch/src/widgets/Autocomplete.tsx
+++ b/packages/react-instantsearch/src/widgets/Autocomplete.tsx
@@ -341,8 +341,14 @@ type IndicesShowPromptSuggestionsConfig = Partial<
 type FeedsShowPromptSuggestionsConfig = {
   feedID: string;
   getURL?: IndexConfig<{ query: string; label?: string }>['getURL'];
-  headerComponent?: IndexConfig<{ query: string; label?: string }>['headerComponent'];
-  itemComponent?: IndexConfig<{ query: string; label?: string }>['itemComponent'];
+  headerComponent?: IndexConfig<{
+    query: string;
+    label?: string;
+  }>['headerComponent'];
+  itemComponent?: IndexConfig<{
+    query: string;
+    label?: string;
+  }>['itemComponent'];
   classNames?: Partial<AutocompleteIndexClassNames>;
 };
 
@@ -378,6 +384,12 @@ type AutocompleteCommonProps<TItem extends BaseHit> = ComponentProps<'div'> & {
   transformItems?: (
     indices: TransformItemsIndicesConfig[]
   ) => TransformItemsIndicesConfig[];
+  /**
+   * Whether this widget should make InstantSearch require a main search request.
+   *
+   * @default true
+   */
+  requiresSearch?: boolean;
   panelComponent?: (props: {
     elements: PanelElements;
     indices: ReturnType<typeof useAutocomplete>['indices'];
@@ -465,6 +477,7 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
     detachedMediaQuery,
     translations: userTranslations = {},
     transformItems,
+    requiresSearch = true,
     ...restProps
   } = props;
   const { autoFocus, placeholder, classNames } = restProps as {
@@ -481,11 +494,13 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
   };
   const { indexUiState, indexRenderState, status } = useInstantSearch();
   const { compositionID } = useInstantSearchContext();
+  const dependsOn = requiresSearch ? ('search' as const) : ('none' as const);
   const { refine } = useSearchBox(
     {},
     {
       $$type: 'ais.autocomplete',
       $$widgetType: 'ais.autocomplete',
+      dependsOn,
       ...(props.aiMode ? { opensChat: true } : {}),
     }
   );
@@ -892,10 +907,7 @@ export function EXPERIMENTAL_Autocomplete<TItem extends BaseHit = BaseHit>(
   }
 
   return (
-    <Index
-      EXPERIMENTAL_isolated
-      indexId={`ais-autocomplete-${instanceKey}`}
-    >
+    <Index EXPERIMENTAL_isolated indexId={`ais-autocomplete-${instanceKey}`}>
       <Configure {...searchParameters} />
       {indicesConfig.map((index) => (
         <Index
@@ -1248,7 +1260,11 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
   const panelContent = (
     <AutocompletePanel
       {...getPanelProps()}
-      classNames={{ root: classNames?.panel, open: classNames?.panelOpen, layout: classNames?.panelLayout }}
+      classNames={{
+        root: classNames?.panel,
+        open: classNames?.panelOpen,
+        layout: classNames?.panelLayout,
+      }}
     >
       {PanelComponent ? (
         <PanelComponent
@@ -1303,9 +1319,7 @@ function InnerAutocomplete<TItem extends BaseHit = BaseHit>({
             <AutocompleteDetachedContainer
               classNames={detachedContainerClassNames}
             >
-              <AutocompleteDetachedFormContainer
-                classNames={classNames}
-              >
+              <AutocompleteDetachedFormContainer classNames={classNames}>
                 {searchBoxContent}
               </AutocompleteDetachedFormContainer>
               {panelContent}

--- a/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Autocomplete.test.tsx
@@ -120,6 +120,49 @@ describe('EXPERIMENTAL_Autocomplete', () => {
   });
 
   describe('lazy activation', () => {
+    test('updates its main search dependency when requiresSearch changes', async () => {
+      const searchClient = createSearchClient({});
+      const indices = [
+        {
+          indexName: 'my-index',
+          itemComponent: ({ item }: { item: { objectID: string } }) =>
+            React.createElement('div', null, String(item.objectID)),
+        },
+      ];
+
+      function App({ requiresSearch }: { requiresSearch: boolean }) {
+        return (
+          <InstantSearchTestWrapper
+            searchClient={searchClient}
+            indexName="indexName"
+          >
+            <EXPERIMENTAL_Autocomplete
+              indices={indices}
+              requiresSearch={requiresSearch}
+            />
+          </InstantSearchTestWrapper>
+        );
+      }
+
+      const { rerender } = render(<App requiresSearch />);
+      await act(async () => {
+        await wait(0);
+      });
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+
+      rerender(<App requiresSearch={false} />);
+      await act(async () => {
+        await wait(0);
+      });
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+
+      rerender(<App requiresSearch />);
+      await act(async () => {
+        await wait(0);
+      });
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
+    });
+
     test('does not search on mount in indices-mode', async () => {
       const searchClient = createSearchClient({});
 

--- a/packages/vue-instantsearch/src/components/Autocomplete.vue
+++ b/packages/vue-instantsearch/src/components/Autocomplete.vue
@@ -44,11 +44,17 @@ export default {
       required: false,
       default: true,
     },
+    requiresSearch: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
   },
   computed: {
     widgetParams() {
       return {
         escapeHTML: this.escapeHTML,
+        requiresSearch: this.requiresSearch,
       };
     },
   },

--- a/packages/vue-instantsearch/src/mixins/__tests__/widget.test.js
+++ b/packages/vue-instantsearch/src/mixins/__tests__/widget.test.js
@@ -174,6 +174,29 @@ describe('on root index', () => {
 
     expect(wrapper.vm.state).toEqual(state);
   });
+
+  it('keeps initial state when the widget requires no request', () => {
+    const instance = createFakeInstance();
+    const widget = { render: () => {}, dependsOn: 'none' };
+    const factory = jest.fn(() => widget);
+    const connector = jest.fn(() => factory);
+    const Test = createFakeComponent({
+      mixins: [createWidgetMixin({ connector })],
+    });
+    const state = {
+      items: [],
+    };
+
+    const wrapper = mount(Test, {
+      provide: {
+        $_ais_instantSearchInstance: instance,
+      },
+    });
+
+    connector.mock.calls[0][0](state, true);
+
+    expect(wrapper.vm.state).toEqual(state);
+  });
 });
 
 describe('on child index', () => {

--- a/packages/vue-instantsearch/src/mixins/widget.js
+++ b/packages/vue-instantsearch/src/mixins/widget.js
@@ -84,9 +84,9 @@ Read more on using connectors: https://alg.li/vue-custom`
   },
   methods: {
     updateState(state = {}, isFirstRender) {
-      if (!isFirstRender) {
-        // Avoid updating the state on first render
-        // otherwise there will be a flash of placeholder data
+      // Search-backed widgets skip placeholder state from init. Request-free
+      // widgets may not receive another render, so their init state is final.
+      if (!isFirstRender || this.widget.dependsOn === 'none') {
         this.state = state;
       }
     },

--- a/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
+++ b/packages/vue-instantsearch/src/util/__tests__/createServerRootMixin.test.js
@@ -15,6 +15,7 @@ import Vuex from 'vuex';
 import { createStore } from 'vuex4';
 
 import { mount, createSSRApp } from '../../../test/utils';
+import Autocomplete from '../../components/Autocomplete.vue';
 import Configure from '../../components/Configure';
 import Index from '../../components/Index';
 import InstantSearchSsr from '../../components/InstantSearchSsr';
@@ -193,6 +194,47 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/instantsear
       });
 
       await renderToString(wrapper);
+    });
+
+    it('returns empty results when no widget requires a search', async () => {
+      const searchClient = createFakeClient();
+      let resultsState;
+
+      const app = {
+        mixins: [
+          forceIsServerMixin,
+          createServerRootMixin({
+            searchClient,
+            indexName: 'hello',
+          }),
+        ],
+        render: renderCompat((h) =>
+          h(InstantSearchSsr, {}, [
+            h(Autocomplete, {
+              attrs: {
+                requiresSearch: false,
+              },
+            }),
+          ])
+        ),
+        async serverPrefetch() {
+          resultsState = await this.instantsearch.findResultsState({
+            component: this,
+            renderToString,
+          });
+        },
+      };
+
+      const wrapper = createSSRApp({
+        mixins: [forceIsServerMixin],
+        render: renderCompat((h) => h(app)),
+      });
+
+      const html = await renderToString(wrapper);
+
+      expect(resultsState).toEqual({});
+      expect(searchClient.search).not.toHaveBeenCalled();
+      expect(html).toContain('ais-Autocomplete');
     });
 
     it('detects child widgets', async () => {

--- a/tests/common/widgets/autocomplete/index.ts
+++ b/tests/common/widgets/autocomplete/index.ts
@@ -17,7 +17,7 @@ export type ReactAutocompleteWidgetParams = AutocompleteProps<any>;
 type AutocompleteWidgetParams = {
   javascript: JSAutocompleteWidgetParams;
   react: ReactAutocompleteWidgetParams;
-  vue: Record<string, never>;
+  vue: { requiresSearch?: boolean };
 };
 
 declare module '../../common' {

--- a/tests/common/widgets/autocomplete/options.tsx
+++ b/tests/common/widgets/autocomplete/options.tsx
@@ -109,6 +109,116 @@ export function createOptionsTests(
       expect(indicesItems[1]).toHaveTextContent('hello');
     });
 
+    test('triggers the main search by default', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {},
+          react: {},
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not trigger the main search when requiresSearch is false', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            requiresSearch: false,
+          },
+          react: {
+            requiresSearch: false,
+          },
+          vue: {
+            requiresSearch: false,
+          },
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.search).not.toHaveBeenCalled();
+    });
+
+    test('does not trigger the main search after activation when requiresSearch is false', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'main',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            requiresSearch: false,
+            indices: [
+              {
+                indexName: 'suggestions',
+                templates: {
+                  item: (props) => props.item.name,
+                },
+              },
+            ],
+          },
+          react: {
+            requiresSearch: false,
+            indices: [
+              {
+                indexName: 'suggestions',
+                itemComponent: (props) => props.item.name,
+              },
+            ],
+          },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      const input = screen.getByRole('combobox', { name: /submit/i });
+      await act(async () => {
+        userEvent.click(input);
+        userEvent.type(input, 'hello');
+        await wait(0);
+      });
+
+      await act(async () => {
+        userEvent.click(screen.getByRole('button', { name: /clear/i }));
+        await wait(0);
+      });
+
+      const requests = (searchClient.search as jest.Mock).mock.calls.flatMap(
+        ([request]) => request
+      );
+      expect(requests).not.toContainEqual(
+        expect.objectContaining({ indexName: 'main' })
+      );
+      expect(requests).toContainEqual(
+        expect.objectContaining({ indexName: 'suggestions' })
+      );
+    });
+
     test('renders suggestions', async () => {
       const searchClient = createMockedSearchClient(
         createMultiSearchResponse(

--- a/tests/common/widgets/chat/index.ts
+++ b/tests/common/widgets/chat/index.ts
@@ -16,8 +16,12 @@ type JSBaseWidgetParams = Parameters<ChatWidget>[0];
 // Explicitly adding ChatConnectorParams back. For some reason
 // ChatConnectorParams are not inferred when Omit is used with WidgetParams.
 export type JSChatWidgetParams = Omit<JSBaseWidgetParams, 'container'> &
-  ChatConnectorParams & { renderRefinements?: boolean };
+  ChatConnectorParams & {
+    renderChat?: boolean;
+    renderRefinements?: boolean;
+  };
 export type ReactChatWidgetParams = ChatProps<unknown> & {
+  renderChat?: boolean;
   renderRefinements?: boolean;
 };
 

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -98,6 +98,64 @@ export function createOptionsTests(
       expect(searchClient.search).not.toHaveBeenCalled();
     });
 
+    test('does not trigger the main search with only a chat trigger', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(),
+            renderChat: false,
+          },
+          react: {
+            ...createDefaultWidgetParams(),
+            renderChat: false,
+          },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.search).not.toHaveBeenCalled();
+    });
+
+    test('triggers the main search when another widget requires it', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(),
+            renderRefinements: true,
+            requiresSearch: false,
+          },
+          react: {
+            ...createDefaultWidgetParams(),
+            renderRefinements: true,
+            requiresSearch: false,
+          },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+    });
+
     test('sends initialUserMessage on init', async () => {
       const searchClient = createSearchClient();
 

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -48,6 +48,56 @@ export function createOptionsTests(
       expect(document.querySelector('.ais-ChatPrompt')).toBeInTheDocument();
     });
 
+    test('triggers the main search by default', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: createDefaultWidgetParams(),
+          react: createDefaultWidgetParams(),
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not trigger the main search when requiresSearch is false', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(),
+            requiresSearch: false,
+          },
+          react: {
+            ...createDefaultWidgetParams(),
+            requiresSearch: false,
+          },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(searchClient.search).not.toHaveBeenCalled();
+    });
+
     test('sends initialUserMessage on init', async () => {
       const searchClient = createSearchClient();
 


### PR DESCRIPTION
## Summary

Adds `requiresSearch?: boolean` to Chat and Autocomplete so consumers can prevent those widgets from requiring a main search request. The option defaults to `true`, preserving existing behavior.

When `requiresSearch: false`, the widget uses `dependsOn: 'none'`. A sibling search widget still triggers the main search and Autocomplete continues to contribute its search parameters.

[FX-3886]

## Implementation

- Extends the existing widget request classifier with `dependsOn: 'none'`.
- Recomputes search and Recommend dependencies when widgets are added or removed, including nested indices.
- Resolves SSR immediately when no search or Recommend request is pending.
- Exposes the option through Chat and the JavaScript, React and Vue Autocomplete APIs.
- Covers React Autocomplete's internal SearchBox registration path.

## Scope guard

This PR does not make Chat standalone outside InstantSearch, add a global InstantSearch option, or introduce mount-only search suppression. It only controls whether Chat or Autocomplete requires the main search request.

## Tests

- Focused connector, lifecycle and SSR tested.
- Autocomplete common widget tests across JavaScript and React.
- Chat common widget tests across JavaScript and React.
- `yarn type-check`
- `yarn lint:changed`
- `git diff --check --cached`

Vue Autocomplete is covered by type checking and package build verification, the existing common Autocomplete suite does not run for Vue.

## Documentation

The public option includes TSDoc on the connector and framework APIs. No standalone documentation page is changed in this PR.

[FX-3886]: https://algolia.atlassian.net/browse/FX-3886
