### PR TITLE
fix(chat): allow tool result submission during response streaming

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "131.25 kB"
+      "maxSize": "131.5 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
@@ -18,7 +18,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "62 kB"
+      "maxSize": "62.25 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "131 kB"
+      "maxSize": "131.25 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
@@ -18,7 +18,7 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "61.75 kB"
+      "maxSize": "62 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "104 kB"
+      "maxSize": "104.25 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "131.5 kB"
+      "maxSize": "131.75 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "131.75 kB"
+      "maxSize": "132.5 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
@@ -18,11 +18,11 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "62.25 kB"
+      "maxSize": "63.25 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "104.25 kB"
+      "maxSize": "105.25 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "103.75 kB"
+      "maxSize": "104 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "130.75 kB"
+      "maxSize": "131 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",
@@ -18,11 +18,11 @@
     },
     {
       "path": "packages/react-instantsearch-core/dist/umd/ReactInstantSearchCore.min.js",
-      "maxSize": "61.5 kB"
+      "maxSize": "61.75 kB"
     },
     {
       "path": "packages/react-instantsearch/dist/umd/ReactInstantSearch.min.js",
-      "maxSize": "103.25 kB"
+      "maxSize": "103.75 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.production.min.js",
-      "maxSize": "130.5 kB"
+      "maxSize": "130.75 kB"
     },
     {
       "path": "./packages/instantsearch.js/dist/instantsearch.development.js",

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -8,12 +8,21 @@ import { MenuIcon } from './icons';
 
 import type { ComponentProps, Renderer, VNode } from '../../types';
 import type {
+  AddToolResult,
   AddToolResultWithOutput,
   ChatMessageBase,
   ChatStatus,
   ChatToolMessage,
+  ClientSideTool,
   ClientSideTools,
 } from './types';
+
+type MessageScopedClientSideTool = ClientSideTool & {
+  '~addToolResultForMessage'?: (
+    message: ChatMessageBase,
+    params: Parameters<AddToolResult>[0]
+  ) => ReturnType<AddToolResult>;
+};
 
 export type ChatMessageSide = 'left' | 'right';
 export type ChatMessageVariant = 'neutral' | 'subtle';
@@ -248,10 +257,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
           // Wrapped in a `<p>` to keep some structure for screen readers
           // (markdown produces semantic elements; a bare text node would not).
           return (
-            <p
-              key={`${message.id}-${index}`}
-              className="ais-ChatMessage-text"
-            >
+            <p key={`${message.id}-${index}`} className="ais-ChatMessage-text">
               {part.text}
             </p>
           );
@@ -264,11 +270,13 @@ export function createChatMessageComponent({ createElement }: Renderer) {
       }
       if (startsWith(part.type, 'tool-')) {
         const toolName = part.type.replace('tool-', '');
-        let tool = tools[toolName];
+        let tool = tools[toolName] as MessageScopedClientSideTool | undefined;
 
         // Compatibility shim with Algolia MCP Server search tool
         if (!tool && startsWith(toolName, `${SearchIndexToolType}_`)) {
-          tool = tools[SearchIndexToolType];
+          tool = tools[SearchIndexToolType] as
+            | MessageScopedClientSideTool
+            | undefined;
         }
 
         const displayResultsEnabled =
@@ -288,11 +296,17 @@ export function createChatMessageComponent({ createElement }: Renderer) {
           const toolMessage = part as ChatToolMessage;
 
           const boundAddToolResult: AddToolResultWithOutput = (params) =>
-            tool.addToolResult?.({
-              output: params.output,
-              tool: part.type,
-              toolCallId: toolMessage.toolCallId,
-            });
+            tool['~addToolResultForMessage']
+              ? tool['~addToolResultForMessage'](message, {
+                  output: params.output,
+                  tool: part.type,
+                  toolCallId: toolMessage.toolCallId,
+                })
+              : tool.addToolResult({
+                  output: params.output,
+                  tool: part.type,
+                  toolCallId: toolMessage.toolCallId,
+                });
 
           if (toolMessage.state === 'input-streaming' && !tool.streamInput) {
             return null;

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -7,6 +7,8 @@ import { Fragment, createElement } from 'preact';
 
 import { createChatMessageComponent } from '../ChatMessage';
 
+import type { AddToolResult, ChatMessageBase, ClientSideTool } from '../types';
+
 const ChatMessage = createChatMessageComponent({
   createElement,
   Fragment,
@@ -469,5 +471,105 @@ describe('ChatMessage', () => {
         </article>
       </div>
     `);
+  });
+
+  test('submits a layout result for the owning assistant message', async () => {
+    let submitResult!: (params: { output: unknown }) => Promise<void>;
+    const addToolResult = jest.fn(() => Promise.resolve());
+    const addToolResultForMessage = jest.fn(() => Promise.resolve());
+    const tool: ClientSideTool & {
+      '~addToolResultForMessage': (
+        message: ChatMessageBase,
+        params: Parameters<AddToolResult>[0]
+      ) => ReturnType<AddToolResult>;
+    } = {
+      layoutComponent: ({ addToolResult: submit }) => {
+        submitResult = submit;
+        return <div />;
+      },
+      addToolResult,
+      '~addToolResultForMessage': addToolResultForMessage,
+      applyFilters: jest.fn(),
+    };
+
+    render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: 'assistant-new',
+          parts: [
+            {
+              type: 'tool-test_tool',
+              toolCallId: 'call-1',
+              input: {},
+              state: 'input-available',
+            },
+          ],
+        }}
+        status="ready"
+        tools={{
+          test_tool: tool,
+        }}
+        onClose={jest.fn()}
+      />
+    );
+
+    await submitResult({ output: { owner: 'new' } });
+
+    expect(addToolResultForMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'assistant-new' }),
+      {
+        tool: 'tool-test_tool',
+        toolCallId: 'call-1',
+        output: { owner: 'new' },
+      }
+    );
+    expect(addToolResult).not.toHaveBeenCalled();
+  });
+
+  test('falls back to the public tool result submission', async () => {
+    let submitResult!: (params: { output: unknown }) => Promise<void>;
+    const addToolResult = jest.fn(() => Promise.resolve());
+
+    render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: 'assistant-1',
+          parts: [
+            {
+              type: 'tool-test_tool',
+              toolCallId: 'call-1',
+              input: {},
+              state: 'input-available',
+            },
+          ],
+        }}
+        status="ready"
+        tools={{
+          test_tool: {
+            layoutComponent: ({ addToolResult: submit }) => {
+              submitResult = submit;
+              return <div />;
+            },
+            addToolResult,
+            applyFilters: jest.fn(),
+          },
+        }}
+        onClose={jest.fn()}
+      />
+    );
+
+    await submitResult({ output: { owner: 'public' } });
+
+    expect(addToolResult).toHaveBeenCalledWith({
+      tool: 'tool-test_tool',
+      toolCallId: 'call-1',
+      output: { owner: 'public' },
+    });
   });
 });

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-production.test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-production.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+import algoliasearchHelper from 'algoliasearch-helper';
+
+import { createInitOptions } from '../../../../test/createWidget';
+import connectChat from '../connectChat';
+
+import type { UIMessageChunk } from '../../../lib/ai-lite';
+import type { ChatConnectorParams } from '../connectChat';
+
+(globalThis as any).__DEV__ = false;
+
+const chatStream = (chunks: UIMessageChunk[]) =>
+  new Response(
+    `${chunks
+      .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
+      .join('')}data: [DONE]`,
+    { headers: { 'Content-Type': 'text/event-stream' } }
+  );
+
+describe('connectChat production tool handling', () => {
+  it('submits the unknown-tool fallback and continues once', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(
+        chatStream([
+          { type: 'start', messageId: 'assistant-1' },
+          {
+            type: 'tool-input-available',
+            toolName: 'missingTool',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          { type: 'finish' },
+        ])
+      )
+      .mockResolvedValueOnce(
+        chatStream([
+          { type: 'start', messageId: 'assistant-2' },
+          { type: 'finish' },
+        ])
+      );
+    const widget = connectChat(jest.fn())({
+      agentId: undefined,
+      disableTriggerValidation: true,
+      transport: { fetch: fetchMock },
+    } as ChatConnectorParams);
+    const helper = algoliasearchHelper(createSearchClient(), '');
+    widget.init(createInitOptions({ helper }));
+
+    await widget.chatInstance.sendMessage({ text: 'use a missing tool' });
+
+    const toolPart = widget.chatInstance.messages
+      .find((message) => message.id === 'assistant-1')
+      ?.parts.find(
+        (part) => 'toolCallId' in part && part.toolCallId === 'call-1'
+      );
+    expect(toolPart).toMatchObject({
+      state: 'output-available',
+      output: 'No tool implemented for "missingTool".',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-production.test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-production.test.ts
@@ -11,7 +11,7 @@ import connectChat from '../connectChat';
 import type { UIMessageChunk } from '../../../lib/ai-lite';
 import type { ChatConnectorParams } from '../connectChat';
 
-(globalThis as any).__DEV__ = false;
+const originalDev = (globalThis as any).__DEV__;
 
 const chatStream = (chunks: UIMessageChunk[]) =>
   new Response(
@@ -22,6 +22,14 @@ const chatStream = (chunks: UIMessageChunk[]) =>
   );
 
 describe('connectChat production tool handling', () => {
+  beforeAll(() => {
+    (globalThis as any).__DEV__ = false;
+  });
+
+  afterAll(() => {
+    (globalThis as any).__DEV__ = originalDev;
+  });
+
   it('submits the unknown-tool fallback and continues once', async () => {
     const fetchMock = jest
       .fn()

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -652,6 +652,47 @@ describe('connectChat', () => {
       );
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
+
+    it('supports returning the injected addToolResult from a configured tool', async () => {
+      const fetchMock = jest.fn().mockResolvedValue(
+        chatStream([
+          { type: 'start', messageId: 'assistant-1' },
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { query: 'hello' },
+          },
+          { type: 'finish' },
+        ])
+      );
+      const onToolCall = jest.fn(({ addToolResult }) =>
+        addToolResult({ output: { hits: ['hello'] } })
+      );
+      const { widget } = getInitializedWidget({
+        agentId: undefined,
+        transport: { fetch: fetchMock },
+        sendAutomaticallyWhen: () => false,
+        tools: { search: { onToolCall } },
+      });
+
+      await expect(
+        widget.chatInstance.sendMessage({ text: 'search for hello' })
+      ).resolves.toBeUndefined();
+
+      const assistant = widget.chatInstance.messages.find(
+        (message) => message.role === 'assistant'
+      );
+      expect(onToolCall).toHaveBeenCalledTimes(1);
+      expect(assistant?.parts[0]).toMatchObject({
+        type: 'tool-search',
+        toolCallId: 'call-1',
+        state: 'output-available',
+        output: { hits: ['hello'] },
+      });
+      expect(widget.chatInstance.status).toBe('ready');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('default chat instance', () => {

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -618,6 +618,7 @@ describe('connectChat', () => {
         testTool: {
           ...mockTool,
           addToolResult: expect.any(Function),
+          '~addToolResultForMessage': expect.any(Function),
           applyFilters: expect.any(Function),
           sendEvent: expect.any(Function),
         },
@@ -1936,6 +1937,10 @@ data: [DONE]`,
   });
 
   describe('sendAutomaticallyWhen', () => {
+    beforeEach(() => {
+      sessionStorage.clear();
+    });
+
     // A minimal, immediately-terminating assistant turn — enough for the
     // automatic follow-up request's stream to settle.
     const terminalStream = () =>

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -14,7 +14,11 @@ import {
 import { Chat } from '../../../lib/chat';
 import connectChat from '../connectChat';
 
-import type { UIMessage, ChatTransport } from '../../../lib/ai-lite';
+import type {
+  UIMessage,
+  UIMessageChunk,
+  ChatTransport,
+} from '../../../lib/ai-lite';
 import type { InstantSearch, IndexWidget } from '../../../types';
 import type { ChatConnectorParams, ChatCustomInstance } from '../connectChat';
 
@@ -592,6 +596,14 @@ describe('connectChat', () => {
   });
 
   describe('tool handling', () => {
+    const chatStream = (chunks: UIMessageChunk[]) =>
+      new Response(
+        `${chunks
+          .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
+          .join('')}data: [DONE]`,
+        { headers: { 'Content-Type': 'text/event-stream' } }
+      );
+
     it('provides tools in render state', () => {
       const mockTool = {};
 
@@ -610,6 +622,35 @@ describe('connectChat', () => {
           sendEvent: expect.any(Function),
         },
       });
+    });
+
+    it('keeps the development diagnostic for an unknown tool', async () => {
+      const fetchMock = jest.fn().mockResolvedValue(
+        chatStream([
+          { type: 'start', messageId: 'assistant-1' },
+          {
+            type: 'tool-input-available',
+            toolName: 'missingTool',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          { type: 'finish' },
+        ])
+      );
+      const { widget } = getInitializedWidget({
+        agentId: undefined,
+        transport: { fetch: fetchMock },
+      } as ChatConnectorParams);
+
+      await widget.chatInstance.sendMessage({ text: 'use a missing tool' });
+
+      expect(widget.chatInstance.status).toBe('error');
+      expect(widget.chatInstance.error).toEqual(
+        new Error(
+          'No tool implementation found for "missingTool". Please provide a tool implementation in the `tools` prop.'
+        )
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1908,7 +1949,16 @@ data: [DONE]`,
         output: { ok: true },
       });
 
+      await widget.chatInstance.addToolResult({
+        tool: 'myTool',
+        toolCallId: 'call_1',
+        output: { ok: false },
+      });
+
       expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(widget.chatInstance.messages[1].parts[0]).toMatchObject({
+        output: { ok: true },
+      });
     });
 
     it('does not auto-continue when a user `sendAutomaticallyWhen` returns false', async () => {

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -19,6 +19,7 @@ import {
 } from '../../lib/utils';
 import { flat } from '../../lib/utils/flat';
 
+import type { ResponseScopedOnToolCallCallback } from '../../lib/ai-lite/abstract-chat';
 import type {
   AbstractChat,
   ChatInit as ChatInitAi,
@@ -45,11 +46,6 @@ import type {
   ClientSideTools,
   ClientSideTool,
 } from 'instantsearch-ui-components';
-
-type ResponseScopedOnToolCallCallback<TUiMessage extends UIMessage> = (
-  options: Parameters<NonNullable<ChatInitAi<TUiMessage>['onToolCall']>>[0],
-  addToolResult?: AbstractChat<TUiMessage>['addToolResult']
-) => ReturnType<NonNullable<ChatInitAi<TUiMessage>['onToolCall']>>;
 
 const withUsage = createDocumentationMessageGenerator({
   name: 'chat',
@@ -620,7 +616,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           }
 
           return Promise.resolve();
-        }) as ResponseScopedOnToolCallCallback<TUiMessage>,
+        }) satisfies ResponseScopedOnToolCallCallback<TUiMessage>,
       } as ChatInitAi<TUiMessage> & { agentId?: string });
     };
 

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -769,11 +769,15 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
 
         const toolsWithAddToolResult: ClientSideTools = {};
         Object.entries(tools).forEach(([key, tool]) => {
-          const toolWithAddToolResult: ClientSideTool = {
+          const toolWithAddToolResult = {
             ...tool,
             addToolResult: _chatInstance.addToolResult,
+            '~addToolResultForMessage':
+              _chatInstance['~addToolResultForMessage'],
             applyFilters,
             sendEvent,
+          } satisfies ClientSideTool & {
+            '~addToolResultForMessage': typeof _chatInstance['~addToolResultForMessage'];
           };
           toolsWithAddToolResult[key] = toolWithAddToolResult;
         });

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -46,6 +46,11 @@ import type {
   ClientSideTool,
 } from 'instantsearch-ui-components';
 
+type ResponseScopedOnToolCallCallback<TUiMessage extends UIMessage> = (
+  options: Parameters<NonNullable<ChatInitAi<TUiMessage>['onToolCall']>>[0],
+  addToolResult?: AbstractChat<TUiMessage>['addToolResult']
+) => ReturnType<NonNullable<ChatInitAi<TUiMessage>['onToolCall']>>;
+
 const withUsage = createDocumentationMessageGenerator({
   name: 'chat',
   connector: true,
@@ -572,7 +577,10 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           if (!tool) return true;
           return Boolean(tool.streamInput);
         },
-        onToolCall({ toolCall }) {
+        onToolCall: ((
+          { toolCall },
+          submitToolResult = _chatInstance.addToolResult
+        ) => {
           let tool = tools[toolCall.toolName];
 
           // Compatibility shim with Algolia MCP Server search tool
@@ -590,7 +598,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
               );
             }
 
-            return _chatInstance.addToolResult({
+            return submitToolResult({
               output: `No tool implemented for "${toolCall.toolName}".`,
               tool: toolCall.toolName,
               toolCallId: toolCall.toolCallId,
@@ -599,7 +607,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
 
           if (tool.onToolCall) {
             const addToolResult: AddToolResultWithOutput = ({ output }) =>
-              _chatInstance.addToolResult({
+              submitToolResult({
                 output,
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
@@ -612,7 +620,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           }
 
           return Promise.resolve();
-        },
+        }) as ResponseScopedOnToolCallCallback<TUiMessage>,
       } as ChatInitAi<TUiMessage> & { agentId?: string });
     };
 

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -573,10 +573,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           if (!tool) return true;
           return Boolean(tool.streamInput);
         },
-        onToolCall: ((
-          { toolCall },
-          submitToolResult = _chatInstance.addToolResult
-        ) => {
+        onToolCall: (({ toolCall }, submitToolResult) => {
           let tool = tools[toolCall.toolName];
 
           // Compatibility shim with Algolia MCP Server search tool

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -39,6 +39,12 @@ class InMemoryChatState implements ChatState<UIMessage> {
 
 class TestChat extends AbstractChat<UIMessage> {}
 
+class ConcurrentTestChat extends TestChat {
+  startResponse(stream: ReadableStream<UIMessageChunk>): Promise<void> {
+    return (this as any).consume(() => Promise.resolve(stream));
+  }
+}
+
 /**
  * Builds a `ReadableStream<Uint8Array>` from raw SSE text, flushing one line
  * at a time (one `Uint8Array` per line). This mimics how a server flushes
@@ -1434,6 +1440,214 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.sendMessages).toHaveBeenCalledTimes(1);
     });
 
+    it('ignores a public result routed through a retired response', async () => {
+      const callbackStarted = deferred<undefined>();
+      const releaseCallback = deferred<undefined>();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'old' },
+          },
+          finishChunk(),
+        ],
+        onToolCall: async () => {
+          callbackStarted.resolve(undefined);
+          await releaseCallback.promise;
+        },
+        sendAutomaticallyWhen,
+      });
+
+      const send = setup.chat.sendMessage({ text: 'old request' });
+      await callbackStarted.promise;
+
+      setup.chat.messages = [];
+      setup.chat.messages = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'restored' },
+            },
+          ],
+        },
+      ];
+
+      await setup.chat.addToolResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'old' },
+      });
+
+      expect(setup.chat.messages[0].parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { q: 'restored' },
+      });
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+
+      releaseCallback.resolve(undefined);
+      await send;
+      expect(setup.state.status).toBe('ready');
+      expect(setup.state.error).toBeUndefined();
+    });
+
+    it('lets a newer response replace a retired routing owner', async () => {
+      const callbackStarted = deferred<undefined>();
+      const releaseCallback = deferred<undefined>();
+      const onError = jest.fn();
+      let callbackCount = 0;
+      const state = new InMemoryChatState();
+      const sendMessages = jest.fn(() =>
+        Promise.resolve(
+          chunksToStream([
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'old' },
+            },
+            finishChunk(),
+          ])
+        )
+      );
+      const onToolCall = (
+        { toolCall }: { toolCall: any },
+        addToolResult?: TestChat['addToolResult']
+      ): void | Promise<void> => {
+        callbackCount++;
+        if (callbackCount === 1) {
+          callbackStarted.resolve(undefined);
+          return releaseCallback.promise;
+        }
+        return addToolResult!({
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          output: { owner: 'new' },
+        });
+      };
+      const chat = new ConcurrentTestChat({
+        id: 'test-chat',
+        state,
+        transport: {
+          sendMessages: sendMessages as any,
+          reconnectToStream: jest.fn(() => Promise.resolve(null)) as any,
+        },
+        onError,
+        onToolCall,
+        sendAutomaticallyWhen: () => false,
+      });
+
+      const oldSend = chat.sendMessage({ text: 'old request' });
+      await callbackStarted.promise;
+      chat.messages = [];
+
+      await chat.startResponse(
+        chunksToStream([
+          startChunk('assistant-new'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'new' },
+          },
+          finishChunk(),
+        ])
+      );
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(state.messages[0].parts[0]).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+
+      releaseCallback.resolve(undefined);
+      await oldSend;
+      expect(state.status).toBe('ready');
+    });
+
+    it('makes a transferred routing owner inert after its message is removed', async () => {
+      let addFirstResult!: TestChat['addToolResult'];
+      let callbackCount = 0;
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          callbackCount++;
+          if (callbackCount === 1) {
+            addFirstResult = addToolResult!;
+          }
+          return addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: callbackCount === 1 ? 'old' : 'new' },
+          });
+        },
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'old request' });
+      await setup.chat.sendMessage({ text: 'new request' });
+
+      setup.chat.messages = setup.chat.messages.filter(
+        (message) => message.id !== 'assistant-old'
+      );
+      setup.chat.messages = [
+        ...setup.chat.messages,
+        {
+          id: 'assistant-old',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'restored' },
+            },
+          ],
+        },
+      ];
+
+      await addFirstResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'stale' },
+      });
+
+      expect(setup.chat.messages.at(-1)?.parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { q: 'restored' },
+      });
+    });
+
     it('cleans a retired owner when the same message id is restored', async () => {
       let chat!: TestChat;
       let settleFirstToolCall!: () => Promise<void>;
@@ -1974,6 +2188,121 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect((part as any).preliminary).toBeUndefined();
       expect((part as any).rawOutput).toBeUndefined();
       expect(setup.state.status).toBe('ready');
+    });
+
+    it('merges later server metadata without replacing a committed client result', async () => {
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          },
+          {
+            type: 'tool-output-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            output: { owner: 'server' },
+            callProviderMetadata: { openai: { itemId: 'fc_123' } },
+            preliminary: true,
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ toolCall }, addToolResult) =>
+          addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: 'client' },
+          }),
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'search' });
+
+      const part = setup.state.messages.find(
+        (message) => message.id === 'assistant-1'
+      )?.parts[0] as any;
+      expect(part).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'client' },
+        callProviderMetadata: { openai: { itemId: 'fc_123' } },
+      });
+      expect(part.preliminary).toBeUndefined();
+    });
+
+    it('merges metadata from a later input error without replacing a committed client result', async () => {
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          },
+          {
+            type: 'tool-input-error',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            errorText: 'late input error',
+            providerMetadata: { openai: { itemId: 'fc_input' } },
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ toolCall }, addToolResult) =>
+          addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: 'client' },
+          }),
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'search' });
+
+      expect(setup.state.messages[1].parts[0]).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'client' },
+        callProviderMetadata: { openai: { itemId: 'fc_input' } },
+      });
+    });
+
+    it('merges metadata from a later output error without replacing a committed client result', async () => {
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          },
+          {
+            type: 'tool-output-error',
+            toolCallId: 'call-1',
+            errorText: 'late output error',
+            providerMetadata: { openai: { itemId: 'fc_output' } },
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ toolCall }, addToolResult) =>
+          addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: 'client' },
+          }),
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'search' });
+
+      expect(setup.state.messages[1].parts[0]).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'client' },
+        callProviderMetadata: { openai: { itemId: 'fc_output' } },
+      });
     });
 
     it('continues once after mixed server and client tool results', async () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -2080,6 +2080,172 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.state.status).toBe('ready');
     });
 
+    it('keeps unrelated tool results active when another call id transfers', async () => {
+      let submitPendingOldResult!: TestChat['addToolResult'];
+      const sendAutomaticallyWhen = jest.fn(
+        ({ messages }: { messages: UIMessage[] }) => {
+          const oldMessage = messages.find(
+            (message) => message.id === 'assistant-old'
+          );
+          const pendingPart = oldMessage?.parts.find(
+            (part) => 'toolCallId' in part && part.toolCallId === 'call-pending'
+          );
+
+          return pendingPart &&
+            'state' in pendingPart &&
+            pendingPart.state === 'output-available'
+            ? true
+            : false;
+        }
+      );
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-reused',
+              input: { q: 'old' },
+            },
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-pending',
+              input: { q: 'pending' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-reused',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-continuation'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          if (toolCall.toolCallId === 'call-pending') {
+            submitPendingOldResult = addToolResult!;
+            return;
+          }
+
+          return addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: toolCall.input.q },
+          });
+        },
+        sendAutomaticallyWhen,
+      });
+
+      await setup.chat.sendMessage({ text: 'first search' });
+      await setup.chat.sendMessage({ text: 'second search' });
+      await submitPendingOldResult({
+        tool: 'search',
+        toolCallId: 'call-pending',
+        output: { owner: 'old' },
+      });
+
+      const oldMessage = setup.state.messages.find(
+        (message) => message.id === 'assistant-old'
+      );
+      expect(
+        oldMessage?.parts.find(
+          (part) => 'toolCallId' in part && part.toolCallId === 'call-pending'
+        )
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'old' },
+      });
+      expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(2);
+      expect(setup.sendMessages).toHaveBeenCalledTimes(3);
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('ignores an ambiguous public result after call ownership transfers', async () => {
+      let submitOldPublicResult!: () => Promise<void>;
+      let submitNewScopedResult!: TestChat['addToolResult'];
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          if (toolCall.input.q === 'old') {
+            submitOldPublicResult = () =>
+              setup.chat.addToolResult({
+                tool: toolCall.toolName,
+                toolCallId: toolCall.toolCallId,
+                output: { owner: 'old' },
+              });
+            return addToolResult!({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { owner: 'old' },
+            });
+          }
+
+          submitNewScopedResult = addToolResult!;
+          return;
+        },
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'first search' });
+      await setup.chat.sendMessage({ text: 'second search' });
+      await submitOldPublicResult();
+
+      const newMessage = setup.state.messages.find(
+        (message) => message.id === 'assistant-new'
+      );
+      expect(newMessage?.parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+
+      await submitNewScopedResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'new' },
+      });
+
+      expect(newMessage?.parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(setup.state.status).toBe('ready');
+    });
+
     it('settles an awaited client result after a server result for the same call', async () => {
       const toolCallStarted = deferred<undefined>();
       const releaseToolResult = deferred<undefined>();

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -3991,6 +3991,62 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.state.status).toBe('ready');
     });
 
+    it('waits for the required client result after a provider result is submitted', async () => {
+      let submitClientResult!: TestChat['addToolResult'];
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const setup = createTestSetup({
+        state,
+        chunksByRequest: [
+          [
+            startChunk('assistant-1'),
+            {
+              type: 'tool-input-available',
+              toolName: 'lookup',
+              toolCallId: 'server-call',
+              input: { q: 'server' },
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'client-call',
+              input: { q: 'client' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-2'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          expect(toolCall.toolCallId).toBe('client-call');
+          submitClientResult = addToolResult!;
+        },
+        sendAutomaticallyWhen,
+      });
+
+      await setup.chat.sendMessage({ text: 'use both tools' });
+      const message = messageById(state, 'assistant-1');
+
+      await setup.chat['~addToolResultForMessage'](message, {
+        tool: 'lookup',
+        toolCallId: 'server-call',
+        output: { owner: 'layout' },
+      });
+
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+
+      await submitClientResult({
+        tool: 'search',
+        toolCallId: 'client-call',
+        output: { owner: 'client' },
+      });
+
+      expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(1);
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(setup.state.status).toBe('ready');
+    });
+
     it('quietly ignores an unknown toolCallId', async () => {
       const sendAutomaticallyWhen = jest.fn(() => true);
       const setup = createTestSetup({ sendAutomaticallyWhen });

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -1210,6 +1210,427 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.sendMessages).toHaveBeenCalledTimes(1);
     });
 
+    it('commits a single fire-and-forget result and settles without hanging', async () => {
+      let chat!: TestChat;
+      const onFinish = jest.fn();
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          },
+          finishChunk(),
+        ],
+        // Fire-and-forget: commit but never return or await the promise.
+        onToolCall: ({ toolCall }, addToolResult) => {
+          void addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { hits: ['hello'] },
+          });
+        },
+        onFinish,
+      });
+      chat = setup.chat;
+
+      const outcome = await Promise.race([
+        chat.sendMessage({ text: 'search for hello' }).then(() => 'settled'),
+        new Promise<string>((resolve) =>
+          setTimeout(() => resolve('timed out'), 100)
+        ),
+      ]);
+
+      expect(outcome).toBe('settled');
+      expect(setup.state.status).toBe('ready');
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { hits: ['hello'] },
+      });
+      expect(onFinish).toHaveBeenCalledTimes(1);
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps response ownership when messages are rehydrated as fresh objects', async () => {
+      let chat!: TestChat;
+      const submitResults = new Map<string, () => Promise<void>>();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-1'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'first' },
+            },
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-2',
+              input: { q: 'second' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-2'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          submitResults.set(toolCall.toolCallId, () =>
+            addToolResult!({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { id: toolCall.toolCallId },
+            })
+          );
+        },
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'search twice' });
+      // True cross-session rehydration: structurally-equal but fresh objects,
+      // so ownership survives only if it is keyed by message id.
+      chat.messages = JSON.parse(JSON.stringify(chat.messages)) as UIMessage[];
+
+      await submitResults.get('call-1')!();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+
+      await submitResults.get('call-2')!();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(1);
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        output: { id: 'call-1' },
+      });
+      expect(assistantToolPart(setup.state, 'call-2')).toMatchObject({
+        output: { id: 'call-2' },
+      });
+    });
+
+    it('does not let an old response retirement disturb a newer active response', async () => {
+      let chat!: TestChat;
+      let secondController!: ReadableStreamDefaultController<UIMessageChunk>;
+      const setup = createTestSetup({
+        streamFactory: (index) => {
+          if (index === 0) {
+            return chunksToStream([
+              startChunk('assistant-1'),
+              {
+                type: 'tool-input-available',
+                toolName: 'search',
+                toolCallId: 'call-1',
+                input: {},
+              },
+              finishChunk(),
+            ]);
+          }
+          // Second response stays open so it remains the active response.
+          return new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controller.enqueue(startChunk('assistant-2'));
+              secondController = controller;
+            },
+          });
+        },
+        // Fire-and-forget so call-1 stays owned by the first response.
+        onToolCall: () => {},
+        sendAutomaticallyWhen: () => false,
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'first' });
+      const second = chat.sendMessage({ text: 'second' });
+      let guard = 0;
+      while (
+        !setup.state.messages.some((message) => message.id === 'assistant-2') &&
+        guard++ < 500
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      expect(setup.state.status).toBe('streaming');
+
+      // Detach the first (old) response's message while the second is active.
+      chat.messages = chat.messages.filter(
+        (message) => message.id !== 'assistant-1'
+      );
+
+      // Retiring the old response must not clear or finalize the newer one.
+      expect(setup.state.status).toBe('streaming');
+      expect(
+        setup.state.messages.some((message) => message.id === 'assistant-2')
+      ).toBe(true);
+
+      secondController.enqueue(finishChunk());
+      secondController.close();
+      await second;
+
+      expect(setup.state.status).toBe('ready');
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(setup.state.error).toBeUndefined();
+    });
+
+    it('settles a tombstoned result after retirement and cleans up ownership', async () => {
+      let chat!: TestChat;
+      let releaseToolResult!: () => Promise<void>;
+      const onError = jest.fn();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        // Returned promise stays pending so the response is held active.
+        onToolCall: ({ toolCall }, addToolResult) =>
+          new Promise<void>((resolve) => {
+            releaseToolResult = async () => {
+              await addToolResult!({
+                tool: toolCall.toolName,
+                toolCallId: toolCall.toolCallId,
+                output: { ok: true },
+              });
+              resolve();
+            };
+          }),
+        onError,
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      const send = chat.sendMessage({ text: 'search' });
+      let guard = 0;
+      while (!releaseToolResult && guard++ < 500) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      // Detach the message while the callback is in flight (tombstone kept).
+      chat.messages = [];
+
+      // The in-flight result now routes through the tombstone and settles.
+      await releaseToolResult();
+      await send;
+
+      expect(setup.state.status).toBe('ready');
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+
+      // Ownership is cleaned up: a later result for the same id is a no-op.
+      await expect(
+        chat.addToolResult({
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { ok: true },
+        })
+      ).resolves.toBeUndefined();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it('cleans a retired owner when the same message id is restored', async () => {
+      let chat!: TestChat;
+      let settleFirstToolCall!: () => Promise<void>;
+      let toolCallCount = 0;
+      const onError = jest.fn();
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-1'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'first' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-2'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'second' },
+            },
+            finishChunk(),
+          ],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          toolCallCount++;
+          if (toolCallCount === 1) {
+            return new Promise<void>((resolve) => {
+              settleFirstToolCall = async () => {
+                await addToolResult!({
+                  tool: toolCall.toolName,
+                  toolCallId: toolCall.toolCallId,
+                  output: { owner: 'first' },
+                });
+                resolve();
+              };
+            });
+          }
+
+          return addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: 'second' },
+          });
+        },
+        onError,
+        sendAutomaticallyWhen: () => false,
+      });
+      chat = setup.chat;
+
+      const firstSend = chat.sendMessage({ text: 'first search' });
+      let guard = 0;
+      while (!settleFirstToolCall && guard++ < 500) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      chat.messages = chat.messages.filter(
+        (message) => message.id !== 'assistant-1'
+      );
+      chat.messages = chat.messages.concat({
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'restored', state: 'done' }],
+      });
+
+      await settleFirstToolCall();
+      await firstSend;
+      await chat.sendMessage({ text: 'second search' });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(setup.state.status).toBe('ready');
+      const secondAssistant = setup.state.messages.find(
+        (message) => message.id === 'assistant-2'
+      );
+      const secondToolPart = secondAssistant?.parts.find(
+        (part) => 'toolCallId' in part && part.toolCallId === 'call-1'
+      );
+      expect(secondToolPart).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'second' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+    });
+
+    it('ignores a scoped result after its response is retired', async () => {
+      let chat!: TestChat;
+      let settleOldToolCall!: () => Promise<void>;
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'old' },
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ toolCall }, addToolResult) =>
+          new Promise<void>((resolve) => {
+            settleOldToolCall = async () => {
+              await addToolResult!({
+                tool: toolCall.toolName,
+                toolCallId: toolCall.toolCallId,
+                output: { owner: 'old' },
+              });
+              resolve();
+            };
+          }),
+        sendAutomaticallyWhen: () => false,
+      });
+      chat = setup.chat;
+
+      const send = chat.sendMessage({ text: 'old request' });
+      let guard = 0;
+      while (!settleOldToolCall && guard++ < 500) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      chat.messages = chat.messages.filter(
+        (message) => message.id !== 'assistant-1'
+      );
+      chat.messages = chat.messages.concat({
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-search',
+            toolCallId: 'call-1',
+            state: 'input-available',
+            input: { q: 'new' },
+          },
+        ],
+      });
+
+      await settleOldToolCall();
+      await send;
+
+      const restoredPart = chat.messages
+        .find((message) => message.id === 'assistant-1')
+        ?.parts.find(
+          (part) => 'toolCallId' in part && part.toolCallId === 'call-1'
+        );
+      expect(restoredPart).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+    });
+
+    it('preserves the error finish when onError clears messages', async () => {
+      let chat!: TestChat;
+      const callbackOrder: string[] = [];
+      const onError = jest.fn(() => {
+        callbackOrder.push('onError');
+        chat.messages = [];
+      });
+      const onFinish = jest.fn(() => {
+        callbackOrder.push('onFinish');
+      });
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: () => {
+          throw new Error('tool failed');
+        },
+        onError,
+        onFinish,
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'fail tool' });
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onFinish).toHaveBeenCalledTimes(1);
+      expect(onFinish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({ id: 'assistant-1' }),
+          messages: [],
+          isError: true,
+        })
+      );
+      expect(callbackOrder).toEqual(['onError', 'onFinish']);
+      expect(chat.messages).toEqual([]);
+    });
+
     it('commits a reused toolCallId to its owning assistant message', async () => {
       let chat!: TestChat;
       const onFinish = jest.fn();

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -94,23 +94,45 @@ type SendMessagesCall = Parameters<ChatTransport<UIMessage>['sendMessages']>[0];
 function createTestSetup(
   {
     chunks,
+    chunksByRequest,
     sse,
+    streamFactory,
+    sendMessagesFactory,
     onToolCall,
     onFinish,
     onError,
+    sendAutomaticallyWhen,
   }: {
     chunks?: UIMessageChunk[];
+    chunksByRequest?: UIMessageChunk[][];
     sse?: string;
+    streamFactory?: (requestIndex: number) => ReadableStream<UIMessageChunk>;
+    sendMessagesFactory?: (
+      requestIndex: number,
+      options: SendMessagesCall
+    ) => Promise<ReadableStream<UIMessageChunk>>;
     onToolCall?: (options: { toolCall: any }) => void | Promise<void>;
     onFinish?: ChatOnFinishCallback<UIMessage>;
     onError?: ChatOnErrorCallback;
+    sendAutomaticallyWhen?: (options: {
+      messages: UIMessage[];
+    }) => boolean | PromiseLike<boolean>;
   } = { chunks: [] }
 ) {
-  const makeStream = (): ReadableStream<UIMessageChunk> =>
-    sse !== undefined ? streamFromSse(sse) : chunksToStream(chunks ?? []);
+  let requestIndex = 0;
+  const makeStream = (index: number): ReadableStream<UIMessageChunk> => {
+    if (streamFactory) return streamFactory(index);
+    if (sse !== undefined) return streamFromSse(sse);
+    return chunksToStream(chunksByRequest?.[index] ?? chunks ?? []);
+  };
   const sendMessages = jest.fn(
-    (_options: SendMessagesCall): Promise<ReadableStream<UIMessageChunk>> =>
-      Promise.resolve(makeStream())
+    (options: SendMessagesCall): Promise<ReadableStream<UIMessageChunk>> => {
+      const index = requestIndex;
+      requestIndex += 1;
+      return sendMessagesFactory
+        ? sendMessagesFactory(index, options)
+        : Promise.resolve(makeStream(index));
+    }
   );
   const reconnectToStream = jest.fn(() => Promise.resolve(null));
   const transport: ChatTransport<UIMessage> = {
@@ -131,6 +153,7 @@ function createTestSetup(
     onError,
     onFinish,
     onToolCall,
+    sendAutomaticallyWhen,
   });
 
   return { chat, state, transport, sendMessages };
@@ -142,9 +165,28 @@ const startChunk = (id = 'msg-1'): UIMessageChunk => ({
 });
 const finishChunk = (): UIMessageChunk => ({ type: 'finish' });
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function assistantPart(state: InMemoryChatState): any {
   const assistant = state.messages.find((m) => m.role === 'assistant');
   return assistant?.parts[0];
+}
+
+function assistantToolPart(state: InMemoryChatState, toolCallId: string): any {
+  const assistant = state.messages.find(
+    (message) => message.role === 'assistant'
+  );
+  return assistant?.parts.find(
+    (part) => 'toolCallId' in part && part.toolCallId === toolCallId
+  );
 }
 
 describe('AbstractChat.processStreamWithCallbacks', () => {
@@ -249,6 +291,469 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
   });
 
   describe('tool-input lifecycle (existing chunks)', () => {
+    it('settles when onToolCall returns addToolResult and commits the output', async () => {
+      let chat!: TestChat;
+      const onFinish = jest.fn();
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ toolCall }) =>
+          chat.addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { hits: ['hello'] },
+          }),
+        onFinish,
+      });
+      chat = setup.chat;
+
+      const outcome = await Promise.race([
+        chat.sendMessage({ text: 'search for hello' }).then(() => 'settled'),
+        new Promise<string>((resolve) =>
+          setTimeout(() => resolve('timed out'), 100)
+        ),
+      ]);
+
+      expect(outcome).toBe('settled');
+      expect(assistantPart(setup.state)).toMatchObject({
+        type: 'tool-search',
+        toolCallId: 'call-1',
+        state: 'output-available',
+        output: { hits: ['hello'] },
+      });
+      expect(onFinish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            parts: [
+              expect.objectContaining({
+                toolCallId: 'call-1',
+                state: 'output-available',
+              }),
+            ],
+          }),
+        })
+      );
+    });
+
+    it('settles when an async onToolCall awaits addToolResult', async () => {
+      let chat!: TestChat;
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          },
+          finishChunk(),
+        ],
+        onToolCall: async ({ toolCall }) => {
+          await chat.addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { hits: ['hello'] },
+          });
+        },
+      });
+      chat = setup.chat;
+
+      await expect(
+        chat.sendMessage({ text: 'search for hello' })
+      ).resolves.toBeUndefined();
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { hits: ['hello'] },
+      });
+    });
+
+    it('does not let later input chunks downgrade a committed tool result', async () => {
+      let chat!: TestChat;
+      const onFinish = jest.fn();
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          },
+          {
+            type: 'tool-input-start',
+            toolName: 'search',
+            toolCallId: 'call-1',
+          },
+          {
+            type: 'tool-input-delta',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            inputTextDelta: '{"q":"stale"}',
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ toolCall }) =>
+          chat.addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { hits: ['canonical'] },
+          }),
+        onFinish,
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'search' });
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { hits: ['canonical'] },
+      });
+      expect(onFinish.mock.calls[0][0].message.parts[0]).toMatchObject({
+        state: 'output-available',
+        output: { hits: ['canonical'] },
+      });
+    });
+
+    it('continues once after reverse-order results and ignores duplicate submissions', async () => {
+      let chat!: TestChat;
+      let submitLateResult!: () => Promise<void>;
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const onFinish = jest.fn();
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-1'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'first' },
+            },
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-2',
+              input: { q: 'second' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-2'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }) => {
+          const submit = () =>
+            chat.addToolResult({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { id: toolCall.toolCallId },
+            });
+          if (toolCall.toolCallId === 'call-1') {
+            submitLateResult = submit;
+          } else {
+            void submit();
+          }
+        },
+        onFinish,
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'search twice' });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      expect(onFinish).toHaveBeenCalledTimes(1);
+
+      await submitLateResult();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(1);
+      expect(onFinish).toHaveBeenCalledTimes(2);
+      expect(onFinish.mock.invocationCallOrder[0]).toBeLessThan(
+        setup.sendMessages.mock.invocationCallOrder[1]
+      );
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        output: { id: 'call-1' },
+      });
+      expect(assistantToolPart(setup.state, 'call-2')).toMatchObject({
+        output: { id: 'call-2' },
+      });
+
+      await submitLateResult();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps a completed result pending until its follow-up request settles', async () => {
+      let chat!: TestChat;
+      let submitLateResult!: () => Promise<void>;
+      const followUpRequest = deferred<ReadableStream<UIMessageChunk>>();
+      const followUpStarted = deferred<undefined>();
+      const setup = createTestSetup({
+        sendMessagesFactory: (requestIndex) => {
+          if (requestIndex === 0) {
+            return Promise.resolve(
+              chunksToStream([
+                startChunk('assistant-1'),
+                {
+                  type: 'tool-input-available',
+                  toolName: 'search',
+                  toolCallId: 'call-1',
+                  input: {},
+                },
+                finishChunk(),
+              ])
+            );
+          }
+
+          followUpStarted.resolve(undefined);
+          return followUpRequest.promise;
+        },
+        onToolCall: ({ toolCall }) => {
+          submitLateResult = () =>
+            chat.addToolResult({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { ok: true },
+            });
+        },
+        sendAutomaticallyWhen: () => true,
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'search' });
+
+      let didSettle = false;
+      const resultPromise = submitLateResult().then(() => {
+        didSettle = true;
+      });
+      await followUpStarted.promise;
+
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(didSettle).toBe(false);
+
+      followUpRequest.resolve(
+        chunksToStream([startChunk('assistant-2'), finishChunk()])
+      );
+      await resultPromise;
+
+      expect(didSettle).toBe(true);
+    });
+
+    it.each([
+      ['synchronous', () => false],
+      ['asynchronous', () => Promise.resolve(false)],
+    ])(
+      'does not continue when a %s sendAutomaticallyWhen returns false',
+      async (_name, sendAutomaticallyWhen) => {
+        let chat!: TestChat;
+        const setup = createTestSetup({
+          chunks: [
+            startChunk(),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: {},
+            },
+            finishChunk(),
+          ],
+          onToolCall: ({ toolCall }) =>
+            chat.addToolResult({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { ok: true },
+            }),
+          sendAutomaticallyWhen,
+        });
+        chat = setup.chat;
+
+        await chat.sendMessage({ text: 'search' });
+
+        expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    it.each([
+      [
+        'throws synchronously',
+        () => {
+          throw new Error('tool failed');
+        },
+      ],
+      [
+        'rejects asynchronously',
+        () => Promise.reject(new Error('tool failed')),
+      ],
+    ])(
+      'uses the existing error path when onToolCall %s',
+      async (_name, onToolCall) => {
+        const onError = jest.fn();
+        const onFinish = jest.fn();
+        const setup = createTestSetup({
+          chunks: [
+            startChunk(),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: {},
+            },
+            finishChunk(),
+          ],
+          onToolCall,
+          onError,
+          onFinish,
+          sendAutomaticallyWhen: () => true,
+        });
+
+        await setup.chat.sendMessage({ text: 'search' });
+
+        expect(setup.state.status).toBe('error');
+        expect(setup.state.error).toEqual(new Error('tool failed'));
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onFinish).toHaveBeenCalledTimes(1);
+        expect(onFinish).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isAbort: false,
+            isDisconnect: false,
+            isError: true,
+          })
+        );
+        expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    it('keeps a successful onFinish and reports a rejected continuation predicate once', async () => {
+      let chat!: TestChat;
+      const onError = jest.fn();
+      const onFinish = jest.fn();
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ toolCall }) =>
+          chat.addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { ok: true },
+          }),
+        onError,
+        onFinish,
+        sendAutomaticallyWhen: () =>
+          Promise.reject(new Error('predicate failed')),
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'search' });
+
+      expect(onFinish).toHaveBeenCalledTimes(1);
+      expect(onFinish).toHaveBeenCalledWith(
+        expect.objectContaining({ isError: false })
+      );
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(setup.state.status).toBe('error');
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['aborts', [{ type: 'abort' } as UIMessageChunk, finishChunk()], 'ready'],
+      [
+        'fails',
+        [{ type: 'error', errorText: 'stream failed' } as UIMessageChunk],
+        'error',
+      ],
+    ])(
+      'does not continue when the owning stream %s before a late result',
+      async (_name, terminalChunks, expectedStatus) => {
+        let submitLateResult!: () => Promise<void>;
+        const sendAutomaticallyWhen = jest.fn(() => true);
+        const setup = createTestSetup({
+          chunks: [
+            startChunk(),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: {},
+            },
+            ...terminalChunks,
+          ],
+          onToolCall: ({ toolCall }) => {
+            submitLateResult = () =>
+              setup.chat.addToolResult({
+                tool: toolCall.toolName,
+                toolCallId: toolCall.toolCallId,
+                output: { ok: true },
+              });
+          },
+          sendAutomaticallyWhen,
+        });
+
+        await setup.chat.sendMessage({ text: 'search' });
+        await submitLateResult();
+
+        expect(setup.state.status).toBe(expectedStatus);
+        expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+          state: 'output-available',
+        });
+        expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+        expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    it('quietly ignores an unknown toolCallId', async () => {
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({ sendAutomaticallyWhen });
+
+      await setup.chat.addToolResult({
+        tool: 'search',
+        toolCallId: 'missing',
+        output: { ok: true },
+      });
+
+      expect(setup.state.messages).toEqual([]);
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+      expect(setup.sendMessages).not.toHaveBeenCalled();
+    });
+
+    it('does not let a stopped response rejection overwrite the next response', async () => {
+      const firstRequest = deferred<ReadableStream<UIMessageChunk>>();
+      const setup = createTestSetup({
+        sendMessagesFactory: (requestIndex) =>
+          requestIndex === 0
+            ? firstRequest.promise
+            : Promise.resolve(
+                chunksToStream([startChunk('assistant-2'), finishChunk()])
+              ),
+      });
+
+      const stoppedSend = setup.chat.sendMessage({ text: 'first' });
+      await Promise.resolve();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      await setup.chat.stop();
+      const nextSend = setup.chat.sendMessage({ text: 'second' });
+      firstRequest.reject(new Error('stale transport failure'));
+
+      await stoppedSend;
+      await nextSend;
+
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(setup.state.status).toBe('ready');
+      expect(setup.state.error).toBeUndefined();
+    });
+
     it('tool-input-start, tool-input-delta and tool-input-available drive a part through input-streaming to input-available, repairing partial JSON and triggering onToolCall', async () => {
       const onToolCall = jest.fn();
       const { chat, state } = createTestSetup({

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -471,6 +471,66 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
     });
 
+    it.each([
+      [
+        'tool-input-error',
+        {
+          type: 'tool-input-error',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: '{"q":"stale"}',
+          errorText: 'stale input error',
+        },
+      ],
+      [
+        'tool-output-error',
+        {
+          type: 'tool-output-error',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          errorText: 'stale output error',
+        },
+      ],
+    ] as const)(
+      'does not let a later %s downgrade a committed tool result',
+      async (_name, staleChunk) => {
+        let chat!: TestChat;
+        const onFinish = jest.fn();
+        const setup = createTestSetup({
+          chunks: [
+            startChunk(),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'hello' },
+            },
+            staleChunk,
+            finishChunk(),
+          ],
+          onToolCall: ({ toolCall }) =>
+            chat.addToolResult({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { hits: ['canonical'] },
+            }),
+          onFinish,
+        });
+        chat = setup.chat;
+
+        await chat.sendMessage({ text: 'search' });
+
+        expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+          state: 'output-available',
+          output: { hits: ['canonical'] },
+        });
+        expect(onFinish.mock.calls[0][0].message.parts[0]).toMatchObject({
+          state: 'output-available',
+          output: { hits: ['canonical'] },
+        });
+      }
+    );
+
     it('continues once after reverse-order results and ignores duplicate submissions', async () => {
       let chat!: TestChat;
       let submitLateResult!: () => Promise<void>;
@@ -533,6 +593,55 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
 
       await submitLateResult();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps response ownership when the same messages are restored', async () => {
+      let chat!: TestChat;
+      const submitResults = new Map<string, () => Promise<void>>();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-1'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'first' },
+            },
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-2',
+              input: { q: 'second' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-2'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }) => {
+          submitResults.set(toolCall.toolCallId, () =>
+            chat.addToolResult({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { id: toolCall.toolCallId },
+            })
+          );
+        },
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'search twice' });
+      chat.messages = [...chat.messages];
+
+      await submitResults.get('call-1')!();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+
+      await submitResults.get('call-2')!();
       expect(setup.sendMessages).toHaveBeenCalledTimes(2);
       expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(1);
     });
@@ -626,6 +735,43 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         expect(setup.sendMessages).toHaveBeenCalledTimes(1);
       }
     );
+
+    it('does not continue when an awaited tool callback commits then rejects without onFinish', async () => {
+      let chat!: TestChat;
+      const onError = jest.fn();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: async ({ toolCall }) => {
+          await chat.addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { ok: true },
+          });
+          throw new Error('tool failed after commit');
+        },
+        onError,
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'search' });
+
+      expect(setup.state.status).toBe('error');
+      expect(setup.state.error).toEqual(new Error('tool failed after commit'));
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+    });
 
     it.each([
       [
@@ -808,6 +954,55 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         state: 'output-available',
         output: { ok: true },
       });
+      expect(setup.state.status).toBe('ready');
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it('settles an awaited late result after stop and messages are cleared', async () => {
+      let chat!: TestChat;
+      const toolCallStarted = deferred<undefined>();
+      const releaseToolResult = deferred<undefined>();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: async ({ toolCall }) => {
+          toolCallStarted.resolve(undefined);
+          await releaseToolResult.promise;
+          await chat.addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { ok: true },
+          });
+        },
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      const send = chat.sendMessage({ text: 'search' });
+      await toolCallStarted.promise;
+      await chat.stop();
+      chat.messages = [];
+      releaseToolResult.resolve(undefined);
+
+      const outcome = await Promise.race([
+        send.then(() => 'settled'),
+        new Promise<string>((resolve) =>
+          setTimeout(() => resolve('timed out'), 100)
+        ),
+      ]);
+
+      expect(outcome).toBe('settled');
+      expect(setup.state.messages).toEqual([]);
       expect(setup.state.status).toBe('ready');
       expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
       expect(setup.sendMessages).toHaveBeenCalledTimes(1);

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -198,6 +198,10 @@ function assistantToolPart(state: InMemoryChatState, toolCallId: string): any {
   );
 }
 
+function messageById(state: InMemoryChatState, messageId: string): UIMessage {
+  return state.messages.find((message) => message.id === messageId)!;
+}
+
 describe('AbstractChat.processStreamWithCallbacks', () => {
   describe('guardrail violations', () => {
     it('replaces partial assistant content with the fallback and finishes ready', async () => {
@@ -1216,6 +1220,75 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.sendMessages).toHaveBeenCalledTimes(1);
     });
 
+    it('does not let an older response predicate change newer response state', async () => {
+      let submitOldResult!: TestChat['addToolResult'];
+      const newerResponseStarted = deferred<undefined>();
+      const finishNewerResponse = deferred<undefined>();
+      const sendAutomaticallyWhen = jest.fn(() =>
+        Promise.reject(new Error('old continuation predicate failed'))
+      );
+      const onError = jest.fn();
+      const setup = createTestSetup({
+        sendMessagesFactory: (requestIndex) => {
+          if (requestIndex === 0) {
+            return Promise.resolve(
+              chunksToStream([
+                startChunk('assistant-old'),
+                {
+                  type: 'tool-input-available',
+                  toolName: 'search',
+                  toolCallId: 'call-old',
+                  input: {},
+                },
+                finishChunk(),
+              ])
+            );
+          }
+
+          return Promise.resolve(
+            new ReadableStream<UIMessageChunk>({
+              start(controller) {
+                controller.enqueue(startChunk('assistant-new'));
+                newerResponseStarted.resolve(undefined);
+                void finishNewerResponse.promise.then(() => {
+                  controller.enqueue(finishChunk());
+                  controller.close();
+                });
+              },
+            })
+          );
+        },
+        onToolCall: ({ toolCall }, addToolResult) => {
+          submitOldResult = addToolResult!;
+          expect(toolCall.toolCallId).toBe('call-old');
+        },
+        sendAutomaticallyWhen,
+        onError,
+      });
+
+      await setup.chat.sendMessage({ text: 'first request' });
+
+      const newerSend = setup.chat.sendMessage({ text: 'second request' });
+      await newerResponseStarted.promise;
+      const oldResult = submitOldResult({
+        tool: 'search',
+        toolCallId: 'call-old',
+        output: { ok: true },
+      });
+
+      finishNewerResponse.resolve(undefined);
+      await newerSend;
+      await oldResult;
+
+      expect(setup.state.status).toBe('ready');
+      expect(setup.state.error).toBeUndefined();
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(
+        new Error('old continuation predicate failed')
+      );
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+    });
+
     it('commits a single fire-and-forget result and settles without hanging', async () => {
       let chat!: TestChat;
       const onFinish = jest.fn();
@@ -1313,6 +1386,38 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
       expect(assistantToolPart(setup.state, 'call-2')).toMatchObject({
         output: { id: 'call-2' },
+      });
+    });
+
+    it('keeps public results available after equivalent message rehydration', async () => {
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'rehydrated' },
+          },
+          finishChunk(),
+        ],
+        onToolCall: () => undefined,
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'search' });
+      setup.chat.messages = JSON.parse(
+        JSON.stringify(setup.chat.messages)
+      ) as UIMessage[];
+      await setup.chat.addToolResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'rehydrated' },
+      });
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'rehydrated' },
       });
     });
 
@@ -1859,8 +1964,8 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
           },
           finishChunk(),
         ],
-        onToolCall: ({ toolCall }) =>
-          chat.addToolResult({
+        onToolCall: ({ toolCall }, addToolResult) =>
+          addToolResult!({
             tool: toolCall.toolName,
             toolCallId: toolCall.toolCallId,
             output: { owner: 'new' },
@@ -1963,9 +2068,9 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
             finishChunk(),
           ],
         ],
-        onToolCall: ({ toolCall }) => {
+        onToolCall: ({ toolCall }, addToolResult) => {
           submitOldResult ??= () =>
-            setup.chat.addToolResult({
+            addToolResult!({
               tool: toolCall.toolName,
               toolCallId: toolCall.toolCallId,
               output: { owner: 'old' },
@@ -2167,6 +2272,73 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.state.status).toBe('ready');
     });
 
+    it('allows a newer response to reuse a call id after the older response is stopped', async () => {
+      const oldToolCallStarted = deferred<undefined>();
+      let closeOldStream!: () => void;
+      const onError = jest.fn();
+      const setup = createTestSetup({
+        streamFactory: (requestIndex) => {
+          if (requestIndex > 0) {
+            return chunksToStream([
+              startChunk('assistant-new'),
+              {
+                type: 'tool-input-available',
+                toolName: 'search',
+                toolCallId: 'call-1',
+                input: { owner: 'new' },
+              },
+              finishChunk(),
+            ]);
+          }
+
+          return new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controller.enqueue(startChunk('assistant-old'));
+              controller.enqueue({
+                type: 'tool-input-available',
+                toolName: 'search',
+                toolCallId: 'call-1',
+                input: { owner: 'old' },
+              });
+              closeOldStream = () => controller.close();
+            },
+          });
+        },
+        onToolCall: ({ toolCall }, addToolResult) => {
+          if (toolCall.input.owner === 'old') {
+            oldToolCallStarted.resolve(undefined);
+            return;
+          }
+
+          return addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: 'new' },
+          });
+        },
+        sendAutomaticallyWhen: () => false,
+        onError,
+      });
+
+      const oldSend = setup.chat.sendMessage({ text: 'first request' });
+      await oldToolCallStarted.promise;
+      await setup.chat.stop();
+      closeOldStream();
+      await oldSend;
+
+      await setup.chat.sendMessage({ text: 'second request' });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(setup.state.status).toBe('ready');
+    });
+
     it('ignores an ambiguous public result after call ownership transfers', async () => {
       let submitOldPublicResult!: () => Promise<void>;
       let submitNewScopedResult!: TestChat['addToolResult'];
@@ -2243,6 +2415,1008 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         state: 'output-available',
         output: { owner: 'new' },
       });
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('routes a message-scoped result to its response when a call id is reused', async () => {
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { owner: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { owner: 'new' },
+            },
+            finishChunk(),
+          ],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          if (toolCall.input.owner === 'old') {
+            return addToolResult!({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { owner: 'old' },
+            });
+          }
+          return;
+        },
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'first request' });
+      await setup.chat.sendMessage({ text: 'second request' });
+
+      await setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-new'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { owner: 'new' },
+        }
+      );
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-old')
+          ?.parts[0]
+      ).toMatchObject({ output: { owner: 'old' } });
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+    });
+
+    it('settles a message-scoped result for a restored tool call', async () => {
+      const followUpStarted = deferred<undefined>();
+      const finishFollowUp = deferred<undefined>();
+      const setup = createTestSetup({
+        sendMessagesFactory: () => {
+          followUpStarted.resolve(undefined);
+          return Promise.resolve(
+            new ReadableStream<UIMessageChunk>({
+              start(controller) {
+                controller.enqueue(startChunk('assistant-follow-up'));
+                finishFollowUp.promise.then(() => {
+                  controller.enqueue(finishChunk());
+                  controller.close();
+                });
+              },
+            })
+          );
+        },
+        sendAutomaticallyWhen: () => true,
+      });
+      setup.chat.messages = [
+        {
+          id: 'assistant-other',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'other' },
+            },
+          ],
+        },
+        {
+          id: 'assistant-restored',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'restored' },
+            },
+          ],
+        },
+      ];
+
+      let settled = false;
+      const result = setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-restored'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { owner: 'restored' },
+        }
+      ).then(() => {
+        settled = true;
+      });
+
+      await followUpStarted.promise;
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      expect(settled).toBe(false);
+      expect(setup.state.messages[0].parts[0]).toMatchObject({
+        state: 'input-available',
+      });
+      expect(setup.state.messages[1].parts[0]).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'restored' },
+      });
+
+      finishFollowUp.resolve(undefined);
+      await result;
+
+      expect(settled).toBe(true);
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('ignores a public result when restored messages share a call id', async () => {
+      const setup = createTestSetup({
+        sendAutomaticallyWhen: () => false,
+      });
+      setup.chat.messages = [
+        {
+          id: 'assistant-old',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'old' },
+            },
+          ],
+        },
+        {
+          id: 'assistant-new',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'new' },
+            },
+          ],
+        },
+      ];
+
+      await setup.chat.addToolResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'unknown' },
+      });
+
+      expect(setup.state.messages[0].parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { q: 'old' },
+      });
+      expect(setup.state.messages[1].parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+
+      await setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-new'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { owner: 'new' },
+        }
+      );
+
+      expect(setup.state.messages[0].parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { q: 'old' },
+      });
+      expect(setup.state.messages[1].parts[0]).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+    });
+
+    it('keeps a call id ambiguous across separate restored messages', async () => {
+      const setup = createTestSetup({
+        sendAutomaticallyWhen: () => false,
+      });
+      setup.chat.messages = [
+        {
+          id: 'assistant-old',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'old' },
+            },
+          ],
+        },
+      ];
+      setup.chat.messages = [];
+      setup.chat.messages = [
+        {
+          id: 'assistant-new',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'new' },
+            },
+          ],
+        },
+      ];
+
+      await setup.chat.addToolResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'old-delayed' },
+      });
+
+      expect(setup.state.messages[0].parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+
+      await setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-new'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { owner: 'new' },
+        }
+      );
+
+      expect(setup.state.messages[0].parts[0]).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('keeps a restored call id ambiguous when a response reuses it', async () => {
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-continuation'), finishChunk()],
+        ],
+        onToolCall: () => undefined,
+        sendAutomaticallyWhen: () => true,
+      });
+      setup.chat.messages = [
+        {
+          id: 'assistant-restored',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'restored' },
+            },
+          ],
+        },
+      ];
+
+      await setup.chat.sendMessage({ text: 'new search' });
+      await setup.chat.addToolResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'restored-delayed' },
+      });
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+
+      await setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-new'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { owner: 'new' },
+        }
+      );
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('ignores a public result when an older message is restored after a live owner', async () => {
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-continuation'), finishChunk()],
+        ],
+        onToolCall: () => undefined,
+        sendAutomaticallyWhen: () => true,
+      });
+
+      await setup.chat.sendMessage({ text: 'new search' });
+      setup.chat.messages = [
+        {
+          id: 'assistant-old',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'old' },
+            },
+          ],
+        },
+        ...setup.chat.messages,
+      ];
+
+      await setup.chat.addToolResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'old-delayed' },
+      });
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-old')
+          ?.parts[0]
+      ).toMatchObject({ state: 'input-available' });
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({ state: 'input-available' });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+
+      await setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-new'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { owner: 'new' },
+        }
+      );
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('invokes a client tool once for repeated input chunks in one response', async () => {
+      const toolCallStarted = deferred<undefined>();
+      const releaseToolResult = deferred<undefined>();
+      const onToolCall = jest.fn(({ toolCall }, addToolResult) => {
+        toolCallStarted.resolve(undefined);
+        return releaseToolResult.promise.then(() =>
+          addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: 'client' },
+          })
+        );
+      });
+      const repeatedChunk: UIMessageChunk = {
+        type: 'tool-input-available',
+        toolName: 'search',
+        toolCallId: 'call-1',
+        input: { q: 'hello' },
+      };
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          repeatedChunk,
+          repeatedChunk,
+          finishChunk(),
+        ],
+        onToolCall,
+        sendAutomaticallyWhen: () => false,
+      });
+
+      const result = setup.chat.sendMessage({ text: 'search' });
+      await toolCallStarted.promise;
+      releaseToolResult.resolve(undefined);
+      await result;
+
+      expect(onToolCall).toHaveBeenCalledTimes(1);
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'client' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('keeps a reused call id ambiguous for delayed public results after pruning', async () => {
+      let submitDelayedOldResult!: () => Promise<void>;
+      const sendAutomaticallyWhen = jest.fn(
+        ({ messages }: { messages: UIMessage[] }) =>
+          messages.some((message) => message.id === 'assistant-new')
+      );
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-continuation'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          if (toolCall.input.q === 'old') {
+            submitDelayedOldResult = () =>
+              setup.chat.addToolResult({
+                tool: toolCall.toolName,
+                toolCallId: toolCall.toolCallId,
+                output: { owner: 'old-delayed' },
+              });
+            return addToolResult!({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { owner: 'old' },
+            });
+          }
+          return;
+        },
+        sendAutomaticallyWhen,
+      });
+
+      await setup.chat.sendMessage({ text: 'first search' });
+      await setup.chat.sendMessage({ text: 'second search' });
+
+      setup.chat.messages = setup.chat.messages.filter(
+        (message) => message.id !== 'assistant-old'
+      );
+
+      await submitDelayedOldResult();
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+
+      await setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-new'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { owner: 'new' },
+        }
+      );
+
+      expect(
+        setup.state.messages
+          .find((message) => message.id === 'assistant-new')
+          ?.parts.find(
+            (part) => 'toolCallId' in part && part.toolCallId === 'call-1'
+          )
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(3);
+      expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(2);
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('keeps a reused call id ambiguous after every owner is pruned', async () => {
+      let submitDelayedOldResult!: () => Promise<void>;
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-latest'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'latest' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-continuation'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          if (toolCall.input.q === 'old') {
+            submitDelayedOldResult = () =>
+              setup.chat.addToolResult({
+                tool: toolCall.toolName,
+                toolCallId: toolCall.toolCallId,
+                output: { owner: 'old-delayed' },
+              });
+            return addToolResult!({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { owner: 'old' },
+            });
+          }
+          return;
+        },
+        sendAutomaticallyWhen: ({ messages }) =>
+          messages.some((message) => message.id === 'assistant-latest'),
+      });
+
+      await setup.chat.sendMessage({ text: 'first search' });
+      await setup.chat.sendMessage({ text: 'second search' });
+      setup.chat.messages = setup.chat.messages.filter(
+        (message) =>
+          message.id !== 'assistant-old' && message.id !== 'assistant-new'
+      );
+      await setup.chat.sendMessage({ text: 'third search' });
+
+      await submitDelayedOldResult();
+
+      expect(
+        setup.state.messages.find(
+          (message) => message.id === 'assistant-latest'
+        )?.parts[0]
+      ).toMatchObject({
+        state: 'input-available',
+        input: { q: 'latest' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(3);
+
+      await setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-latest'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { owner: 'latest' },
+        }
+      );
+
+      expect(
+        setup.state.messages.find(
+          (message) => message.id === 'assistant-latest'
+        )?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'latest' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(4);
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('keeps a call id ambiguous when its first owner is pruned before reuse', async () => {
+      let submitDelayedOldResult!: () => Promise<void>;
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-continuation'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          if (toolCall.input.q === 'old') {
+            submitDelayedOldResult = () =>
+              setup.chat.addToolResult({
+                tool: toolCall.toolName,
+                toolCallId: toolCall.toolCallId,
+                output: { owner: 'old-delayed' },
+              });
+            return addToolResult!({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { owner: 'old' },
+            });
+          }
+          return;
+        },
+        sendAutomaticallyWhen: ({ messages }) =>
+          messages.some((message) => message.id === 'assistant-new'),
+      });
+
+      await setup.chat.sendMessage({ text: 'first search' });
+      setup.chat.messages = setup.chat.messages.filter(
+        (message) => message.id !== 'assistant-old'
+      );
+      await setup.chat.sendMessage({ text: 'second search' });
+
+      await submitDelayedOldResult();
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+
+      await setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-new'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { owner: 'new' },
+        }
+      );
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(3);
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('keeps a regenerated call ambiguous when the message id is reused', async () => {
+      let submitDelayedOldResult!: () => Promise<void>;
+      let submitNewScopedResult!: TestChat['addToolResult'];
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-shared'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { owner: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-shared'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { owner: 'new' },
+            },
+            finishChunk(),
+          ],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          if (toolCall.input.owner === 'old') {
+            submitDelayedOldResult = () =>
+              setup.chat.addToolResult({
+                tool: toolCall.toolName,
+                toolCallId: toolCall.toolCallId,
+                output: { owner: 'old-delayed' },
+              });
+            return addToolResult!({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { owner: 'old' },
+            });
+          }
+
+          submitNewScopedResult = addToolResult!;
+          return;
+        },
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'first search' });
+      await setup.chat.regenerate({ messageId: 'assistant-shared' });
+      await submitDelayedOldResult();
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'input-available',
+        input: { owner: 'new' },
+      });
+
+      await submitNewScopedResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'new' },
+      });
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('ignores a layout result captured before regenerating the same message id', async () => {
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-shared'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { owner: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-shared'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { owner: 'new' },
+            },
+            finishChunk(),
+          ],
+        ],
+        onToolCall: () => undefined,
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'first search' });
+      const oldMessage = setup.state.messages.find(
+        (message) => message.id === 'assistant-shared'
+      )!;
+      await setup.chat.regenerate({ messageId: 'assistant-shared' });
+
+      await setup.chat['~addToolResultForMessage'](oldMessage, {
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'old-layout' },
+      });
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'input-available',
+        input: { owner: 'new' },
+      });
+    });
+
+    it('retires a response when its message occurrence is replaced with the same id', async () => {
+      let submitOldScopedResult!: TestChat['addToolResult'];
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-shared'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { owner: 'old' },
+          },
+          finishChunk(),
+        ],
+        onToolCall: (_options, addToolResult) => {
+          submitOldScopedResult = addToolResult!;
+        },
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'first search' });
+      const replacement = {
+        id: 'assistant-shared',
+        role: 'assistant' as const,
+        parts: [
+          {
+            type: 'tool-search' as const,
+            toolCallId: 'call-1',
+            state: 'input-available' as const,
+            input: { owner: 'new' },
+          },
+        ],
+      };
+      setup.chat.messages = setup.chat.messages.map((message) =>
+        message.id === replacement.id ? replacement : message
+      );
+
+      await submitOldScopedResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'old-delayed' },
+      });
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'input-available',
+        input: { owner: 'new' },
+      });
+
+      await setup.chat['~addToolResultForMessage'](replacement, {
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'new' },
+      });
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+    });
+
+    it('prunes detached tool ownership after every reset', async () => {
+      const requestCount = 100;
+      const setup = createTestSetup({
+        chunksByRequest: Array.from({ length: requestCount }, (_, index) => [
+          startChunk(`assistant-${index}`),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: `call-${index}`,
+            input: { index },
+          },
+          finishChunk(),
+        ]),
+        onToolCall: () => undefined,
+        sendAutomaticallyWhen: () => false,
+      });
+
+      for (let index = 0; index < requestCount; index++) {
+        await setup.chat.sendMessage({ text: `search ${index}` });
+        expect((setup.chat as any).responsesByToolCallId.size).toBe(1);
+        setup.chat.messages = [];
+        setup.chat.resetConversationId();
+        expect((setup.chat as any).responsesByToolCallId.size).toBe(0);
+      }
+
+      expect(setup.sendMessages).toHaveBeenCalledTimes(requestCount);
+      expect(setup.chat.messages).toEqual([]);
+      expect((setup.chat as any).responsesByToolCallId.size).toBe(0);
+    });
+
+    it('keeps stale public results inert after clearing and resetting', async () => {
+      let submitDelayedOldResult!: () => Promise<void>;
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-continuation'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          if (toolCall.input.q === 'old') {
+            submitDelayedOldResult = () =>
+              setup.chat.addToolResult({
+                tool: toolCall.toolName,
+                toolCallId: toolCall.toolCallId,
+                output: { owner: 'old-delayed' },
+              });
+            return addToolResult!({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { owner: 'old' },
+            });
+          }
+          return;
+        },
+        sendAutomaticallyWhen: ({ messages }) =>
+          messages.some((message) => message.id === 'assistant-new'),
+      });
+
+      await setup.chat.sendMessage({ text: 'old search' });
+      setup.chat.messages = [];
+      setup.chat.resetConversationId();
+      await setup.chat.sendMessage({ text: 'new search' });
+
+      await submitDelayedOldResult();
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+
+      await setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-new'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { owner: 'new' },
+        }
+      );
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(setup.sendMessages).toHaveBeenCalledTimes(3);
       expect(setup.state.status).toBe('ready');
     });
 

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -713,6 +713,148 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       }
     );
 
+    it('settles an awaited late result after stop without continuing', async () => {
+      let chat!: TestChat;
+      const toolCallStarted = deferred<undefined>();
+      const releaseToolResult = deferred<undefined>();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: async ({ toolCall }) => {
+          toolCallStarted.resolve(undefined);
+          await releaseToolResult.promise;
+          await chat.addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { ok: true },
+          });
+        },
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      const send = chat.sendMessage({ text: 'search' });
+      await toolCallStarted.promise;
+      await chat.stop();
+      releaseToolResult.resolve(undefined);
+
+      const outcome = await Promise.race([
+        send.then(() => 'settled'),
+        new Promise<string>((resolve) =>
+          setTimeout(() => resolve('timed out'), 100)
+        ),
+      ]);
+
+      expect(outcome).toBe('settled');
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { ok: true },
+      });
+      expect(setup.state.status).toBe('ready');
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it('commits a reused toolCallId to its owning assistant message', async () => {
+      let chat!: TestChat;
+      const onFinish = jest.fn();
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-new'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'new' },
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ toolCall }) =>
+          chat.addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: 'new' },
+          }),
+        onFinish,
+      });
+      chat = setup.chat;
+      setup.state.messages = [
+        {
+          id: 'assistant-old',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { q: 'old' },
+            },
+          ],
+        },
+      ];
+
+      await chat.sendMessage({ text: 'search again' });
+
+      const oldMessage = setup.state.messages.find(
+        (message) => message.id === 'assistant-old'
+      );
+      const newMessage = setup.state.messages.find(
+        (message) => message.id === 'assistant-new'
+      );
+
+      expect(oldMessage?.parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { q: 'old' },
+      });
+      expect(newMessage?.parts[0]).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(onFinish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            id: 'assistant-new',
+            parts: [
+              expect.objectContaining({
+                state: 'output-available',
+                output: { owner: 'new' },
+              }),
+            ],
+          }),
+        })
+      );
+
+      await chat.addToolResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'duplicate' },
+      });
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-old')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'input-available',
+        input: { q: 'old' },
+      });
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+    });
+
     it('quietly ignores an unknown toolCallId', async () => {
       const sendAutomaticallyWhen = jest.fn(() => true);
       const setup = createTestSetup({ sendAutomaticallyWhen });

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -111,7 +111,10 @@ function createTestSetup(
       requestIndex: number,
       options: SendMessagesCall
     ) => Promise<ReadableStream<UIMessageChunk>>;
-    onToolCall?: (options: { toolCall: any }) => void | Promise<void>;
+    onToolCall?: (
+      options: { toolCall: any },
+      addToolResult?: TestChat['addToolResult']
+    ) => void | Promise<void>;
     onFinish?: ChatOnFinishCallback<UIMessage>;
     onError?: ChatOnErrorCallback;
     sendAutomaticallyWhen?: (options: {
@@ -1201,6 +1204,242 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.sendMessages).toHaveBeenCalledTimes(2);
     });
 
+    it('keeps a stale callback scoped when a later response reuses its resolved toolCallId', async () => {
+      let submitOldResult!: TestChat['addToolResult'];
+      let submitNewResult!: TestChat['addToolResult'];
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) => {
+          if (toolCall.input.q === 'old') {
+            submitOldResult = addToolResult!;
+          } else {
+            submitNewResult = addToolResult!;
+          }
+        },
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'first search' });
+      await submitOldResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'old' },
+      });
+      await setup.chat.sendMessage({ text: 'second search' });
+
+      await submitOldResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'stale' },
+      });
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-old')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'old' },
+      });
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+
+      await submitNewResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'new' },
+      });
+
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-new')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new' },
+      });
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('settles an awaited client result after a server result for the same call', async () => {
+      const toolCallStarted = deferred<undefined>();
+      const releaseToolResult = deferred<undefined>();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-1'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'hello' },
+            },
+            {
+              type: 'tool-output-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              output: { owner: 'server' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-2'), finishChunk()],
+        ],
+        onToolCall: async ({ toolCall }, addToolResult) => {
+          toolCallStarted.resolve(undefined);
+          await releaseToolResult.promise;
+          await addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: 'client' },
+          });
+        },
+        sendAutomaticallyWhen,
+      });
+
+      const send = setup.chat.sendMessage({ text: 'search' });
+      await toolCallStarted.promise;
+      releaseToolResult.resolve(undefined);
+
+      const outcome = await Promise.race([
+        send.then(() => 'settled'),
+        new Promise<string>((resolve) =>
+          setTimeout(() => resolve('timed out'), 100)
+        ),
+      ]);
+
+      expect(outcome).toBe('settled');
+      expect(
+        setup.state.messages.find((message) => message.id === 'assistant-1')
+          ?.parts[0]
+      ).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'server' },
+      });
+      expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(1);
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('lets an awaited client result replace preliminary server output', async () => {
+      const toolCallStarted = deferred<undefined>();
+      const releaseToolResult = deferred<undefined>();
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          },
+          {
+            type: 'tool-output-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            output: { owner: 'server', phase: 'partial' },
+            preliminary: true,
+          },
+          finishChunk(),
+        ],
+        onToolCall: async ({ toolCall }, addToolResult) => {
+          toolCallStarted.resolve(undefined);
+          await releaseToolResult.promise;
+          await addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: 'client', phase: 'final' },
+          });
+        },
+        sendAutomaticallyWhen: () => false,
+      });
+
+      const send = setup.chat.sendMessage({ text: 'search' });
+      await toolCallStarted.promise;
+      releaseToolResult.resolve(undefined);
+      await send;
+
+      const part = setup.state.messages.find(
+        (message) => message.id === 'assistant-1'
+      )?.parts[0];
+      expect(part).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'client', phase: 'final' },
+      });
+      expect((part as any).preliminary).toBeUndefined();
+      expect((part as any).rawOutput).toBeUndefined();
+      expect(setup.state.status).toBe('ready');
+    });
+
+    it('continues once after mixed server and client tool results', async () => {
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-1'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'client-call',
+              input: { q: 'client' },
+            },
+            {
+              type: 'tool-input-available',
+              toolName: 'lookup',
+              toolCallId: 'server-call',
+              input: { q: 'server' },
+              providerExecuted: true,
+            },
+            {
+              type: 'tool-output-available',
+              toolName: 'lookup',
+              toolCallId: 'server-call',
+              output: { owner: 'server' },
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-2'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) =>
+          addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { owner: 'client' },
+          }),
+        sendAutomaticallyWhen,
+      });
+
+      await setup.chat.sendMessage({ text: 'use both tools' });
+
+      expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(1);
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      expect(setup.state.status).toBe('ready');
+    });
+
     it('quietly ignores an unknown toolCallId', async () => {
       const sendAutomaticallyWhen = jest.fn(() => true);
       const setup = createTestSetup({ sendAutomaticallyWhen });
@@ -1285,13 +1524,16 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         input: { q: 'hello' },
       });
       expect(onToolCall).toHaveBeenCalledTimes(1);
-      expect(onToolCall).toHaveBeenCalledWith({
-        toolCall: expect.objectContaining({
-          toolName: 'search',
-          toolCallId: 'call-1',
-          input: { q: 'hello' },
-        }),
-      });
+      expect(onToolCall).toHaveBeenCalledWith(
+        {
+          toolCall: expect.objectContaining({
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          }),
+        },
+        expect.any(Function)
+      );
     });
 
     it('repairs partial JSON during streaming and exposes intermediate input on rawInput', async () => {
@@ -1374,6 +1616,42 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
       expect(part.rawOutput).toBeUndefined();
       expect(part.preliminary).toBeUndefined();
+    });
+
+    it('keeps a final server result after preliminary output for a client-owned tool', async () => {
+      const { chat, state } = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hi' },
+          },
+          {
+            type: 'tool-output-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            output: { r: 'partial' },
+            preliminary: true,
+          },
+          {
+            type: 'tool-output-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            output: { r: 'final' },
+          },
+          finishChunk(),
+        ],
+        onToolCall: () => Promise.resolve(),
+      });
+
+      await chat.sendMessage({ text: 'hi' });
+
+      expect(assistantPart(state)).toMatchObject({
+        state: 'output-available',
+        output: { r: 'final' },
+      });
     });
   });
 

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -375,6 +375,55 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
     });
 
+    it('passes the canonical delayed tool result to onFinish after the stream closes', async () => {
+      let chat!: TestChat;
+      const toolCallStarted = deferred<undefined>();
+      const releaseToolResult = deferred<undefined>();
+      const onFinish = jest.fn();
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          },
+          finishChunk(),
+        ],
+        onToolCall: async ({ toolCall }) => {
+          toolCallStarted.resolve(undefined);
+          await releaseToolResult.promise;
+          await chat.addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { hits: ['delayed'] },
+          });
+        },
+        onFinish,
+      });
+      chat = setup.chat;
+
+      const send = chat.sendMessage({ text: 'search for hello' });
+      await toolCallStarted.promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      releaseToolResult.resolve(undefined);
+      await send;
+
+      const assistant = setup.state.messages.find(
+        (message) => message.role === 'assistant'
+      );
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { hits: ['delayed'] },
+      });
+      expect(setup.state.status).toBe('ready');
+      expect(onFinish).toHaveBeenCalledTimes(1);
+      expect(onFinish).toHaveBeenCalledWith(
+        expect.objectContaining({ message: assistant })
+      );
+    });
+
     it('does not let later input chunks downgrade a committed tool result', async () => {
       let chat!: TestChat;
       const onFinish = jest.fn();

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -2570,6 +2570,152 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       }
     });
 
+    it('commits a layout result captured before a later snapshot of the same response', async () => {
+      const toolCallAvailable = deferred<undefined>();
+      const releaseLaterChunk = deferred<undefined>();
+      const laterChunkProcessed = deferred<undefined>();
+      const releaseStream = deferred<undefined>();
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      state['~registerMessagesCallback'](() => {
+        const assistant = state.messages.find(
+          (message) => message.id === 'assistant-1'
+        );
+        if (
+          assistant?.parts.some(
+            (part) => part.type === 'text' && part.text === 'Still working'
+          )
+        ) {
+          laterChunkProcessed.resolve(undefined);
+        }
+      });
+      const setup = createTestSetup({
+        state,
+        streamFactory: () =>
+          new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controller.enqueue(startChunk('assistant-1'));
+              controller.enqueue({
+                type: 'tool-input-available',
+                toolName: 'search',
+                toolCallId: 'call-1',
+                input: { q: 'phone' },
+              });
+              releaseLaterChunk.promise.then(() => {
+                controller.enqueue({ type: 'text-start', id: 'text-1' });
+                controller.enqueue({
+                  type: 'text-delta',
+                  id: 'text-1',
+                  delta: 'Still working',
+                });
+                releaseStream.promise.then(() => {
+                  controller.enqueue(finishChunk());
+                  controller.close();
+                });
+              });
+            },
+          }),
+        onToolCall: () => {
+          toolCallAvailable.resolve(undefined);
+        },
+        sendAutomaticallyWhen: () => false,
+      });
+
+      const send = setup.chat.sendMessage({ text: 'search' });
+      await toolCallAvailable.promise;
+      const capturedMessage = messageById(state, 'assistant-1');
+      releaseLaterChunk.resolve(undefined);
+      await laterChunkProcessed.promise;
+
+      const currentMessage = messageById(state, 'assistant-1');
+      expect(currentMessage).not.toBe(capturedMessage);
+
+      try {
+        await setup.chat['~addToolResultForMessage'](capturedMessage, {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { hits: 1 },
+        });
+
+        expect(assistantToolPart(state, 'call-1')).toMatchObject({
+          state: 'output-available',
+          output: { hits: 1 },
+        });
+      } finally {
+        releaseStream.resolve(undefined);
+        await send;
+      }
+    });
+
+    it('ignores a layout result captured by an older response with the same message id', async () => {
+      const oldToolAvailable = deferred<undefined>();
+      const failOldResponse = deferred<undefined>();
+      const state = new InMemoryChatState();
+      const chat = new ConcurrentTestChat({
+        state,
+        onError: jest.fn(),
+        onToolCall: () => {
+          oldToolAvailable.resolve(undefined);
+        },
+        sendAutomaticallyWhen: () => false,
+      });
+
+      const oldResponse = chat.startResponse(
+        new ReadableStream<UIMessageChunk>({
+          start(controller) {
+            controller.enqueue(startChunk('assistant-shared'));
+            controller.enqueue({
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { owner: 'old' },
+            });
+            failOldResponse.promise.then(() => {
+              controller.error(new Error('disconnected'));
+            });
+          },
+        })
+      );
+      await oldToolAvailable.promise;
+      const oldMessage = messageById(state, 'assistant-shared');
+      failOldResponse.resolve(undefined);
+      await oldResponse;
+
+      await chat.startResponse(
+        chunksToStream([
+          startChunk('assistant-shared'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { owner: 'new' },
+          },
+          finishChunk(),
+        ])
+      );
+      const currentMessage = messageById(state, 'assistant-shared');
+      expect(currentMessage).not.toBe(oldMessage);
+
+      await chat['~addToolResultForMessage'](oldMessage, {
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'old-layout' },
+      });
+      expect(assistantToolPart(state, 'call-1')).toMatchObject({
+        state: 'input-available',
+        input: { owner: 'new' },
+      });
+
+      await chat['~addToolResultForMessage'](currentMessage, {
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'new-layout' },
+      });
+      expect(assistantToolPart(state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'new-layout' },
+      });
+    });
+
     it('settles a message-scoped result for a restored tool call', async () => {
       const followUpStarted = deferred<undefined>();
       const finishFollowUp = deferred<undefined>();
@@ -2645,6 +2791,71 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
 
       expect(settled).toBe(true);
       expect(setup.state.status).toBe('ready');
+    });
+
+    it('commits concurrent public results queued for the same message', async () => {
+      const responseStarted = deferred<undefined>();
+      const releaseResponse = deferred<undefined>();
+      const setup = createTestSetup({
+        streamFactory: () =>
+          new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controller.enqueue(startChunk('assistant-active'));
+              responseStarted.resolve(undefined);
+              releaseResponse.promise.then(() => {
+                controller.enqueue(finishChunk());
+                controller.close();
+              });
+            },
+          }),
+        sendAutomaticallyWhen: () => false,
+      });
+      setup.chat.messages = [
+        {
+          id: 'assistant-restored',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-a',
+              state: 'input-available',
+              input: {},
+            },
+            {
+              type: 'tool-search',
+              toolCallId: 'call-b',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
+
+      const send = setup.chat.sendMessage({ text: 'keep working' });
+      await responseStarted.promise;
+      const results = Promise.all([
+        setup.chat.addToolResult({
+          tool: 'search',
+          toolCallId: 'call-a',
+          output: { value: 'a' },
+        }),
+        setup.chat.addToolResult({
+          tool: 'search',
+          toolCallId: 'call-b',
+          output: { value: 'b' },
+        }),
+      ]);
+
+      releaseResponse.resolve(undefined);
+      await send;
+      await results;
+
+      expect(
+        messageById(setup.state, 'assistant-restored').parts
+      ).toMatchObject([
+        { state: 'output-available', output: { value: 'a' } },
+        { state: 'output-available', output: { value: 'b' } },
+      ]);
     });
 
     it('ignores a public result when restored messages share a call id', async () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
+import { ChatState as RuntimeChatState } from '../../chat/chat';
 import { AbstractChat } from '../abstract-chat';
 import { parseJsonEventStream } from '../stream-parser';
 
@@ -108,6 +109,7 @@ function createTestSetup(
     onFinish,
     onError,
     sendAutomaticallyWhen,
+    state = new InMemoryChatState(),
   }: {
     chunks?: UIMessageChunk[];
     chunksByRequest?: UIMessageChunk[][];
@@ -126,6 +128,7 @@ function createTestSetup(
     sendAutomaticallyWhen?: (options: {
       messages: UIMessage[];
     }) => boolean | PromiseLike<boolean>;
+    state?: ChatState<UIMessage>;
   } = { chunks: [] }
 ) {
   let requestIndex = 0;
@@ -149,7 +152,6 @@ function createTestSetup(
     reconnectToStream: reconnectToStream as any,
   };
 
-  const state = new InMemoryChatState();
   const chat = new TestChat({
     id: 'test-chat',
     state,
@@ -184,12 +186,15 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
-function assistantPart(state: InMemoryChatState): any {
+function assistantPart(state: ChatState<UIMessage>): any {
   const assistant = state.messages.find((m) => m.role === 'assistant');
   return assistant?.parts[0];
 }
 
-function assistantToolPart(state: InMemoryChatState, toolCallId: string): any {
+function assistantToolPart(
+  state: ChatState<UIMessage>,
+  toolCallId: string
+): any {
   const assistant = state.messages.find(
     (message) => message.role === 'assistant'
   );
@@ -198,7 +203,10 @@ function assistantToolPart(state: InMemoryChatState, toolCallId: string): any {
   );
 }
 
-function messageById(state: InMemoryChatState, messageId: string): UIMessage {
+function messageById(
+  state: ChatState<UIMessage>,
+  messageId: string
+): UIMessage {
   return state.messages.find((message) => message.id === messageId)!;
 }
 
@@ -2478,6 +2486,88 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         state: 'output-available',
         output: { owner: 'new' },
       });
+    });
+
+    it('keeps identifier-only results available when state snapshots messages', async () => {
+      const setup = createTestSetup({
+        state: new RuntimeChatState<UIMessage>('test-chat', [], false),
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'phone' },
+          },
+          finishChunk(),
+        ],
+        onToolCall: () => undefined,
+        sendAutomaticallyWhen: () => false,
+      });
+
+      await setup.chat.sendMessage({ text: 'search' });
+      await setup.chat.addToolResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { hits: 1 },
+      });
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { hits: 1 },
+      });
+    });
+
+    it('commits a message-scoped result while snapshotting state is streaming', async () => {
+      const toolCallAvailable = deferred<undefined>();
+      const releaseStream = deferred<undefined>();
+      const setup = createTestSetup({
+        state: new RuntimeChatState<UIMessage>('test-chat', [], false),
+        streamFactory: () =>
+          new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controller.enqueue(startChunk('assistant-1'));
+              controller.enqueue({
+                type: 'tool-input-available',
+                toolName: 'search',
+                toolCallId: 'call-1',
+                input: { q: 'phone' },
+              });
+              releaseStream.promise.then(() => {
+                controller.enqueue(finishChunk());
+                controller.close();
+              });
+            },
+          }),
+        onToolCall: () => {
+          toolCallAvailable.resolve(undefined);
+        },
+        sendAutomaticallyWhen: () => false,
+      });
+
+      const send = setup.chat.sendMessage({ text: 'search' });
+      await toolCallAvailable.promise;
+      const result = setup.chat['~addToolResultForMessage'](
+        messageById(setup.state, 'assistant-1'),
+        {
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { hits: 1 },
+        }
+      );
+
+      try {
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+          state: 'output-available',
+          output: { hits: 1 },
+        });
+      } finally {
+        releaseStream.resolve(undefined);
+        await send;
+        await result;
+      }
     });
 
     it('settles a message-scoped result for a restored tool call', async () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -1008,6 +1008,45 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.sendMessages).toHaveBeenCalledTimes(1);
     });
 
+    it('settles when onToolCall synchronously stops, clears and returns a result', async () => {
+      let chat!: TestChat;
+      const onError = jest.fn();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ toolCall }) => {
+          chat.stop();
+          chat.messages = [];
+          return chat.addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { ok: true },
+          });
+        },
+        onError,
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      await expect(
+        chat.sendMessage({ text: 'search' })
+      ).resolves.toBeUndefined();
+      expect(setup.state.messages).toEqual([]);
+      expect(setup.state.status).toBe('ready');
+      expect(onError).not.toHaveBeenCalled();
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+    });
+
     it('commits a reused toolCallId to its owning assistant message', async () => {
       let chat!: TestChat;
       const onFinish = jest.fn();
@@ -1097,6 +1136,69 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         state: 'output-available',
         output: { owner: 'new' },
       });
+    });
+
+    it('rejects overlapping response ownership for a reused toolCallId', async () => {
+      let submitOldResult!: () => Promise<void>;
+      const onError = jest.fn();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-old'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'old' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-new'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { q: 'new' },
+            },
+            finishChunk(),
+          ],
+        ],
+        onToolCall: ({ toolCall }) => {
+          submitOldResult ??= () =>
+            setup.chat.addToolResult({
+              tool: toolCall.toolName,
+              toolCallId: toolCall.toolCallId,
+              output: { owner: 'old' },
+            });
+        },
+        onError,
+        sendAutomaticallyWhen,
+      });
+
+      await setup.chat.sendMessage({ text: 'first search' });
+      await setup.chat.sendMessage({ text: 'second search' });
+      await submitOldResult();
+
+      const oldMessage = setup.state.messages.find(
+        (message) => message.id === 'assistant-old'
+      );
+      const newMessage = setup.state.messages.find(
+        (message) => message.id === 'assistant-new'
+      );
+      expect(oldMessage?.parts[0]).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'old' },
+      });
+      expect(newMessage?.parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { q: 'new' },
+      });
+      expect(setup.state.status).toBe('error');
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
     });
 
     it('quietly ignores an unknown toolCallId', async () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -1050,6 +1050,166 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.sendMessages).toHaveBeenCalledTimes(1);
     });
 
+    it('does not let a detached response overwrite its replacement message', async () => {
+      let chat!: TestChat;
+      const replacementMessage: UIMessage = {
+        id: 'assistant-replacement',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'replacement', state: 'done' }],
+      };
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-detached'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'stale' },
+          finishChunk(),
+        ],
+        onToolCall: () => {
+          chat.messages = [chat.messages[0], replacementMessage];
+        },
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'search' });
+
+      expect(setup.state.messages).toEqual([
+        expect.objectContaining({ role: 'user' }),
+        replacementMessage,
+      ]);
+      expect(
+        setup.state.messages.some(
+          (message) => message.id === 'assistant-detached'
+        )
+      ).toBe(false);
+    });
+
+    it('does not continue a response removed by onFinish', async () => {
+      let chat!: TestChat;
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-1'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: {},
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-2'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) =>
+          addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { ok: true },
+          }),
+        onFinish: () => {
+          chat.messages = [];
+        },
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      await chat.sendMessage({ text: 'search' });
+
+      expect(setup.state.messages).toEqual([]);
+      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not continue when its message is removed while the predicate is pending', async () => {
+      let chat!: TestChat;
+      const predicateStarted = deferred<undefined>();
+      const predicateResult = deferred<boolean>();
+      const sendAutomaticallyWhen = jest.fn(() => {
+        predicateStarted.resolve(undefined);
+        return predicateResult.promise;
+      });
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-1'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: {},
+            },
+            finishChunk(),
+          ],
+          [startChunk('assistant-2'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) =>
+          addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { ok: true },
+          }),
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      const send = chat.sendMessage({ text: 'search' });
+      await predicateStarted.promise;
+      chat.messages = [];
+      predicateResult.resolve(true);
+      await send;
+
+      expect(setup.state.messages).toEqual([]);
+      expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(1);
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not surface a predicate error after its message is removed', async () => {
+      let chat!: TestChat;
+      const predicateStarted = deferred<undefined>();
+      const predicateResult = deferred<boolean>();
+      const sendAutomaticallyWhen = jest.fn(() => {
+        predicateStarted.resolve(undefined);
+        return predicateResult.promise;
+      });
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ toolCall }, addToolResult) =>
+          addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { ok: true },
+          }),
+        sendAutomaticallyWhen,
+      });
+      chat = setup.chat;
+
+      const send = chat.sendMessage({ text: 'search' });
+      await predicateStarted.promise;
+      chat.messages = [];
+      predicateResult.reject(new Error('stale predicate failure'));
+      await send;
+
+      expect(setup.state.messages).toEqual([]);
+      expect(setup.state.status).toBe('ready');
+      expect(setup.state.error).toBeUndefined();
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+    });
+
     it('commits a reused toolCallId to its owning assistant message', async () => {
       let chat!: TestChat;
       const onFinish = jest.fn();
@@ -1453,6 +1613,40 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.state.messages).toEqual([]);
       expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
       expect(setup.sendMessages).not.toHaveBeenCalled();
+    });
+
+    it('settles an unknown public result returned from onToolCall', async () => {
+      let chat!: TestChat;
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: () =>
+          chat.addToolResult({
+            tool: 'search',
+            toolCallId: 'missing',
+            output: { ok: true },
+          }),
+      });
+      chat = setup.chat;
+
+      const outcome = await Promise.race([
+        chat.sendMessage({ text: 'search' }).then(() => 'settled'),
+        new Promise<string>((resolve) =>
+          setTimeout(() => resolve('timed out'), 100)
+        ),
+      ]);
+
+      expect(outcome).toBe('settled');
+      expect(setup.state.status).toBe('ready');
+      expect(setup.sendMessages).toHaveBeenCalledTimes(1);
     });
 
     it('does not let a stopped response rejection overwrite the next response', async () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -27,13 +27,19 @@ import type {
   ChatOnDataCallback,
 } from './types';
 
-// pendingToolCalls is a lifecycle latch: undefined = none, >0 = pending,
-// 0 = continue, -1 = terminal or consumed, -2 = callback failure reported.
-type ActiveResponse = [
-  controller: AbortController,
-  pendingToolCalls?: number,
-  messageId?: string
-];
+type ResponseOutcome = 'active' | 'succeeded' | 'aborted' | 'failed';
+
+type ResponseRecord = {
+  abortController: AbortController;
+  messageId?: string;
+  outcome: ResponseOutcome;
+  requiredToolCallIds: Set<string>;
+  resolvedToolCallIds: Set<string>;
+  returnedToolCallbacks: Array<Promise<void>>;
+  pendingToolCallbacks: number;
+  didNotifyFinish: boolean;
+  didEvaluateContinuation: boolean;
+};
 
 const tryParseJson = (value: string): unknown | undefined => {
   try {
@@ -132,11 +138,11 @@ const defaultGuardrailFallbackResponse =
  * Abstract base class for chat implementations.
  */
 export abstract class AbstractChat<TUIMessage extends UIMessage> {
-  private chatId: string;
+  private conversationId: string;
   readonly generateId: IdGenerator;
 
   get id(): string {
-    return this.chatId;
+    return this.conversationId;
   }
   protected state: ChatState<TUIMessage>;
 
@@ -145,14 +151,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   private onToolCall?: ChatOnToolCallCallback<TUIMessage>;
   private onFinish?: ChatOnFinishCallback<TUIMessage>;
   private onData?: ChatOnDataCallback<TUIMessage>;
-  private autoSend?: (options: {
+  private sendAutomaticallyWhen?: (options: {
     messages: TUIMessage[];
   }) => boolean | PromiseLike<boolean>;
-  private repairToolInput?: (toolName: string) => boolean;
+  private shouldRepairToolInput?: (toolName: string) => boolean;
 
-  private active: ActiveResponse | null = null;
-  private calls = new Map<string, ActiveResponse>();
-  private jobs = new SerialJobExecutor();
+  private activeResponse: ResponseRecord | null = null;
+  private responseByToolCallId = new Map<string, ResponseRecord>();
+  private jobExecutor = new SerialJobExecutor();
 
   constructor({
     generateId = defaultGenerateId,
@@ -168,7 +174,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   }: Omit<ChatInit<TUIMessage>, 'messages'> & {
     state: ChatState<TUIMessage>;
   }) {
-    this.chatId = id;
+    this.conversationId = id;
     this.generateId = generateId;
     this.state = state;
     this.transport = transport;
@@ -176,8 +182,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     this.onToolCall = onToolCall;
     this.onFinish = onFinish;
     this.onData = onData;
-    this.autoSend = sendAutomaticallyWhen;
-    this.repairToolInput = shouldRepairToolInput;
+    this.sendAutomaticallyWhen = sendAutomaticallyWhen;
+    this.shouldRepairToolInput = shouldRepairToolInput;
   }
 
   /**
@@ -216,7 +222,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * context.
    */
   resetConversationId(): void {
-    this.chatId = this.generateId();
+    this.conversationId = this.generateId();
   }
 
   get messages(): TUIMessage[] {
@@ -225,7 +231,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
   set messages(messages: TUIMessage[]) {
     this.state.messages = messages;
-    this.calls.clear();
+    const retainedMessageIds = new Set(messages.map((message) => message.id));
+    this.responseByToolCallId.forEach((response) => {
+      if (!response.messageId || !retainedMessageIds.has(response.messageId)) {
+        this.pruneDetachedResponse(response);
+      }
+    });
   }
 
   get lastMessage(): TUIMessage | undefined {
@@ -258,7 +269,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         },
     options?: ChatRequestOptions
   ): Promise<void> => {
-    return this.jobs.run(() => {
+    return this.jobExecutor.run(() => {
       // Build the user message
       let userMessagePromise: Promise<TUIMessage | undefined>;
 
@@ -339,7 +350,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     messageId,
     ...options
   }: { messageId?: string } & ChatRequestOptions = {}): Promise<void> => {
-    return this.jobs.run(() => {
+    return this.jobExecutor.run(() => {
       // Find the message to regenerate from
       let targetIndex = -1;
 
@@ -372,7 +383,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * Attempt to resume an ongoing streaming response.
    */
   resumeStream = (options?: ChatRequestOptions): Promise<void> => {
-    return this.jobs.run(() => {
+    return this.jobExecutor.run(() => {
       if (!this.transport) {
         return Promise.reject(
           new Error(
@@ -438,19 +449,26 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     return true;
   }
 
-  private resume(response?: ActiveResponse): Promise<void> {
+  private continueResponse(response?: ResponseRecord): Promise<void> {
     if (response) {
-      if (this.active === response || response[1] !== 0) {
+      if (
+        response.outcome !== 'succeeded' ||
+        response.requiredToolCallIds.size === 0 ||
+        response.resolvedToolCallIds.size !==
+          response.requiredToolCallIds.size ||
+        !response.didNotifyFinish ||
+        response.didEvaluateContinuation
+      ) {
         return Promise.resolve();
       }
-      response[1] = -1;
+      response.didEvaluateContinuation = true;
     }
 
-    if (!this.autoSend) return Promise.resolve();
+    if (!this.sendAutomaticallyWhen) return Promise.resolve();
 
     return Promise.resolve()
       .then(() =>
-        this.autoSend!({
+        this.sendAutomaticallyWhen!({
           messages: this.messages,
         })
       )
@@ -464,6 +482,22 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       });
   }
 
+  private pruneDetachedResponse(response: ResponseRecord): void {
+    if (
+      response.pendingToolCallbacks > 0 ||
+      (response.messageId &&
+        this.messages.some((message) => message.id === response.messageId))
+    ) {
+      return;
+    }
+
+    this.responseByToolCallId.forEach((owner, toolCallId) => {
+      if (owner === response) {
+        this.responseByToolCallId.delete(toolCallId);
+      }
+    });
+  }
+
   /**
    * Add a tool result for a tool call.
    */
@@ -475,34 +509,39 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     toolCallId: string;
     output: InferUIMessageTools<TUIMessage>[TTool]['output'];
   }): Promise<void> => {
-    const response = this.calls.get(toolCallId);
+    const response = this.responseByToolCallId.get(toolCallId);
     const commitResult = (): Promise<void> => {
-      if (!this.commit(toolCallId, output, response?.[2])) {
+      if (!this.commit(toolCallId, output, response?.messageId)) {
         return Promise.resolve();
       }
 
-      if (response && response[1]! > 0) {
-        response[1]!--;
+      if (response) {
+        response.resolvedToolCallIds.add(toolCallId);
       }
-      return this.resume(response);
+      return this.continueResponse(response);
     };
 
-    if (response && (this.active === response || response[1]! < 0)) {
+    if (
+      response &&
+      (this.activeResponse === response ||
+        response.outcome !== 'succeeded' ||
+        response.didEvaluateContinuation)
+    ) {
       return commitResult();
     }
 
-    return this.jobs.run(commitResult);
+    return this.jobExecutor.run(commitResult);
   };
 
   /**
    * Abort the current request immediately, keep the generated tokens if any.
    */
   stop = (): Promise<void> => {
-    if (this.active) {
-      const response = this.active;
-      response[1] = -1;
-      this.active = null;
-      response[0].abort();
+    if (this.activeResponse) {
+      const response = this.activeResponse;
+      response.outcome = 'aborted';
+      this.activeResponse = null;
+      response.abortController.abort();
     }
     this.setStatus({ status: 'ready' });
     return Promise.resolve();
@@ -541,29 +580,41 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       abortSignal: AbortSignal
     ) => Promise<ReadableStream<InferUIMessageChunk<TUIMessage>> | null>
   ): Promise<void> {
-    if (this.active) {
-      this.active[1] = -1;
-      this.active[0].abort();
+    if (this.activeResponse) {
+      this.activeResponse.outcome = 'aborted';
+      this.activeResponse.abortController.abort();
     }
-    const response: ActiveResponse = [new AbortController()];
-    this.active = response;
+    const response: ResponseRecord = {
+      abortController: new AbortController(),
+      outcome: 'active',
+      requiredToolCallIds: new Set(),
+      resolvedToolCallIds: new Set(),
+      returnedToolCallbacks: [],
+      pendingToolCallbacks: 0,
+      didNotifyFinish: false,
+      didEvaluateContinuation: false,
+    };
+    this.activeResponse = response;
     this.setStatus({ status: 'submitted' });
 
-    return createStream(response[0].signal).then(
+    return createStream(response.abortController.signal).then(
       (stream) => {
-        if (this.active === response) {
+        if (this.activeResponse === response) {
           if (stream) return this.processStream(stream, response);
-          this.active = null;
+          response.outcome = 'succeeded';
+          this.activeResponse = null;
           this.setStatus({ status: 'ready' });
         }
         return undefined;
       },
       (error) => {
-        if (this.active !== response) return;
-        this.active = null;
+        if (this.activeResponse !== response) return;
+        this.activeResponse = null;
         if ((error as Error).name === 'AbortError') {
+          response.outcome = 'aborted';
           this.setStatus({ status: 'ready' });
         } else {
+          response.outcome = 'failed';
           this.handleError(error as Error);
         }
       }
@@ -572,7 +623,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
   private processStream(
     stream: ReadableStream<InferUIMessageChunk<TUIMessage>>,
-    response: ActiveResponse
+    response: ResponseRecord
   ): Promise<void> {
     this.setStatus({ status: 'streaming' });
 
@@ -585,7 +636,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const toolRawInputByCallId: Record<string, string> = {};
     const toolRawOutputByCallId: Record<string, string> = {};
 
-    const pendingToolCalls: Array<Promise<void>> = [];
     const findToolPart = (toolCallId: string): number =>
       currentMessage!.parts.findIndex(
         (part) => 'toolCallId' in part && part.toolCallId === toolCallId
@@ -597,47 +647,64 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       this.state.replaceMessage(currentMessageIndex, currentMessage);
     };
     const getCanonicalMessage = (): TUIMessage | undefined =>
-      response[2]
-        ? this.messages.find((message) => message.id === response[2]) ??
+      response.messageId
+        ? this.messages.find((message) => message.id === response.messageId) ??
           currentMessage
         : currentMessage;
-    const failToolCall = (reason: unknown): void => {
-      if (response[1]! < 0) return;
-      const error =
-        reason instanceof Error ? reason : new Error(String(reason));
-      response[1] = -2;
-      response[0].abort();
+    const notifyFinish = ({
+      isAbort,
+      isDisconnect,
+      isError,
+    }: {
+      isAbort: boolean;
+      isDisconnect: boolean;
+      isError: boolean;
+    }): void => {
+      if (response.didNotifyFinish) return;
+      response.didNotifyFinish = true;
 
-      if (this.active === response) {
-        this.active = null;
-        this.handleError(error);
-      }
       const canonicalMessage = getCanonicalMessage();
       if (this.onFinish && canonicalMessage) {
         this.onFinish({
           message: canonicalMessage,
           messages: this.messages,
-          isAbort: false,
-          isDisconnect: false,
-          isError: true,
+          isAbort,
+          isDisconnect,
+          isError,
         });
       }
+    };
+    const failToolCall = (reason: unknown): void => {
+      if (response.outcome !== 'active') return;
+      const error =
+        reason instanceof Error ? reason : new Error(String(reason));
+      response.outcome = 'failed';
+      response.abortController.abort();
+
+      if (this.activeResponse === response) {
+        this.activeResponse = null;
+        this.handleError(error);
+      }
+      notifyFinish({
+        isAbort: false,
+        isDisconnect: false,
+        isError: true,
+      });
     };
 
     return new Promise((resolve) => {
       const finish = (error?: Error): void => {
-        if (response[1] === -2) {
+        if (response.outcome === 'failed') {
           resolve();
           return;
         }
 
         isAbort ||=
-          response[1]! < 0 || (!!error && error.name === 'AbortError');
-        if (isAbort || error) {
-          response[1] = -1;
-        }
-        if (this.active === response) {
-          this.active = null;
+          response.outcome === 'aborted' ||
+          (!!error && error.name === 'AbortError');
+        response.outcome = isAbort ? 'aborted' : error ? 'failed' : 'succeeded';
+        if (this.activeResponse === response) {
+          this.activeResponse = null;
           if (error && !isAbort) {
             this.handleError(error);
           } else {
@@ -645,24 +712,19 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           }
         }
 
-        const canonicalMessage = getCanonicalMessage();
-        if (this.onFinish && canonicalMessage) {
-          this.onFinish({
-            message: canonicalMessage,
-            messages: this.messages,
-            isAbort,
-            isDisconnect: !!error && !isAbort,
-            isError,
-          });
-        }
-        resolve(isAbort || error ? undefined : this.resume(response));
+        notifyFinish({
+          isAbort,
+          isDisconnect: !!error && !isAbort,
+          isError,
+        });
+        resolve(isAbort || error ? undefined : this.continueResponse(response));
       };
 
       processStream<UIMessageChunk>(
         stream as ReadableStream<UIMessageChunk>,
         // eslint-disable-next-line complexity
         (chunk) => {
-          if (this.active !== response) return;
+          if (this.activeResponse !== response) return;
 
           if (currentMessageId) {
             const canonicalMessageIndex = this.messages.findIndex(
@@ -677,7 +739,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           switch (chunk.type) {
             case 'start': {
               currentMessageId = chunk.messageId || this.generateId();
-              response[2] = currentMessageId;
+              response.messageId = currentMessageId;
 
               // Check if we're continuing an existing message or creating a new one
               const lastMessage = this.lastMessage;
@@ -810,7 +872,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               const toolName =
                 chunk.toolName ?? existingPart?.type?.replace('tool-', '');
               const shouldRepair = toolName
-                ? this.repairToolInput?.(toolName) ?? true
+                ? this.shouldRepairToolInput?.(toolName) ?? true
                 : true;
               const parsedInput = shouldRepair
                 ? parseToolInputDelta(nextRawInput, existingPart?.input)
@@ -862,8 +924,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               // Trigger onToolCall callback only for client-executed tools
               // (server-executed tools have providerExecuted: true and don't need client handling)
               if (this.onToolCall && !chunk.providerExecuted) {
-                response[1] = (response[1] || 0) + 1;
-                this.calls.set(chunk.toolCallId, response);
+                response.requiredToolCallIds.add(chunk.toolCallId);
+                this.responseByToolCallId.set(chunk.toolCallId, response);
 
                 try {
                   const result = this.onToolCall({
@@ -875,8 +937,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                     } as InferUIMessageToolCall<TUIMessage>,
                   });
                   if (result) {
-                    pendingToolCalls.push(
-                      Promise.resolve(result).catch(failToolCall)
+                    response.pendingToolCallbacks++;
+                    response.returnedToolCallbacks.push(
+                      Promise.resolve(result)
+                        .catch(failToolCall)
+                        .then(() => {
+                          response.pendingToolCallbacks--;
+                          this.pruneDetachedResponse(response);
+                        })
                     );
                   }
                 } catch (error) {
@@ -894,6 +962,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 toolName: string;
                 delta: string;
               };
+              if (response.resolvedToolCallIds.has(toolCallId)) break;
 
               const toolIndex = findToolPart(toolCallId);
 
@@ -931,6 +1000,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
             case 'tool-output-available': {
               if (!currentMessage) break;
+              if (response.resolvedToolCallIds.has(chunk.toolCallId)) break;
 
               const toolIndex = findToolPart(chunk.toolCallId);
 
@@ -954,6 +1024,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
             case 'tool-input-error': {
               if (!currentMessage) break;
+              if (response.resolvedToolCallIds.has(chunk.toolCallId)) break;
               delete toolRawInputByCallId[chunk.toolCallId];
               delete toolRawOutputByCallId[chunk.toolCallId];
 
@@ -993,6 +1064,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
             case 'tool-output-error': {
               if (!currentMessage) break;
+              if (response.resolvedToolCallIds.has(chunk.toolCallId)) break;
 
               const toolIndex = findToolPart(chunk.toolCallId);
               if (toolIndex < 0) break;
@@ -1163,7 +1235,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             }
           }
         },
-        () => Promise.all(pendingToolCalls).then(() => finish()),
+        () => Promise.all(response.returnedToolCallbacks).then(() => finish()),
         (error) => finish(error)
       );
     });

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -27,17 +27,9 @@ import type {
   ChatOnDataCallback,
 } from './types';
 
-type ActiveResponse<TChunk extends UIMessageChunk = UIMessageChunk> = {
-  abortController: AbortController;
-  stream?: ReadableStream<TChunk>;
-  messageId?: string;
-  requiredToolCallIds: Set<string>;
-  resolvedToolCallIds: Set<string>;
-  outcome: 'active' | 'success' | 'error' | 'abort';
-  finishNotified: boolean;
-  continuationChecked: boolean;
-  errorHandled: boolean;
-};
+// pendingToolCalls is a lifecycle latch: undefined = none, >0 = pending,
+// 0 = continue, -1 = terminal or consumed, -2 = callback failure reported.
+type ActiveResponse = [controller: AbortController, pendingToolCalls?: number];
 
 const tryParseJson = (value: string): unknown | undefined => {
   try {
@@ -154,13 +146,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   }) => boolean | PromiseLike<boolean>;
   private shouldRepairToolInput?: (toolName: string) => boolean;
 
-  private activeResponse: ActiveResponse<
-    InferUIMessageChunk<TUIMessage>
-  > | null = null;
-  private toolCallResponses = new Map<
-    string,
-    ActiveResponse<InferUIMessageChunk<TUIMessage>>
-  >();
+  private activeResponse: ActiveResponse | null = null;
+  private toolCallResponses = new Map<string, ActiveResponse>();
   private jobExecutor = new SerialJobExecutor();
 
   constructor({
@@ -353,11 +340,11 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       let targetIndex = -1;
 
       if (messageId) {
-        targetIndex = this.state.messages.findIndex((m) => m.id === messageId);
+        targetIndex = this.messages.findIndex((m) => m.id === messageId);
       } else {
         // Find the last assistant message
-        for (let i = this.state.messages.length - 1; i >= 0; i--) {
-          if (this.state.messages[i].role === 'assistant') {
+        for (let i = this.messages.length - 1; i >= 0; i--) {
+          if (this.messages[i].role === 'assistant') {
             targetIndex = i;
             break;
           }
@@ -366,8 +353,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
       if (targetIndex >= 0) {
         // Remove the assistant message and all messages after it
-        this.state.messages = this.state.messages.slice(0, targetIndex);
-        this.pruneToolCallResponses();
+        this.messages = this.messages.slice(0, targetIndex);
       }
 
       return this.makeRequest({
@@ -391,46 +377,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         );
       }
 
-      if (this.activeResponse) {
-        this.activeResponse.outcome = 'abort';
-        this.activeResponse.abortController.abort();
-      }
-
-      const response = this.createResponse();
-      this.activeResponse = response;
-      this.setStatus({ status: 'submitted' });
-
-      return this.transport
-        .reconnectToStream({
+      return this.consumeResponse(() =>
+        this.transport!.reconnectToStream({
           chatId: this.id,
           ...options,
         })
-        .then(
-          (stream) => {
-            if (stream) {
-              if (this.activeResponse !== response) return Promise.resolve();
-              response.stream = stream;
-              return this.processStreamWithCallbacks(stream, response);
-            } else {
-              response.outcome = 'success';
-              if (this.activeResponse === response) {
-                this.activeResponse = null;
-                this.setStatus({ status: 'ready' });
-              }
-              return Promise.resolve();
-            }
-          },
-          (error) => {
-            if (
-              response.outcome === 'abort' ||
-              this.activeResponse !== response
-            ) {
-              return Promise.resolve();
-            }
-            this.failResponse(response, error as Error);
-            return Promise.resolve();
-          }
-        );
+      );
     });
   };
 
@@ -443,71 +395,31 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     }
   };
 
-  private createResponse(): ActiveResponse<InferUIMessageChunk<TUIMessage>> {
-    return {
-      abortController: new AbortController(),
-      requiredToolCallIds: new Set(),
-      resolvedToolCallIds: new Set(),
-      outcome: 'active',
-      finishNotified: false,
-      continuationChecked: false,
-      errorHandled: false,
-    };
-  }
-
-  private getResponseForToolCall(
-    toolCallId: string
-  ): ActiveResponse<InferUIMessageChunk<TUIMessage>> | undefined {
-    this.pruneToolCallResponses();
-    return this.toolCallResponses.get(toolCallId);
-  }
-
-  private pruneToolCallResponses(): void {
-    const messageIds = new Set(
-      this.state.messages.map((message) => message.id)
-    );
-
-    this.toolCallResponses.forEach((response, toolCallId) => {
-      if (response.messageId && !messageIds.has(response.messageId)) {
-        this.toolCallResponses.delete(toolCallId);
-      }
-    });
-  }
-
   private commitToolResult(toolCallId: string, output: unknown): boolean {
-    const messageIndex = this.state.messages.findIndex((message) =>
-      message.parts?.some(
-        (part) => 'toolCallId' in part && part.toolCallId === toolCallId
-      )
+    const isTargetPart = (part: TUIMessage['parts'][number]): boolean =>
+      'toolCallId' in part && part.toolCallId === toolCallId;
+    const messageIndex = this.messages.findIndex((message) =>
+      message.parts.some(isTargetPart)
     );
 
     if (messageIndex === -1) return false;
 
-    const message = this.state.messages[messageIndex];
-    let didUpdate = false;
-    const updatedParts = message.parts.map((part) => {
-      if (
-        'toolCallId' in part &&
-        part.toolCallId === toolCallId &&
-        'state' in part
-      ) {
-        if (
-          part.state === 'output-available' ||
-          part.state === 'output-error'
-        ) {
-          return part;
-        }
-        didUpdate = true;
-        return {
-          ...part,
-          state: 'output-available' as const,
-          output,
-        };
-      }
-      return part;
-    });
-
-    if (!didUpdate) return false;
+    const message = this.messages[messageIndex];
+    const partIndex = message.parts.findIndex(isTargetPart);
+    const part = message.parts[partIndex];
+    if (
+      !('state' in part) ||
+      part.state === 'output-available' ||
+      part.state === 'output-error'
+    ) {
+      return false;
+    }
+    const updatedParts = [...message.parts];
+    updatedParts[partIndex] = {
+      ...part,
+      state: 'output-available' as const,
+      output,
+    } as any;
 
     this.state.replaceMessage(messageIndex, {
       ...message,
@@ -516,57 +428,26 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     return true;
   }
 
-  private hasAllToolResults(
-    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>
-  ): boolean {
-    return (
-      response.requiredToolCallIds.size > 0 &&
-      Array.from(response.requiredToolCallIds).every((toolCallId) =>
-        response.resolvedToolCallIds.has(toolCallId)
-      )
-    );
-  }
-
-  private continueResponseIfReady(
-    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>
-  ): Promise<void> {
-    if (
-      response.outcome !== 'success' ||
-      !response.finishNotified ||
-      response.continuationChecked ||
-      !this.hasAllToolResults(response)
-    ) {
-      return Promise.resolve();
+  private continueIfReady(response?: ActiveResponse): Promise<void> {
+    if (response) {
+      if (this.activeResponse === response || response[1] !== 0) {
+        return Promise.resolve();
+      }
+      response[1] = -1;
     }
 
-    response.continuationChecked = true;
     if (!this.sendAutomaticallyWhen) return Promise.resolve();
 
     return Promise.resolve()
       .then(() =>
         this.sendAutomaticallyWhen!({
-          messages: this.state.messages,
+          messages: this.messages,
         })
       )
       .then((shouldSend) => {
-        if (!shouldSend) return Promise.resolve();
-        return this.makeRequest({ trigger: 'submit-message' });
-      })
-      .catch((error) => {
-        this.failResponse(response, error as Error, true);
-      });
-  }
-
-  private continueUnownedResult(): Promise<void> {
-    if (!this.sendAutomaticallyWhen) return Promise.resolve();
-
-    return Promise.resolve()
-      .then(() =>
-        this.sendAutomaticallyWhen!({ messages: this.state.messages })
-      )
-      .then((shouldSend) => {
-        if (!shouldSend) return Promise.resolve();
-        return this.makeRequest({ trigger: 'submit-message' });
+        return shouldSend
+          ? this.makeRequest({ trigger: 'submit-message' })
+          : undefined;
       })
       .catch((error) => {
         this.handleError(error as Error);
@@ -577,7 +458,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * Add a tool result for a tool call.
    */
   addToolResult = <TTool extends keyof InferUIMessageTools<TUIMessage>>({
-    tool: _tool,
     toolCallId,
     output,
   }: {
@@ -585,21 +465,20 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     toolCallId: string;
     output: InferUIMessageTools<TUIMessage>[TTool]['output'];
   }): Promise<void> => {
-    const response = this.getResponseForToolCall(toolCallId);
+    const response = this.toolCallResponses.get(toolCallId);
     const commitResult = (): Promise<void> => {
       if (!this.commitToolResult(toolCallId, output)) {
         return Promise.resolve();
       }
 
       if (response) {
-        response.resolvedToolCallIds.add(toolCallId);
-        return this.continueResponseIfReady(response);
+        response[1]!--;
+        this.toolCallResponses.delete(toolCallId);
       }
-
-      return this.continueUnownedResult();
+      return this.continueIfReady(response);
     };
 
-    if (response?.outcome === 'active') {
+    if (response && this.activeResponse === response) {
       return commitResult();
     }
 
@@ -612,9 +491,9 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   stop = (): Promise<void> => {
     if (this.activeResponse) {
       const response = this.activeResponse;
-      response.outcome = 'abort';
+      response[1] = -1;
       this.activeResponse = null;
-      response.abortController.abort();
+      response[0].abort();
     }
     this.setStatus({ status: 'ready' });
     return Promise.resolve();
@@ -634,156 +513,154 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       );
     }
 
-    // Abort any existing request
-    if (this.activeResponse) {
-      const previousResponse = this.activeResponse;
-      previousResponse.outcome = 'abort';
-      previousResponse.abortController.abort();
-    }
-
-    const response = this.createResponse();
-    this.activeResponse = response;
-
-    this.setStatus({ status: 'submitted' });
-
-    return this.transport
-      .sendMessages({
+    return this.consumeResponse((abortSignal) =>
+      this.transport!.sendMessages({
         chatId: this.id,
-        messages: this.state.messages,
-        abortSignal: response.abortController.signal,
+        messages: this.messages,
+        abortSignal,
         trigger: options.trigger,
         messageId: options.messageId,
         headers: options.headers,
         body: options.body,
         requestMetadata: options.metadata,
       })
-      .then(
-        (stream) => {
-          if (this.activeResponse !== response) return Promise.resolve();
-          response.stream = stream;
-          return this.processStreamWithCallbacks(stream, response);
-        },
-        (error) => {
-          if ((error as Error).name === 'AbortError') {
-            response.outcome = 'abort';
-            if (this.activeResponse === response) {
-              this.activeResponse = null;
-              this.setStatus({ status: 'ready' });
-            }
-            return Promise.resolve();
-          }
-          if (
-            response.outcome === 'abort' ||
-            this.activeResponse !== response
-          ) {
-            return Promise.resolve();
-          }
-          this.failResponse(response, error as Error);
-          return Promise.resolve();
-        }
-      );
-  }
-
-  private getResponseMessage(
-    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>
-  ): TUIMessage | undefined {
-    if (!response.messageId) return undefined;
-    return this.state.messages.find(
-      (message) => message.id === response.messageId
     );
   }
 
-  private notifyResponseFinish(
-    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>,
-    flags: {
-      isAbort: boolean;
-      isDisconnect: boolean;
-      isError: boolean;
+  private consumeResponse(
+    createStream: (
+      abortSignal: AbortSignal
+    ) => Promise<ReadableStream<InferUIMessageChunk<TUIMessage>> | null>
+  ): Promise<void> {
+    if (this.activeResponse) {
+      this.activeResponse[1] = -1;
+      this.activeResponse[0].abort();
     }
-  ): void {
-    if (response.finishNotified) return;
-    response.finishNotified = true;
+    const response: ActiveResponse = [new AbortController()];
+    this.activeResponse = response;
+    this.setStatus({ status: 'submitted' });
 
-    const message = this.getResponseMessage(response);
-    if (this.onFinish && message) {
-      this.onFinish({
-        message,
-        messages: this.state.messages,
-        ...flags,
-      });
-    }
-  }
-
-  private failResponse(
-    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>,
-    error: Error,
-    allowInactive = false
-  ): void {
-    if (response.errorHandled) return;
-
-    response.errorHandled = true;
-    response.outcome = 'error';
-    response.continuationChecked = true;
-    response.abortController.abort();
-
-    if (this.activeResponse === response || allowInactive) {
-      if (this.activeResponse === response) {
+    return createStream(response[0].signal).then(
+      (stream) => {
+        if (this.activeResponse === response) {
+          if (stream) return this.processStreamWithCallbacks(stream, response);
+          this.activeResponse = null;
+          this.setStatus({ status: 'ready' });
+        }
+        return undefined;
+      },
+      (error) => {
+        if (this.activeResponse !== response) return;
         this.activeResponse = null;
+        if ((error as Error).name === 'AbortError') {
+          this.setStatus({ status: 'ready' });
+        } else {
+          this.handleError(error as Error);
+        }
       }
-      this.handleError(error);
-    }
-
-    this.notifyResponseFinish(response, {
-      isAbort: false,
-      isDisconnect: false,
-      isError: true,
-    });
+    );
   }
 
   private processStreamWithCallbacks(
     stream: ReadableStream<InferUIMessageChunk<TUIMessage>>,
-    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>
+    response: ActiveResponse
   ): Promise<void> {
-    if (this.activeResponse === response) {
-      this.setStatus({ status: 'streaming' });
-    }
+    this.setStatus({ status: 'streaming' });
 
     let currentMessageId: string | undefined;
     let currentMessage: TUIMessage | undefined;
     let currentMessageIndex = -1;
     let isAbort = false;
-    let isDisconnect = false;
     let isError = false;
 
-    // Track current text/reasoning part state
-    let currentTextPartId: string | undefined;
-    let currentReasoningPartId: string | undefined;
     const toolRawInputByCallId: Record<string, string> = {};
     const toolRawOutputByCallId: Record<string, string> = {};
 
     const pendingToolCalls: Array<Promise<void>> = [];
+    const findToolPart = (toolCallId: string): number =>
+      currentMessage!.parts.findIndex(
+        (part) => 'toolCallId' in part && part.toolCallId === toolCallId
+      );
+    const setPart = (index: number, part: any): void => {
+      const parts = [...currentMessage!.parts];
+      parts[index < 0 ? parts.length : index] = part;
+      currentMessage = { ...currentMessage!, parts } as TUIMessage;
+      this.state.replaceMessage(currentMessageIndex, currentMessage);
+    };
+    const failToolCall = (reason: unknown): void => {
+      if (response[1]! < 0) return;
+      const error =
+        reason instanceof Error ? reason : new Error(String(reason));
+      response[1] = -2;
+      response[0].abort();
+
+      if (this.activeResponse === response) {
+        this.activeResponse = null;
+        this.handleError(error);
+      }
+      if (this.onFinish && currentMessage) {
+        this.onFinish({
+          message: currentMessage,
+          messages: this.messages,
+          isAbort: false,
+          isDisconnect: false,
+          isError: true,
+        });
+      }
+    };
 
     return new Promise((resolve) => {
+      const finish = (error?: Error): void => {
+        if (response[1] === -2) {
+          resolve();
+          return;
+        }
+
+        isAbort ||=
+          response[1]! < 0 || (!!error && error.name === 'AbortError');
+        if (isAbort || error) {
+          response[1] = -1;
+        }
+        if (this.activeResponse === response) {
+          this.activeResponse = null;
+          if (error && !isAbort) {
+            this.handleError(error);
+          } else {
+            this.setStatus({ status: 'ready' });
+          }
+        }
+
+        if (this.onFinish && currentMessage) {
+          this.onFinish({
+            message: currentMessage,
+            messages: this.messages,
+            isAbort,
+            isDisconnect: !!error && !isAbort,
+            isError,
+          });
+        }
+        resolve(isAbort || error ? undefined : this.continueIfReady(response));
+      };
+
       processStream<UIMessageChunk>(
         stream as ReadableStream<UIMessageChunk>,
         // eslint-disable-next-line complexity
         (chunk) => {
-          if (response.outcome !== 'active') return;
+          if (this.activeResponse !== response) return;
 
           if (currentMessageId) {
-            const canonicalMessageIndex = this.state.messages.findIndex(
+            const canonicalMessageIndex = this.messages.findIndex(
               (message) => message.id === currentMessageId
             );
             if (canonicalMessageIndex >= 0) {
               currentMessageIndex = canonicalMessageIndex;
-              currentMessage = this.state.messages[canonicalMessageIndex];
+              currentMessage = this.messages[canonicalMessageIndex];
             }
           }
 
           switch (chunk.type) {
             case 'start': {
               currentMessageId = chunk.messageId || this.generateId();
-              response.messageId = currentMessageId;
 
               // Check if we're continuing an existing message or creating a new one
               const lastMessage = this.lastMessage;
@@ -793,7 +670,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 lastMessage.id === currentMessageId
               ) {
                 currentMessage = lastMessage;
-                currentMessageIndex = this.state.messages.length - 1;
+                currentMessageIndex = this.messages.length - 1;
               } else {
                 currentMessage = {
                   id: currentMessageId,
@@ -802,156 +679,57 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   metadata: chunk.messageMetadata,
                 } as unknown as TUIMessage;
                 this.state.pushMessage(currentMessage);
-                currentMessageIndex = this.state.messages.length - 1;
+                currentMessageIndex = this.messages.length - 1;
               }
               break;
             }
 
-            case 'text-start': {
-              if (!currentMessage) break;
-              currentTextPartId = chunk.id;
-
-              const textPart = {
-                type: 'text' as const,
-                text: '',
-                state: 'streaming' as const,
-                providerMetadata: chunk.providerMetadata,
-              };
-
-              currentMessage = {
-                ...currentMessage,
-                parts: [...currentMessage.parts, textPart],
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
-              break;
-            }
-
-            case 'text-delta': {
-              if (!currentMessage || !currentTextPartId) break;
-
-              const partIndex = currentMessage.parts.findIndex(
-                (p) => p.type === 'text' && p.state === 'streaming'
-              );
-              if (partIndex === -1) break;
-
-              const updatedParts = [...currentMessage.parts];
-              const textPart = updatedParts[partIndex] as {
-                type: 'text';
-                text: string;
-                state?: 'streaming' | 'done';
-              };
-              updatedParts[partIndex] = {
-                ...textPart,
-                text: textPart.text + chunk.delta,
-              };
-
-              currentMessage = {
-                ...currentMessage,
-                parts: updatedParts,
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
-              break;
-            }
-
-            case 'text-end': {
-              if (!currentMessage) break;
-
-              const partIndex = currentMessage.parts.findIndex(
-                (p) => p.type === 'text' && p.state === 'streaming'
-              );
-              if (partIndex === -1) break;
-
-              const updatedParts = [...currentMessage.parts];
-              const textPart = updatedParts[partIndex] as {
-                type: 'text';
-                text: string;
-                state?: 'streaming' | 'done';
-              };
-              updatedParts[partIndex] = {
-                ...textPart,
-                state: 'done' as const,
-              };
-
-              currentMessage = {
-                ...currentMessage,
-                parts: updatedParts,
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
-              currentTextPartId = undefined;
-              break;
-            }
-
+            case 'text-start':
             case 'reasoning-start': {
               if (!currentMessage) break;
-              currentReasoningPartId = chunk.id;
-
-              const reasoningPart = {
-                type: 'reasoning' as const,
+              const type = chunk.type === 'text-start' ? 'text' : 'reasoning';
+              setPart(-1, {
+                type,
                 text: '',
                 state: 'streaming' as const,
                 providerMetadata: chunk.providerMetadata,
-              };
-
-              currentMessage = {
-                ...currentMessage,
-                parts: [...currentMessage.parts, reasoningPart],
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              });
               break;
             }
 
+            case 'text-delta':
             case 'reasoning-delta': {
-              if (!currentMessage || !currentReasoningPartId) break;
-
-              const partIndex = currentMessage.parts.findIndex(
-                (p) => p.type === 'reasoning' && p.state === 'streaming'
-              );
-              if (partIndex === -1) break;
-
-              const updatedParts = [...currentMessage.parts];
-              const reasoningPart = updatedParts[partIndex] as {
-                type: 'reasoning';
-                text: string;
-                state?: 'streaming' | 'done';
-              };
-              updatedParts[partIndex] = {
-                ...reasoningPart,
-                text: reasoningPart.text + chunk.delta,
-              };
-
-              currentMessage = {
-                ...currentMessage,
-                parts: updatedParts,
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
-              break;
-            }
-
-            case 'reasoning-end': {
+              const type = chunk.type === 'text-delta' ? 'text' : 'reasoning';
               if (!currentMessage) break;
 
               const partIndex = currentMessage.parts.findIndex(
-                (p) => p.type === 'reasoning' && p.state === 'streaming'
+                (part) => part.type === type && part.state === 'streaming'
               );
               if (partIndex === -1) break;
 
-              const updatedParts = [...currentMessage.parts];
-              const reasoningPart = updatedParts[partIndex] as {
-                type: 'reasoning';
+              const part = currentMessage.parts[partIndex] as {
+                type: 'text' | 'reasoning';
                 text: string;
                 state?: 'streaming' | 'done';
               };
-              updatedParts[partIndex] = {
-                ...reasoningPart,
-                state: 'done' as const,
-              };
+              setPart(partIndex, { ...part, text: part.text + chunk.delta });
+              break;
+            }
 
-              currentMessage = {
-                ...currentMessage,
-                parts: updatedParts,
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
-              currentReasoningPartId = undefined;
+            case 'text-end':
+            case 'reasoning-end': {
+              if (!currentMessage) break;
+              const type = chunk.type === 'text-end' ? 'text' : 'reasoning';
+
+              const partIndex = currentMessage.parts.findIndex(
+                (part) => part.type === type && part.state === 'streaming'
+              );
+              if (partIndex === -1) break;
+
+              setPart(partIndex, {
+                ...currentMessage.parts[partIndex],
+                state: 'done',
+              });
               break;
             }
 
@@ -986,20 +764,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 providerExecuted: chunk.providerExecuted,
               };
 
-              currentMessage = {
-                ...currentMessage,
-                parts: [...currentMessage.parts, toolPart],
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              setPart(-1, toolPart);
               break;
             }
 
             case 'tool-input-delta': {
               if (!currentMessage) break;
 
-              const toolIndex = currentMessage.parts.findIndex(
-                (p) => 'toolCallId' in p && p.toolCallId === chunk.toolCallId
-              );
+              const toolIndex = findToolPart(chunk.toolCallId);
 
               const existingPart =
                 toolIndex >= 0
@@ -1037,21 +809,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 rawInput: nextRawInput,
               };
 
-              if (toolIndex >= 0) {
-                const updatedParts = [...currentMessage.parts];
-                updatedParts[toolIndex] = nextToolPart;
-                currentMessage = {
-                  ...currentMessage,
-                  parts: updatedParts,
-                } as TUIMessage;
-              } else {
-                currentMessage = {
-                  ...currentMessage,
-                  parts: [...currentMessage.parts, nextToolPart],
-                } as TUIMessage;
-              }
-
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              setPart(toolIndex, nextToolPart);
               break;
             }
 
@@ -1061,9 +819,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               delete toolRawInputByCallId[chunk.toolCallId];
 
               // Find existing tool part or create new one
-              const existingIndex = currentMessage.parts.findIndex(
-                (p) => 'toolCallId' in p && p.toolCallId === chunk.toolCallId
-              );
+              const existingIndex = findToolPart(chunk.toolCallId);
               const existingPart =
                 existingIndex >= 0
                   ? (currentMessage.parts[existingIndex] as any)
@@ -1084,25 +840,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 providerExecuted: chunk.providerExecuted,
               };
 
-              if (existingIndex >= 0) {
-                const updatedParts = [...currentMessage.parts];
-                updatedParts[existingIndex] = toolPart;
-                currentMessage = {
-                  ...currentMessage,
-                  parts: updatedParts,
-                } as TUIMessage;
-              } else {
-                currentMessage = {
-                  ...currentMessage,
-                  parts: [...currentMessage.parts, toolPart],
-                } as TUIMessage;
-              }
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              setPart(existingIndex, toolPart);
 
               // Trigger onToolCall callback only for client-executed tools
               // (server-executed tools have providerExecuted: true and don't need client handling)
               if (this.onToolCall && !chunk.providerExecuted) {
-                response.requiredToolCallIds.add(chunk.toolCallId);
+                response[1] = (response[1] || 0) + 1;
                 this.toolCallResponses.set(chunk.toolCallId, response);
 
                 try {
@@ -1114,23 +857,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                       dynamic: 'dynamic' in chunk ? chunk.dynamic : undefined,
                     } as InferUIMessageToolCall<TUIMessage>,
                   });
-                  if (result && typeof result.then === 'function') {
+                  if (result) {
                     pendingToolCalls.push(
-                      Promise.resolve(result).catch((error) => {
-                        this.failResponse(
-                          response,
-                          error instanceof Error
-                            ? error
-                            : new Error(String(error))
-                        );
-                      })
+                      Promise.resolve(result).catch(failToolCall)
                     );
                   }
                 } catch (error) {
-                  this.failResponse(
-                    response,
-                    error instanceof Error ? error : new Error(String(error))
-                  );
+                  failToolCall(error);
                 }
               }
               break;
@@ -1145,9 +878,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 delta: string;
               };
 
-              const toolIndex = currentMessage.parts.findIndex(
-                (p) => 'toolCallId' in p && p.toolCallId === toolCallId
-              );
+              const toolIndex = findToolPart(toolCallId);
 
               const existingPart =
                 toolIndex >= 0
@@ -1177,51 +908,29 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 preliminary: true,
               };
 
-              if (toolIndex >= 0) {
-                const updatedParts = [...currentMessage.parts];
-                updatedParts[toolIndex] = nextToolPart;
-                currentMessage = {
-                  ...currentMessage,
-                  parts: updatedParts,
-                } as TUIMessage;
-              } else {
-                currentMessage = {
-                  ...currentMessage,
-                  parts: [...currentMessage.parts, nextToolPart],
-                } as TUIMessage;
-              }
-
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              setPart(toolIndex, nextToolPart);
               break;
             }
 
             case 'tool-output-available': {
               if (!currentMessage) break;
 
-              const toolIndex = currentMessage.parts.findIndex(
-                (p) => 'toolCallId' in p && p.toolCallId === chunk.toolCallId
-              );
+              const toolIndex = findToolPart(chunk.toolCallId);
 
               if (toolIndex >= 0) {
                 delete toolRawInputByCallId[chunk.toolCallId];
                 delete toolRawOutputByCallId[chunk.toolCallId];
 
-                const updatedParts = [...currentMessage.parts];
-                const existingPart = updatedParts[toolIndex] as any;
+                const existingPart = currentMessage.parts[toolIndex] as any;
                 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
                 const { rawOutput: _ignored, ...rest } = existingPart;
-                updatedParts[toolIndex] = {
+                setPart(toolIndex, {
                   ...rest,
                   state: 'output-available',
                   output: chunk.output,
                   callProviderMetadata: chunk.callProviderMetadata,
                   preliminary: chunk.preliminary,
-                };
-                currentMessage = {
-                  ...currentMessage,
-                  parts: updatedParts,
-                } as TUIMessage;
-                this.state.replaceMessage(currentMessageIndex, currentMessage);
+                });
               }
               break;
             }
@@ -1231,9 +940,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               delete toolRawInputByCallId[chunk.toolCallId];
               delete toolRawOutputByCallId[chunk.toolCallId];
 
-              const toolIndex = currentMessage.parts.findIndex(
-                (p) => 'toolCallId' in p && p.toolCallId === chunk.toolCallId
-              );
+              const toolIndex = findToolPart(chunk.toolCallId);
               const existingPart =
                 toolIndex >= 0
                   ? (currentMessage.parts[toolIndex] as any)
@@ -1263,36 +970,20 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   chunk.providerMetadata ?? carryOver.callProviderMetadata,
               };
 
-              if (toolIndex >= 0) {
-                const updatedParts = [...currentMessage.parts];
-                updatedParts[toolIndex] = nextToolPart;
-                currentMessage = {
-                  ...currentMessage,
-                  parts: updatedParts,
-                } as TUIMessage;
-              } else {
-                currentMessage = {
-                  ...currentMessage,
-                  parts: [...currentMessage.parts, nextToolPart],
-                } as TUIMessage;
-              }
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              setPart(toolIndex, nextToolPart);
               break;
             }
 
             case 'tool-output-error': {
               if (!currentMessage) break;
 
-              const toolIndex = currentMessage.parts.findIndex(
-                (p) => 'toolCallId' in p && p.toolCallId === chunk.toolCallId
-              );
+              const toolIndex = findToolPart(chunk.toolCallId);
               if (toolIndex < 0) break;
 
               delete toolRawInputByCallId[chunk.toolCallId];
               delete toolRawOutputByCallId[chunk.toolCallId];
 
-              const updatedParts = [...currentMessage.parts];
-              const existingPart = updatedParts[toolIndex] as any;
+              const existingPart = currentMessage.parts[toolIndex] as any;
               const {
                 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
                 rawOutput: _ignoredRawOutput,
@@ -1302,7 +993,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 output: _ignoredOutput,
                 ...rest
               } = existingPart;
-              updatedParts[toolIndex] = {
+              setPart(toolIndex, {
                 ...rest,
                 state: 'output-error',
                 errorText: chunk.errorText,
@@ -1310,12 +1001,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   chunk.providerExecuted ?? rest.providerExecuted,
                 callProviderMetadata:
                   chunk.providerMetadata ?? rest.callProviderMetadata,
-              };
-              currentMessage = {
-                ...currentMessage,
-                parts: updatedParts,
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              });
               break;
             }
 
@@ -1329,11 +1015,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 title: chunk.title,
               };
 
-              currentMessage = {
-                ...currentMessage,
-                parts: [...currentMessage.parts, sourcePart],
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              setPart(-1, sourcePart);
               break;
             }
 
@@ -1349,11 +1031,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 providerMetadata: chunk.providerMetadata,
               };
 
-              currentMessage = {
-                ...currentMessage,
-                parts: [...currentMessage.parts, docPart],
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              setPart(-1, docPart);
               break;
             }
 
@@ -1366,24 +1044,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 mediaType: chunk.mediaType,
               };
 
-              currentMessage = {
-                ...currentMessage,
-                parts: [...currentMessage.parts, filePart],
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              setPart(-1, filePart);
               break;
             }
 
             case 'start-step': {
               if (!currentMessage) break;
 
-              const stepPart = { type: 'step-start' as const };
-
-              currentMessage = {
-                ...currentMessage,
-                parts: [...currentMessage.parts, stepPart],
-              } as TUIMessage;
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              setPart(-1, { type: 'step-start' });
               break;
             }
 
@@ -1451,13 +1119,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 this.state.replaceMessage(currentMessageIndex, currentMessage);
               } else {
                 this.state.pushMessage(currentMessage);
-                currentMessageIndex = this.state.messages.length - 1;
+                currentMessageIndex = this.messages.length - 1;
               }
 
               currentMessageId = currentMessage.id;
-              response.messageId = currentMessageId;
-              currentTextPartId = undefined;
-              currentReasoningPartId = undefined;
               break;
             }
 
@@ -1471,11 +1136,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   data: (chunk as any).data,
                 };
 
-                currentMessage = {
-                  ...currentMessage,
-                  parts: [...currentMessage.parts, dataPart],
-                } as TUIMessage;
-                this.state.replaceMessage(currentMessageIndex, currentMessage);
+                setPart(-1, dataPart);
 
                 // Trigger onData callback
                 if (this.onData) {
@@ -1485,83 +1146,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             }
           }
         },
-        () => {
-          Promise.all(pendingToolCalls).then(() => {
-            if (response.outcome === 'error') {
-              resolve();
-              return;
-            }
-
-            if (response.outcome === 'abort') {
-              this.notifyResponseFinish(response, {
-                isAbort: true,
-                isDisconnect: false,
-                isError: false,
-              });
-              resolve();
-              return;
-            }
-
-            response.outcome = isAbort ? 'abort' : 'success';
-            if (this.activeResponse === response) {
-              this.activeResponse = null;
-              this.setStatus({ status: 'ready' });
-            }
-
-            this.notifyResponseFinish(response, {
-              isAbort,
-              isDisconnect,
-              isError,
-            });
-
-            if (response.outcome === 'success') {
-              this.continueResponseIfReady(response).then(resolve);
-            } else {
-              resolve();
-            }
-          });
-        },
-        (error) => {
-          if (response.outcome === 'error') {
-            resolve();
-            return;
-          }
-
-          if (response.outcome === 'abort') {
-            this.notifyResponseFinish(response, {
-              isAbort: true,
-              isDisconnect: false,
-              isError: false,
-            });
-            resolve();
-            return;
-          }
-
-          if (error.name === 'AbortError') {
-            isAbort = true;
-            response.outcome = 'abort';
-            if (this.activeResponse === response) {
-              this.activeResponse = null;
-              this.setStatus({ status: 'ready' });
-            }
-          } else {
-            isDisconnect = true;
-            response.outcome = 'error';
-            response.continuationChecked = true;
-            if (this.activeResponse === response) {
-              this.activeResponse = null;
-              this.handleError(error);
-            }
-          }
-
-          this.notifyResponseFinish(response, {
-            isAbort,
-            isDisconnect,
-            isError,
-          });
-
-          resolve();
-        }
+        () => Promise.all(pendingToolCalls).then(() => finish()),
+        (error) => finish(error)
       );
     });
   }

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -924,8 +924,23 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               // Trigger onToolCall callback only for client-executed tools
               // (server-executed tools have providerExecuted: true and don't need client handling)
               if (this.onToolCall && !chunk.providerExecuted) {
+                const existingOwner = this.responseByToolCallId.get(
+                  chunk.toolCallId
+                );
+                if (existingOwner && existingOwner !== response) {
+                  // Neither response may continue once ownership is ambiguous.
+                  existingOwner.didEvaluateContinuation = true;
+                  failToolCall(
+                    new Error(
+                      `Tool call "${chunk.toolCallId}" is already owned by another response.`
+                    )
+                  );
+                  break;
+                }
+
                 response.requiredToolCallIds.add(chunk.toolCallId);
                 this.responseByToolCallId.set(chunk.toolCallId, response);
+                response.pendingToolCallbacks++;
 
                 try {
                   const result = this.onToolCall({
@@ -937,7 +952,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                     } as InferUIMessageToolCall<TUIMessage>,
                   });
                   if (result) {
-                    response.pendingToolCallbacks++;
                     response.returnedToolCallbacks.push(
                       Promise.resolve(result)
                         .catch(failToolCall)
@@ -946,9 +960,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                           this.pruneDetachedResponse(response);
                         })
                     );
+                  } else {
+                    response.pendingToolCallbacks--;
+                    this.pruneDetachedResponse(response);
                   }
                 } catch (error) {
+                  response.pendingToolCallbacks--;
                   failToolCall(error);
+                  this.pruneDetachedResponse(response);
                 }
               }
               break;

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -595,8 +595,9 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         response.isRetired ||
         response.outcome !== 'succeeded' ||
         response.requiredToolCallIds.size === 0 ||
-        response.resolvedToolCallIds.size !==
-          response.requiredToolCallIds.size ||
+        Array.from(response.requiredToolCallIds).some(
+          (toolCallId) => !response.resolvedToolCallIds.has(toolCallId)
+        ) ||
         !response.didNotifyFinish ||
         response.didEvaluateContinuation
       ) {
@@ -697,7 +698,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         return Promise.resolve();
       }
 
-      if (response) {
+      if (response?.requiredToolCallIds.has(toolCallId)) {
         response.resolvedToolCallIds.add(toolCallId);
       }
       return this.continueResponse(response);

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -518,14 +518,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   }
 
   private pruneDetachedResponse(response: ResponseRecord): void {
-    if (
-      !response.messageId ||
-      this.messages.some((message) => message.id === response.messageId)
-    ) {
-      return;
-    }
-
     if (!response.isRetired) {
+      if (
+        !response.messageId ||
+        this.messages.some((message) => message.id === response.messageId)
+      ) {
+        return;
+      }
+
       response.isRetired = true;
       response.didEvaluateContinuation = true;
 
@@ -721,16 +721,22 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       isAbort,
       isDisconnect,
       isError,
+      message,
+      allowRetired = false,
     }: {
       isAbort: boolean;
       isDisconnect: boolean;
       isError: boolean;
+      message?: TUIMessage;
+      allowRetired?: boolean;
     }): void => {
       this.pruneDetachedResponse(response);
-      if (response.isRetired || response.didNotifyFinish) return;
+      if ((response.isRetired && !allowRetired) || response.didNotifyFinish) {
+        return;
+      }
       response.didNotifyFinish = true;
 
-      const canonicalMessage = getCanonicalMessage();
+      const canonicalMessage = message ?? getCanonicalMessage();
       if (this.onFinish && canonicalMessage) {
         this.onFinish({
           message: canonicalMessage,
@@ -743,6 +749,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     };
     const failToolCall = (reason: unknown): void => {
       if (response.outcome !== 'active') return;
+      const message = getCanonicalMessage();
+      const wasRetired = response.isRetired;
       const error =
         reason instanceof Error ? reason : new Error(String(reason));
       response.outcome = 'failed';
@@ -756,6 +764,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         isAbort: false,
         isDisconnect: false,
         isError: true,
+        message,
+        allowRetired: !wasRetired,
       });
     };
     const acceptServerToolResult = (toolCallId: string): void => {
@@ -1033,7 +1043,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                         dynamic: 'dynamic' in chunk ? chunk.dynamic : undefined,
                       } as InferUIMessageToolCall<TUIMessage>,
                     },
-                    (options) => this.submitToolResult(response, options)
+                    (options) =>
+                      response.isRetired
+                        ? Promise.resolve()
+                        : this.submitToolResult(response, options)
                   );
                   if (result) {
                     response.returnedToolCallbacks.push(

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { isEqual } from '../utils/isEqual';
+
 import { processStream } from './stream-parser';
 import {
   generateId as defaultGenerateId,
@@ -173,8 +175,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   private shouldRepairToolInput?: (toolName: string) => boolean;
 
   private activeResponse: ResponseRecord | null = null;
+  private latestResponse: ResponseRecord | null = null;
   private responsesByToolCallId = new Map<string, Set<ResponseRecord>>();
-  private ambiguousPublicToolCallIds = new Set<string>();
+  private responseByMessage = new WeakMap<TUIMessage, ResponseRecord>();
+  // Once tool ownership is discarded, an identifier-only result cannot prove
+  // which response generation submitted it. Scoped submissions remain safe.
+  private acceptsIdentifierOnlyToolResults = true;
   private jobExecutor = new SerialJobExecutor();
 
   constructor({
@@ -239,6 +245,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * context.
    */
   resetConversationId(): void {
+    if (
+      this.responsesByToolCallId.size > 0 ||
+      this.messages.some((message) =>
+        message.parts?.some((part) => 'toolCallId' in part)
+      )
+    ) {
+      this.acceptsIdentifierOnlyToolResults = false;
+    }
     this.conversationId = this.generateId();
   }
 
@@ -247,6 +261,68 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   }
 
   set messages(messages: TUIMessage[]) {
+    const getToolOccurrences = (message: TUIMessage) =>
+      message.parts
+        .filter(
+          (
+            part
+          ): part is TUIMessage['parts'][number] & { toolCallId: string } =>
+            'toolCallId' in part
+        )
+        .map((part) => ({
+          type: part.type,
+          toolCallId: part.toolCallId,
+          state: 'state' in part ? part.state : undefined,
+          input: 'input' in part ? part.input : undefined,
+          output: 'output' in part ? part.output : undefined,
+          errorText: 'errorText' in part ? part.errorText : undefined,
+          providerExecuted:
+            'providerExecuted' in part ? part.providerExecuted : undefined,
+        }));
+    const isEquivalentRehydration = (message: TUIMessage): boolean => {
+      const replacements = messages.filter(
+        (candidate) => candidate.id === message.id
+      );
+      if (replacements.length !== 1) return false;
+
+      const toolOccurrences = getToolOccurrences(message);
+      const replacementToolOccurrences = getToolOccurrences(replacements[0]);
+      return toolOccurrences.length > 0 || replacementToolOccurrences.length > 0
+        ? isEqual(toolOccurrences, replacementToolOccurrences)
+        : isEqual(message.parts, replacements[0].parts);
+    };
+    const detachedResponses = new Set<ResponseRecord>();
+    this.state.messages.forEach((message) => {
+      if (!messages.includes(message)) {
+        const response = this.responseByMessage.get(message);
+        if (response && !isEquivalentRehydration(message)) {
+          detachedResponses.add(response);
+        }
+      }
+    });
+    const removedToolOwner = this.state.messages.some(
+      (message) =>
+        message.parts?.some((part) => 'toolCallId' in part) &&
+        !messages.includes(message) &&
+        !isEquivalentRehydration(message)
+    );
+    const toolCallIds = new Set<string>();
+    const hasDuplicateToolCallId = messages.some(
+      (message) =>
+        message.parts?.some((part) => {
+          if (!('toolCallId' in part)) {
+            return false;
+          }
+          if (toolCallIds.has(part.toolCallId)) {
+            return true;
+          }
+          toolCallIds.add(part.toolCallId);
+          return false;
+        }) === true
+    );
+    if (removedToolOwner || hasDuplicateToolCallId) {
+      this.acceptsIdentifierOnlyToolResults = false;
+    }
     this.state.messages = messages;
     const retainedMessageIds = new Set(messages.map((message) => message.id));
     const responses = new Set<ResponseRecord>();
@@ -256,8 +332,31 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     if (this.activeResponse) {
       responses.add(this.activeResponse);
     }
+    detachedResponses.forEach((response) => {
+      responses.add(response);
+      this.retireResponse(response);
+    });
     responses.forEach((response) => {
-      if (response.messageId && !retainedMessageIds.has(response.messageId)) {
+      const message = response.messageId
+        ? messages.find((candidate) => candidate.id === response.messageId)
+        : undefined;
+      if (message && !response.isRetired && !detachedResponses.has(response)) {
+        this.responseByMessage.set(message, response);
+      }
+    });
+    if (this.activeResponse?.messageId) {
+      const activeMessage = messages.find(
+        (message) => message.id === this.activeResponse!.messageId
+      );
+      if (activeMessage) {
+        this.responseByMessage.set(activeMessage, this.activeResponse);
+      }
+    }
+    responses.forEach((response) => {
+      if (
+        detachedResponses.has(response) ||
+        (response.messageId && !retainedMessageIds.has(response.messageId))
+      ) {
         this.pruneDetachedResponse(response);
       }
     });
@@ -437,13 +536,16 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   private commit(
     toolCallId: string,
     output: unknown,
-    messageId?: string
+    messageId?: string,
+    response?: ResponseRecord,
+    expectedMessage?: TUIMessage
   ): boolean {
     const isTargetPart = (part: TUIMessage['parts'][number]): boolean =>
       'toolCallId' in part && part.toolCallId === toolCallId;
     const messageIndex = this.messages.findIndex(
       (message) =>
         (!messageId || message.id === messageId) &&
+        (!expectedMessage || message === expectedMessage) &&
         message.parts.some(isTargetPart)
     );
 
@@ -473,10 +575,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       output,
     };
 
-    this.state.replaceMessage(messageIndex, {
+    const updatedMessage = {
       ...message,
       parts: updatedParts,
-    } as TUIMessage);
+    } as TUIMessage;
+    if (response) {
+      this.responseByMessage.set(updatedMessage, response);
+    }
+    this.state.replaceMessage(messageIndex, updatedMessage);
     return true;
   }
 
@@ -518,9 +624,27 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         if (response) {
           this.pruneDetachedResponse(response);
           if (response.isRetired) return;
+          this.handleError(error as Error, {
+            updateState: this.latestResponse === response,
+          });
+          return;
         }
         this.handleError(error as Error);
       });
+  }
+
+  private retireResponse(response: ResponseRecord): void {
+    if (response.isRetired) return;
+
+    response.isRetired = true;
+    response.didEvaluateContinuation = true;
+
+    if (this.activeResponse === response) {
+      response.outcome = 'aborted';
+      this.activeResponse = null;
+      response.abortController.abort();
+      this.setStatus({ status: 'ready' });
+    }
   }
 
   private pruneDetachedResponse(response: ResponseRecord): void {
@@ -532,15 +656,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         return;
       }
 
-      response.isRetired = true;
-      response.didEvaluateContinuation = true;
-
-      if (this.activeResponse === response) {
-        response.outcome = 'aborted';
-        this.activeResponse = null;
-        response.abortController.abort();
-        this.setStatus({ status: 'ready' });
-      }
+      this.retireResponse(response);
     }
 
     // Keep a routing tombstone while a callback is running so public
@@ -551,7 +667,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       owners.delete(response);
       if (owners.size === 0) {
         this.responsesByToolCallId.delete(toolCallId);
-        this.ambiguousPublicToolCallIds.delete(toolCallId);
       }
     });
   }
@@ -565,12 +680,18 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       tool: TTool;
       toolCallId: string;
       output: InferUIMessageTools<TUIMessage>[TTool]['output'];
-    }
+    },
+    messageId = response?.messageId,
+    expectedMessage = messageId
+      ? this.messages.find((message) => message.id === messageId)
+      : undefined
   ): Promise<void> {
     if (response?.isRetired) return Promise.resolve();
 
     const commitResult = (): Promise<void> => {
-      if (!this.commit(toolCallId, output, response?.messageId)) {
+      if (
+        !this.commit(toolCallId, output, messageId, response, expectedMessage)
+      ) {
         return Promise.resolve();
       }
 
@@ -596,24 +717,52 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * Add a tool result for a tool call.
    */
   addToolResult: ToolResultSubmission<TUIMessage> = (options) => {
-    // A public result only carries a tool call id, so it cannot identify an
-    // owner after that id has been reused by multiple retained responses.
-    if (this.ambiguousPublicToolCallIds.has(options.toolCallId)) {
+    if (!this.acceptsIdentifierOnlyToolResults) {
       return Promise.resolve();
     }
 
     const owners = this.responsesByToolCallId.get(options.toolCallId);
     const response =
       owners?.size === 1 ? owners.values().next().value : undefined;
-    const hasRestoredToolCall = this.messages.some((message) =>
-      message.parts.some(
+    if (response) return this.submitToolResult(response, options);
+
+    const matchingMessages = this.messages.filter((message) =>
+      message.parts?.some(
         (part) => 'toolCallId' in part && part.toolCallId === options.toolCallId
       )
     );
+    if (matchingMessages.length !== 1) return Promise.resolve();
 
-    if (!response && !hasRestoredToolCall) return Promise.resolve();
+    return this.submitToolResult(
+      undefined,
+      options,
+      matchingMessages[0].id,
+      matchingMessages[0]
+    );
+  };
 
-    return this.submitToolResult(response, options);
+  /** @internal */
+  '~addToolResultForMessage' = <
+    TTool extends keyof InferUIMessageTools<TUIMessage>
+  >(
+    message: TUIMessage,
+    options: {
+      tool: TTool;
+      toolCallId: string;
+      output: InferUIMessageTools<TUIMessage>[TTool]['output'];
+    }
+  ): Promise<void> => {
+    if (
+      !this.messages.includes(message) ||
+      !message.parts?.some(
+        (part) => 'toolCallId' in part && part.toolCallId === options.toolCallId
+      )
+    ) {
+      return Promise.resolve();
+    }
+
+    const response = this.responseByMessage.get(message);
+    return this.submitToolResult(response, options, message.id, message);
   };
 
   /**
@@ -679,6 +828,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       didEvaluateContinuation: false,
     };
     this.activeResponse = response;
+    this.latestResponse = response;
     this.setStatus({ status: 'submitted' });
 
     return createStream(response.abortController.signal).then(
@@ -728,6 +878,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       const parts = [...currentMessage!.parts];
       parts[index < 0 ? parts.length : index] = part;
       currentMessage = { ...currentMessage!, parts } as TUIMessage;
+      this.responseByMessage.set(currentMessage, response);
       this.state.replaceMessage(currentMessageIndex, currentMessage);
     };
     const mergeCallProviderMetadata = (
@@ -849,6 +1000,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             }
             currentMessageIndex = canonicalMessageIndex;
             currentMessage = this.messages[canonicalMessageIndex];
+            this.responseByMessage.set(currentMessage, response);
           }
 
           switch (chunk.type) {
@@ -863,8 +1015,15 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 lastMessage.role === 'assistant' &&
                 lastMessage.id === currentMessageId
               ) {
-                currentMessage = lastMessage;
+                if (lastMessage.parts.some((part) => 'toolCallId' in part)) {
+                  this.acceptsIdentifierOnlyToolResults = false;
+                }
+                currentMessage = {
+                  ...lastMessage,
+                  parts: [...lastMessage.parts],
+                } as TUIMessage;
                 currentMessageIndex = this.messages.length - 1;
+                this.state.replaceMessage(currentMessageIndex, currentMessage);
               } else {
                 currentMessage = {
                   id: currentMessageId,
@@ -875,6 +1034,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 this.state.pushMessage(currentMessage);
                 currentMessageIndex = this.messages.length - 1;
               }
+              this.responseByMessage.set(currentMessage, response);
               break;
             }
 
@@ -1010,6 +1170,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             case 'tool-input-available': {
               if (!currentMessage) break;
 
+              if (response.requiredToolCallIds.has(chunk.toolCallId)) break;
+
               delete toolRawInputByCallId[chunk.toolCallId];
 
               // Find existing tool part or create new one
@@ -1036,6 +1198,20 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
               setPart(existingIndex, toolPart);
 
+              if (
+                this.messages.some(
+                  (message) =>
+                    message !== currentMessage &&
+                    message.parts?.some(
+                      (part) =>
+                        'toolCallId' in part &&
+                        part.toolCallId === chunk.toolCallId
+                    )
+                )
+              ) {
+                this.acceptsIdentifierOnlyToolResults = false;
+              }
+
               // Trigger onToolCall callback only for client-executed tools
               // (server-executed tools have providerExecuted: true and don't need client handling)
               if (this.onToolCall && !chunk.providerExecuted) {
@@ -1046,12 +1222,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   (owner) => owner !== response
                 );
                 if (existingOwners.length > 0) {
+                  this.acceptsIdentifierOnlyToolResults = false;
                   const conflictingOwner = existingOwners.find(
                     (owner) =>
                       !owner.isRetired &&
-                      (owner.outcome !== 'succeeded' ||
-                        !owner.resolvedToolCallIds.has(chunk.toolCallId) ||
-                        owner.pendingToolCallbacks > 0)
+                      (owner.outcome === 'active' ||
+                        (owner.outcome === 'succeeded' &&
+                          (!owner.resolvedToolCallIds.has(chunk.toolCallId) ||
+                            owner.pendingToolCallbacks > 0)))
                   );
                   if (conflictingOwner) {
                     // Neither response may continue once ownership is ambiguous.
@@ -1063,9 +1241,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                     );
                     break;
                   }
-                  this.ambiguousPublicToolCallIds.add(chunk.toolCallId);
                 }
-
                 response.requiredToolCallIds.add(chunk.toolCallId);
                 owners.add(response);
                 this.responsesByToolCallId.set(chunk.toolCallId, owners);
@@ -1328,6 +1504,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 ...currentMessage,
                 metadata: chunk.messageMetadata,
               } as TUIMessage;
+              this.responseByMessage.set(currentMessage, response);
               this.state.replaceMessage(currentMessageIndex, currentMessage);
               break;
             }
@@ -1351,6 +1528,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   ...currentMessage,
                   metadata: chunk.messageMetadata,
                 } as TUIMessage;
+                this.responseByMessage.set(currentMessage, response);
                 this.state.replaceMessage(currentMessageIndex, currentMessage);
               }
               break;
@@ -1380,6 +1558,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   },
                 ],
               } as unknown as TUIMessage;
+              this.responseByMessage.set(currentMessage, response);
 
               if (currentMessageIndex >= 0) {
                 this.state.replaceMessage(currentMessageIndex, currentMessage);
@@ -1418,8 +1597,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     });
   }
 
-  private handleError(error: Error): void {
-    this.setStatus({ status: 'error', error });
+  private handleError(
+    error: Error,
+    { updateState = true }: { updateState?: boolean } = {}
+  ): void {
+    if (updateState) {
+      this.setStatus({ status: 'error', error });
+    }
 
     if (this.onError) {
       this.onError(error);

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -29,7 +29,11 @@ import type {
 
 // pendingToolCalls is a lifecycle latch: undefined = none, >0 = pending,
 // 0 = continue, -1 = terminal or consumed, -2 = callback failure reported.
-type ActiveResponse = [controller: AbortController, pendingToolCalls?: number];
+type ActiveResponse = [
+  controller: AbortController,
+  pendingToolCalls?: number,
+  messageId?: string
+];
 
 const tryParseJson = (value: string): unknown | undefined => {
   try {
@@ -128,11 +132,11 @@ const defaultGuardrailFallbackResponse =
  * Abstract base class for chat implementations.
  */
 export abstract class AbstractChat<TUIMessage extends UIMessage> {
-  private conversationId: string;
+  private chatId: string;
   readonly generateId: IdGenerator;
 
   get id(): string {
-    return this.conversationId;
+    return this.chatId;
   }
   protected state: ChatState<TUIMessage>;
 
@@ -141,14 +145,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   private onToolCall?: ChatOnToolCallCallback<TUIMessage>;
   private onFinish?: ChatOnFinishCallback<TUIMessage>;
   private onData?: ChatOnDataCallback<TUIMessage>;
-  private sendAutomaticallyWhen?: (options: {
+  private autoSend?: (options: {
     messages: TUIMessage[];
   }) => boolean | PromiseLike<boolean>;
-  private shouldRepairToolInput?: (toolName: string) => boolean;
+  private repairToolInput?: (toolName: string) => boolean;
 
-  private activeResponse: ActiveResponse | null = null;
-  private toolCallResponses = new Map<string, ActiveResponse>();
-  private jobExecutor = new SerialJobExecutor();
+  private active: ActiveResponse | null = null;
+  private calls = new Map<string, ActiveResponse>();
+  private jobs = new SerialJobExecutor();
 
   constructor({
     generateId = defaultGenerateId,
@@ -164,7 +168,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   }: Omit<ChatInit<TUIMessage>, 'messages'> & {
     state: ChatState<TUIMessage>;
   }) {
-    this.conversationId = id;
+    this.chatId = id;
     this.generateId = generateId;
     this.state = state;
     this.transport = transport;
@@ -172,8 +176,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     this.onToolCall = onToolCall;
     this.onFinish = onFinish;
     this.onData = onData;
-    this.sendAutomaticallyWhen = sendAutomaticallyWhen;
-    this.shouldRepairToolInput = shouldRepairToolInput;
+    this.autoSend = sendAutomaticallyWhen;
+    this.repairToolInput = shouldRepairToolInput;
   }
 
   /**
@@ -212,7 +216,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * context.
    */
   resetConversationId(): void {
-    this.conversationId = this.generateId();
+    this.chatId = this.generateId();
   }
 
   get messages(): TUIMessage[] {
@@ -221,7 +225,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
   set messages(messages: TUIMessage[]) {
     this.state.messages = messages;
-    this.toolCallResponses.clear();
+    this.calls.clear();
   }
 
   get lastMessage(): TUIMessage | undefined {
@@ -254,7 +258,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         },
     options?: ChatRequestOptions
   ): Promise<void> => {
-    return this.jobExecutor.run(() => {
+    return this.jobs.run(() => {
       // Build the user message
       let userMessagePromise: Promise<TUIMessage | undefined>;
 
@@ -335,7 +339,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     messageId,
     ...options
   }: { messageId?: string } & ChatRequestOptions = {}): Promise<void> => {
-    return this.jobExecutor.run(() => {
+    return this.jobs.run(() => {
       // Find the message to regenerate from
       let targetIndex = -1;
 
@@ -368,7 +372,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * Attempt to resume an ongoing streaming response.
    */
   resumeStream = (options?: ChatRequestOptions): Promise<void> => {
-    return this.jobExecutor.run(() => {
+    return this.jobs.run(() => {
       if (!this.transport) {
         return Promise.reject(
           new Error(
@@ -377,7 +381,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         );
       }
 
-      return this.consumeResponse(() =>
+      return this.consume(() =>
         this.transport!.reconnectToStream({
           chatId: this.id,
           ...options,
@@ -395,11 +399,17 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     }
   };
 
-  private commitToolResult(toolCallId: string, output: unknown): boolean {
+  private commit(
+    toolCallId: string,
+    output: unknown,
+    messageId?: string
+  ): boolean {
     const isTargetPart = (part: TUIMessage['parts'][number]): boolean =>
       'toolCallId' in part && part.toolCallId === toolCallId;
-    const messageIndex = this.messages.findIndex((message) =>
-      message.parts.some(isTargetPart)
+    const messageIndex = this.messages.findIndex(
+      (message) =>
+        (!messageId || message.id === messageId) &&
+        message.parts.some(isTargetPart)
     );
 
     if (messageIndex === -1) return false;
@@ -428,19 +438,19 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     return true;
   }
 
-  private continueIfReady(response?: ActiveResponse): Promise<void> {
+  private resume(response?: ActiveResponse): Promise<void> {
     if (response) {
-      if (this.activeResponse === response || response[1] !== 0) {
+      if (this.active === response || response[1] !== 0) {
         return Promise.resolve();
       }
       response[1] = -1;
     }
 
-    if (!this.sendAutomaticallyWhen) return Promise.resolve();
+    if (!this.autoSend) return Promise.resolve();
 
     return Promise.resolve()
       .then(() =>
-        this.sendAutomaticallyWhen!({
+        this.autoSend!({
           messages: this.messages,
         })
       )
@@ -465,34 +475,33 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     toolCallId: string;
     output: InferUIMessageTools<TUIMessage>[TTool]['output'];
   }): Promise<void> => {
-    const response = this.toolCallResponses.get(toolCallId);
+    const response = this.calls.get(toolCallId);
     const commitResult = (): Promise<void> => {
-      if (!this.commitToolResult(toolCallId, output)) {
+      if (!this.commit(toolCallId, output, response?.[2])) {
         return Promise.resolve();
       }
 
-      if (response) {
+      if (response && response[1]! > 0) {
         response[1]!--;
-        this.toolCallResponses.delete(toolCallId);
       }
-      return this.continueIfReady(response);
+      return this.resume(response);
     };
 
-    if (response && this.activeResponse === response) {
+    if (response && (this.active === response || response[1]! < 0)) {
       return commitResult();
     }
 
-    return this.jobExecutor.run(commitResult);
+    return this.jobs.run(commitResult);
   };
 
   /**
    * Abort the current request immediately, keep the generated tokens if any.
    */
   stop = (): Promise<void> => {
-    if (this.activeResponse) {
-      const response = this.activeResponse;
+    if (this.active) {
+      const response = this.active;
       response[1] = -1;
-      this.activeResponse = null;
+      this.active = null;
       response[0].abort();
     }
     this.setStatus({ status: 'ready' });
@@ -513,7 +522,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       );
     }
 
-    return this.consumeResponse((abortSignal) =>
+    return this.consume((abortSignal) =>
       this.transport!.sendMessages({
         chatId: this.id,
         messages: this.messages,
@@ -527,31 +536,31 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     );
   }
 
-  private consumeResponse(
+  private consume(
     createStream: (
       abortSignal: AbortSignal
     ) => Promise<ReadableStream<InferUIMessageChunk<TUIMessage>> | null>
   ): Promise<void> {
-    if (this.activeResponse) {
-      this.activeResponse[1] = -1;
-      this.activeResponse[0].abort();
+    if (this.active) {
+      this.active[1] = -1;
+      this.active[0].abort();
     }
     const response: ActiveResponse = [new AbortController()];
-    this.activeResponse = response;
+    this.active = response;
     this.setStatus({ status: 'submitted' });
 
     return createStream(response[0].signal).then(
       (stream) => {
-        if (this.activeResponse === response) {
-          if (stream) return this.processStreamWithCallbacks(stream, response);
-          this.activeResponse = null;
+        if (this.active === response) {
+          if (stream) return this.processStream(stream, response);
+          this.active = null;
           this.setStatus({ status: 'ready' });
         }
         return undefined;
       },
       (error) => {
-        if (this.activeResponse !== response) return;
-        this.activeResponse = null;
+        if (this.active !== response) return;
+        this.active = null;
         if ((error as Error).name === 'AbortError') {
           this.setStatus({ status: 'ready' });
         } else {
@@ -561,7 +570,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     );
   }
 
-  private processStreamWithCallbacks(
+  private processStream(
     stream: ReadableStream<InferUIMessageChunk<TUIMessage>>,
     response: ActiveResponse
   ): Promise<void> {
@@ -594,8 +603,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       response[1] = -2;
       response[0].abort();
 
-      if (this.activeResponse === response) {
-        this.activeResponse = null;
+      if (this.active === response) {
+        this.active = null;
         this.handleError(error);
       }
       if (this.onFinish && currentMessage) {
@@ -621,8 +630,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         if (isAbort || error) {
           response[1] = -1;
         }
-        if (this.activeResponse === response) {
-          this.activeResponse = null;
+        if (this.active === response) {
+          this.active = null;
           if (error && !isAbort) {
             this.handleError(error);
           } else {
@@ -639,14 +648,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             isError,
           });
         }
-        resolve(isAbort || error ? undefined : this.continueIfReady(response));
+        resolve(isAbort || error ? undefined : this.resume(response));
       };
 
       processStream<UIMessageChunk>(
         stream as ReadableStream<UIMessageChunk>,
         // eslint-disable-next-line complexity
         (chunk) => {
-          if (this.activeResponse !== response) return;
+          if (this.active !== response) return;
 
           if (currentMessageId) {
             const canonicalMessageIndex = this.messages.findIndex(
@@ -661,6 +670,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           switch (chunk.type) {
             case 'start': {
               currentMessageId = chunk.messageId || this.generateId();
+              response[2] = currentMessageId;
 
               // Check if we're continuing an existing message or creating a new one
               const lastMessage = this.lastMessage;
@@ -793,7 +803,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               const toolName =
                 chunk.toolName ?? existingPart?.type?.replace('tool-', '');
               const shouldRepair = toolName
-                ? this.shouldRepairToolInput?.(toolName) ?? true
+                ? this.repairToolInput?.(toolName) ?? true
                 : true;
               const parsedInput = shouldRepair
                 ? parseToolInputDelta(nextRawInput, existingPart?.input)
@@ -846,7 +856,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               // (server-executed tools have providerExecuted: true and don't need client handling)
               if (this.onToolCall && !chunk.providerExecuted) {
                 response[1] = (response[1] || 0) + 1;
-                this.toolCallResponses.set(chunk.toolCallId, response);
+                this.calls.set(chunk.toolCallId, response);
 
                 try {
                   const result = this.onToolCall({

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -173,7 +173,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   private shouldRepairToolInput?: (toolName: string) => boolean;
 
   private activeResponse: ResponseRecord | null = null;
-  private responseByToolCallId = new Map<string, ResponseRecord>();
+  private responsesByToolCallId = new Map<string, Set<ResponseRecord>>();
+  private ambiguousPublicToolCallIds = new Set<string>();
   private jobExecutor = new SerialJobExecutor();
 
   constructor({
@@ -248,7 +249,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   set messages(messages: TUIMessage[]) {
     this.state.messages = messages;
     const retainedMessageIds = new Set(messages.map((message) => message.id));
-    const responses = new Set(this.responseByToolCallId.values());
+    const responses = new Set<ResponseRecord>();
+    this.responsesByToolCallId.forEach((owners) => {
+      owners.forEach((response) => responses.add(response));
+    });
     if (this.activeResponse) {
       responses.add(this.activeResponse);
     }
@@ -543,9 +547,11 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     // addToolResult calls settle directly instead of entering the executor.
     if (response.pendingToolCallbacks > 0) return;
 
-    this.responseByToolCallId.forEach((owner, toolCallId) => {
-      if (owner === response) {
-        this.responseByToolCallId.delete(toolCallId);
+    this.responsesByToolCallId.forEach((owners, toolCallId) => {
+      owners.delete(response);
+      if (owners.size === 0) {
+        this.responsesByToolCallId.delete(toolCallId);
+        this.ambiguousPublicToolCallIds.delete(toolCallId);
       }
     });
   }
@@ -590,7 +596,15 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * Add a tool result for a tool call.
    */
   addToolResult: ToolResultSubmission<TUIMessage> = (options) => {
-    const response = this.responseByToolCallId.get(options.toolCallId);
+    // A public result only carries a tool call id, so it cannot identify an
+    // owner after that id has been reused by multiple retained responses.
+    if (this.ambiguousPublicToolCallIds.has(options.toolCallId)) {
+      return Promise.resolve();
+    }
+
+    const owners = this.responsesByToolCallId.get(options.toolCallId);
+    const response =
+      owners?.size === 1 ? owners.values().next().value : undefined;
     const hasRestoredToolCall = this.messages.some((message) =>
       message.parts.some(
         (part) => 'toolCallId' in part && part.toolCallId === options.toolCallId
@@ -1025,18 +1039,23 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               // Trigger onToolCall callback only for client-executed tools
               // (server-executed tools have providerExecuted: true and don't need client handling)
               if (this.onToolCall && !chunk.providerExecuted) {
-                const existingOwner = this.responseByToolCallId.get(
-                  chunk.toolCallId
+                const owners =
+                  this.responsesByToolCallId.get(chunk.toolCallId) ??
+                  new Set<ResponseRecord>();
+                const existingOwners = Array.from(owners).filter(
+                  (owner) => owner !== response
                 );
-                if (existingOwner && existingOwner !== response) {
-                  const canTransferOwnership =
-                    existingOwner.isRetired ||
-                    (existingOwner.outcome === 'succeeded' &&
-                      existingOwner.resolvedToolCallIds.has(chunk.toolCallId) &&
-                      existingOwner.pendingToolCallbacks === 0);
-                  if (!canTransferOwnership) {
+                if (existingOwners.length > 0) {
+                  const conflictingOwner = existingOwners.find(
+                    (owner) =>
+                      !owner.isRetired &&
+                      (owner.outcome !== 'succeeded' ||
+                        !owner.resolvedToolCallIds.has(chunk.toolCallId) ||
+                        owner.pendingToolCallbacks > 0)
+                  );
+                  if (conflictingOwner) {
                     // Neither response may continue once ownership is ambiguous.
-                    existingOwner.didEvaluateContinuation = true;
+                    conflictingOwner.didEvaluateContinuation = true;
                     failToolCall(
                       new Error(
                         `Tool call "${chunk.toolCallId}" is already owned by another response.`
@@ -1044,12 +1063,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                     );
                     break;
                   }
-                  existingOwner.isRetired = true;
-                  existingOwner.didEvaluateContinuation = true;
+                  this.ambiguousPublicToolCallIds.add(chunk.toolCallId);
                 }
 
                 response.requiredToolCallIds.add(chunk.toolCallId);
-                this.responseByToolCallId.set(chunk.toolCallId, response);
+                owners.add(response);
+                this.responsesByToolCallId.set(chunk.toolCallId, owners);
                 response.pendingToolCallbacks++;
 
                 try {

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -728,19 +728,35 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       owners?.size === 1 ? owners.values().next().value : undefined;
     if (response) return this.submitToolResult(response, options);
 
-    const matchingMessages = this.messages.filter((message) =>
-      message.parts?.some(
-        (part) => 'toolCallId' in part && part.toolCallId === options.toolCallId
-      )
-    );
-    if (matchingMessages.length !== 1) return Promise.resolve();
+    const findMatchingMessage = (): TUIMessage | undefined => {
+      const matchingMessages = this.messages.filter((message) =>
+        message.parts?.some(
+          (part) =>
+            'toolCallId' in part && part.toolCallId === options.toolCallId
+        )
+      );
+      return matchingMessages.length === 1 ? matchingMessages[0] : undefined;
+    };
+    if (!findMatchingMessage()) return Promise.resolve();
 
-    return this.submitToolResult(
-      undefined,
-      options,
-      matchingMessages[0].id,
-      matchingMessages[0]
-    );
+    return this.jobExecutor.run(() => {
+      if (!this.acceptsIdentifierOnlyToolResults) return Promise.resolve();
+
+      const message = findMatchingMessage();
+      if (
+        !message ||
+        !this.commit(
+          options.toolCallId,
+          options.output,
+          message.id,
+          undefined,
+          message
+        )
+      ) {
+        return Promise.resolve();
+      }
+      return this.continueResponse();
+    });
   };
 
   /** @internal */
@@ -754,17 +770,33 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       output: InferUIMessageTools<TUIMessage>[TTool]['output'];
     }
   ): Promise<void> => {
-    if (
-      !this.messages.includes(message) ||
-      !message.parts?.some(
+    const hasToolCall = (candidate: TUIMessage): boolean =>
+      candidate.parts?.some(
         (part) => 'toolCallId' in part && part.toolCallId === options.toolCallId
-      )
-    ) {
+      ) === true;
+    if (!hasToolCall(message)) {
       return Promise.resolve();
     }
 
     const response = this.responseByMessage.get(message);
-    return this.submitToolResult(response, options, message.id, message);
+    const currentMessage = this.messages.includes(message)
+      ? message
+      : response && !response.isRetired
+      ? this.messages.find(
+          (candidate) =>
+            candidate.id === message.id &&
+            this.responseByMessage.get(candidate) === response &&
+            hasToolCall(candidate)
+        )
+      : undefined;
+    if (!currentMessage) return Promise.resolve();
+
+    return this.submitToolResult(
+      response,
+      options,
+      currentMessage.id,
+      currentMessage
+    );
   };
 
   /**

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -596,6 +596,11 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       currentMessage = { ...currentMessage!, parts } as TUIMessage;
       this.state.replaceMessage(currentMessageIndex, currentMessage);
     };
+    const getCanonicalMessage = (): TUIMessage | undefined =>
+      response[2]
+        ? this.messages.find((message) => message.id === response[2]) ??
+          currentMessage
+        : currentMessage;
     const failToolCall = (reason: unknown): void => {
       if (response[1]! < 0) return;
       const error =
@@ -607,9 +612,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         this.active = null;
         this.handleError(error);
       }
-      if (this.onFinish && currentMessage) {
+      const canonicalMessage = getCanonicalMessage();
+      if (this.onFinish && canonicalMessage) {
         this.onFinish({
-          message: currentMessage,
+          message: canonicalMessage,
           messages: this.messages,
           isAbort: false,
           isDisconnect: false,
@@ -639,9 +645,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           }
         }
 
-        if (this.onFinish && currentMessage) {
+        const canonicalMessage = getCanonicalMessage();
+        if (this.onFinish && canonicalMessage) {
           this.onFinish({
-            message: currentMessage,
+            message: canonicalMessage,
             messages: this.messages,
             isAbort,
             isDisconnect: !!error && !isAbort,

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -30,6 +30,13 @@ import type {
 type ActiveResponse<TChunk extends UIMessageChunk = UIMessageChunk> = {
   abortController: AbortController;
   stream?: ReadableStream<TChunk>;
+  messageId?: string;
+  requiredToolCallIds: Set<string>;
+  resolvedToolCallIds: Set<string>;
+  outcome: 'active' | 'success' | 'error' | 'abort';
+  finishNotified: boolean;
+  continuationChecked: boolean;
+  errorHandled: boolean;
 };
 
 const tryParseJson = (value: string): unknown | undefined => {
@@ -150,6 +157,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   private activeResponse: ActiveResponse<
     InferUIMessageChunk<TUIMessage>
   > | null = null;
+  private toolCallResponses = new Map<
+    string,
+    ActiveResponse<InferUIMessageChunk<TUIMessage>>
+  >();
   private jobExecutor = new SerialJobExecutor();
 
   constructor({
@@ -223,6 +234,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
   set messages(messages: TUIMessage[]) {
     this.state.messages = messages;
+    this.toolCallResponses.clear();
   }
 
   get lastMessage(): TUIMessage | undefined {
@@ -355,6 +367,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       if (targetIndex >= 0) {
         // Remove the assistant message and all messages after it
         this.state.messages = this.state.messages.slice(0, targetIndex);
+        this.pruneToolCallResponses();
       }
 
       return this.makeRequest({
@@ -378,6 +391,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         );
       }
 
+      if (this.activeResponse) {
+        this.activeResponse.outcome = 'abort';
+        this.activeResponse.abortController.abort();
+      }
+
+      const response = this.createResponse();
+      this.activeResponse = response;
       this.setStatus({ status: 'submitted' });
 
       return this.transport
@@ -388,14 +408,26 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         .then(
           (stream) => {
             if (stream) {
-              return this.processStreamWithCallbacks(stream);
+              if (this.activeResponse !== response) return Promise.resolve();
+              response.stream = stream;
+              return this.processStreamWithCallbacks(stream, response);
             } else {
-              this.setStatus({ status: 'ready' });
+              response.outcome = 'success';
+              if (this.activeResponse === response) {
+                this.activeResponse = null;
+                this.setStatus({ status: 'ready' });
+              }
               return Promise.resolve();
             }
           },
           (error) => {
-            this.handleError(error as Error);
+            if (
+              response.outcome === 'abort' ||
+              this.activeResponse !== response
+            ) {
+              return Promise.resolve();
+            }
+            this.failResponse(response, error as Error);
             return Promise.resolve();
           }
         );
@@ -411,11 +443,141 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     }
   };
 
+  private createResponse(): ActiveResponse<InferUIMessageChunk<TUIMessage>> {
+    return {
+      abortController: new AbortController(),
+      requiredToolCallIds: new Set(),
+      resolvedToolCallIds: new Set(),
+      outcome: 'active',
+      finishNotified: false,
+      continuationChecked: false,
+      errorHandled: false,
+    };
+  }
+
+  private getResponseForToolCall(
+    toolCallId: string
+  ): ActiveResponse<InferUIMessageChunk<TUIMessage>> | undefined {
+    this.pruneToolCallResponses();
+    return this.toolCallResponses.get(toolCallId);
+  }
+
+  private pruneToolCallResponses(): void {
+    const messageIds = new Set(
+      this.state.messages.map((message) => message.id)
+    );
+
+    this.toolCallResponses.forEach((response, toolCallId) => {
+      if (response.messageId && !messageIds.has(response.messageId)) {
+        this.toolCallResponses.delete(toolCallId);
+      }
+    });
+  }
+
+  private commitToolResult(toolCallId: string, output: unknown): boolean {
+    const messageIndex = this.state.messages.findIndex((message) =>
+      message.parts?.some(
+        (part) => 'toolCallId' in part && part.toolCallId === toolCallId
+      )
+    );
+
+    if (messageIndex === -1) return false;
+
+    const message = this.state.messages[messageIndex];
+    let didUpdate = false;
+    const updatedParts = message.parts.map((part) => {
+      if (
+        'toolCallId' in part &&
+        part.toolCallId === toolCallId &&
+        'state' in part
+      ) {
+        if (
+          part.state === 'output-available' ||
+          part.state === 'output-error'
+        ) {
+          return part;
+        }
+        didUpdate = true;
+        return {
+          ...part,
+          state: 'output-available' as const,
+          output,
+        };
+      }
+      return part;
+    });
+
+    if (!didUpdate) return false;
+
+    this.state.replaceMessage(messageIndex, {
+      ...message,
+      parts: updatedParts,
+    } as TUIMessage);
+    return true;
+  }
+
+  private hasAllToolResults(
+    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>
+  ): boolean {
+    return (
+      response.requiredToolCallIds.size > 0 &&
+      Array.from(response.requiredToolCallIds).every((toolCallId) =>
+        response.resolvedToolCallIds.has(toolCallId)
+      )
+    );
+  }
+
+  private continueResponseIfReady(
+    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>
+  ): Promise<void> {
+    if (
+      response.outcome !== 'success' ||
+      !response.finishNotified ||
+      response.continuationChecked ||
+      !this.hasAllToolResults(response)
+    ) {
+      return Promise.resolve();
+    }
+
+    response.continuationChecked = true;
+    if (!this.sendAutomaticallyWhen) return Promise.resolve();
+
+    return Promise.resolve()
+      .then(() =>
+        this.sendAutomaticallyWhen!({
+          messages: this.state.messages,
+        })
+      )
+      .then((shouldSend) => {
+        if (!shouldSend) return Promise.resolve();
+        return this.makeRequest({ trigger: 'submit-message' });
+      })
+      .catch((error) => {
+        this.failResponse(response, error as Error, true);
+      });
+  }
+
+  private continueUnownedResult(): Promise<void> {
+    if (!this.sendAutomaticallyWhen) return Promise.resolve();
+
+    return Promise.resolve()
+      .then(() =>
+        this.sendAutomaticallyWhen!({ messages: this.state.messages })
+      )
+      .then((shouldSend) => {
+        if (!shouldSend) return Promise.resolve();
+        return this.makeRequest({ trigger: 'submit-message' });
+      })
+      .catch((error) => {
+        this.handleError(error as Error);
+      });
+  }
+
   /**
    * Add a tool result for a tool call.
    */
   addToolResult = <TTool extends keyof InferUIMessageTools<TUIMessage>>({
-    tool,
+    tool: _tool,
     toolCallId,
     output,
   }: {
@@ -423,58 +585,25 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     toolCallId: string;
     output: InferUIMessageTools<TUIMessage>[TTool]['output'];
   }): Promise<void> => {
-    return this.jobExecutor.run(() => {
-      // Find the message with this tool call
-      const messageIndex = this.state.messages.findIndex(
-        (m) =>
-          m.parts?.some(
-            (p) =>
-              ('toolCallId' in p && p.toolCallId === toolCallId) ||
-              ('type' in p && p.type === `tool-${String(tool)}`)
-          ) ?? false
-      );
-
-      if (messageIndex === -1) return Promise.resolve();
-
-      const message = this.state.messages[messageIndex];
-      const updatedParts = message.parts.map((part) => {
-        if (
-          'toolCallId' in part &&
-          part.toolCallId === toolCallId &&
-          'state' in part
-        ) {
-          return {
-            ...part,
-            state: 'output-available' as const,
-            output,
-          };
-        }
-        return part;
-      });
-
-      this.state.replaceMessage(messageIndex, {
-        ...message,
-        parts: updatedParts,
-      } as TUIMessage);
-
-      // Check if we should auto-send based on sendAutomaticallyWhen
-      if (this.sendAutomaticallyWhen) {
-        return Promise.resolve(
-          this.sendAutomaticallyWhen({
-            messages: this.state.messages,
-          })
-        ).then((shouldSend) => {
-          if (shouldSend) {
-            return this.makeRequest({
-              trigger: 'submit-message',
-            });
-          }
-          return Promise.resolve();
-        });
+    const response = this.getResponseForToolCall(toolCallId);
+    const commitResult = (): Promise<void> => {
+      if (!this.commitToolResult(toolCallId, output)) {
+        return Promise.resolve();
       }
 
-      return Promise.resolve();
-    });
+      if (response) {
+        response.resolvedToolCallIds.add(toolCallId);
+        return this.continueResponseIfReady(response);
+      }
+
+      return this.continueUnownedResult();
+    };
+
+    if (response?.outcome === 'active') {
+      return commitResult();
+    }
+
+    return this.jobExecutor.run(commitResult);
   };
 
   /**
@@ -482,8 +611,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    */
   stop = (): Promise<void> => {
     if (this.activeResponse) {
-      this.activeResponse.abortController.abort();
+      const response = this.activeResponse;
+      response.outcome = 'abort';
       this.activeResponse = null;
+      response.abortController.abort();
     }
     this.setStatus({ status: 'ready' });
     return Promise.resolve();
@@ -505,11 +636,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
     // Abort any existing request
     if (this.activeResponse) {
-      this.activeResponse.abortController.abort();
+      const previousResponse = this.activeResponse;
+      previousResponse.outcome = 'abort';
+      previousResponse.abortController.abort();
     }
 
-    const abortController = new AbortController();
-    this.activeResponse = { abortController };
+    const response = this.createResponse();
+    this.activeResponse = response;
 
     this.setStatus({ status: 'submitted' });
 
@@ -517,7 +650,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       .sendMessages({
         chatId: this.id,
         messages: this.state.messages,
-        abortSignal: abortController.signal,
+        abortSignal: response.abortController.signal,
         trigger: options.trigger,
         messageId: options.messageId,
         headers: options.headers,
@@ -526,24 +659,94 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       })
       .then(
         (stream) => {
-          this.activeResponse!.stream = stream;
-          return this.processStreamWithCallbacks(stream);
+          if (this.activeResponse !== response) return Promise.resolve();
+          response.stream = stream;
+          return this.processStreamWithCallbacks(stream, response);
         },
         (error) => {
           if ((error as Error).name === 'AbortError') {
-            // Request was aborted, don't treat as error
+            response.outcome = 'abort';
+            if (this.activeResponse === response) {
+              this.activeResponse = null;
+              this.setStatus({ status: 'ready' });
+            }
             return Promise.resolve();
           }
-          this.handleError(error as Error);
+          if (
+            response.outcome === 'abort' ||
+            this.activeResponse !== response
+          ) {
+            return Promise.resolve();
+          }
+          this.failResponse(response, error as Error);
           return Promise.resolve();
         }
       );
   }
 
+  private getResponseMessage(
+    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>
+  ): TUIMessage | undefined {
+    if (!response.messageId) return undefined;
+    return this.state.messages.find(
+      (message) => message.id === response.messageId
+    );
+  }
+
+  private notifyResponseFinish(
+    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>,
+    flags: {
+      isAbort: boolean;
+      isDisconnect: boolean;
+      isError: boolean;
+    }
+  ): void {
+    if (response.finishNotified) return;
+    response.finishNotified = true;
+
+    const message = this.getResponseMessage(response);
+    if (this.onFinish && message) {
+      this.onFinish({
+        message,
+        messages: this.state.messages,
+        ...flags,
+      });
+    }
+  }
+
+  private failResponse(
+    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>,
+    error: Error,
+    allowInactive = false
+  ): void {
+    if (response.errorHandled) return;
+
+    response.errorHandled = true;
+    response.outcome = 'error';
+    response.continuationChecked = true;
+    response.abortController.abort();
+
+    if (this.activeResponse === response || allowInactive) {
+      if (this.activeResponse === response) {
+        this.activeResponse = null;
+      }
+      this.handleError(error);
+    }
+
+    this.notifyResponseFinish(response, {
+      isAbort: false,
+      isDisconnect: false,
+      isError: true,
+    });
+  }
+
   private processStreamWithCallbacks(
-    stream: ReadableStream<InferUIMessageChunk<TUIMessage>>
+    stream: ReadableStream<InferUIMessageChunk<TUIMessage>>,
+    response: ActiveResponse<InferUIMessageChunk<TUIMessage>>
   ): Promise<void> {
-    this.setStatus({ status: 'streaming' });
+    if (this.activeResponse === response) {
+      this.setStatus({ status: 'streaming' });
+    }
 
     let currentMessageId: string | undefined;
     let currentMessage: TUIMessage | undefined;
@@ -558,17 +761,29 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const toolRawInputByCallId: Record<string, string> = {};
     const toolRawOutputByCallId: Record<string, string> = {};
 
-    // Promise chain for handling tool calls that return promises
-    let pendingToolCall: Promise<void> = Promise.resolve();
+    const pendingToolCalls: Array<Promise<void>> = [];
 
     return new Promise((resolve) => {
       processStream<UIMessageChunk>(
         stream as ReadableStream<UIMessageChunk>,
         // eslint-disable-next-line complexity
         (chunk) => {
+          if (response.outcome !== 'active') return;
+
+          if (currentMessageId) {
+            const canonicalMessageIndex = this.state.messages.findIndex(
+              (message) => message.id === currentMessageId
+            );
+            if (canonicalMessageIndex >= 0) {
+              currentMessageIndex = canonicalMessageIndex;
+              currentMessage = this.state.messages[canonicalMessageIndex];
+            }
+          }
+
           switch (chunk.type) {
             case 'start': {
               currentMessageId = chunk.messageId || this.generateId();
+              response.messageId = currentMessageId;
 
               // Check if we're continuing an existing message or creating a new one
               const lastMessage = this.lastMessage;
@@ -743,6 +958,16 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             case 'tool-input-start': {
               if (!currentMessage) break;
 
+              const completedPart = currentMessage.parts.find(
+                (part) =>
+                  'toolCallId' in part &&
+                  part.toolCallId === chunk.toolCallId &&
+                  'state' in part &&
+                  (part.state === 'output-available' ||
+                    part.state === 'output-error')
+              );
+              if (completedPart) break;
+
               const initialRawInput =
                 typeof chunk.input === 'string'
                   ? chunk.input
@@ -780,6 +1005,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 toolIndex >= 0
                   ? (currentMessage.parts[toolIndex] as any)
                   : null;
+              if (
+                existingPart?.state === 'output-available' ||
+                existingPart?.state === 'output-error'
+              ) {
+                break;
+              }
               const previousRawInput =
                 existingPart?.rawInput ??
                 toolRawInputByCallId[chunk.toolCallId] ??
@@ -833,6 +1064,16 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               const existingIndex = currentMessage.parts.findIndex(
                 (p) => 'toolCallId' in p && p.toolCallId === chunk.toolCallId
               );
+              const existingPart =
+                existingIndex >= 0
+                  ? (currentMessage.parts[existingIndex] as any)
+                  : null;
+              if (
+                existingPart?.state === 'output-available' ||
+                existingPart?.state === 'output-error'
+              ) {
+                break;
+              }
 
               const toolPart = {
                 type: `tool-${chunk.toolName}` as const,
@@ -861,16 +1102,35 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               // Trigger onToolCall callback only for client-executed tools
               // (server-executed tools have providerExecuted: true and don't need client handling)
               if (this.onToolCall && !chunk.providerExecuted) {
-                const result = this.onToolCall({
-                  toolCall: {
-                    toolName: chunk.toolName,
-                    toolCallId: chunk.toolCallId,
-                    input: chunk.input,
-                    dynamic: 'dynamic' in chunk ? chunk.dynamic : undefined,
-                  } as InferUIMessageToolCall<TUIMessage>,
-                });
-                if (result && typeof result.then === 'function') {
-                  pendingToolCall = pendingToolCall.then(() => result);
+                response.requiredToolCallIds.add(chunk.toolCallId);
+                this.toolCallResponses.set(chunk.toolCallId, response);
+
+                try {
+                  const result = this.onToolCall({
+                    toolCall: {
+                      toolName: chunk.toolName,
+                      toolCallId: chunk.toolCallId,
+                      input: chunk.input,
+                      dynamic: 'dynamic' in chunk ? chunk.dynamic : undefined,
+                    } as InferUIMessageToolCall<TUIMessage>,
+                  });
+                  if (result && typeof result.then === 'function') {
+                    pendingToolCalls.push(
+                      Promise.resolve(result).catch((error) => {
+                        this.failResponse(
+                          response,
+                          error instanceof Error
+                            ? error
+                            : new Error(String(error))
+                        );
+                      })
+                    );
+                  }
+                } catch (error) {
+                  this.failResponse(
+                    response,
+                    error instanceof Error ? error : new Error(String(error))
+                  );
                 }
               }
               break;
@@ -1195,6 +1455,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               }
 
               currentMessageId = currentMessage.id;
+              response.messageId = currentMessageId;
               currentTextPartId = undefined;
               currentReasoningPartId = undefined;
               break;
@@ -1225,48 +1486,79 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           }
         },
         () => {
-          // Wait for any pending tool calls to complete
-          pendingToolCall.then(() => {
-            // Stream finished successfully
-            this.setStatus({ status: 'ready' });
-            this.activeResponse = null;
-
-            // Trigger onFinish callback
-            if (this.onFinish && currentMessage) {
-              this.onFinish({
-                message: currentMessage,
-                messages: this.state.messages,
-                isAbort,
-                isDisconnect,
-                isError,
-              });
+          Promise.all(pendingToolCalls).then(() => {
+            if (response.outcome === 'error') {
+              resolve();
+              return;
             }
 
-            // Note: sendAutomaticallyWhen is only checked in addToolResult,
-            // not here. For server-executed tools, the server continues the
-            // conversation. For client-executed tools, addToolResult handles it.
-            resolve();
-          });
-        },
-        (error) => {
-          if (error.name === 'AbortError') {
-            isAbort = true;
-            this.setStatus({ status: 'ready' });
-          } else {
-            isDisconnect = true;
-            this.handleError(error);
-          }
+            if (response.outcome === 'abort') {
+              this.notifyResponseFinish(response, {
+                isAbort: true,
+                isDisconnect: false,
+                isError: false,
+              });
+              resolve();
+              return;
+            }
 
-          // Still call onFinish even on error/abort
-          if (this.onFinish && currentMessage) {
-            this.onFinish({
-              message: currentMessage,
-              messages: this.state.messages,
+            response.outcome = isAbort ? 'abort' : 'success';
+            if (this.activeResponse === response) {
+              this.activeResponse = null;
+              this.setStatus({ status: 'ready' });
+            }
+
+            this.notifyResponseFinish(response, {
               isAbort,
               isDisconnect,
               isError,
             });
+
+            if (response.outcome === 'success') {
+              this.continueResponseIfReady(response).then(resolve);
+            } else {
+              resolve();
+            }
+          });
+        },
+        (error) => {
+          if (response.outcome === 'error') {
+            resolve();
+            return;
           }
+
+          if (response.outcome === 'abort') {
+            this.notifyResponseFinish(response, {
+              isAbort: true,
+              isDisconnect: false,
+              isError: false,
+            });
+            resolve();
+            return;
+          }
+
+          if (error.name === 'AbortError') {
+            isAbort = true;
+            response.outcome = 'abort';
+            if (this.activeResponse === response) {
+              this.activeResponse = null;
+              this.setStatus({ status: 'ready' });
+            }
+          } else {
+            isDisconnect = true;
+            response.outcome = 'error';
+            response.continuationChecked = true;
+            if (this.activeResponse === response) {
+              this.activeResponse = null;
+              this.handleError(error);
+            }
+          }
+
+          this.notifyResponseFinish(response, {
+            isAbort,
+            isDisconnect,
+            isError,
+          });
 
           resolve();
         }

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -344,14 +344,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         this.responseByMessage.set(message, response);
       }
     });
-    if (this.activeResponse?.messageId) {
-      const activeMessage = messages.find(
-        (message) => message.id === this.activeResponse!.messageId
-      );
-      if (activeMessage) {
-        this.responseByMessage.set(activeMessage, this.activeResponse);
-      }
-    }
     responses.forEach((response) => {
       if (
         detachedResponses.has(response) ||
@@ -533,6 +525,19 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     }
   };
 
+  private replaceMessage(
+    index: number,
+    message: TUIMessage,
+    response?: ResponseRecord
+  ): TUIMessage {
+    this.state.replaceMessage(index, message);
+    const canonicalMessage = this.messages[index] ?? message;
+    if (response && this.messages.includes(canonicalMessage)) {
+      this.responseByMessage.set(canonicalMessage, response);
+    }
+    return canonicalMessage;
+  }
+
   private commit(
     toolCallId: string,
     output: unknown,
@@ -579,10 +584,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       ...message,
       parts: updatedParts,
     } as TUIMessage;
-    if (response) {
-      this.responseByMessage.set(updatedMessage, response);
-    }
-    this.state.replaceMessage(messageIndex, updatedMessage);
+    this.replaceMessage(messageIndex, updatedMessage, response);
     return true;
   }
 
@@ -878,8 +880,11 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       const parts = [...currentMessage!.parts];
       parts[index < 0 ? parts.length : index] = part;
       currentMessage = { ...currentMessage!, parts } as TUIMessage;
-      this.responseByMessage.set(currentMessage, response);
-      this.state.replaceMessage(currentMessageIndex, currentMessage);
+      currentMessage = this.replaceMessage(
+        currentMessageIndex,
+        currentMessage,
+        response
+      );
     };
     const mergeCallProviderMetadata = (
       toolCallId: string,
@@ -1023,7 +1028,11 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   parts: [...lastMessage.parts],
                 } as TUIMessage;
                 currentMessageIndex = this.messages.length - 1;
-                this.state.replaceMessage(currentMessageIndex, currentMessage);
+                currentMessage = this.replaceMessage(
+                  currentMessageIndex,
+                  currentMessage,
+                  response
+                );
               } else {
                 currentMessage = {
                   id: currentMessageId,
@@ -1033,8 +1042,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 } as unknown as TUIMessage;
                 this.state.pushMessage(currentMessage);
                 currentMessageIndex = this.messages.length - 1;
+                this.responseByMessage.set(currentMessage, response);
               }
-              this.responseByMessage.set(currentMessage, response);
               break;
             }
 
@@ -1504,8 +1513,11 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 ...currentMessage,
                 metadata: chunk.messageMetadata,
               } as TUIMessage;
-              this.responseByMessage.set(currentMessage, response);
-              this.state.replaceMessage(currentMessageIndex, currentMessage);
+              currentMessage = this.replaceMessage(
+                currentMessageIndex,
+                currentMessage,
+                response
+              );
               break;
             }
 
@@ -1528,8 +1540,11 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   ...currentMessage,
                   metadata: chunk.messageMetadata,
                 } as TUIMessage;
-                this.responseByMessage.set(currentMessage, response);
-                this.state.replaceMessage(currentMessageIndex, currentMessage);
+                currentMessage = this.replaceMessage(
+                  currentMessageIndex,
+                  currentMessage,
+                  response
+                );
               }
               break;
             }
@@ -1558,13 +1573,16 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   },
                 ],
               } as unknown as TUIMessage;
-              this.responseByMessage.set(currentMessage, response);
-
               if (currentMessageIndex >= 0) {
-                this.state.replaceMessage(currentMessageIndex, currentMessage);
+                currentMessage = this.replaceMessage(
+                  currentMessageIndex,
+                  currentMessage,
+                  response
+                );
               } else {
                 this.state.pushMessage(currentMessage);
                 currentMessageIndex = this.messages.length - 1;
+                this.responseByMessage.set(currentMessage, response);
               }
 
               currentMessageId = currentMessage.id;

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -19,6 +19,7 @@ import type {
   InferUIMessageMetadata,
   InferUIMessageToolCall,
   InferUIMessageTools,
+  ProviderMetadata,
   UIMessage,
   UIMessageChunk,
   ChatOnErrorCallback,
@@ -50,9 +51,10 @@ type ToolResultSubmission<TUIMessage extends UIMessage> = <
   output: InferUIMessageTools<TUIMessage>[TTool]['output'];
 }) => Promise<void>;
 
-type ResponseScopedOnToolCallCallback<TUIMessage extends UIMessage> = (
+/** @internal */
+export type ResponseScopedOnToolCallCallback<TUIMessage extends UIMessage> = (
   options: Parameters<ChatOnToolCallCallback<TUIMessage>>[0],
-  addToolResult?: ToolResultSubmission<TUIMessage>
+  addToolResult: ToolResultSubmission<TUIMessage>
 ) => ReturnType<ChatOnToolCallCallback<TUIMessage>>;
 
 const tryParseJson = (value: string): unknown | undefined => {
@@ -559,6 +561,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       output: InferUIMessageTools<TUIMessage>[TTool]['output'];
     }
   ): Promise<void> {
+    if (response?.isRetired) return Promise.resolve();
+
     const commitResult = (): Promise<void> => {
       if (!this.commit(toolCallId, output, response?.messageId)) {
         return Promise.resolve();
@@ -711,6 +715,19 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       parts[index < 0 ? parts.length : index] = part;
       currentMessage = { ...currentMessage!, parts } as TUIMessage;
       this.state.replaceMessage(currentMessageIndex, currentMessage);
+    };
+    const mergeCallProviderMetadata = (
+      toolCallId: string,
+      metadata?: ProviderMetadata
+    ): void => {
+      const toolIndex = findToolPart(toolCallId);
+      if (toolIndex < 0) return;
+
+      const existingPart = currentMessage!.parts[toolIndex] as any;
+      setPart(toolIndex, {
+        ...existingPart,
+        callProviderMetadata: metadata ?? existingPart.callProviderMetadata,
+      });
     };
     const getCanonicalMessage = (): TUIMessage | undefined =>
       response.messageId
@@ -1013,9 +1030,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 );
                 if (existingOwner && existingOwner !== response) {
                   const canTransferOwnership =
-                    existingOwner.outcome === 'succeeded' &&
-                    existingOwner.resolvedToolCallIds.has(chunk.toolCallId) &&
-                    existingOwner.pendingToolCallbacks === 0;
+                    existingOwner.isRetired ||
+                    (existingOwner.outcome === 'succeeded' &&
+                      existingOwner.resolvedToolCallIds.has(chunk.toolCallId) &&
+                      existingOwner.pendingToolCallbacks === 0);
                   if (!canTransferOwnership) {
                     // Neither response may continue once ownership is ambiguous.
                     existingOwner.didEvaluateContinuation = true;
@@ -1026,6 +1044,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                     );
                     break;
                   }
+                  existingOwner.isRetired = true;
                   existingOwner.didEvaluateContinuation = true;
                 }
 
@@ -1116,8 +1135,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
             case 'tool-output-available': {
               if (!currentMessage) break;
-              if (response.resolvedToolCallIds.has(chunk.toolCallId)) break;
-
               const toolIndex = findToolPart(chunk.toolCallId);
 
               if (toolIndex >= 0) {
@@ -1125,6 +1142,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 delete toolRawOutputByCallId[chunk.toolCallId];
 
                 const existingPart = currentMessage.parts[toolIndex] as any;
+                if (response.resolvedToolCallIds.has(chunk.toolCallId)) {
+                  mergeCallProviderMetadata(
+                    chunk.toolCallId,
+                    chunk.callProviderMetadata
+                  );
+                  break;
+                }
+
                 // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
                 const { rawOutput: _ignored, ...rest } = existingPart;
                 setPart(toolIndex, {
@@ -1143,7 +1168,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
             case 'tool-input-error': {
               if (!currentMessage) break;
-              if (response.resolvedToolCallIds.has(chunk.toolCallId)) break;
+              if (response.resolvedToolCallIds.has(chunk.toolCallId)) {
+                mergeCallProviderMetadata(
+                  chunk.toolCallId,
+                  chunk.providerMetadata
+                );
+                break;
+              }
               delete toolRawInputByCallId[chunk.toolCallId];
               delete toolRawOutputByCallId[chunk.toolCallId];
 
@@ -1184,7 +1215,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
             case 'tool-output-error': {
               if (!currentMessage) break;
-              if (response.resolvedToolCallIds.has(chunk.toolCallId)) break;
+              if (response.resolvedToolCallIds.has(chunk.toolCallId)) {
+                mergeCallProviderMetadata(
+                  chunk.toolCallId,
+                  chunk.providerMetadata
+                );
+                break;
+              }
 
               const toolIndex = findToolPart(chunk.toolCallId);
               if (toolIndex < 0) break;

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -33,6 +33,7 @@ type ResponseRecord = {
   abortController: AbortController;
   messageId?: string;
   outcome: ResponseOutcome;
+  isRetired: boolean;
   requiredToolCallIds: Set<string>;
   resolvedToolCallIds: Set<string>;
   returnedToolCallbacks: Array<Promise<void>>;
@@ -245,8 +246,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   set messages(messages: TUIMessage[]) {
     this.state.messages = messages;
     const retainedMessageIds = new Set(messages.map((message) => message.id));
-    this.responseByToolCallId.forEach((response) => {
-      if (!response.messageId || !retainedMessageIds.has(response.messageId)) {
+    const responses = new Set(this.responseByToolCallId.values());
+    if (this.activeResponse) {
+      responses.add(this.activeResponse);
+    }
+    responses.forEach((response) => {
+      if (response.messageId && !retainedMessageIds.has(response.messageId)) {
         this.pruneDetachedResponse(response);
       }
     });
@@ -471,7 +476,9 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
   private continueResponse(response?: ResponseRecord): Promise<void> {
     if (response) {
+      this.pruneDetachedResponse(response);
       if (
+        response.isRetired ||
         response.outcome !== 'succeeded' ||
         response.requiredToolCallIds.size === 0 ||
         response.resolvedToolCallIds.size !==
@@ -493,23 +500,46 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         })
       )
       .then((shouldSend) => {
+        if (response) {
+          this.pruneDetachedResponse(response);
+          if (response.isRetired) return undefined;
+        }
         return shouldSend
           ? this.makeRequest({ trigger: 'submit-message' })
           : undefined;
       })
       .catch((error) => {
+        if (response) {
+          this.pruneDetachedResponse(response);
+          if (response.isRetired) return;
+        }
         this.handleError(error as Error);
       });
   }
 
   private pruneDetachedResponse(response: ResponseRecord): void {
     if (
-      response.pendingToolCallbacks > 0 ||
-      (response.messageId &&
-        this.messages.some((message) => message.id === response.messageId))
+      !response.messageId ||
+      this.messages.some((message) => message.id === response.messageId)
     ) {
       return;
     }
+
+    if (!response.isRetired) {
+      response.isRetired = true;
+      response.didEvaluateContinuation = true;
+
+      if (this.activeResponse === response) {
+        response.outcome = 'aborted';
+        this.activeResponse = null;
+        response.abortController.abort();
+        this.setStatus({ status: 'ready' });
+      }
+    }
+
+    // Keep a routing tombstone while a callback is running so public
+    // addToolResult calls settle directly instead of entering the executor.
+    if (response.pendingToolCallbacks > 0) return;
 
     this.responseByToolCallId.forEach((owner, toolCallId) => {
       if (owner === response) {
@@ -556,10 +586,16 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    * Add a tool result for a tool call.
    */
   addToolResult: ToolResultSubmission<TUIMessage> = (options) => {
-    return this.submitToolResult(
-      this.responseByToolCallId.get(options.toolCallId),
-      options
+    const response = this.responseByToolCallId.get(options.toolCallId);
+    const hasRestoredToolCall = this.messages.some((message) =>
+      message.parts.some(
+        (part) => 'toolCallId' in part && part.toolCallId === options.toolCallId
+      )
     );
+
+    if (!response && !hasRestoredToolCall) return Promise.resolve();
+
+    return this.submitToolResult(response, options);
   };
 
   /**
@@ -616,6 +652,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const response: ResponseRecord = {
       abortController: new AbortController(),
       outcome: 'active',
+      isRetired: false,
       requiredToolCallIds: new Set(),
       resolvedToolCallIds: new Set(),
       returnedToolCallbacks: [],
@@ -689,7 +726,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       isDisconnect: boolean;
       isError: boolean;
     }): void => {
-      if (response.didNotifyFinish) return;
+      this.pruneDetachedResponse(response);
+      if (response.isRetired || response.didNotifyFinish) return;
       response.didNotifyFinish = true;
 
       const canonicalMessage = getCanonicalMessage();
@@ -758,16 +796,18 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         stream as ReadableStream<UIMessageChunk>,
         // eslint-disable-next-line complexity
         (chunk) => {
-          if (this.activeResponse !== response) return;
+          if (this.activeResponse !== response || response.isRetired) return;
 
           if (currentMessageId) {
             const canonicalMessageIndex = this.messages.findIndex(
               (message) => message.id === currentMessageId
             );
-            if (canonicalMessageIndex >= 0) {
-              currentMessageIndex = canonicalMessageIndex;
-              currentMessage = this.messages[canonicalMessageIndex];
+            if (canonicalMessageIndex === -1) {
+              this.pruneDetachedResponse(response);
+              return;
             }
+            currentMessageIndex = canonicalMessageIndex;
+            currentMessage = this.messages[canonicalMessageIndex];
           }
 
           switch (chunk.type) {

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -41,6 +41,19 @@ type ResponseRecord = {
   didEvaluateContinuation: boolean;
 };
 
+type ToolResultSubmission<TUIMessage extends UIMessage> = <
+  TTool extends keyof InferUIMessageTools<TUIMessage>
+>(options: {
+  tool: TTool;
+  toolCallId: string;
+  output: InferUIMessageTools<TUIMessage>[TTool]['output'];
+}) => Promise<void>;
+
+type ResponseScopedOnToolCallCallback<TUIMessage extends UIMessage> = (
+  options: Parameters<ChatOnToolCallCallback<TUIMessage>>[0],
+  addToolResult?: ToolResultSubmission<TUIMessage>
+) => ReturnType<ChatOnToolCallCallback<TUIMessage>>;
+
 const tryParseJson = (value: string): unknown | undefined => {
   try {
     return JSON.parse(value);
@@ -148,7 +161,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
   private readonly transport?: ChatTransport<TUIMessage>;
   private onError?: ChatOnErrorCallback;
-  private onToolCall?: ChatOnToolCallCallback<TUIMessage>;
+  private onToolCall?: ResponseScopedOnToolCallCallback<TUIMessage>;
   private onFinish?: ChatOnFinishCallback<TUIMessage>;
   private onData?: ChatOnDataCallback<TUIMessage>;
   private sendAutomaticallyWhen?: (options: {
@@ -430,17 +443,24 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const part = message.parts[partIndex];
     if (
       !('state' in part) ||
-      part.state === 'output-available' ||
+      (part.state === 'output-available' && !part.preliminary) ||
       part.state === 'output-error'
     ) {
       return false;
     }
+    const {
+      // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+      preliminary: _ignoredPreliminary,
+      // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+      rawOutput: _ignoredRawOutput,
+      ...committedPart
+    } = part as any;
     const updatedParts = [...message.parts];
     updatedParts[partIndex] = {
-      ...part,
+      ...committedPart,
       state: 'output-available' as const,
       output,
-    } as any;
+    };
 
     this.state.replaceMessage(messageIndex, {
       ...message,
@@ -498,18 +518,17 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     });
   }
 
-  /**
-   * Add a tool result for a tool call.
-   */
-  addToolResult = <TTool extends keyof InferUIMessageTools<TUIMessage>>({
-    toolCallId,
-    output,
-  }: {
-    tool: TTool;
-    toolCallId: string;
-    output: InferUIMessageTools<TUIMessage>[TTool]['output'];
-  }): Promise<void> => {
-    const response = this.responseByToolCallId.get(toolCallId);
+  private submitToolResult<TTool extends keyof InferUIMessageTools<TUIMessage>>(
+    response: ResponseRecord | undefined,
+    {
+      toolCallId,
+      output,
+    }: {
+      tool: TTool;
+      toolCallId: string;
+      output: InferUIMessageTools<TUIMessage>[TTool]['output'];
+    }
+  ): Promise<void> {
     const commitResult = (): Promise<void> => {
       if (!this.commit(toolCallId, output, response?.messageId)) {
         return Promise.resolve();
@@ -531,6 +550,16 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     }
 
     return this.jobExecutor.run(commitResult);
+  }
+
+  /**
+   * Add a tool result for a tool call.
+   */
+  addToolResult: ToolResultSubmission<TUIMessage> = (options) => {
+    return this.submitToolResult(
+      this.responseByToolCallId.get(options.toolCallId),
+      options
+    );
   };
 
   /**
@@ -690,6 +719,11 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         isDisconnect: false,
         isError: true,
       });
+    };
+    const acceptServerToolResult = (toolCallId: string): void => {
+      if (response.requiredToolCallIds.has(toolCallId)) {
+        response.resolvedToolCallIds.add(toolCallId);
+      }
     };
 
     return new Promise((resolve) => {
@@ -928,14 +962,21 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   chunk.toolCallId
                 );
                 if (existingOwner && existingOwner !== response) {
-                  // Neither response may continue once ownership is ambiguous.
+                  const canTransferOwnership =
+                    existingOwner.outcome === 'succeeded' &&
+                    existingOwner.resolvedToolCallIds.has(chunk.toolCallId) &&
+                    existingOwner.pendingToolCallbacks === 0;
+                  if (!canTransferOwnership) {
+                    // Neither response may continue once ownership is ambiguous.
+                    existingOwner.didEvaluateContinuation = true;
+                    failToolCall(
+                      new Error(
+                        `Tool call "${chunk.toolCallId}" is already owned by another response.`
+                      )
+                    );
+                    break;
+                  }
                   existingOwner.didEvaluateContinuation = true;
-                  failToolCall(
-                    new Error(
-                      `Tool call "${chunk.toolCallId}" is already owned by another response.`
-                    )
-                  );
-                  break;
                 }
 
                 response.requiredToolCallIds.add(chunk.toolCallId);
@@ -943,14 +984,17 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 response.pendingToolCallbacks++;
 
                 try {
-                  const result = this.onToolCall({
-                    toolCall: {
-                      toolName: chunk.toolName,
-                      toolCallId: chunk.toolCallId,
-                      input: chunk.input,
-                      dynamic: 'dynamic' in chunk ? chunk.dynamic : undefined,
-                    } as InferUIMessageToolCall<TUIMessage>,
-                  });
+                  const result = this.onToolCall(
+                    {
+                      toolCall: {
+                        toolName: chunk.toolName,
+                        toolCallId: chunk.toolCallId,
+                        input: chunk.input,
+                        dynamic: 'dynamic' in chunk ? chunk.dynamic : undefined,
+                      } as InferUIMessageToolCall<TUIMessage>,
+                    },
+                    (options) => this.submitToolResult(response, options)
+                  );
                   if (result) {
                     response.returnedToolCallbacks.push(
                       Promise.resolve(result)
@@ -1037,6 +1081,9 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   callProviderMetadata: chunk.callProviderMetadata,
                   preliminary: chunk.preliminary,
                 });
+                if (!chunk.preliminary) {
+                  acceptServerToolResult(chunk.toolCallId);
+                }
               }
               break;
             }
@@ -1078,6 +1125,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               };
 
               setPart(toolIndex, nextToolPart);
+              acceptServerToolResult(chunk.toolCallId);
               break;
             }
 
@@ -1110,6 +1158,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 callProviderMetadata:
                   chunk.providerMetadata ?? rest.callProviderMetadata,
               });
+              acceptServerToolResult(chunk.toolCallId);
               break;
             }
 


### PR DESCRIPTION
## Summary

Allows client-side Chat tool callbacks to safely return or await `addToolResult` while the assistant response is still streaming.

The tool output is committed to its owning response without deadlocking the active stream. Automatic continuation then runs at most once, after the response finishes successfully and every required client tool result is available.

[FX-3873]

## Implementation

- Tracks tool calls and continuation state per assistant response.
- Commits active tool results re-entrantly while preserving serialized follow-up requests.
- Keeps completed tool output canonical when later stream chunks arrive.
- Supports multiple tool results in any order with one continuation.
- Prevents continuation after callback failure, stream failure or abort, using the existing Chat error path.
- Covers the production unknown-tool fallback through the same lifecycle.

## Scope guard

This PR does not add a public option, change the documented callback API, introduce tool-specific error UI or change flavor wrappers. React and JavaScript inherit the shared Chat lifecycle fix and Vue has no Chat widget.

## Validation

- Focused `AbstractChat` and connector tests.
- 35 existing Chat and widget regression tests.
- 144 common Chat tests across JavaScript and React.
- QA and browser test for returned, awaited, predicate-disabled, aborted and failed tool callbacks.
- type-checks, build, lint and prettier checks

[FX-3873]: https://algolia.atlassian.net/browse/FX-3873
