### PR TITLE
feat(chat): add Chat + ChatTrigger widgets to Vue (phase 1)

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -26,19 +26,19 @@
     },
     {
       "path": "packages/vue-instantsearch/vue2/umd/index.js",
-      "maxSize": "75 kB"
+      "maxSize": "106 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/umd/index.js",
-      "maxSize": "75.5 kB"
+      "maxSize": "106 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue2/cjs/index.js",
-      "maxSize": "21 kB"
+      "maxSize": "23.5 kB"
     },
     {
       "path": "packages/vue-instantsearch/vue3/cjs/index.js",
-      "maxSize": "21.75 kB"
+      "maxSize": "24 kB"
     },
     {
       "path": "./packages/instantsearch.css/themes/algolia.css",

--- a/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
+++ b/packages/vue-instantsearch/src/__tests__/common-widgets.test.js
@@ -30,6 +30,8 @@ import {
   AisMenuSelect,
   AisDynamicWidgets,
   AisRelatedProducts,
+  AisChat,
+  AisChatTrigger,
 } from '../instantsearch';
 import { renderCompat } from '../util/vue-compat';
 
@@ -603,8 +605,49 @@ const testSetups = {
       document.body.appendChild(document.createElement('div'))
     );
   },
-  createChatWidgetTests() {
-    throw new Error('Chat is not supported in Vue InstantSearch');
+  async createChatWidgetTests({ instantSearchOptions, widgetParams }) {
+    const {
+      renderChat = true,
+      renderRefinements,
+      ...chatWidgetParams
+    } = widgetParams;
+
+    mountApp(
+      {
+        render: renderCompat((h) =>
+          h(AisInstantSearch, { props: instantSearchOptions }, [
+            renderRefinements && h(AisSearchBox, { key: 'searchbox' }),
+            renderRefinements &&
+              h(AisRefinementList, {
+                key: 'brand',
+                props: { attribute: 'brand' },
+              }),
+            renderRefinements &&
+              h(AisRefinementList, {
+                key: 'category',
+                props: { attribute: 'category' },
+              }),
+            renderRefinements &&
+              h(AisHierarchicalMenu, {
+                key: 'hierarchy',
+                props: {
+                  attributes: [
+                    'hierarchicalCategories.lvl0',
+                    'hierarchicalCategories.lvl1',
+                    'hierarchicalCategories.lvl2',
+                  ],
+                },
+              }),
+            h(AisChatTrigger, { key: 'trigger' }),
+            renderChat && h(AisChat, { key: 'chat', props: chatWidgetParams }),
+            h(GlobalErrorSwallower, { key: 'errors' }),
+          ])
+        ),
+      },
+      document.body.appendChild(document.createElement('div'))
+    );
+
+    await nextTick();
   },
   createAutocompleteWidgetTests() {
     throw new Error('Autocomplete is not supported in Vue InstantSearch');
@@ -661,6 +704,12 @@ const testOptions = {
   },
   createPoweredByWidgetTests: undefined,
   createDynamicWidgetsWidgetTests: undefined,
+  // The AisChat/AisChatTrigger widgets are implemented and covered by
+  // component tests. The shared common suite stays skipped until its `vue`
+  // widgetParams variant is extended to carry a `chat` instance + options
+  // (it's currently `Record<string, never>`, and the tests drive a
+  // test-owned `chat` that only reaches the JS/React widgets). Tracked as a
+  // follow-up.
   createChatWidgetTests: {
     skippedTests: { 'Chat widget common tests': true },
   },

--- a/packages/vue-instantsearch/src/__tests__/index.js
+++ b/packages/vue-instantsearch/src/__tests__/index.js
@@ -46,7 +46,7 @@ function getAllComponents() {
 
     try {
       suitClass = mixins
-        .find(mixin => mixin.methods && mixin.methods.suit)
+        .find((mixin) => mixin.methods && mixin.methods.suit)
         .methods.suit();
     } catch (e) {
       /* no suit class, so will fail the assertions */
@@ -82,12 +82,19 @@ function getAllComponents() {
         props.isolated = false;
       } else if (name === 'AisRelatedProducts') {
         props.objectIDs = ['1'];
+      } else if (name === 'AisChat') {
+        // A transport avoids the agentId appId/apiKey requirement; the trigger
+        // validation is disabled since no ChatTrigger is mounted here.
+        props.transport = {};
+        props.disableTriggerValidation = true;
+      } else if (name === 'AisChatTrigger') {
+        // no required props
       } else {
         props.attribute = 'attr';
       }
 
       const Component = {
-        render: renderCompat(h =>
+        render: renderCompat((h) =>
           h(
             AisInstantSearch,
             {
@@ -149,6 +156,9 @@ describe('DOM component', () => {
         expect(suitClass).toBe(`ais-InstantSearch`);
       } else if (name === 'AisExperimentalDynamicWidgets') {
         expect(suitClass).toBe(`ais-DynamicWidgets`);
+      } else if (name === 'AisChatTrigger') {
+        // Renders the shared ChatToggleButton markup.
+        expect(suitClass).toBe(`ais-ChatToggleButton`);
       } else {
         expect(suitClass).toBe(`ais-${name.substr(3)}`);
       }

--- a/packages/vue-instantsearch/src/components/Carousel.js
+++ b/packages/vue-instantsearch/src/components/Carousel.js
@@ -46,6 +46,28 @@ export default {
       required: false,
       default: undefined,
     },
+    // Optional overrides used by the chat tools (custom header, no built-in
+    // navigation, custom scroll icons).
+    headerComponent: {
+      type: Function,
+      required: false,
+      default: undefined,
+    },
+    showNavigation: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    previousIconComponent: {
+      type: Function,
+      required: false,
+      default: undefined,
+    },
+    nextIconComponent: {
+      type: Function,
+      required: false,
+      default: undefined,
+    },
   },
   created() {
     this.hooksStore = createHooksStore(() => this.$forceUpdate());
@@ -81,6 +103,10 @@ export default {
       itemComponent: this.itemComponent,
       sendEvent: this.sendEvent,
       translations: this.translations,
+      headerComponent: this.headerComponent,
+      showNavigation: this.showNavigation,
+      previousIconComponent: this.previousIconComponent,
+      nextIconComponent: this.nextIconComponent,
       // The parent recommend widget forwards its own `list`/`item` classes.
       classNames: this.classNames && {
         list: this.classNames.list,

--- a/packages/vue-instantsearch/src/components/Chat.js
+++ b/packages/vue-instantsearch/src/components/Chat.js
@@ -1,0 +1,208 @@
+import {
+  createChatComponent,
+  createStickToBottom,
+} from 'instantsearch-ui-components';
+import { connectChat } from 'instantsearch.js/es/connectors/index';
+
+import { createSuitMixin } from '../mixins/suit';
+import { createWidgetMixin } from '../mixins/widget';
+import { createHooksStore } from '../util/hooks';
+import { Fragment, isVue3, renderReactCompat } from '../util/vue-compat';
+
+import { createDefaultTools } from './chat/tools';
+
+export default {
+  name: 'AisChat',
+  mixins: [
+    createWidgetMixin({ connector: connectChat }, { $$widgetType: 'ais.chat' }),
+    createSuitMixin({ name: 'Chat' }),
+  ],
+  props: {
+    // Transport (one of these is required by the connector)
+    agentId: { type: String, required: false, default: undefined },
+    transport: { type: Object, required: false, default: undefined },
+    chat: { type: Object, required: false, default: undefined },
+    // Connector options
+    tools: { type: Object, required: false, default: undefined },
+    initialMessages: { type: Array, required: false, default: undefined },
+    initialUserMessage: { type: String, required: false, default: undefined },
+    context: { type: [Object, Function], required: false, default: undefined },
+    persistence: { type: Boolean, required: false, default: undefined },
+    requiresSearch: { type: Boolean, required: false, default: undefined },
+    resume: { type: Boolean, required: false, default: undefined },
+    type: { type: String, required: false, default: undefined },
+    disableTriggerValidation: {
+      type: Boolean,
+      required: false,
+      default: undefined,
+    },
+    // Rendering
+    title: { type: String, required: false, default: undefined },
+    itemComponent: { type: Function, required: false, default: undefined },
+    getSearchPageURL: { type: Function, required: false, default: undefined },
+    layoutComponent: { type: Function, required: false, default: undefined },
+    classNames: { type: Object, required: false, default: undefined },
+    translations: { type: Object, required: false, default: undefined },
+  },
+  created() {
+    this.hooksStore = createHooksStore(() => this.$forceUpdate());
+    this.useStickToBottom = createStickToBottom(this.hooksStore.hooks);
+  },
+  mounted() {
+    this.hooksStore.flushEffects();
+  },
+  updated() {
+    this.hooksStore.flushEffects();
+  },
+  [isVue3 ? 'beforeUnmount' : 'beforeDestroy']() {
+    this.hooksStore.cleanup();
+  },
+  computed: {
+    widgetParams() {
+      const tools = Object.assign(
+        {},
+        createDefaultTools(this.itemComponent, this.getSearchPageURL),
+        this.tools
+      );
+
+      // Only include defined options; the connector requires exactly one of
+      // `chat` / `agentId` / `transport`.
+      const params = { tools };
+      const optional = {
+        agentId: this.agentId,
+        transport: this.transport,
+        chat: this.chat,
+        initialMessages: this.initialMessages,
+        initialUserMessage: this.initialUserMessage,
+        context: this.context,
+        persistence: this.persistence,
+        requiresSearch: this.requiresSearch,
+        resume: this.resume,
+        type: this.type,
+        disableTriggerValidation: this.disableTriggerValidation,
+      };
+      Object.keys(optional).forEach((key) => {
+        if (optional[key] !== undefined) {
+          params[key] = optional[key];
+        }
+      });
+      return params;
+    },
+  },
+  render: renderReactCompat(function (h) {
+    if (!this.state) {
+      return null;
+    }
+
+    const { useState, useRef, useEffect, memo } = this.hooksStore.hooks;
+
+    this.hooksStore.beginRender();
+
+    const ChatUiComponent = createChatComponent({
+      createElement: h,
+      Fragment,
+      memo,
+      useState,
+    });
+
+    const [maximized, setMaximized] = useState(false);
+    const promptRef = useRef(null);
+    const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
+      this.useStickToBottom({ initial: 'smooth', resize: 'smooth' });
+
+    const state = this.state;
+
+    // Focus the prompt when the chat transitions from closed to open.
+    useEffect(() => {
+      if (!this.wasOpen && state.open) {
+        window.requestAnimationFrame(() => {
+          if (promptRef.current) {
+            promptRef.current.focus();
+          }
+        });
+      }
+      this.wasOpen = state.open;
+    }, [state.open]);
+
+    // Keep pinned to the bottom while streaming (carousels grow horizontally
+    // without changing height, so re-pin on every message/status change).
+    useEffect(() => {
+      if (state.status === 'streaming' || state.status === 'submitted') {
+        scrollToBottom({ preserveScrollPosition: true });
+      }
+    }, [state.messages, state.status, scrollToBottom]);
+
+    const headerTranslations = this.translations && this.translations.header;
+    const promptTranslations = this.translations && this.translations.prompt;
+    const messageTranslations = this.translations && this.translations.message;
+    const messagesTranslations =
+      this.translations && this.translations.messages;
+
+    const tree = h(ChatUiComponent, {
+      title: this.title,
+      open: state.open,
+      maximized,
+      sendMessage: state.sendMessage,
+      regenerate: state.regenerate,
+      stop: state.stop,
+      error: state.error,
+      layoutComponent: this.layoutComponent,
+      classNames: this.classNames,
+      headerProps: {
+        onClose: () => state.setOpen(false),
+        maximized,
+        onToggleMaximize: () => setMaximized(!maximized),
+        onClear: state.clearMessages,
+        canClear: Boolean(state.messages && state.messages.length),
+        translations: headerTranslations,
+      },
+      messagesProps: {
+        status: state.status,
+        onReload: (messageId) => state.regenerate({ messageId }),
+        onNewConversation: state.clearMessages,
+        onClose: () => state.setOpen(false),
+        sendMessage: state.sendMessage,
+        setInput: state.setInput,
+        onFeedback: state.sendChatMessageFeedback,
+        feedbackState: state.feedbackState,
+        messages: state.messages,
+        tools: state.tools,
+        indexUiState: state.indexUiState,
+        setIndexUiState: state.setIndexUiState,
+        isScrollAtBottom: isAtBottom,
+        scrollRef,
+        contentRef,
+        onScrollToBottom: scrollToBottom,
+        translations: messagesTranslations,
+        messageTranslations,
+        error: state.error,
+      },
+      promptProps: {
+        promptRef,
+        status: state.status,
+        value: state.input,
+        translations: promptTranslations,
+        onInput: (event) => {
+          state.setInput(event.currentTarget.value);
+        },
+        onSubmit: () => {
+          state.sendMessage({ text: state.input });
+          state.setInput('');
+        },
+        onStop: () => {
+          state.stop();
+        },
+      },
+      suggestionsProps: {
+        suggestions: state.suggestions,
+        onSuggestionClick: (suggestion) => {
+          state.sendMessage({ text: suggestion });
+        },
+      },
+    });
+
+    this.hooksStore.endRender();
+
+    return tree;
+  }),
+};

--- a/packages/vue-instantsearch/src/components/ChatTrigger.js
+++ b/packages/vue-instantsearch/src/components/ChatTrigger.js
@@ -1,0 +1,52 @@
+import { createChatToggleButtonComponent } from 'instantsearch-ui-components';
+import { connectChatTrigger } from 'instantsearch.js/es/connectors/index';
+
+import { createSuitMixin } from '../mixins/suit';
+import { createWidgetMixin } from '../mixins/widget';
+import { Fragment, renderReactCompat } from '../util/vue-compat';
+
+export default {
+  name: 'AisChatTrigger',
+  mixins: [
+    createWidgetMixin(
+      { connector: connectChatTrigger },
+      { $$widgetType: 'ais.chatTrigger' }
+    ),
+    createSuitMixin({ name: 'ChatToggleButton' }),
+  ],
+  props: {
+    floating: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+  },
+  computed: {
+    widgetParams() {
+      return {};
+    },
+  },
+  render: renderReactCompat(function (h) {
+    if (!this.state) {
+      return null;
+    }
+
+    const ChatToggleButton = createChatToggleButtonComponent({
+      createElement: h,
+      Fragment,
+    });
+
+    const rootClassName = [
+      this.floating && 'ais-ChatToggleButton--floating',
+      this.classNames && this.classNames['ais-ChatToggleButton'],
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    return h(ChatToggleButton, {
+      open: this.state.open,
+      onClick: () => this.state.toggleOpen(),
+      classNames: rootClassName ? { root: rootClassName } : undefined,
+    });
+  }),
+};

--- a/packages/vue-instantsearch/src/components/ChatTrigger.js
+++ b/packages/vue-instantsearch/src/components/ChatTrigger.js
@@ -45,7 +45,8 @@ export default {
 
     return h(ChatToggleButton, {
       open: this.state.open,
-      onClick: () => this.state.toggleOpen(),
+      // `toggleOpen` is already bound by the connector; pass it directly.
+      onClick: this.state.toggleOpen,
       classNames: rootClassName ? { root: rootClassName } : undefined,
     });
   }),

--- a/packages/vue-instantsearch/src/components/__tests__/Chat.js
+++ b/packages/vue-instantsearch/src/components/__tests__/Chat.js
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+import { Chat } from 'instantsearch.js/es/lib/chat';
+
+import { mount, nextTick } from '../../../test/utils';
+import ChatComponent from '../Chat';
+import ChatTrigger from '../ChatTrigger';
+import InstantSearch from '../InstantSearch';
+
+jest.unmock('instantsearch.js/es');
+
+const wait = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let wrapper;
+
+afterEach(() => {
+  if (wrapper) {
+    wrapper.destroy();
+    wrapper = undefined;
+  }
+  document.body.innerHTML = '';
+  sessionStorage.clear();
+});
+
+function mountChat(chat, chatProps = {}) {
+  wrapper = mount(
+    {
+      components: { InstantSearch, ChatComponent, ChatTrigger },
+      data() {
+        return {
+          searchClient: createSearchClient(),
+          // `connectChat` requires an `agentId`/`transport` even when a `chat`
+          // instance is supplied (see makeChatInstance), matching the common
+          // tests' `createDefaultWidgetParams`. `requiresSearch: false` keeps
+          // these behavioral assertions independent of the main search.
+          chatProps: {
+            agentId: 'agentId',
+            requiresSearch: false,
+            chat,
+            ...chatProps,
+          },
+        };
+      },
+      template: `
+        <InstantSearch :search-client="searchClient" index-name="indexName">
+          <ChatTrigger />
+          <ChatComponent v-bind="chatProps" />
+        </InstantSearch>
+      `,
+    },
+    { attachTo: document.body }
+  );
+  return wrapper;
+}
+
+const textMessage = (text) => ({
+  id: 'm1',
+  role: 'assistant',
+  parts: [{ type: 'text', text }],
+});
+
+const carouselMessage = () => ({
+  id: 'm2',
+  role: 'assistant',
+  parts: [
+    {
+      type: 'tool-algolia_search_index',
+      toolCallId: 'tool-call-1',
+      state: 'output-available',
+      input: { query: 'products' },
+      output: {
+        hits: [
+          { objectID: '1', name: 'Product 1', __position: 1 },
+          { objectID: '2', name: 'Product 2', __position: 2 },
+          { objectID: '3', name: 'Product 3', __position: 3 },
+        ],
+        nbHits: 100,
+      },
+    },
+  ],
+});
+
+describe('AisChat', () => {
+  it('renders a trigger and opens the chat on click', async () => {
+    const chat = new Chat({});
+    mountChat(chat);
+
+    await wait(0);
+    await nextTick();
+
+    const toggle = document.querySelector('.ais-ChatToggleButton');
+    expect(toggle).not.toBeNull();
+    expect(document.querySelector('.ais-Chat-container--open')).toBeNull();
+
+    toggle.click();
+    await wait(0);
+    await nextTick();
+
+    expect(document.querySelector('.ais-Chat')).not.toBeNull();
+    expect(document.querySelector('.ais-ChatPrompt-textarea')).not.toBeNull();
+    expect(document.querySelector('.ais-Chat-container--open')).not.toBeNull();
+  });
+
+  it('submits the prompt via the connector sendMessage', async () => {
+    const chat = new Chat({});
+    const sendMessage = jest
+      .spyOn(chat, 'sendMessage')
+      .mockImplementation(() => Promise.resolve());
+
+    mountChat(chat);
+    await wait(0);
+    await nextTick();
+    document.querySelector('.ais-ChatToggleButton').click();
+    await wait(0);
+    await nextTick();
+
+    const textarea = document.querySelector('.ais-ChatPrompt-textarea');
+    textarea.value = 'hello';
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    await nextTick();
+
+    document.querySelector('.ais-ChatPrompt-submit').click();
+    await wait(0);
+    await nextTick();
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'hello' })
+    );
+  });
+
+  it('renders a pre-seeded assistant message', async () => {
+    const chat = new Chat({ messages: [textMessage('Hello from Algolia')] });
+    mountChat(chat);
+
+    await wait(0);
+    await nextTick();
+    document.querySelector('.ais-ChatToggleButton').click();
+    await wait(0);
+    await nextTick();
+
+    expect(
+      document.querySelectorAll('.ais-ChatMessage').length
+    ).toBeGreaterThan(0);
+    expect(document.querySelector('.ais-ChatMessages').textContent).toContain(
+      'Hello from Algolia'
+    );
+  });
+
+  it('renders a search-tool carousel (reuses AisCarousel)', async () => {
+    const chat = new Chat({ messages: [carouselMessage()] });
+    mountChat(chat);
+
+    await wait(0);
+    await nextTick();
+    document.querySelector('.ais-ChatToggleButton').click();
+    await wait(0);
+    await nextTick();
+
+    expect(document.querySelector('.ais-Carousel')).not.toBeNull();
+    expect(
+      document.querySelectorAll('.ais-Carousel-item').length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/vue-instantsearch/src/components/chat/tools/DisplayResultsTool.js
+++ b/packages/vue-instantsearch/src/components/chat/tools/DisplayResultsTool.js
@@ -1,0 +1,116 @@
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  createButtonComponent,
+  createDisplayResultsToolComponent,
+} from 'instantsearch-ui-components';
+
+import { Fragment, renderReactCompat } from '../../../util/vue-compat';
+import AisCarousel from '../../Carousel';
+
+// A non-memoizing `useMemo`: recomputes every render. The shared
+// DisplayResults component only uses `useMemo` to hydrate hits by objectID
+// (a perf optimization), so recomputing is functionally correct.
+const passthroughUseMemo = (factory) => factory();
+
+/**
+ * Vue equivalent of react-instantsearch's chat DisplayResultsTool: renders the
+ * shared DisplayResults component, feeding it `AisCarousel` per result group.
+ */
+export function createDisplayResultsTool(itemComponent) {
+  const layoutComponent = {
+    name: 'AisChatDisplayResultsTool',
+    props: {
+      message: { type: Object, default: undefined },
+      indexUiState: { type: Object, default: undefined },
+      setIndexUiState: { type: Function, default: undefined },
+      messages: { type: Array, default: undefined },
+      addToolResult: { type: Function, default: undefined },
+      applyFilters: { type: Function, default: undefined },
+      sendEvent: { type: Function, default: () => {} },
+      onClose: { type: Function, default: () => {} },
+    },
+    render: renderReactCompat(function (h) {
+      const DisplayResultsUiComponent = createDisplayResultsToolComponent({
+        createElement: h,
+        Fragment,
+        useMemo: passthroughUseMemo,
+      });
+      const Button = createButtonComponent({ createElement: h });
+
+      const toolProps = {
+        message: this.message,
+        indexUiState: this.indexUiState,
+        setIndexUiState: this.setIndexUiState,
+        messages: this.messages,
+        addToolResult: this.addToolResult,
+        applyFilters: this.applyFilters,
+        sendEvent: this.sendEvent,
+        onClose: this.onClose,
+      };
+
+      const groupCarouselComponent = ({ items, sendEvent }) =>
+        h(AisCarousel, {
+          items,
+          itemComponent,
+          sendEvent,
+          showNavigation: false,
+          headerComponent: ({
+            canScrollLeft,
+            canScrollRight,
+            scrollLeft,
+            scrollRight,
+          }) =>
+            h(
+              'div',
+              { className: 'ais-ChatToolDisplayResultsCarouselHeader' },
+              h(
+                'div',
+                { className: 'ais-ChatToolDisplayResultsCarouselHeaderCount' },
+                `${items.length} result${items.length > 1 ? 's' : ''}`
+              ),
+              h(
+                'div',
+                {
+                  className:
+                    'ais-ChatToolDisplayResultsCarouselHeaderScrollButtons',
+                },
+                h(
+                  Button,
+                  {
+                    variant: 'outline',
+                    size: 'sm',
+                    iconOnly: true,
+                    onClick: scrollLeft,
+                    disabled: !canScrollLeft,
+                    className:
+                      'ais-ChatToolDisplayResultsCarouselHeaderScrollButton',
+                  },
+                  h(ChevronLeftIcon, { createElement: h })
+                ),
+                h(
+                  Button,
+                  {
+                    variant: 'outline',
+                    size: 'sm',
+                    iconOnly: true,
+                    onClick: scrollRight,
+                    disabled: !canScrollRight,
+                    className:
+                      'ais-ChatToolDisplayResultsCarouselHeaderScrollButton',
+                  },
+                  h(ChevronRightIcon, { createElement: h })
+                )
+              )
+            ),
+        });
+
+      return h(DisplayResultsUiComponent, {
+        toolProps,
+        groupCarouselComponent,
+      });
+    }),
+  };
+
+  return { layoutComponent };
+}

--- a/packages/vue-instantsearch/src/components/chat/tools/SearchIndexTool.js
+++ b/packages/vue-instantsearch/src/components/chat/tools/SearchIndexTool.js
@@ -86,12 +86,14 @@ export function createCarouselTool(
                       facetFilters: getFacetFiltersFromToolInput(input),
                     });
 
+                    const searchPageURL =
+                      getSearchPageURL && getSearchPageURL(params);
                     if (
-                      getSearchPageURL &&
-                      new URL(getSearchPageURL(params)).pathname !==
+                      searchPageURL &&
+                      new URL(searchPageURL).pathname !==
                         window.location.pathname
                     ) {
-                      window.location.href = getSearchPageURL(params);
+                      window.location.href = searchPageURL;
                     }
 
                     onClose();

--- a/packages/vue-instantsearch/src/components/chat/tools/SearchIndexTool.js
+++ b/packages/vue-instantsearch/src/components/chat/tools/SearchIndexTool.js
@@ -1,0 +1,151 @@
+import {
+  ArrowRightIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  createButtonComponent,
+  getFacetFiltersFromToolInput,
+} from 'instantsearch-ui-components';
+import { addAbsolutePosition, addQueryID } from 'instantsearch.js/es/lib/utils';
+
+import { renderReactCompat } from '../../../util/vue-compat';
+import AisCarousel from '../../Carousel';
+
+/**
+ * Vue equivalent of react-instantsearch's chat SearchIndexTool: a tool
+ * `layoutComponent` that renders the search/recommend results in the shared
+ * Carousel (reusing `AisCarousel`) with a custom header (result count, an
+ * optional "View all" button, and scroll buttons).
+ */
+export function createCarouselTool(
+  showViewAll,
+  itemComponent,
+  getSearchPageURL
+) {
+  const layoutComponent = {
+    name: 'AisChatSearchIndexTool',
+    props: {
+      message: { type: Object, default: undefined },
+      applyFilters: { type: Function, default: undefined },
+      onClose: { type: Function, default: () => {} },
+      sendEvent: { type: Function, default: () => {} },
+    },
+    render: renderReactCompat(function (h) {
+      const Button = createButtonComponent({ createElement: h });
+
+      const input = this.message && this.message.input;
+      const output = (this.message && this.message.output) || {};
+      const hits = output.hits || [];
+
+      const hitsWithAbsolutePosition = addAbsolutePosition(
+        hits,
+        0,
+        (input && input.number_of_results) || hits.length || 5
+      );
+      const items = addQueryID(hitsWithAbsolutePosition, output.queryID);
+
+      const { applyFilters, onClose, sendEvent } = this;
+
+      const headerComponent = ({
+        canScrollLeft,
+        canScrollRight,
+        scrollLeft,
+        scrollRight,
+      }) => {
+        const hitsPerPage = items.length;
+        if (hitsPerPage < 1) {
+          return null;
+        }
+
+        return h(
+          'div',
+          { className: 'ais-ChatToolSearchIndexCarouselHeader' },
+          h(
+            'div',
+            { className: 'ais-ChatToolSearchIndexCarouselHeaderResults' },
+            output.nbHits &&
+              h(
+                'div',
+                { className: 'ais-ChatToolSearchIndexCarouselHeaderCount' },
+                `${hitsPerPage} of ${output.nbHits.toLocaleString()} result${
+                  output.nbHits > 1 ? 's' : ''
+                }`
+              ),
+            showViewAll &&
+              h(
+                Button,
+                {
+                  variant: 'ghost',
+                  size: 'sm',
+                  className: 'ais-ChatToolSearchIndexCarouselHeaderViewAll',
+                  onClick: () => {
+                    if (!input || !applyFilters) {
+                      return;
+                    }
+                    const params = applyFilters({
+                      query: input.query,
+                      facetFilters: getFacetFiltersFromToolInput(input),
+                    });
+
+                    if (
+                      getSearchPageURL &&
+                      new URL(getSearchPageURL(params)).pathname !==
+                        window.location.pathname
+                    ) {
+                      window.location.href = getSearchPageURL(params);
+                    }
+
+                    onClose();
+                  },
+                },
+                'View all',
+                h(ArrowRightIcon, { createElement: h })
+              )
+          ),
+          hitsPerPage > 2 &&
+            h(
+              'div',
+              {
+                className: 'ais-ChatToolSearchIndexCarouselHeaderScrollButtons',
+              },
+              h(
+                Button,
+                {
+                  variant: 'outline',
+                  size: 'sm',
+                  iconOnly: true,
+                  onClick: scrollLeft,
+                  disabled: !canScrollLeft,
+                  className:
+                    'ais-ChatToolSearchIndexCarouselHeaderScrollButton',
+                },
+                h(ChevronLeftIcon, { createElement: h })
+              ),
+              h(
+                Button,
+                {
+                  variant: 'outline',
+                  size: 'sm',
+                  iconOnly: true,
+                  onClick: scrollRight,
+                  disabled: !canScrollRight,
+                  className:
+                    'ais-ChatToolSearchIndexCarouselHeaderScrollButton',
+                },
+                h(ChevronRightIcon, { createElement: h })
+              )
+            )
+        );
+      };
+
+      return h(AisCarousel, {
+        items,
+        itemComponent,
+        sendEvent,
+        showNavigation: false,
+        headerComponent,
+      });
+    }),
+  };
+
+  return { layoutComponent };
+}

--- a/packages/vue-instantsearch/src/components/chat/tools/index.js
+++ b/packages/vue-instantsearch/src/components/chat/tools/index.js
@@ -1,0 +1,37 @@
+import {
+  SearchIndexToolType,
+  RecommendToolType,
+  DisplayResultsToolType,
+  MemorizeToolType,
+  MemorySearchToolType,
+  PonderToolType,
+} from 'instantsearch.js/es/lib/chat';
+
+import { createDisplayResultsTool } from './DisplayResultsTool';
+import { createCarouselTool } from './SearchIndexTool';
+
+export { createCarouselTool, createDisplayResultsTool };
+
+/**
+ * Default client-side tools for the Vue Chat widget, mirroring
+ * react-instantsearch's `createDefaultTools`. Carousel-based tools reuse the
+ * ported `AisCarousel`; memory/ponder tools are no-op placeholders.
+ */
+export function createDefaultTools(itemComponent, getSearchPageURL) {
+  return {
+    [SearchIndexToolType]: createCarouselTool(
+      true,
+      itemComponent,
+      getSearchPageURL
+    ),
+    [RecommendToolType]: createCarouselTool(
+      false,
+      itemComponent,
+      getSearchPageURL
+    ),
+    [DisplayResultsToolType]: createDisplayResultsTool(itemComponent),
+    [MemorizeToolType]: {},
+    [MemorySearchToolType]: {},
+    [PonderToolType]: {},
+  };
+}

--- a/packages/vue-instantsearch/src/util/hooks.js
+++ b/packages/vue-instantsearch/src/util/hooks.js
@@ -125,8 +125,15 @@ export function createHooksStore(scheduleRender) {
     }
   };
 
+  // `memo(component, propsAreEqual?)` — the React/Preact HOC that skips
+  // re-rendering when props are shallow-equal. In this eager-invocation model
+  // it's an identity passthrough: functionally correct (same output), it only
+  // forgoes the streaming re-render optimization. A real per-key memo is a
+  // future optimization (see the vue-instantsearch chat notes).
+  const memo = (component) => component;
+
   return {
-    hooks: { useState, useEffect, useRef, useMemo, useCallback, useId },
+    hooks: { useState, useEffect, useRef, useMemo, useCallback, useId, memo },
     beginRender,
     endRender,
     flushEffects,

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
@@ -145,22 +145,35 @@ function isEventProp(name, value) {
 }
 
 function bindMutableRef(data, ref) {
-  if (!ref || typeof ref !== 'object' || !('current' in ref)) {
+  // Support both MutableRef objects (`{ current }`) and callback refs
+  // (`(element) => void`), the two shapes shared components use.
+  const isMutableRef = ref && typeof ref === 'object' && 'current' in ref;
+  const isCallbackRef = typeof ref === 'function';
+
+  if (!isMutableRef && !isCallbackRef) {
     return;
   }
 
-  // Vue 2 has no function refs, so populate the MutableRef via vnode lifecycle
-  // hooks. `vnode.elm` is the underlying DOM node.
+  const assign = (element) => {
+    if (isCallbackRef) {
+      ref(element);
+    } else {
+      ref.current = element;
+    }
+  };
+
+  // Vue 2 has no function refs, so populate the ref via vnode lifecycle hooks.
+  // `vnode.elm` is the underlying DOM node.
   data.hook = data.hook || {};
   const previousInsert = data.hook.insert;
   const previousDestroy = data.hook.destroy;
 
   data.hook.insert = (vnode) => {
-    ref.current = vnode.elm;
+    assign(vnode.elm);
     if (previousInsert) previousInsert(vnode);
   };
   data.hook.destroy = (vnode) => {
-    ref.current = null;
+    assign(null);
     if (previousDestroy) previousDestroy(vnode);
   };
 }

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
@@ -92,9 +92,9 @@ export function augmentReactCreateElement(baseH) {
       } else if (name === 'children') {
         // handled via the children argument
       } else if (name === 'ref') {
-        const functionRef = makeFunctionRef(value);
-        if (functionRef) {
-          data.ref = functionRef;
+        const vueRef = toVueRef(value);
+        if (vueRef) {
+          data.ref = vueRef;
         }
       } else if (isEventProp(name, value)) {
         // React `onKeyDown` -> Vue 3 `onKeydown` (compiler-style handler key)
@@ -132,13 +132,19 @@ function isEventProp(name, value) {
   );
 }
 
-function makeFunctionRef(ref) {
-  if (!ref || typeof ref !== 'object' || !('current' in ref)) {
-    return undefined;
+function toVueRef(ref) {
+  // Callback refs pass through as Vue 3 function refs.
+  if (typeof ref === 'function') {
+    return ref;
   }
-  return (element) => {
-    ref.current = element;
-  };
+  // MutableRef objects (`{ current }`) become a function ref that writes
+  // through to `.current`.
+  if (ref && typeof ref === 'object' && 'current' in ref) {
+    return (element) => {
+      ref.current = element;
+    };
+  }
+  return undefined;
 }
 
 function flattenChildren(nodes) {

--- a/packages/vue-instantsearch/src/widgets.js
+++ b/packages/vue-instantsearch/src/widgets.js
@@ -22,6 +22,8 @@ export { default as AisQueryRuleContext } from './components/QueryRuleContext';
 export { default as AisQueryRuleCustomData } from './components/QueryRuleCustomData.vue';
 export { default as AisRangeInput } from './components/RangeInput.vue';
 export { default as AisRatingMenu } from './components/RatingMenu.vue';
+export { default as AisChat } from './components/Chat';
+export { default as AisChatTrigger } from './components/ChatTrigger';
 export { default as AisRelatedProducts } from './components/RelatedProducts';
 export { default as AisRefinementList } from './components/RefinementList.vue';
 export { default as AisStateResults } from './components/StateResults.vue';


### PR DESCRIPTION
**Stacked on #7127** (base = `feat/vue-related-products`) — it reuses that PR's hook-based infra + `AisCarousel`.

## What

Ports the **Chat** and **ChatTrigger** widgets to `vue-instantsearch` — the last major widget missing from Vue. It reuses the `createHooksStore` + `renderReactCompat` infrastructure and `AisCarousel` from the recommend port, and consumes the same framework-agnostic `instantsearch.js` chat runtime (`connectChat`/`connectChatTrigger`, `ai-lite`) the React/JS widgets use — **no new runtime deps**.

### Infra
- `memo` on the hooks runtime (identity passthrough — see follow-ups).
- Function-ref support in the react-compat adapter (Vue 2 vnode hooks / Vue 3 function refs), for `ChatPrompt`'s callback ref.
- `AisCarousel` gains `headerComponent`/`showNavigation`/icon props for the chat tools.

### Widgets
- **`AisChat`** — wraps `connectChat`, renders the shared `createChatComponent` with a Vue pragma (`createElement`/`Fragment`/`memo`/`useState`), drives streaming autoscroll via `createStickToBottom` with the Vue hooks, and maps the connector render state to the Chat props.
- **`AisChatTrigger`** — wraps `connectChatTrigger` (`.ais-ChatToggleButton`).
- Vue **SearchIndexTool** + **DisplayResultsTool** wrappers render results in `AisCarousel`; `createDefaultTools` maps the six tool types.

## Test plan
- New component tests (`components/__tests__/Chat.js`): open-via-trigger, prompt submit → `sendMessage`, pre-seeded message rendering, and the search-tool carousel. Green on **Vue 2 and Vue 3**.
- Exports-validation test covers `AisChat`/`AisChatTrigger`.
- Full `vue-instantsearch` suite green on both versions; oxlint + prettier clean; Vue bundlesize thresholds bumped (Chat pulls in the chat UI + `markdown-to-jsx`, ~+30 kB UMD).

## Scope / follow-ups (phase 2)
- **Shared common suite stays skipped.** Its `vue` widgetParams variant is `Record<string, never>` and the tests drive a **test-owned `chat` instance** that only reaches the JS/React widgets. Enabling it for Vue needs that variant extended to carry a `chat` instance + options — a change to the shared `tests/common/widgets/chat/*` files. Component tests cover the core behavior in the meantime.
- **Streaming memoization:** `memo` is an identity passthrough, so completed messages re-render on each streaming delta (correct output, not yet optimized). A real per-key memo is deferred.
- `connectChat` emits a runtime "Chat is not yet stable" warning — the API is explicitly unstable upstream.

Draft, stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)