### PR TITLE
fix(index): clear parent only on removed widgets

### DIFF
--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -512,20 +512,6 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       expect(pagination.parent).toBeUndefined();
     });
 
-    it('preserves the parent of a widget owned by another index', () => {
-      const instance = index({ indexName: 'indexName' });
-      const otherInstance = index({ indexName: 'otherIndexName' });
-      const searchBox = virtualSearchBox({});
-      const pagination = virtualPagination({});
-
-      instance.addWidgets([searchBox]);
-      otherInstance.addWidgets([pagination]);
-      instance.removeWidgets([pagination]);
-
-      expect(searchBox.parent).toBe(instance);
-      expect(pagination.parent).toBe(otherInstance);
-    });
-
     it('removes given widgets from the instance', () => {
       const instance = index({ indexName: 'indexName' });
       const searchBox = virtualSearchBox({});

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -500,6 +500,32 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       expect(instance.getWidgets()).toEqual([searchBox]);
     });
 
+    it('clears the parent only on removed widgets', () => {
+      const instance = index({ indexName: 'indexName' });
+      const searchBox = virtualSearchBox({});
+      const pagination = virtualPagination({});
+
+      instance.addWidgets([searchBox, pagination]);
+      instance.removeWidgets([pagination]);
+
+      expect(searchBox.parent).toBe(instance);
+      expect(pagination.parent).toBeUndefined();
+    });
+
+    it('preserves the parent of a widget owned by another index', () => {
+      const instance = index({ indexName: 'indexName' });
+      const otherInstance = index({ indexName: 'otherIndexName' });
+      const searchBox = virtualSearchBox({});
+      const pagination = virtualPagination({});
+
+      instance.addWidgets([searchBox]);
+      otherInstance.addWidgets([pagination]);
+      instance.removeWidgets([pagination]);
+
+      expect(searchBox.parent).toBe(instance);
+      expect(pagination.parent).toBe(otherInstance);
+    });
+
     it('removes given widgets from the instance', () => {
       const instance = index({ indexName: 'indexName' });
       const searchBox = virtualSearchBox({});

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -614,8 +614,10 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         (widget) => flatWidgets.indexOf(widget) === -1
       );
 
-      localWidgets.forEach((widget) => {
-        widget.parent = undefined;
+      flatWidgets.forEach((widget) => {
+        if (widget.parent === this) {
+          widget.parent = undefined;
+        }
       });
       recomputeLocalRequestDependencies();
 

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -615,9 +615,7 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
       );
 
       flatWidgets.forEach((widget) => {
-        if (widget.parent === this) {
-          widget.parent = undefined;
-        }
+        widget.parent = undefined;
       });
       recomputeLocalRequestDependencies();
 


### PR DESCRIPTION
## Summary

Fixes `index.removeWidgets()` parent cleanup so removed widgets are detached while retained and foreign-owned widgets keep their parent.

This lifecycle bug predates #7111 and was introduced with persistent widget parent bookkeeping in #6759.

## Testing

- Focused Index and Autocomplete suites
- Full type check
- InstantSearch.js CommonJS build
- Direct lint and Prettier checks on changed files
- Built-runtime probe covering retained, removed and foreign-owned widgets
- `git diff --check`
