### PR TITLE
feat(chat): let display tools mark tool results terminal to stop auto-continuation

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -439,6 +439,12 @@ export interface AbstractChat<TUIMessage extends UIMessage> {
     tool: TTool;
     toolCallId: string;
     output: InferUIMessageTools<TUIMessage>[TTool]['output'];
+    /**
+     * Resolve without arming an automatic follow-up completion. Set by
+     * display/render-only tools whose result the model does not consume, so
+     * they resolve cleanly server-side without triggering another turn.
+     */
+    terminal?: boolean;
   }) => Promise<void>;
 
   stop: () => Promise<void>;
@@ -446,7 +452,7 @@ export interface AbstractChat<TUIMessage extends UIMessage> {
 export type AddToolResult = AbstractChat<UIMessage>['addToolResult'];
 
 export type AddToolResultWithOutput = (
-  params: Pick<Parameters<AddToolResult>[0], 'output'>
+  params: Pick<Parameters<AddToolResult>[0], 'output' | 'terminal'>
 ) => ReturnType<AddToolResult>;
 
 type SearchToolInputBase = {

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -598,9 +598,13 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           }
 
           if (tool.onToolCall) {
-            const addToolResult: AddToolResultWithOutput = ({ output }) =>
+            const addToolResult: AddToolResultWithOutput = ({
+              output,
+              terminal,
+            }) =>
               _chatInstance.addToolResult({
                 output,
+                terminal,
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
               });

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/utils.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/utils.test.ts
@@ -1,7 +1,30 @@
 /**
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
-import { tryParseErrorMessage } from '../utils';
+import {
+  lastAssistantMessageIsCompleteWithToolCalls,
+  tryParseErrorMessage,
+} from '../utils';
+
+import type { UIMessage } from '../types';
+
+function assistantWithTools(
+  tools: Array<{ resolved?: boolean; terminal?: boolean }>
+): UIMessage {
+  return {
+    id: 'a1',
+    role: 'assistant',
+    parts: tools.map((t, i) => ({
+      type: `tool-showProductCards`,
+      toolCallId: `call-${i}`,
+      state: t.resolved === false ? 'input-available' : 'output-available',
+      input: {},
+      ...(t.resolved === false
+        ? {}
+        : { output: { displayed: true }, terminal: t.terminal }),
+    })) as UIMessage['parts'],
+  } as UIMessage;
+}
 
 describe('tryParseErrorMessage', () => {
   it('returns the trimmed `message` from a JSON object', () => {
@@ -35,5 +58,46 @@ describe('tryParseErrorMessage', () => {
 
   it('returns undefined for empty input', () => {
     expect(tryParseErrorMessage('')).toBeUndefined();
+  });
+});
+
+describe('lastAssistantMessageIsCompleteWithToolCalls', () => {
+  it('auto-continues when a resolved tool call is not terminal', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: [assistantWithTools([{ resolved: true }])],
+      })
+    ).toBe(true);
+  });
+
+  it('does NOT auto-continue when every resolved tool call is terminal', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: [assistantWithTools([{ resolved: true, terminal: true }])],
+      })
+    ).toBe(false);
+  });
+
+  it('auto-continues when at least one resolved call is non-terminal (mixed)', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: [
+          assistantWithTools([
+            { resolved: true, terminal: true },
+            { resolved: true, terminal: false },
+          ]),
+        ],
+      })
+    ).toBe(true);
+  });
+
+  it('waits until all tool calls are resolved before continuing', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: [
+          assistantWithTools([{ resolved: true }, { resolved: false }]),
+        ],
+      })
+    ).toBe(false);
   });
 });

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -418,10 +418,18 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     tool,
     toolCallId,
     output,
+    terminal,
   }: {
     tool: TTool;
     toolCallId: string;
     output: InferUIMessageTools<TUIMessage>[TTool]['output'];
+    /**
+     * Resolve this tool call without arming an automatic follow-up completion.
+     * Set by display/render-only tools whose result the model does not consume.
+     * See `ToolUIPart`'s `terminal`. Defaults to `false` (result feeds the next
+     * turn, preserving existing behavior).
+     */
+    terminal?: boolean;
   }): Promise<void> => {
     return this.jobExecutor.run(() => {
       // Find the message with this tool call
@@ -447,6 +455,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             ...part,
             state: 'output-available' as const,
             output,
+            terminal,
           };
         }
         return part;

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -105,6 +105,16 @@ export type ToolUIPart<TOOLS extends UITools = UITools> = ValueOf<{
         providerExecuted?: boolean;
         callProviderMetadata?: ProviderMetadata;
         preliminary?: boolean;
+        /**
+         * Marks this resolved tool call as terminating the turn: the call is
+         * fully resolved (no dangling server-side state), but its result carries
+         * nothing the model needs to reason about, so it must NOT trigger an
+         * automatic follow-up completion. Display/render-only tools (e.g. product
+         * cards) set this. Mirrors the server-side `is_terminal` semantic that
+         * already exists for `algolia_display_results`. Absent/false preserves
+         * today's behavior (the result feeds the next turn).
+         */
+        terminal?: boolean;
       }
     | {
         state: 'output-error';
@@ -144,6 +154,8 @@ export type DynamicToolUIPart = {
       errorText?: never;
       callProviderMetadata?: ProviderMetadata;
       preliminary?: boolean;
+      /** See `ToolUIPart`'s `terminal`. */
+      terminal?: boolean;
     }
   | {
       state: 'output-error';

--- a/packages/instantsearch.js/src/lib/ai-lite/utils.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/utils.ts
@@ -37,9 +37,25 @@ export function lastAssistantMessageIsCompleteWithToolCalls({
 
   if (toolParts.length === 0) return false;
 
-  return toolParts.every(
+  const allResolved = toolParts.every(
     (part) => part.state === 'output-available' || part.state === 'output-error'
   );
+
+  if (!allResolved) return false;
+
+  // A resolved tool call that marked itself `terminal` (a display/render-only
+  // tool) carries nothing the model needs to act on. If EVERY resolved tool
+  // call is terminal, the turn is done — do not fire an automatic follow-up
+  // completion. This is what stops display tools (e.g. product cards) from
+  // looping: the tool is still resolved server-side (no dangling call), it just
+  // doesn't re-invoke the model. A single non-terminal result (a data tool the
+  // model must reason about) keeps today's auto-continue behavior, so legitimate
+  // multi-tool turns are unaffected.
+  const everyResolvedToolIsTerminal = toolParts.every(
+    (part) => part.state === 'output-available' && part.terminal === true
+  );
+
+  return !everyResolvedToolIsTerminal;
 }
 
 export class SerialJobExecutor {


### PR DESCRIPTION
## Summary

Part of [FX-3900]. Refs CR-11753.

[FX-3900]: https://algolia.atlassian.net/browse/FX-3900

Follow-up to #7116 (which exposed `sendAutomaticallyWhen`). This makes the loop protection work **by default**, not just when an integrator writes a custom predicate.

**Problem (CR-11753).** A client-side *display-only* tool (e.g. `showProductCards`) resolves its tool call purely to avoid a dangling call server-side. That resolution trips the default `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls` predicate, which fires a fresh completion; the model re-calls the same display tool, and it loops — 44 calls / 1.5M input tokens in the reported case. There was no structured way to say "this result is display-only, don't continue."

**Fix.** Add an optional `terminal` flag on a resolved tool result:
- The call still resolves cleanly (no dangling server-side state).
- `lastAssistantMessageIsCompleteWithToolCalls` no longer auto-continues when **every** resolved tool call is `terminal`.
- A single non-terminal (data) result keeps today's behavior, so legitimate multi-tool turns are unaffected — **no arbitrary call cap**.

This mirrors the `is_terminal` concept the backend already has for server display tools (`algolia_display_results`). A companion backend PR (Agent Studio / conversational-ai) accepts the flag and adds a cost backstop.

## Changes
- `ai-lite/types.ts` — optional `terminal?: boolean` on the `output-available` tool-part variant (`ToolUIPart` + `DynamicToolUIPart`).
- `ai-lite/abstract-chat.ts` — `addToolResult({ …, terminal })` stamps the flag onto the resolved part.
- `ai-lite/utils.ts` — terminal-aware default predicate.
- `connectChat.ts` — forward `terminal` through the `onToolCall` `addToolResult` wrapper.
- `instantsearch-ui-components` chat `types.ts` — `AddToolResult` / `AddToolResultWithOutput` accept `terminal`.

## Usage
A display tool drops any `SYSTEM_DIRECTIVE`/`TURN_ALREADY_COMPLETE` prose hack and resolves with `terminal: true`:
```ts
addToolResult({ output: { displayed: true }, terminal: true });
```

## Scope
Connector + shared-types layer only. Not included (tracked in the FX ticket): making display tools terminal automatically (zero-config), and threading through React/Vue wrappers + `tests/common/widgets/chat/`.

## Validation
- New + existing `ai-lite` unit tests (predicate: continues on non-terminal, stops when all terminal, mixed continues, waits for all resolved).
- `abstract-chat` + `connectChat` suites (95 tests) pass; type-check clean (no new errors); oxlint clean.

Refs CR-11753.

🤖 Generated with [Claude Code](https://claude.com/claude-code)