### PR TITLE
feat(relatedProducts): add RelatedProducts to Vue + hook-based UI infra

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -26,11 +26,11 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "73 kB"
+      "maxSize": "75 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "73.25 kB"
+      "maxSize": "75.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",
@@ -38,7 +38,7 @@
     },
     {
       "path": "packages/vue-instantsearch/vue3/cjs/index.js",
-      "maxSize": "21 kB"
+      "maxSize": "21.75 kB"
     },
     {
       "path": "./packages/instantsearch.css/themes/algolia.css",

--- a/packages/vue-instantsearch/CLAUDE.md
+++ b/packages/vue-instantsearch/CLAUDE.md
@@ -8,6 +8,17 @@ Vue 2 **and** Vue 3 bindings (single source, built for both). Components wrap th
 - `src/mixins/` — shared connector-wiring logic reused across components.
 - To reuse shared markup, import the `create<Name>Component` factory from `instantsearch-ui-components` and render it inside a **`renderCompat`** render function, passing Vue's `h` as `createElement` — e.g. `render: renderCompat((h) => h(createHitsComponent({ createElement: h }), { … }))` (see `src/components/Hits.js`). `renderCompat` (`src/util/vue-compat/`) is the Vue 2/3 render-fn shim. **Creating or changing the shared component itself is the `instantsearch-ui-components` package's job** — do that there, then consume the factory here.
 
+## Consuming hook-based shared components (Carousel, Autocomplete, Chat)
+
+Most shared factories are stateless markup and consume via `renderCompat` (above). But some are **hook-driven** (`createAutocompletePropGetters`, `createCarouselComponent`) — written against a React-style `Hooks` contract (`useState`/`useEffect`/`useRef`/`useMemo`/`useId`) and emitting React-style props (`className`, `onClick`, `ref={mutableRef}`). Vue can't supply React hooks natively, so:
+
+- Give the component a hooks store: `this.hooksStore = createHooksStore(() => this.$forceUpdate())` (`src/util/hooks.js`). Call `beginRender()` before the hook calls and `endRender()` after in `render`, flush effects in `mounted`/`updated`, and `cleanup()` in `beforeDestroy`/`beforeUnmount`. Each hook-using component needs its **own** store — a shared store breaks on conditionally-mounted subtrees (React gives each component its own hook context).
+- Render with **`renderReactCompat`** (not `renderCompat`) so `className` → `class`, `onX` → listeners, and `ref` MutableRefs are bridged (Vue 2 vnode `insert`/`destroy` hooks; Vue 3 function refs). `renderCompat`'s augmenter drops vnode `hook`s, so it can't carry refs.
+- Use the plain-function `Fragment` from `vue-compat` (never Vue 3's native `Fragment` symbol — it adds whitespace/anchor nodes that break shared snapshots).
+- Testing gotcha: boolean attrs serialize differently across versions (`hidden="hidden"` in Vue 2, `hidden=""` in Vue 3) — assert on the DOM `.hidden` property, not the attribute string. Focus/`ref.focus()` are no-ops on detached nodes, so mount with `attachTo: document.body`.
+
+See `src/components/Carousel.js` (+ `RelatedProducts.js` which uses it as an opt-in layout) for a worked example.
+
 ## Working here
 
 ```bash

--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -29,6 +29,7 @@ import {
   AisPoweredBy,
   AisMenuSelect,
   AisDynamicWidgets,
+  AisRelatedProducts,
 } from '../instantsearch';
 import { renderCompat } from '../util/vue-compat';
 
@@ -512,8 +513,23 @@ const testSetups = {
 
     await nextTick();
   },
-  createRelatedProductsWidgetTests() {
-    throw new Error('RelatedProduct is not supported in Vue InstantSearch');
+  async createRelatedProductsWidgetTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisRelatedProducts, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
+
+    await nextTick();
   },
   createFrequentlyBoughtTogetherWidgetTests() {
     throw new Error(
@@ -630,11 +646,7 @@ const testOptions = {
   },
   createSortByWidgetTests: undefined,
   createStatsWidgetTests: undefined,
-  createRelatedProductsWidgetTests: {
-    skippedTests: {
-      'RelatedProducts widget common tests': true,
-    },
-  },
+  createRelatedProductsWidgetTests: undefined,
   createFrequentlyBoughtTogetherWidgetTests: {
     skippedTests: { 'FrequentlyBoughtTogether widget common tests': true },
   },

--- a/packages/vue-instantsearch/src/__tests__/index.js
+++ b/packages/vue-instantsearch/src/__tests__/index.js
@@ -80,6 +80,8 @@ function getAllComponents() {
         props.indexName = 'indexName';
       } else if (name === 'AisFeeds') {
         props.isolated = false;
+      } else if (name === 'AisRelatedProducts') {
+        props.objectIDs = ['1'];
       } else {
         props.attribute = 'attr';
       }

--- a/packages/vue-instantsearch/src/components/Carousel.js
+++ b/packages/vue-instantsearch/src/components/Carousel.js
@@ -1,0 +1,103 @@
+import {
+  createCarouselComponent,
+  generateCarouselId,
+} from 'instantsearch-ui-components';
+
+import { createHooksStore } from '../util/hooks';
+import { Fragment, isVue3, renderReactCompat } from '../util/vue-compat';
+
+/**
+ * Vue wrapper around the shared `instantsearch-ui-components` Carousel.
+ *
+ * The shared Carousel is a hook-driven component (`useState` for scroll
+ * affordances, `useRef` for the list/buttons). Vue can't supply React hooks
+ * natively, so this component owns a `hooksStore` (see `util/hooks.js`) and
+ * drives it through its own render cycle — mirroring how React's
+ * `components/Carousel.tsx` uses `useState` / `useRef`.
+ *
+ * It's a real Vue child component (not a plain function) so it gets its own
+ * hook context, which matters because the layout is mounted/unmounted
+ * conditionally by the parent recommend widget.
+ */
+export default {
+  name: 'AisCarousel',
+  props: {
+    items: {
+      type: Array,
+      required: true,
+    },
+    itemComponent: {
+      type: Function,
+      required: false,
+      default: undefined,
+    },
+    sendEvent: {
+      type: Function,
+      required: false,
+      default: () => {},
+    },
+    classNames: {
+      type: Object,
+      required: false,
+      default: undefined,
+    },
+    translations: {
+      type: Object,
+      required: false,
+      default: undefined,
+    },
+  },
+  created() {
+    this.hooksStore = createHooksStore(() => this.$forceUpdate());
+  },
+  mounted() {
+    this.hooksStore.flushEffects();
+  },
+  updated() {
+    this.hooksStore.flushEffects();
+  },
+  [isVue3 ? 'beforeUnmount' : 'beforeDestroy']() {
+    this.hooksStore.cleanup();
+  },
+  render: renderReactCompat(function (h) {
+    const CarouselUiComponent = createCarouselComponent({
+      createElement: h,
+      Fragment,
+    });
+
+    const { useState, useRef } = this.hooksStore.hooks;
+
+    this.hooksStore.beginRender();
+
+    const [canScrollLeft, setCanScrollLeft] = useState(false);
+    const [canScrollRight, setCanScrollRight] = useState(true);
+    const listRef = useRef(null);
+    const nextButtonRef = useRef(null);
+    const previousButtonRef = useRef(null);
+    const carouselIdRef = useRef(generateCarouselId());
+
+    const tree = h(CarouselUiComponent, {
+      items: this.items,
+      itemComponent: this.itemComponent,
+      sendEvent: this.sendEvent,
+      translations: this.translations,
+      // The parent recommend widget forwards its own `list`/`item` classes.
+      classNames: this.classNames && {
+        list: this.classNames.list,
+        item: this.classNames.item,
+      },
+      listRef,
+      nextButtonRef,
+      previousButtonRef,
+      carouselIdRef,
+      canScrollLeft,
+      canScrollRight,
+      setCanScrollLeft,
+      setCanScrollRight,
+    });
+
+    this.hooksStore.endRender();
+
+    return tree;
+  }),
+};

--- a/packages/vue-instantsearch/src/components/RelatedProducts.js
+++ b/packages/vue-instantsearch/src/components/RelatedProducts.js
@@ -46,7 +46,7 @@ export default {
       default: undefined,
     },
     fallbackParameters: {
-      type: Array,
+      type: Object,
       required: false,
       default: undefined,
     },

--- a/packages/vue-instantsearch/src/components/RelatedProducts.js
+++ b/packages/vue-instantsearch/src/components/RelatedProducts.js
@@ -1,0 +1,104 @@
+import { createRelatedProductsComponent } from 'instantsearch-ui-components';
+import { connectRelatedProducts } from 'instantsearch.js/es/connectors/index';
+
+import { createSuitMixin } from '../mixins/suit';
+import { createWidgetMixin } from '../mixins/widget';
+import { Fragment, renderReactCompat } from '../util/vue-compat';
+
+import AisCarousel from './Carousel';
+
+function mapClassNames(classNames) {
+  if (!classNames) {
+    return undefined;
+  }
+  return {
+    root: classNames['ais-RelatedProducts'],
+    emptyRoot: classNames['ais-RelatedProducts--empty'],
+    title: classNames['ais-RelatedProducts-title'],
+    container: classNames['ais-RelatedProducts-container'],
+    list: classNames['ais-RelatedProducts-list'],
+    item: classNames['ais-RelatedProducts-item'],
+  };
+}
+
+export default {
+  name: 'AisRelatedProducts',
+  mixins: [
+    createWidgetMixin(
+      { connector: connectRelatedProducts },
+      { $$widgetType: 'ais.relatedProducts' }
+    ),
+    createSuitMixin({ name: 'RelatedProducts' }),
+  ],
+  props: {
+    objectIDs: {
+      type: Array,
+      required: true,
+    },
+    limit: {
+      type: Number,
+      required: false,
+      default: undefined,
+    },
+    threshold: {
+      type: Number,
+      required: false,
+      default: undefined,
+    },
+    fallbackParameters: {
+      type: Array,
+      required: false,
+      default: undefined,
+    },
+    queryParameters: {
+      type: Object,
+      required: false,
+      default: undefined,
+    },
+    escapeHTML: {
+      type: Boolean,
+      required: false,
+      default: undefined,
+    },
+    transformItems: {
+      type: Function,
+      required: false,
+      default: undefined,
+    },
+    layout: {
+      type: String,
+      required: false,
+      default: 'list',
+      validator: (value) => ['list', 'carousel'].indexOf(value) !== -1,
+    },
+  },
+  computed: {
+    widgetParams() {
+      return {
+        objectIDs: this.objectIDs,
+        limit: this.limit,
+        threshold: this.threshold,
+        fallbackParameters: this.fallbackParameters,
+        queryParameters: this.queryParameters,
+        escapeHTML: this.escapeHTML,
+        transformItems: this.transformItems,
+      };
+    },
+  },
+  render: renderReactCompat(function (h) {
+    const RelatedProductsUiComponent = createRelatedProductsComponent({
+      createElement: h,
+      Fragment,
+    });
+
+    return h(RelatedProductsUiComponent, {
+      items: this.state ? this.state.items : [],
+      status: this.instantSearchInstance.status,
+      sendEvent: this.state ? this.state.sendEvent : () => {},
+      classNames: mapClassNames(this.classNames),
+      // A Vue child component (own hook context) rendered as the shared
+      // component's layout; `undefined` keeps the shared default list layout.
+      layout: this.layout === 'carousel' ? AisCarousel : undefined,
+    });
+  }),
+};

--- a/packages/vue-instantsearch/src/components/__tests__/RelatedProducts.js
+++ b/packages/vue-instantsearch/src/components/__tests__/RelatedProducts.js
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
+
+import { mount, nextTick } from '../../../test/utils';
+import InstantSearch from '../InstantSearch';
+import RelatedProducts from '../RelatedProducts';
+
+jest.unmock('instantsearch.js/es');
+
+const wait = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function mountRelatedProducts(props) {
+  return mount(
+    {
+      components: { InstantSearch, RelatedProducts },
+      data() {
+        return {
+          searchClient: createRecommendSearchClient(),
+          props,
+        };
+      },
+      template: `
+        <InstantSearch :search-client="searchClient" index-name="indexName">
+          <RelatedProducts v-bind="props" />
+        </InstantSearch>
+      `,
+    },
+    { attachTo: document.body }
+  );
+}
+
+describe('AisRelatedProducts', () => {
+  it('renders the default list layout', async () => {
+    const wrapper = mountRelatedProducts({ objectIDs: ['1'] });
+
+    await wait(0);
+    await nextTick();
+
+    const root = wrapper.find('.ais-RelatedProducts');
+    expect(root.exists()).toBe(true);
+    expect(wrapper.find('.ais-RelatedProducts-title').text()).toBe(
+      'Related products'
+    );
+    expect(wrapper.findAll('.ais-RelatedProducts-list').length).toBe(1);
+    expect(wrapper.findAll('.ais-RelatedProducts-item').length).toBeGreaterThan(
+      0
+    );
+    // The list layout has no carousel navigation.
+    expect(wrapper.find('.ais-Carousel').exists()).toBe(false);
+  });
+
+  describe('carousel layout (hooks + ref + event infra)', () => {
+    it('renders the shared Carousel with navigation and items', async () => {
+      const wrapper = mountRelatedProducts({
+        objectIDs: ['1'],
+        layout: 'carousel',
+      });
+
+      await wait(0);
+      await nextTick();
+
+      expect(wrapper.find('.ais-Carousel').exists()).toBe(true);
+      expect(wrapper.findAll('.ais-Carousel-item').length).toBeGreaterThan(0);
+
+      // Both navigation buttons render; the previous one starts hidden
+      // (canScrollLeft is false initially — driven by the hooks `useState`).
+      const previous = wrapper.find('.ais-Carousel-navigation--previous');
+      const next = wrapper.find('.ais-Carousel-navigation--next');
+      expect(previous.exists()).toBe(true);
+      expect(next.exists()).toBe(true);
+      // `.hidden` (DOM property) is robust across Vue 2/3 attribute serialization.
+      expect(previous.element.hidden).toBe(true);
+    });
+
+    it('updates navigation state on scroll (proves ref + useState + event wiring)', async () => {
+      const wrapper = mountRelatedProducts({
+        objectIDs: ['1'],
+        layout: 'carousel',
+      });
+
+      await wait(0);
+      await nextTick();
+
+      const list = wrapper.find('.ais-Carousel-list');
+      const next = wrapper.find('.ais-Carousel-navigation--next');
+
+      // Initially the next button is visible. The shared Carousel toggles it
+      // imperatively via the ref (a DOM property), so assert on `.hidden`.
+      expect(next.element.hidden).toBe(false);
+
+      // In jsdom there's no layout, so after a scroll the carousel computes
+      // that it can no longer scroll right. This exercises:
+      //  - the onScroll React-style handler (event adapter),
+      //  - listRef/nextButtonRef being populated (ref adapter),
+      //  - setCanScrollRight re-rendering via the hooks runtime.
+      await list.trigger('scroll');
+      await nextTick();
+
+      expect(
+        wrapper.find('.ais-Carousel-navigation--next').element.hidden
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/vue-instantsearch/src/util/__tests__/autocompletePropGetters.poc.test.js
+++ b/packages/vue-instantsearch/src/util/__tests__/autocompletePropGetters.poc.test.js
@@ -1,0 +1,188 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ *
+ * PROOF-OF-CONCEPT: drives the REAL `createAutocompletePropGetters` from
+ * `instantsearch-ui-components` through the Vue hooks runtime + React-style
+ * createElement adapter, to check whether Vue can consume the shared,
+ * hook-based autocomplete controller (approach 3).
+ */
+
+import { createAutocompletePropGetters } from 'instantsearch-ui-components';
+
+import { mount } from '../../../test/utils';
+import { createHooksStore } from '../hooks';
+import { renderReactCompat } from '../vue-compat';
+
+function buildComboboxComponent({ hits, onSelect, onRefine }) {
+  return {
+    created() {
+      this.hooksStore = createHooksStore(() => this.$forceUpdate());
+      this.usePropGetters = createAutocompletePropGetters(
+        this.hooksStore.hooks
+      );
+    },
+    mounted() {
+      this.hooksStore.flushEffects();
+    },
+    updated() {
+      this.hooksStore.flushEffects();
+    },
+    beforeDestroy() {
+      this.hooksStore.cleanup();
+    },
+    beforeUnmount() {
+      this.hooksStore.cleanup();
+    },
+    // `renderReactCompat` supplies a React-style `createElement` (className +
+    // onX events + MutableRef bridging) — the promoted vue-compat infra.
+    render: renderReactCompat(function (h) {
+      this.hooksStore.beginRender();
+
+      const {
+        getInputProps,
+        getItemProps,
+        getPanelProps,
+        getRootProps,
+        focusInput,
+      } = this.usePropGetters({
+        indices: [{ indexName: 'idx', indexId: 'idx', hits }],
+        indicesConfig: [{ indexName: 'idx', getQuery: (item) => item.name }],
+        onRefine: onRefine || (() => {}),
+        onSelect: onSelect || (() => {}),
+        onApply: () => {},
+      });
+
+      this.focusInput = focusInput;
+
+      const tree = h(
+        'div',
+        getRootProps(),
+        h(
+          'form',
+          { role: 'search' },
+          h('input', getInputProps()),
+          h(
+            'button',
+            {
+              type: 'reset',
+              // mirrors the shared AutocompleteSearch reset behavior
+              onClick: () => {
+                onRefine && onRefine('');
+                focusInput();
+              },
+            },
+            'clear'
+          )
+        ),
+        h(
+          'div',
+          getPanelProps(),
+          hits.map((hit, index) => {
+            const itemProps = getItemProps(
+              { __indexName: 'idx', ...hit },
+              index
+            );
+            return h(
+              'div',
+              {
+                key: hit.objectID,
+                id: itemProps.id,
+                role: itemProps.role,
+                'aria-selected': itemProps['aria-selected'],
+                className: 'ais-AutocompleteIndexItem',
+                onClick: itemProps.onSelect,
+              },
+              hit.name
+            );
+          })
+        )
+      );
+
+      this.hooksStore.endRender();
+      return tree;
+    }),
+  };
+}
+
+describe('Autocomplete prop getters driven by Vue (PoC)', () => {
+  const hits = [
+    { objectID: '1', name: 'Item 1' },
+    { objectID: '2', name: 'Item 2' },
+  ];
+
+  it('opens the panel on focus and closes on Escape', async () => {
+    const wrapper = mount(buildComboboxComponent({ hits }), {
+      attachTo: document.body,
+    });
+    const input = wrapper.find('input');
+    const panel = wrapper.find('[role="grid"]');
+
+    // Closed initially. Assert on the DOM `.hidden` property, which is robust
+    // across Vue 2 (`hidden="hidden"`) and Vue 3 (`hidden=""`) serialization.
+    expect(input.attributes('aria-expanded')).toBe('false');
+    expect(panel.element.hidden).toBe(true);
+
+    await input.trigger('focus');
+    expect(input.attributes('aria-expanded')).toBe('true');
+    expect(panel.element.hidden).toBe(false);
+
+    await input.trigger('keydown', { key: 'Escape' });
+    expect(input.attributes('aria-expanded')).toBe('false');
+  });
+
+  it('navigates items with the keyboard and sets aria-activedescendant', async () => {
+    const wrapper = mount(buildComboboxComponent({ hits }), {
+      attachTo: document.body,
+    });
+    const input = wrapper.find('input');
+
+    await input.trigger('focus');
+
+    expect(wrapper.findAll('[aria-selected="true"]').length).toBe(0);
+
+    await input.trigger('keydown', { key: 'ArrowDown' });
+
+    const selected = wrapper.find('[aria-selected="true"]');
+    expect(selected.exists()).toBe(true);
+    expect(selected.text()).toBe('Item 1');
+    expect(input.attributes('aria-activedescendant')).toBe(
+      selected.attributes('id')
+    );
+
+    await input.trigger('keydown', { key: 'ArrowDown' });
+    expect(wrapper.find('[aria-selected="true"]').text()).toBe('Item 2');
+  });
+
+  it('selecting an item via Enter calls onSelect (through the ref-backed submit)', async () => {
+    const onSelect = jest.fn();
+    const wrapper = mount(buildComboboxComponent({ hits, onSelect }), {
+      attachTo: document.body,
+    });
+    const input = wrapper.find('input');
+
+    await input.trigger('focus');
+    await input.trigger('keydown', { key: 'ArrowDown' });
+    await input.trigger('keydown', { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        item: expect.objectContaining({ objectID: '1', name: 'Item 1' }),
+      })
+    );
+  });
+
+  it('populates the input ref (focusInput works)', async () => {
+    const wrapper = mount(
+      buildComboboxComponent({ hits, onRefine: jest.fn() }),
+      {
+        attachTo: document.body,
+      }
+    );
+    const inputEl = wrapper.find('input').element;
+
+    // The ref must have been populated with the real DOM node for focusInput
+    // to work — this is the Vue-2 vnode-hook ref bridge under test.
+    wrapper.vm.focusInput();
+    expect(document.activeElement).toBe(inputEl);
+  });
+});

--- a/packages/vue-instantsearch/src/util/__tests__/hooks.test.js
+++ b/packages/vue-instantsearch/src/util/__tests__/hooks.test.js
@@ -3,8 +3,8 @@
  */
 
 import { mount } from '../../../test/utils';
-import { renderCompat } from '../vue-compat';
 import { createHooksStore } from '../hooks';
+import { renderCompat } from '../vue-compat';
 
 function makeHookedComponent(useBody) {
   return {

--- a/packages/vue-instantsearch/src/util/__tests__/hooks.test.js
+++ b/packages/vue-instantsearch/src/util/__tests__/hooks.test.js
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { mount } from '../../../test/utils';
+import { renderCompat } from '../vue-compat';
+import { createHooksStore } from '../hooks';
+
+function makeHookedComponent(useBody) {
+  return {
+    created() {
+      this.hooksStore = createHooksStore(() => this.$forceUpdate());
+    },
+    mounted() {
+      this.hooksStore.flushEffects();
+    },
+    updated() {
+      this.hooksStore.flushEffects();
+    },
+    beforeDestroy() {
+      this.hooksStore.cleanup();
+    },
+    beforeUnmount() {
+      this.hooksStore.cleanup();
+    },
+    render: renderCompat(function (h) {
+      this.hooksStore.beginRender();
+      const vnode = useBody(this.hooksStore.hooks, h);
+      this.hooksStore.endRender();
+      return vnode;
+    }),
+  };
+}
+
+describe('Vue hooks runtime (PoC)', () => {
+  it('useState re-renders on update and persists across renders', async () => {
+    const Counter = makeHookedComponent((hooks, h) => {
+      const [count, setCount] = hooks.useState(0);
+      return h(
+        'button',
+        {
+          attrs: { 'data-count': count },
+          on: { click: () => setCount((prev) => prev + 1) },
+        },
+        [`count: ${count}`]
+      );
+    });
+
+    const wrapper = mount(Counter);
+    expect(wrapper.find('button').text()).toBe('count: 0');
+
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.find('button').text()).toBe('count: 1');
+
+    await wrapper.find('button').trigger('click');
+    expect(wrapper.find('button').text()).toBe('count: 2');
+  });
+
+  it('useEffect runs after commit and re-runs only when deps change', async () => {
+    const effectSpy = jest.fn();
+    const cleanupSpy = jest.fn();
+
+    const Component = makeHookedComponent((hooks, h) => {
+      const [count, setCount] = hooks.useState(0);
+      const [other, setOther] = hooks.useState(0);
+
+      hooks.useEffect(() => {
+        effectSpy(count);
+        return cleanupSpy;
+      }, [count]);
+
+      return h('div', {}, [
+        h('button', {
+          attrs: { id: 'inc-count' },
+          on: { click: () => setCount((p) => p + 1) },
+        }),
+        h('button', {
+          attrs: { id: 'inc-other' },
+          on: { click: () => setOther((p) => p + 1) },
+        }),
+        h('span', {}, [`${count}-${other}`]),
+      ]);
+    });
+
+    const wrapper = mount(Component);
+
+    // Runs once after initial mount
+    expect(effectSpy).toHaveBeenCalledTimes(1);
+    expect(effectSpy).toHaveBeenLastCalledWith(0);
+    expect(cleanupSpy).not.toHaveBeenCalled();
+
+    // Changing an unrelated state does NOT re-run the effect
+    await wrapper.find('#inc-other').trigger('click');
+    expect(effectSpy).toHaveBeenCalledTimes(1);
+
+    // Changing the tracked dep re-runs the effect (after cleanup)
+    await wrapper.find('#inc-count').trigger('click');
+    expect(cleanupSpy).toHaveBeenCalledTimes(1);
+    expect(effectSpy).toHaveBeenCalledTimes(2);
+    expect(effectSpy).toHaveBeenLastCalledWith(1);
+  });
+
+  it('useRef and useMemo persist values across renders', async () => {
+    const factorySpy = jest.fn((v) => ({ doubled: v * 2 }));
+
+    const Component = makeHookedComponent((hooks, h) => {
+      const [count, setCount] = hooks.useState(1);
+      const renderCountRef = hooks.useRef(0);
+      renderCountRef.current += 1;
+      const memoized = hooks.useMemo(() => factorySpy(count), [count]);
+
+      return h('div', {}, [
+        h('span', { attrs: { id: 'renders' } }, [`${renderCountRef.current}`]),
+        h('span', { attrs: { id: 'memo' } }, [`${memoized.doubled}`]),
+        h('button', {
+          attrs: { id: 'inc' },
+          on: { click: () => setCount((p) => p + 1) },
+        }),
+        h('button', {
+          attrs: { id: 'force' },
+          on: { click: () => setCount((p) => p) }, // no-op value: won't re-render
+        }),
+      ]);
+    });
+
+    const wrapper = mount(Component);
+    expect(wrapper.find('#renders').text()).toBe('1');
+    expect(wrapper.find('#memo').text()).toBe('2');
+    expect(factorySpy).toHaveBeenCalledTimes(1);
+
+    await wrapper.find('#inc').trigger('click');
+    expect(wrapper.find('#renders').text()).toBe('2');
+    expect(wrapper.find('#memo').text()).toBe('4');
+    // memo recomputed because dep changed
+    expect(factorySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleanup runs on unmount', async () => {
+    const cleanupSpy = jest.fn();
+
+    const Component = makeHookedComponent((hooks, h) => {
+      hooks.useEffect(() => cleanupSpy, []);
+      return h('div', {}, ['x']);
+    });
+
+    const wrapper = mount(Component);
+    expect(cleanupSpy).not.toHaveBeenCalled();
+
+    wrapper.destroy();
+    expect(cleanupSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/vue-instantsearch/src/util/hooks.js
+++ b/packages/vue-instantsearch/src/util/hooks.js
@@ -1,0 +1,150 @@
+/**
+ * A minimal React/Preact-style hooks runtime that a Vue component drives
+ * through its own render cycle.
+ *
+ * The shared `instantsearch-ui-components` factories (e.g.
+ * `createAutocompletePropGetters`) are written against a React-style `Hooks`
+ * contract (`useState`, `useEffect`, `useRef`, `useMemo`, `useCallback`,
+ * `useId`). React and Preact satisfy it natively; Vue does not. This store
+ * reimplements the pieces those factories rely on so a Vue component can
+ * consume the shared logic instead of reimplementing it.
+ *
+ * Usage from a Vue component:
+ *
+ *   created() {
+ *     this.hooksStore = createHooksStore(() => this.$forceUpdate());
+ *   },
+ *   render(h) {
+ *     this.hooksStore.beginRender();
+ *     const result = usePropGetters(...);   // calls the hooks
+ *     this.hooksStore.endRender();
+ *     return renderTree(result);
+ *   },
+ *   mounted() { this.hooksStore.flushEffects(); },
+ *   updated() { this.hooksStore.flushEffects(); },
+ *   beforeDestroy() { this.hooksStore.cleanup(); }
+ *
+ * PROOF-OF-CONCEPT: this validates whether Vue can drive React-style hooks.
+ * It intentionally does not (yet) cover `useLayoutEffect` or `memo`.
+ */
+export function createHooksStore(scheduleRender) {
+  // One cell per hook call site, keyed by call order within a render pass.
+  const cells = [];
+  let cursor = 0;
+  let idCounter = 0;
+  // Effects whose deps changed during the current render, flushed post-commit.
+  let pendingEffects = [];
+
+  function beginRender() {
+    cursor = 0;
+    pendingEffects = [];
+  }
+
+  function endRender() {
+    // no-op for now; kept for symmetry and future hook-order validation
+  }
+
+  function flushEffects() {
+    const effects = pendingEffects;
+    pendingEffects = [];
+    effects.forEach((cell) => {
+      if (typeof cell.cleanup === 'function') {
+        cell.cleanup();
+      }
+      const cleanup = cell.effect();
+      cell.cleanup = typeof cleanup === 'function' ? cleanup : undefined;
+    });
+  }
+
+  function cleanup() {
+    cells.forEach((cell) => {
+      if (cell && typeof cell.cleanup === 'function') {
+        cell.cleanup();
+      }
+    });
+  }
+
+  const useState = (initialState) => {
+    const index = cursor++;
+    if (cells[index] === undefined) {
+      cells[index] = {
+        value:
+          typeof initialState === 'function' ? initialState() : initialState,
+      };
+    }
+    const cell = cells[index];
+    const setState = (next) => {
+      const nextValue = typeof next === 'function' ? next(cell.value) : next;
+      if (Object.is(nextValue, cell.value)) {
+        return;
+      }
+      cell.value = nextValue;
+      scheduleRender();
+    };
+    return [cell.value, setState];
+  };
+
+  const useRef = (initialValue) => {
+    const index = cursor++;
+    if (cells[index] === undefined) {
+      cells[index] = { value: { current: initialValue } };
+    }
+    return cells[index].value;
+  };
+
+  const useMemo = (factory, deps) => {
+    const index = cursor++;
+    const cell = cells[index];
+    if (cell === undefined || !areDepsEqual(cell.deps, deps)) {
+      cells[index] = { value: factory(), deps };
+    }
+    return cells[index].value;
+  };
+
+  const useCallback = (callback, deps) => useMemo(() => callback, deps);
+
+  const useId = () => {
+    const index = cursor++;
+    if (cells[index] === undefined) {
+      cells[index] = { value: `aisVueHook${(idCounter++).toString(36)}` };
+    }
+    return cells[index].value;
+  };
+
+  const useEffect = (effect, deps) => {
+    const index = cursor++;
+    const cell = cells[index];
+    if (cell === undefined) {
+      const created = { effect, deps, cleanup: undefined };
+      cells[index] = created;
+      pendingEffects.push(created);
+    } else if (deps === undefined || !areDepsEqual(cell.deps, deps)) {
+      cell.effect = effect;
+      cell.deps = deps;
+      pendingEffects.push(cell);
+    }
+  };
+
+  return {
+    hooks: { useState, useEffect, useRef, useMemo, useCallback, useId },
+    beginRender,
+    endRender,
+    flushEffects,
+    cleanup,
+  };
+}
+
+function areDepsEqual(prevDeps, nextDeps) {
+  if (prevDeps === undefined || nextDeps === undefined) {
+    return false;
+  }
+  if (prevDeps.length !== nextDeps.length) {
+    return false;
+  }
+  for (let i = 0; i < prevDeps.length; i++) {
+    if (!Object.is(prevDeps[i], nextDeps[i])) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
@@ -51,6 +51,118 @@ export function renderCompat(fn) {
   };
 }
 
+/**
+ * A Fragment for the React-style renderer: a plain function component that
+ * returns its children. Vue 2 has no native Fragment, but shared
+ * `instantsearch-ui-components` factories only use it to group children.
+ */
+export const Fragment = (props) => (props && props.children) || [];
+
+/**
+ * A `createElement` that understands the React-style markup emitted by
+ * `instantsearch-ui-components` factories (`className`, `onClick`/`onKeyDown`
+ * handlers, and `ref` as a MutableRef `{ current }`), mapping them onto Vue 2's
+ * `h`. This is what lets Vue consume shared, hook-driven components (Carousel,
+ * Autocomplete, …) rather than reimplementing their markup.
+ */
+export function augmentReactCreateElement(createElement) {
+  return function reactCreateElement(tag, rawProps, ...rest) {
+    const props = rawProps || {};
+    const children = flattenChildren(rest);
+    const childArg = children.length > 0 ? children : undefined;
+
+    // Plain function components (shared sub-factories, Fragment) render eagerly.
+    if (typeof tag === 'function') {
+      return tag(
+        Object.assign({}, props, {
+          class: props.className || props.class,
+          children: childArg,
+        })
+      );
+    }
+
+    const data = { attrs: {}, on: {} };
+
+    Object.keys(props).forEach((name) => {
+      const value = props[name];
+
+      if (name === 'className') {
+        data.class = value;
+      } else if (name === 'class') {
+        data.class = data.class || value;
+      } else if (name === 'style') {
+        data.style = value;
+      } else if (name === 'key') {
+        data.key = value;
+      } else if (name === 'children') {
+        // handled via the children argument
+      } else if (name === 'ref') {
+        bindMutableRef(data, value);
+      } else if (isEventProp(name, value)) {
+        // onKeyDown -> keydown, onClick -> click, onFocus -> focus
+        data.on[name.slice(2).toLowerCase()] = value;
+      } else if (typeof value === 'boolean' && name.indexOf('aria-') === 0) {
+        // React renders `aria-expanded={false}` as "false"; Vue 2 drops falsy
+        // boolean attrs, so stringify to preserve the accessibility contract.
+        data.attrs[name] = String(value);
+      } else {
+        data.attrs[name] = value;
+      }
+    });
+
+    return createElement(tag, data, childArg);
+  };
+}
+
+/**
+ * Wraps a render function so it receives a React-style `createElement`, the way
+ * `renderCompat` provides the Vue-style one.
+ */
+export function renderReactCompat(fn) {
+  return function (createElement) {
+    return fn.call(this, augmentReactCreateElement(createElement));
+  };
+}
+
+function isEventProp(name, value) {
+  return (
+    typeof value === 'function' && name.length > 2 && /^on[A-Z]/.test(name)
+  );
+}
+
+function bindMutableRef(data, ref) {
+  if (!ref || typeof ref !== 'object' || !('current' in ref)) {
+    return;
+  }
+
+  // Vue 2 has no function refs, so populate the MutableRef via vnode lifecycle
+  // hooks. `vnode.elm` is the underlying DOM node.
+  data.hook = data.hook || {};
+  const previousInsert = data.hook.insert;
+  const previousDestroy = data.hook.destroy;
+
+  data.hook.insert = (vnode) => {
+    ref.current = vnode.elm;
+    if (previousInsert) previousInsert(vnode);
+  };
+  data.hook.destroy = (vnode) => {
+    ref.current = null;
+    if (previousDestroy) previousDestroy(vnode);
+  };
+}
+
+function flattenChildren(nodes) {
+  return nodes.reduce((acc, node) => {
+    if (Array.isArray(node)) {
+      return acc.concat(flattenChildren(node));
+    }
+    if (node !== undefined && node !== null && node !== false) {
+      acc.push(node);
+    }
+    return acc;
+  }, []);
+}
+
 export function getDefaultSlot(component) {
   return component.$slots.default;
 }

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
@@ -81,7 +81,7 @@ export function augmentReactCreateElement(createElement) {
       );
     }
 
-    const data = { attrs: {}, on: {} };
+    const data = { attrs: {}, domProps: {}, on: {} };
 
     Object.keys(props).forEach((name) => {
       const value = props[name];
@@ -101,6 +101,11 @@ export function augmentReactCreateElement(createElement) {
       } else if (isEventProp(name, value)) {
         // onKeyDown -> keydown, onClick -> click, onFocus -> focus
         data.on[name.slice(2).toLowerCase()] = value;
+      } else if (name === 'value' || name === 'checked') {
+        // Controlled form fields from shared TSX (e.g. `<input value={query} />`
+        // in AutocompleteSearch). In Vue 2, `attrs.value` sets only the initial
+        // attribute and won't stay in sync across rerenders — use `domProps`.
+        data.domProps[name] = value;
       } else if (typeof value === 'boolean' && name.indexOf('aria-') === 0) {
         // React renders `aria-expanded={false}` as "false"; Vue 2 drops falsy
         // boolean attrs, so stringify to preserve the accessibility contract.
@@ -125,8 +130,17 @@ export function renderReactCompat(fn) {
 }
 
 function isEventProp(name, value) {
+  if (typeof value !== 'function' || name.length < 3) {
+    return false;
+  }
+  // Matches `on` followed by an uppercase letter (e.g. onClick, onKeyDown)
+  // without a regex, to keep static analysers happy.
+  const thirdCharCode = name.charCodeAt(2);
   return (
-    typeof value === 'function' && name.length > 2 && /^on[A-Z]/.test(name)
+    name[0] === 'o' &&
+    name[1] === 'n' &&
+    thirdCharCode >= 65 &&
+    thirdCharCode <= 90
   );
 }
 

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
@@ -118,8 +118,17 @@ export function renderReactCompat(fn) {
 }
 
 function isEventProp(name, value) {
+  if (typeof value !== 'function' || name.length < 3) {
+    return false;
+  }
+  // Matches `on` followed by an uppercase letter (e.g. onClick, onKeyDown)
+  // without a regex, to keep static analysers happy.
+  const thirdCharCode = name.charCodeAt(2);
   return (
-    typeof value === 'function' && name.length > 2 && /^on[A-Z]/.test(name)
+    name[0] === 'o' &&
+    name[1] === 'n' &&
+    thirdCharCode >= 65 &&
+    thirdCharCode <= 90
   );
 }
 

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
@@ -7,6 +7,14 @@ const Vue2 = undefined;
 export { createApp, createSSRApp, h, version, nextTick } from 'vue';
 export { Vue, Vue2, isVue2, isVue3 };
 
+/**
+ * A Fragment for the React-style renderer: a plain function component that
+ * returns its children. Matches the Vue 2 implementation so shared markup
+ * serializes identically across versions — the real Vue 3 `Fragment` symbol
+ * introduces anchor/whitespace nodes that would break shared snapshots.
+ */
+export const Fragment = (props) => (props && props.children) || [];
+
 export function renderCompat(fn) {
   function h(tag, props, ...childrenArray) {
     const children = childrenArray.length > 0 ? childrenArray : undefined;
@@ -50,6 +58,90 @@ export function renderCompat(fn) {
   return function () {
     return fn.call(this, h);
   };
+}
+
+/**
+ * A `createElement` that understands the React-style markup emitted by
+ * `instantsearch-ui-components` factories (`className`, `onClick`/`onKeyDown`
+ * handlers, and `ref` as a MutableRef `{ current }`), mapping them onto Vue 3's
+ * `h`. Mirrors the Vue 2 implementation in `index-vue2.js`.
+ */
+export function augmentReactCreateElement(baseH) {
+  return function reactCreateElement(tag, rawProps, ...rest) {
+    const props = rawProps || {};
+    const children = flattenChildren(rest);
+    const childArg = children.length > 0 ? children : undefined;
+
+    // Plain function components (shared sub-factories, Fragment) render eagerly.
+    if (typeof tag === 'function') {
+      return tag(
+        Object.assign({}, props, {
+          class: props.className || props.class,
+          children: childArg,
+        })
+      );
+    }
+
+    const data = {};
+
+    Object.keys(props).forEach((name) => {
+      const value = props[name];
+
+      if (name === 'className') {
+        data.class = value;
+      } else if (name === 'children') {
+        // handled via the children argument
+      } else if (name === 'ref') {
+        const functionRef = makeFunctionRef(value);
+        if (functionRef) {
+          data.ref = functionRef;
+        }
+      } else if (isEventProp(name, value)) {
+        // React `onKeyDown` -> Vue 3 `onKeydown` (compiler-style handler key)
+        const eventName = name.slice(2).toLowerCase();
+        data[`on${eventName[0].toUpperCase()}${eventName.slice(1)}`] = value;
+      } else if (typeof value === 'boolean' && name.indexOf('aria-') === 0) {
+        data[name] = String(value);
+      } else {
+        data[name] = value;
+      }
+    });
+
+    return baseH(tag, data, childArg);
+  };
+}
+
+export function renderReactCompat(fn) {
+  return function () {
+    return fn.call(this, augmentReactCreateElement(Vue.h));
+  };
+}
+
+function isEventProp(name, value) {
+  return (
+    typeof value === 'function' && name.length > 2 && /^on[A-Z]/.test(name)
+  );
+}
+
+function makeFunctionRef(ref) {
+  if (!ref || typeof ref !== 'object' || !('current' in ref)) {
+    return undefined;
+  }
+  return (element) => {
+    ref.current = element;
+  };
+}
+
+function flattenChildren(nodes) {
+  return nodes.reduce((acc, node) => {
+    if (Array.isArray(node)) {
+      return acc.concat(flattenChildren(node));
+    }
+    if (node !== undefined && node !== null && node !== false) {
+      acc.push(node);
+    }
+    return acc;
+  }, []);
 }
 
 export function getDefaultSlot(component) {

--- a/packages/vue-instantsearch/src/widgets.js
+++ b/packages/vue-instantsearch/src/widgets.js
@@ -22,6 +22,7 @@ export { default as AisQueryRuleContext } from './components/QueryRuleContext';
 export { default as AisQueryRuleCustomData } from './components/QueryRuleCustomData.vue';
 export { default as AisRangeInput } from './components/RangeInput.vue';
 export { default as AisRatingMenu } from './components/RatingMenu.vue';
+export { default as AisRelatedProducts } from './components/RelatedProducts';
 export { default as AisRefinementList } from './components/RefinementList.vue';
 export { default as AisStateResults } from './components/StateResults.vue';
 export { default as AisSearchBox } from './components/SearchBox.vue';


### PR DESCRIPTION
## What & why

This is a **pilot** that ports the **RelatedProducts** widget to `vue-instantsearch` and, in doing so, builds the shared `vue-compat` infrastructure required to consume **hook-driven** `instantsearch-ui-components` factories from Vue.

Motivation: the graduated **Autocomplete** widget (and Chat) don't live in Vue because their interaction logic is a React/Preact-hooks controller (`createAutocompletePropGetters`) that Vue can't consume natively — Vue has only ever consumed *stateless* shared markup. Rather than validate that on the 1,400-line Autocomplete directly, this proves the approach on the smallest shared component that needs the same three pieces (hooks runtime + event forwarding + ref forwarding): the **Carousel** layout used by the recommend widgets (which are all currently missing from Vue).

## What's in here

**Shared infra** (`src/util/hooks.js`, `src/util/vue-compat/`):
- `createHooksStore` — a React-style hooks runtime (`useState`/`useEffect`/`useRef`/`useMemo`/`useCallback`/`useId`) driven by a Vue component's render cycle via `$forceUpdate`.
- `augmentReactCreateElement` + `renderReactCompat` — a `createElement` mapping React-style props (`className`, `onClick`/`onKeyDown`, `ref={mutableRef}`) onto Vue's `h`, for **Vue 2** (vnode `insert`/`destroy` hooks) and **Vue 3** (function refs).
- A plain-function `Fragment` shared by both versions.

**Widgets:**
- `AisRelatedProducts` — wraps `connectRelatedProducts`, renders the shared UI component. Default list layout passes the existing common suite; opt-in `layout="carousel"`.
- `AisCarousel` (internal) — renders the shared Carousel with its **own** hooks store (per-component hook context, safe for conditional mounting).

**Docs:** a `vue-instantsearch/CLAUDE.md` section documenting how to consume hook-based shared components.

## Test plan

- `RelatedProducts` common suite unskipped and passing (Vue 2 **and** Vue 3).
- New tests: `hooks.test.js` (runtime), `autocompletePropGetters.poc.test.js` (drives the **real** Autocomplete controller through the infra as forward-looking regression coverage), `RelatedProducts.js` (list + carousel; the carousel test exercises `useState` + refs + events together).
- Full `vue-instantsearch` suite green on both Vue versions; oxlint + prettier clean.

## Notes / open questions for review

- `AisCarousel` is intentionally **not** exported as a public `Ais*` widget (it's an internal layout, like the React `components/Carousel`). Happy to expose it if preferred.
- `autocompletePropGetters.poc.test.js` is kept as infra-validation coverage — it proves the shared Autocomplete controller runs under Vue. Can be removed if it reads as premature.
- Next step (separate PR): the full Autocomplete port, which reuses this infra.

Draft: opening early to align on the infra approach before the Autocomplete port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)