### PR TITLE
feat(index): support isolated index in Vue

### DIFF
--- a/packages/vue-instantsearch/src/components/Index.js
+++ b/packages/vue-instantsearch/src/components/Index.js
@@ -26,13 +26,22 @@ export default {
     };
   },
   props: {
+    // Not `required` because it's optional when `isolated` is `true`. The
+    // underlying index widget throws when neither `indexName` nor `isolated`
+    // is provided.
     indexName: {
       type: String,
-      required: true,
+      required: false,
+      default: undefined,
     },
     indexId: {
       type: String,
       required: false,
+    },
+    isolated: {
+      type: Boolean,
+      required: false,
+      default: false,
     },
   },
   render: renderCompat(function (h) {
@@ -43,6 +52,7 @@ export default {
       return {
         indexName: this.indexName,
         indexId: this.indexId,
+        isolated: this.isolated,
       };
     },
   },

--- a/packages/vue-instantsearch/src/components/__tests__/Index.js
+++ b/packages/vue-instantsearch/src/components/__tests__/Index.js
@@ -24,6 +24,21 @@ it('passes props to widgetParams', () => {
   expect(wrapper.vm.widgetParams).toEqual({
     indexName: 'the name',
     indexId: 'the id',
+    isolated: false,
+  });
+});
+
+it('passes the `isolated` prop to widgetParams without an `indexName`', () => {
+  const wrapper = mount(Index, {
+    propsData: {
+      isolated: true,
+    },
+  });
+
+  expect(wrapper.vm.widgetParams).toEqual({
+    indexName: undefined,
+    indexId: undefined,
+    isolated: true,
   });
 });
 


### PR DESCRIPTION
## What

Adds an `isolated` prop to Vue's `<ais-index>` (`AisIndex`), threading it through to the index widget's `isolated` option (graduated from `EXPERIMENTAL_isolated` in #7117). This brings Vue to parity with JS and React, which already expose `isolated`.

- `indexName` is no longer `required` on `<ais-index>`, since isolated indices don't need one. The underlying `index` widget already validates that either `indexName` or `isolated` is provided.
- Vue never shipped the experimental `EXPERIMENTAL_isolated`, so only the stable `isolated` prop is exposed — no deprecated alias is needed (unlike JS/React, which kept aliases for their previously-shipped experimental names).

## Test plan

- `yarn jest packages/vue-instantsearch/src/components/__tests__/Index.js` — added a test asserting `isolated: true` is passed to `widgetParams` without an `indexName`.
- Full `vue-instantsearch` suite green on Vue 2 and Vue 3.

Draft: opening early for review of the API shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)