### PR TITLE
feat(frequentlyBoughtTogether): add FrequentlyBoughtTogether to Vue

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -26,19 +26,19 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "75 kB"
+      "maxSize": "76 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "75.5 kB"
+      "maxSize": "76 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",
-      "maxSize": "21 kB"
+      "maxSize": "21.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/cjs/index.js",
-      "maxSize": "21.75 kB"
+      "maxSize": "22 kB"
     },
     {
       "path": "./packages/instantsearch.css/themes/algolia.css",

--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -30,6 +30,7 @@ import {
   AisMenuSelect,
   AisDynamicWidgets,
   AisRelatedProducts,
+  AisFrequentlyBoughtTogether,
 } from '../instantsearch';
 import { renderCompat } from '../util/vue-compat';
 
@@ -531,10 +532,23 @@ const testSetups = {
 
     await nextTick();
   },
-  createFrequentlyBoughtTogetherWidgetTests() {
-    throw new Error(
-      'FrequentlyBoughtTogether is not supported in Vue InstantSearch'
+  async createFrequentlyBoughtTogetherWidgetTests({
+    instantSearchOptions,
+    widgetParams,
+  }) {
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            h(AisFrequentlyBoughtTogether, { props: widgetParams }),
+            h(GlobalErrorSwallower),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
     );
+
+    await nextTick();
   },
   createTrendingItemsWidgetTests() {
     throw new Error('TrendingItems is not supported in Vue InstantSearch');
@@ -647,9 +661,7 @@ const testOptions = {
   createSortByWidgetTests: undefined,
   createStatsWidgetTests: undefined,
   createRelatedProductsWidgetTests: undefined,
-  createFrequentlyBoughtTogetherWidgetTests: {
-    skippedTests: { 'FrequentlyBoughtTogether widget common tests': true },
-  },
+  createFrequentlyBoughtTogetherWidgetTests: undefined,
   createTrendingItemsWidgetTests: {
     skippedTests: { 'TrendingItems widget common tests': true },
   },

--- a/packages/vue-instantsearch/src/__tests__/index.js
+++ b/packages/vue-instantsearch/src/__tests__/index.js
@@ -80,7 +80,10 @@ function getAllComponents() {
         props.indexName = 'indexName';
       } else if (name === 'AisFeeds') {
         props.isolated = false;
-      } else if (name === 'AisRelatedProducts') {
+      } else if (
+        name === 'AisRelatedProducts' ||
+        name === 'AisFrequentlyBoughtTogether'
+      ) {
         props.objectIDs = ['1'];
       } else {
         props.attribute = 'attr';

--- a/packages/vue-instantsearch/src/components/FrequentlyBoughtTogether.js
+++ b/packages/vue-instantsearch/src/components/FrequentlyBoughtTogether.js
@@ -1,0 +1,105 @@
+import { createFrequentlyBoughtTogetherComponent } from 'instantsearch-ui-components';
+import { connectFrequentlyBoughtTogether } from 'instantsearch.js/es/connectors/index';
+
+import { createSuitMixin } from '../mixins/suit';
+import { createWidgetMixin } from '../mixins/widget';
+import { Fragment, renderReactCompat } from '../util/vue-compat';
+
+import AisCarousel from './Carousel';
+
+function mapClassNames(classNames) {
+  if (!classNames) {
+    return undefined;
+  }
+  return {
+    root: classNames['ais-FrequentlyBoughtTogether'],
+    emptyRoot: classNames['ais-FrequentlyBoughtTogether--empty'],
+    title: classNames['ais-FrequentlyBoughtTogether-title'],
+    container: classNames['ais-FrequentlyBoughtTogether-container'],
+    list: classNames['ais-FrequentlyBoughtTogether-list'],
+    item: classNames['ais-FrequentlyBoughtTogether-item'],
+  };
+}
+
+export default {
+  name: 'AisFrequentlyBoughtTogether',
+  mixins: [
+    createWidgetMixin(
+      { connector: connectFrequentlyBoughtTogether },
+      { $$widgetType: 'ais.frequentlyBoughtTogether' }
+    ),
+    createSuitMixin({ name: 'FrequentlyBoughtTogether' }),
+  ],
+  props: {
+    objectIDs: {
+      type: Array,
+      required: true,
+    },
+    limit: {
+      type: Number,
+      required: false,
+      default: undefined,
+    },
+    threshold: {
+      type: Number,
+      required: false,
+      default: undefined,
+    },
+    fallbackParameters: {
+      type: Object,
+      required: false,
+      default: undefined,
+    },
+    queryParameters: {
+      type: Object,
+      required: false,
+      default: undefined,
+    },
+    escapeHTML: {
+      type: Boolean,
+      required: false,
+      default: undefined,
+    },
+    transformItems: {
+      type: Function,
+      required: false,
+      default: undefined,
+    },
+    layout: {
+      type: String,
+      required: false,
+      default: 'list',
+      validator: (value) => ['list', 'carousel'].indexOf(value) !== -1,
+    },
+  },
+  computed: {
+    widgetParams() {
+      return {
+        objectIDs: this.objectIDs,
+        limit: this.limit,
+        threshold: this.threshold,
+        fallbackParameters: this.fallbackParameters,
+        queryParameters: this.queryParameters,
+        escapeHTML: this.escapeHTML,
+        transformItems: this.transformItems,
+      };
+    },
+  },
+  render: renderReactCompat(function (h) {
+    const FrequentlyBoughtTogetherUiComponent =
+      createFrequentlyBoughtTogetherComponent({
+        createElement: h,
+        Fragment,
+      });
+
+    return h(FrequentlyBoughtTogetherUiComponent, {
+      items: this.state ? this.state.items : [],
+      status: this.instantSearchInstance.status,
+      sendEvent: this.state ? this.state.sendEvent : () => {},
+      classNames: mapClassNames(this.classNames),
+      // A Vue child component (own hook context) rendered as the shared
+      // component's layout; `undefined` keeps the shared default list layout.
+      layout: this.layout === 'carousel' ? AisCarousel : undefined,
+    });
+  }),
+};

--- a/packages/vue-instantsearch/src/components/__tests__/FrequentlyBoughtTogether.js
+++ b/packages/vue-instantsearch/src/components/__tests__/FrequentlyBoughtTogether.js
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createRecommendSearchClient } from '@instantsearch/mocks/fixtures';
+
+import { mount, nextTick } from '../../../test/utils';
+import FrequentlyBoughtTogether from '../FrequentlyBoughtTogether';
+import InstantSearch from '../InstantSearch';
+
+jest.unmock('instantsearch.js/es');
+
+const wait = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function mountFrequentlyBoughtTogether(props) {
+  return mount(
+    {
+      components: { InstantSearch, FrequentlyBoughtTogether },
+      data() {
+        return {
+          searchClient: createRecommendSearchClient(),
+          props,
+        };
+      },
+      template: `
+        <InstantSearch :search-client="searchClient" index-name="indexName">
+          <FrequentlyBoughtTogether v-bind="props" />
+        </InstantSearch>
+      `,
+    },
+    { attachTo: document.body }
+  );
+}
+
+describe('AisFrequentlyBoughtTogether', () => {
+  it('renders the default list layout', async () => {
+    const wrapper = mountFrequentlyBoughtTogether({ objectIDs: ['1'] });
+
+    await wait(0);
+    await nextTick();
+
+    expect(wrapper.find('.ais-FrequentlyBoughtTogether').exists()).toBe(true);
+    expect(wrapper.find('.ais-FrequentlyBoughtTogether-title').text()).toBe(
+      'Frequently bought together'
+    );
+    expect(
+      wrapper.findAll('.ais-FrequentlyBoughtTogether-item').length
+    ).toBeGreaterThan(0);
+    expect(wrapper.find('.ais-Carousel').exists()).toBe(false);
+  });
+
+  it('renders the shared Carousel layout (reuses the hook-based infra)', async () => {
+    const wrapper = mountFrequentlyBoughtTogether({
+      objectIDs: ['1'],
+      layout: 'carousel',
+    });
+
+    await wait(0);
+    await nextTick();
+
+    expect(wrapper.find('.ais-Carousel').exists()).toBe(true);
+    expect(wrapper.findAll('.ais-Carousel-item').length).toBeGreaterThan(0);
+    // Navigation state is driven by the hooks runtime; previous starts hidden.
+    expect(
+      wrapper.find('.ais-Carousel-navigation--previous').element.hidden
+    ).toBe(true);
+  });
+});

--- a/packages/vue-instantsearch/src/widgets.js
+++ b/packages/vue-instantsearch/src/widgets.js
@@ -23,6 +23,7 @@ export { default as AisQueryRuleCustomData } from './components/QueryRuleCustomD
 export { default as AisRangeInput } from './components/RangeInput.vue';
 export { default as AisRatingMenu } from './components/RatingMenu.vue';
 export { default as AisRelatedProducts } from './components/RelatedProducts';
+export { default as AisFrequentlyBoughtTogether } from './components/FrequentlyBoughtTogether';
 export { default as AisRefinementList } from './components/RefinementList.vue';
 export { default as AisStateResults } from './components/StateResults.vue';
 export { default as AisSearchBox } from './components/SearchBox.vue';


### PR DESCRIPTION
**Stacked on #7127** (base = `feat/vue-related-products`) — review/merge that one first.

## What

Ports the **FrequentlyBoughtTogether** recommend widget to `vue-instantsearch`, reusing the hook-based UI infrastructure + Carousel layout introduced in #7127. It's a near-mirror of `AisRelatedProducts`, which validates that the shared infra generalizes cleanly to a second recommend widget.

- `AisFrequentlyBoughtTogether` wraps `connectFrequentlyBoughtTogether`, renders the shared UI component. Default list layout passes the common suite; opt-in `layout="carousel"`.
- Enables the FrequentlyBoughtTogether common suite for Vue; adds component-level tests (list + carousel).

## Test plan

- FrequentlyBoughtTogether common suite unskipped and passing (Vue 2 + Vue 3).
- New component tests (list + carousel).
- Full `vue-instantsearch` suite green; oxlint + prettier clean.

## Notes

- Only new code here is the widget + its tests + registration — no infra changes (all in #7127).
- Remaining recommend widgets (LookingSimilar, TrendingItems, TrendingFacets) can follow the same pattern in subsequent PRs.

Draft, stacked on the infra PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)