### PR TITLE
fix(chat): allow user to override `sendAutomaticallyWhen` in the Chat widget

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "103 kB"
+      "maxSize": "103.25 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1831,4 +1831,91 @@ data: [DONE]`,
       expect(sendMessageSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('sendAutomaticallyWhen', () => {
+    // A minimal, immediately-terminating assistant turn — enough for the
+    // automatic follow-up request's stream to settle.
+    const terminalStream = () =>
+      new Response(
+        `data: {"type": "start", "messageId": "assistant-2"}
+
+data: {"type": "finish"}
+
+data: [DONE]`,
+        { headers: { 'Content-Type': 'text/event-stream' } }
+      );
+
+    // An assistant message with a single, still-unresolved tool call. Assigning
+    // it directly (rather than streaming it in) keeps the test deterministic:
+    // the only request that can fire is the auto-continuation from
+    // `addToolResult`.
+    const assistantWithPendingTool = () =>
+      [
+        { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+        {
+          id: 'a1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-myTool',
+              toolCallId: 'call_1',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ] as unknown as UIMessage[];
+
+    it('auto-continues by default once a resolved tool completes the assistant message', async () => {
+      const fetchMock = jest.fn(() => Promise.resolve(terminalStream()));
+
+      const { widget } = getInitializedWidget({
+        agentId: undefined,
+        transport: { fetch: fetchMock },
+      } as ChatConnectorParams);
+
+      widget.chatInstance.messages = assistantWithPendingTool();
+
+      // Resolving the tool result flips the last assistant message's tool part
+      // to `output-available`; the default
+      // `lastAssistantMessageIsCompleteWithToolCalls` then resubmits. Awaiting
+      // `addToolResult` waits for that follow-up to complete, so the assertion
+      // is deterministic.
+      await widget.chatInstance.addToolResult({
+        tool: 'myTool',
+        toolCallId: 'call_1',
+        output: { ok: true },
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not auto-continue when a user `sendAutomaticallyWhen` returns false', async () => {
+      const fetchMock = jest.fn(() => Promise.resolve(terminalStream()));
+      const sendAutomaticallyWhen = jest.fn(() => false);
+
+      const { widget } = getInitializedWidget({
+        agentId: undefined,
+        transport: { fetch: fetchMock },
+        sendAutomaticallyWhen,
+      } as ChatConnectorParams);
+
+      widget.chatInstance.messages = assistantWithPendingTool();
+
+      await widget.chatInstance.addToolResult({
+        tool: 'myTool',
+        toolCallId: 'call_1',
+        output: { ok: true },
+      });
+
+      // The user predicate was consulted with the resolved messages...
+      expect(sendAutomaticallyWhen).toHaveBeenCalledWith(
+        expect.objectContaining({ messages: expect.any(Array) })
+      );
+      // ...and because it returned `false`, no automatic follow-up fired at
+      // all. This is the escape hatch for the runaway auto-continuation loop: a
+      // resolved tool no longer forces another completions request.
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -161,11 +161,6 @@ export type ChatCustomInstance<TUiMessage extends UIMessage> = {
   feedback?: never;
   requestOptions?: never;
   persistence?: never;
-  // A custom `chat` instance already configures its own auto-continuation
-  // predicate, so this option doesn't apply here. Declaring it `never` (like
-  // `feedback`/`requestOptions`/`persistence` above) forbids passing it
-  // alongside a custom instance and keeps it a common key across the union so
-  // the connector can destructure it with a default.
   sendAutomaticallyWhen?: never;
 };
 

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -159,6 +159,7 @@ export type ChatCustomInstance<TUiMessage extends UIMessage> = {
   feedback?: never;
   requestOptions?: never;
   persistence?: never;
+  sendAutomaticallyWhen?: never;
 };
 
 export type ApplyFiltersParams = {
@@ -331,6 +332,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       initialUserMessage,
       initialMessages,
       disableTriggerValidation = false,
+      sendAutomaticallyWhen = lastAssistantMessageIsCompleteWithToolCalls,
       ...options
     } = widgetParams || {};
 
@@ -549,8 +551,8 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       }
 
       return new Chat({
-        sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
         ...options,
+        sendAutomaticallyWhen,
         transport,
         shouldRepairToolInput(toolName) {
           let tool = tools[toolName];

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -549,9 +549,9 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       }
 
       return new Chat({
+        sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
         ...options,
         transport,
-        sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
         shouldRepairToolInput(toolName) {
           let tool = tools[toolName];
           if (!tool && toolName.startsWith(`${SearchIndexToolType}_`)) {


### PR DESCRIPTION
This PR fixes the `sendAutomaticallyWhen` prop not being overridable by the user. This allows users to provide their own custom function that can handle things like custom max client side tool calls to prevent their looping.