### PR TITLE
feat(chat): render reasoning parts

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -4,6 +4,11 @@ import { compiler } from 'markdown-to-jsx';
 import { cx, startsWith } from '../../lib';
 import { createButtonComponent } from '../Button';
 
+import {
+  createChatMessageReasoningComponent,
+  type ChatMessageReasoningClassNames,
+  type ChatMessageReasoningTranslations,
+} from './ChatMessageReasoning';
 import { MenuIcon } from './icons';
 
 import type { ComponentProps, Renderer, VNode } from '../../types';
@@ -36,7 +41,7 @@ export type ChatMessageTranslations = {
    * The label for message actions
    */
   actionsLabel: string;
-};
+} & ChatMessageReasoningTranslations;
 
 export type ChatMessageClassNames = {
   /**
@@ -67,7 +72,7 @@ export type ChatMessageClassNames = {
    * Class names to apply to the footer element
    */
   footer: string | string[];
-};
+} & ChatMessageReasoningClassNames;
 
 export type ChatMessageActionProps = {
   /**
@@ -155,6 +160,10 @@ export type ChatMessageProps = ComponentProps<'article'> & {
    */
   suggestionsElement?: VNode;
   /**
+   * Whether to render reasoning parts
+   */
+  showReasoning?: boolean;
+  /**
    * Optional class names
    */
   classNames?: Partial<ChatMessageClassNames>;
@@ -180,6 +189,9 @@ const SearchIndexToolType = 'algolia_search_index';
 
 export function createChatMessageComponent({ createElement }: Renderer) {
   const Button = createButtonComponent({ createElement });
+  const ChatMessageReasoning = createChatMessageReasoningComponent({
+    createElement,
+  });
 
   return function ChatMessage(userProps: ChatMessageProps) {
     const {
@@ -200,6 +212,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
       onClose,
       translations: userTranslations,
       suggestionsElement,
+      showReasoning = false,
       parseMarkdown = true,
       ...props
     } = userProps;
@@ -207,6 +220,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
     const translations: Required<ChatMessageTranslations> = {
       messageLabel: 'Message',
       actionsLabel: 'Message actions',
+      reasoningLabel: 'Reasoning',
       ...userTranslations,
     };
 
@@ -229,6 +243,31 @@ export function createChatMessageComponent({ createElement }: Renderer) {
       message: cx('ais-ChatMessage-message', classNames.message),
       actions: cx('ais-ChatMessage-actions', classNames.actions),
       footer: cx('ais-ChatMessage-footer', classNames.footer),
+      reasoning: cx('ais-ChatMessageReasoning', classNames.reasoning),
+      reasoningHeader: cx(
+        'ais-ChatMessageReasoning-header',
+        classNames.reasoningHeader
+      ),
+      reasoningIcon: cx(
+        'ais-ChatMessageReasoning-icon',
+        classNames.reasoningIcon
+      ),
+      reasoningLabel: cx(
+        'ais-ChatMessageReasoning-label',
+        classNames.reasoningLabel
+      ),
+      reasoningChevron: cx(
+        'ais-ChatMessageReasoning-chevron',
+        classNames.reasoningChevron
+      ),
+      reasoningBody: cx(
+        'ais-ChatMessageReasoning-body',
+        classNames.reasoningBody
+      ),
+      reasoningText: cx(
+        'ais-ChatMessageReasoning-text',
+        classNames.reasoningText
+      ),
     };
 
     function renderMessagePart(
@@ -237,6 +276,28 @@ export function createChatMessageComponent({ createElement }: Renderer) {
     ) {
       if (part.type === 'step-start') {
         return null;
+      }
+      if (part.type === 'reasoning') {
+        if (!showReasoning) {
+          return null;
+        }
+
+        return (
+          <ChatMessageReasoning
+            key={`${message.id}-${index}`}
+            part={part}
+            translations={translations}
+            classNames={{
+              ...cssClasses,
+              reasoningLabel: cx(
+                'ais-ChatMessageReasoning-label',
+                part.state === 'streaming' &&
+                  'ais-ChatMessageReasoning-label--streaming',
+                classNames.reasoningLabel
+              ),
+            }}
+          />
+        );
       }
       if (part.type === 'text') {
         // Back-compat shim for sessions started before the move from a

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -297,6 +297,10 @@ export function createChatMessageComponent({ createElement }: Renderer) {
                 laterPart.state === 'streaming'
             );
 
+        if (!isReasoningStreaming && part.text.trim().length === 0) {
+          return null;
+        }
+
         return (
           <ChatMessageReasoning
             key={`${message.id}-${index}`}

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -2,6 +2,7 @@
 import { compiler } from 'markdown-to-jsx';
 
 import { cx, startsWith } from '../../lib';
+import { isReasoningPartActive } from '../../lib/utils/chat';
 import { createButtonComponent } from '../Button';
 
 import {
@@ -286,16 +287,9 @@ export function createChatMessageComponent({ createElement }: Renderer) {
         }
 
         const isReasoningStreaming =
-          part.state === 'streaming' &&
           status === 'streaming' &&
           isCurrentMessage &&
-          !message.parts
-            .slice(index + 1)
-            .some(
-              (laterPart) =>
-                laterPart.type !== 'reasoning' ||
-                laterPart.state === 'streaming'
-            );
+          isReasoningPartActive(message.parts, index);
 
         if (!isReasoningStreaming && part.text.trim().length === 0) {
           return null;

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -288,7 +288,14 @@ export function createChatMessageComponent({ createElement }: Renderer) {
         const isReasoningStreaming =
           part.state === 'streaming' &&
           status === 'streaming' &&
-          isCurrentMessage;
+          isCurrentMessage &&
+          !message.parts
+            .slice(index + 1)
+            .some(
+              (laterPart) =>
+                laterPart.type !== 'reasoning' ||
+                laterPart.state === 'streaming'
+            );
 
         return (
           <ChatMessageReasoning

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -225,6 +225,9 @@ export function createChatMessageComponent({ createElement }: Renderer) {
     };
 
     const hasLeading = Boolean(LeadingComponent);
+    const isCurrentMessage =
+      messages === undefined ||
+      messages[messages.length - 1]?.id === message.id;
 
     const showActions =
       Boolean(actions.length > 0 || ActionsComponent) && status === 'ready';
@@ -282,16 +285,22 @@ export function createChatMessageComponent({ createElement }: Renderer) {
           return null;
         }
 
+        const isReasoningStreaming =
+          part.state === 'streaming' &&
+          status === 'streaming' &&
+          isCurrentMessage;
+
         return (
           <ChatMessageReasoning
             key={`${message.id}-${index}`}
             part={part}
+            isStreaming={isReasoningStreaming}
             translations={translations}
             classNames={{
               ...cssClasses,
               reasoningLabel: cx(
                 'ais-ChatMessageReasoning-label',
-                part.state === 'streaming' &&
+                isReasoningStreaming &&
                   'ais-ChatMessageReasoning-label--streaming',
                 classNames.reasoningLabel
               ),

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
@@ -1,0 +1,91 @@
+/** @jsx createElement */
+import { compiler } from 'markdown-to-jsx';
+
+import { cx } from '../../lib';
+
+import { BrainIcon, ChevronDownIcon } from './icons';
+
+import type { Renderer } from '../../types';
+import type { ReasoningUIPart } from './types';
+
+export type ChatMessageReasoningTranslations = {
+  /**
+   * The label for a reasoning disclosure
+   */
+  reasoningLabel: string;
+};
+
+export type ChatMessageReasoningClassNames = {
+  /**
+   * Class names to apply to a reasoning disclosure
+   */
+  reasoning: string | string[];
+  /**
+   * Class names to apply to a reasoning disclosure header
+   */
+  reasoningHeader: string | string[];
+  /**
+   * Class names to apply to a reasoning disclosure icon
+   */
+  reasoningIcon: string | string[];
+  /**
+   * Class names to apply to a reasoning disclosure label
+   */
+  reasoningLabel: string | string[];
+  /**
+   * Class names to apply to a reasoning disclosure chevron
+   */
+  reasoningChevron: string | string[];
+  /**
+   * Class names to apply to a reasoning disclosure body
+   */
+  reasoningBody: string | string[];
+  /**
+   * Class names to apply to reasoning text
+   */
+  reasoningText: string | string[];
+};
+
+type ChatMessageReasoningProps = {
+  key?: string | number;
+  part: ReasoningUIPart;
+  translations: ChatMessageReasoningTranslations;
+  classNames: ChatMessageReasoningClassNames;
+};
+
+export function createChatMessageReasoningComponent({
+  createElement,
+}: Pick<Renderer, 'createElement'>) {
+  return function ChatMessageReasoning(userProps: ChatMessageReasoningProps) {
+    const { part, translations, classNames } = userProps;
+    const isStreaming = part.state === 'streaming';
+    const markdown = compiler(part.text, {
+      createElement: createElement as any,
+      disableParsingRawHTML: true,
+    });
+
+    return (
+      <details
+        className={cx(classNames.reasoning)}
+        aria-label={translations.reasoningLabel}
+        aria-busy={isStreaming}
+      >
+        <summary className={cx(classNames.reasoningHeader)}>
+          <span className={cx(classNames.reasoningIcon)} aria-hidden="true">
+            <BrainIcon createElement={createElement} />
+          </span>
+          <span className={cx(classNames.reasoningLabel)}>
+            {translations.reasoningLabel}
+          </span>
+          <span className={cx(classNames.reasoningChevron)} aria-hidden="true">
+            <ChevronDownIcon createElement={createElement} />
+          </span>
+        </summary>
+
+        <div className={cx(classNames.reasoningBody)}>
+          <div className={cx(classNames.reasoningText)}>{markdown}</div>
+        </div>
+      </details>
+    );
+  };
+}

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
@@ -82,12 +82,7 @@ export function createChatMessageReasoningComponent({
           </span>
         </summary>
 
-        <div
-          className={cx(classNames.reasoningBody)}
-          role="region"
-          aria-label={translations.reasoningLabel}
-          tabIndex={0}
-        >
+        <div className={cx(classNames.reasoningBody)} tabIndex={0}>
           <div className={cx(classNames.reasoningText)}>{markdown}</div>
         </div>
       </details>

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
@@ -49,6 +49,7 @@ export type ChatMessageReasoningClassNames = {
 type ChatMessageReasoningProps = {
   key?: string | number;
   part: ReasoningUIPart;
+  isStreaming: boolean;
   translations: ChatMessageReasoningTranslations;
   classNames: ChatMessageReasoningClassNames;
 };
@@ -57,8 +58,7 @@ export function createChatMessageReasoningComponent({
   createElement,
 }: Pick<Renderer, 'createElement'>) {
   return function ChatMessageReasoning(userProps: ChatMessageReasoningProps) {
-    const { part, translations, classNames } = userProps;
-    const isStreaming = part.state === 'streaming';
+    const { part, isStreaming, translations, classNames } = userProps;
     const markdown = compiler(part.text, {
       createElement: createElement as any,
       disableParsingRawHTML: true,

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
@@ -82,7 +82,12 @@ export function createChatMessageReasoningComponent({
           </span>
         </summary>
 
-        <div className={cx(classNames.reasoningBody)}>
+        <div
+          className={cx(classNames.reasoningBody)}
+          role="region"
+          aria-label={translations.reasoningLabel}
+          tabIndex={0}
+        >
           <div className={cx(classNames.reasoningText)}>{markdown}</div>
         </div>
       </details>

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
@@ -76,6 +76,7 @@ export function createChatMessageReasoningComponent({
           </span>
           <span className={cx(classNames.reasoningLabel)}>
             {translations.reasoningLabel}
+            {isStreaming ? <span aria-hidden="true">…</span> : null}
           </span>
           <span className={cx(classNames.reasoningChevron)} aria-hidden="true">
             <ChevronDownIcon createElement={createElement} />

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -397,6 +397,7 @@ export function createChatMessagesComponent({
     props: Parameters<typeof DefaultMessageComponent>[0]
   ) {
     const messageFeedback = props.feedbackState?.[props.message.id];
+    const showReasoning = props.assistantMessageProps?.showReasoning;
     return useMemo(
       () => <DefaultMessageComponent {...props} />,
       [
@@ -404,6 +405,7 @@ export function createChatMessagesComponent({
         props.status,
         props.suggestionsElement,
         messageFeedback,
+        showReasoning,
       ]
     );
   }

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -623,7 +623,7 @@ const getShowLoader = (
   if (!lastPart) return true;
   if (isPartText(lastPart)) return false;
   if (lastPart.type === 'reasoning' && showReasoning) {
-    return lastPart.state !== 'streaming' && !lastPart.text.trim();
+    return lastPart.state !== 'streaming';
   }
 
   if (isPartTool(lastPart) && lastPart.state === 'input-streaming') {

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -400,7 +400,9 @@ export function createChatMessagesComponent({
   ) {
     const messageFeedback = props.feedbackState?.[props.message.id];
     const showReasoning = props.assistantMessageProps?.showReasoning;
-    const reasoningLabel = props.messageTranslations?.reasoningLabel;
+    const reasoningLabel =
+      props.assistantMessageProps?.translations?.reasoningLabel ??
+      props.messageTranslations?.reasoningLabel;
     return useMemo(
       () => <DefaultMessageComponent {...props} />,
       [

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -486,7 +486,12 @@ export function createChatMessagesComponent({
 
     const lastMessage = messages[messages.length - 1];
     const lastPart = lastMessage?.parts?.[lastMessage.parts.length - 1];
-    const showLoader = getShowLoader(status, lastPart, tools);
+    const showLoader = getShowLoader(
+      status,
+      lastPart,
+      tools,
+      assistantMessageProps?.showReasoning
+    );
 
     const showEmpty =
       messages.length === 0 && !showLoader && !isClearing && status !== 'error';
@@ -609,13 +614,15 @@ export function createChatMessagesComponent({
 const getShowLoader = (
   status: ChatStatus,
   lastPart: ChatMessageBase['parts'][number] | undefined,
-  tools: ClientSideTools
+  tools: ClientSideTools,
+  showReasoning: boolean | undefined
 ): boolean => {
   if (status !== 'submitted' && status !== 'streaming') return false;
   if (status === 'submitted') return true;
 
   if (!lastPart) return true;
   if (isPartText(lastPart)) return false;
+  if (lastPart.type === 'reasoning' && showReasoning) return false;
 
   if (isPartTool(lastPart) && lastPart.state === 'input-streaming') {
     const tool = findTool(lastPart.type, tools);

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -5,6 +5,7 @@ import {
   findTool,
   getTextContent,
   hasTextContent,
+  isReasoningPartActive,
   isPartText,
   isPartTool,
 } from '../../lib/utils/chat';
@@ -486,11 +487,16 @@ export function createChatMessagesComponent({
 
     const lastMessage = messages[messages.length - 1];
     const lastPart = lastMessage?.parts?.[lastMessage.parts.length - 1];
+    const hasActiveReasoning =
+      lastMessage?.parts.some((_, index) =>
+        isReasoningPartActive(lastMessage.parts, index)
+      ) ?? false;
     const showLoader = getShowLoader(
       status,
       lastPart,
       tools,
-      assistantMessageProps?.showReasoning
+      assistantMessageProps?.showReasoning,
+      hasActiveReasoning
     );
 
     const showEmpty =
@@ -615,12 +621,14 @@ const getShowLoader = (
   status: ChatStatus,
   lastPart: ChatMessageBase['parts'][number] | undefined,
   tools: ClientSideTools,
-  showReasoning: boolean | undefined
+  showReasoning: boolean | undefined,
+  hasActiveReasoning: boolean
 ): boolean => {
   if (status !== 'submitted' && status !== 'streaming') return false;
   if (status === 'submitted') return true;
 
   if (!lastPart) return true;
+  if (showReasoning && hasActiveReasoning) return false;
   if (isPartText(lastPart)) return false;
   if (lastPart.type === 'reasoning' && showReasoning) {
     return lastPart.state !== 'streaming';

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -273,6 +273,7 @@ function createDefaultMessageComponent<
   }: {
     key: string;
     message: TMessage;
+    isCurrentMessage: boolean;
     status: ChatStatus;
     userMessageProps?: Partial<ChatMessageProps>;
     assistantMessageProps?: Partial<ChatMessageProps>;
@@ -398,14 +399,17 @@ export function createChatMessagesComponent({
   ) {
     const messageFeedback = props.feedbackState?.[props.message.id];
     const showReasoning = props.assistantMessageProps?.showReasoning;
+    const reasoningLabel = props.messageTranslations?.reasoningLabel;
     return useMemo(
       () => <DefaultMessageComponent {...props} />,
       [
         props.message,
+        props.isCurrentMessage,
         props.status,
         props.suggestionsElement,
         messageFeedback,
         showReasoning,
+        reasoningLabel,
       ]
     );
   }
@@ -528,6 +532,7 @@ export function createChatMessagesComponent({
               <DefaultMessage
                 key={message.id}
                 message={message}
+                isCurrentMessage={index === messages.length - 1}
                 status={status}
                 userMessageProps={userMessageProps}
                 assistantMessageProps={assistantMessageProps}

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -622,7 +622,9 @@ const getShowLoader = (
 
   if (!lastPart) return true;
   if (isPartText(lastPart)) return false;
-  if (lastPart.type === 'reasoning' && showReasoning) return false;
+  if (lastPart.type === 'reasoning' && showReasoning) {
+    return lastPart.state !== 'streaming' && !lastPart.text.trim();
+  }
 
   if (isPartTool(lastPart) && lastPart.state === 'input-streaming') {
     const tool = findTool(lastPart.type, tools);

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -3,6 +3,7 @@
  */
 /** @jsx createElement */
 import { render } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
 import { Fragment, createElement } from 'preact';
 
 import { createChatMessageComponent } from '../ChatMessage';
@@ -206,6 +207,205 @@ describe('ChatMessage', () => {
         </div>
       </div>
     `);
+  });
+
+  test('renders reasoning in an accessible disclosure when enabled', () => {
+    const { getByRole, getByText } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'I should search the catalog first.',
+              state: 'done',
+            },
+          ],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    expect(getByRole('group', { name: 'Reasoning' })).toBeInTheDocument();
+    expect(getByText('I should search the catalog first.')).toBeInTheDocument();
+  });
+
+  test('does not render reasoning unless it is enabled', () => {
+    const { queryByRole, queryByText } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'reasoning', text: 'Private reasoning' }],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(queryByRole('group', { name: 'Reasoning' })).not.toBeInTheDocument();
+    expect(queryByText('Private reasoning')).not.toBeInTheDocument();
+  });
+
+  test('keeps reasoning disclosures in message part order', () => {
+    const { container, getAllByRole, getByText } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            { type: 'reasoning', text: 'First thought', state: 'done' },
+            {
+              type: 'tool-test_tool',
+              toolCallId: '123',
+              input: {},
+              state: 'output-available',
+              output: { data: 'Tool result' },
+            },
+            { type: 'reasoning', text: 'Second thought', state: 'done' },
+            { type: 'text', text: 'Final answer' },
+          ],
+        }}
+        status="ready"
+        tools={{
+          test_tool: {
+            layoutComponent: () => <div>Tool result</div>,
+            addToolResult: jest.fn(),
+            applyFilters: jest.fn(),
+          },
+        }}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    const message = container.querySelector('.ais-ChatMessage-message')!;
+    const children = Array.from(message.children);
+    const disclosures = getAllByRole('group', { name: 'Reasoning' });
+
+    expect(children).toHaveLength(4);
+    expect(children[0]).toBe(disclosures[0]);
+    expect(children[1]).toContainElement(getByText('Tool result'));
+    expect(children[2]).toBe(disclosures[1]);
+    expect(children[3]).toContainElement(getByText('Final answer'));
+  });
+
+  test('marks only the streaming reasoning disclosure as busy', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'First thought',
+          state: 'done' as const,
+        },
+        {
+          type: 'reasoning' as const,
+          text: 'Second thought',
+          state: 'streaming' as const,
+        },
+      ],
+    };
+    const { getAllByRole, rerender } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={message}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    let disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
+    expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+
+    rerender(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          ...message,
+          parts: [message.parts[0], { ...message.parts[1], state: 'done' }],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
+    expect(disclosures[1]).toHaveAttribute('aria-busy', 'false');
+  });
+
+  test('preserves an open disclosure while reasoning text streams', () => {
+    const renderMessage = (text: string) => (
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'reasoning', text, state: 'streaming' }],
+        }}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+    const { getByRole, rerender } = render(renderMessage('First'));
+    const disclosure = getByRole('group', { name: 'Reasoning' });
+
+    userEvent.click(disclosure.querySelector('summary')!);
+    expect(disclosure).toHaveAttribute('open');
+
+    rerender(renderMessage('First second'));
+    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute('open');
+  });
+
+  test('renders reasoning as markdown with a translated label', () => {
+    const { container, getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Check the **release date**.',
+              state: 'done',
+            },
+          ],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+        translations={{ reasoningLabel: 'Raisonnement' }}
+      />
+    );
+
+    expect(getByRole('group', { name: 'Raisonnement' })).toBeInTheDocument();
+    expect(container.querySelector('strong')).toHaveTextContent('release date');
   });
 
   test('parses text parts as markdown by default', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -354,6 +354,55 @@ describe('ChatMessage', () => {
     expect(disclosures[1]).toHaveAttribute('aria-busy', 'false');
   });
 
+  test('marks reasoning as busy only on the active response', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'previous',
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Stopped reasoning',
+            state: 'streaming' as const,
+          },
+        ],
+      },
+      {
+        role: 'assistant' as const,
+        id: 'current',
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Current reasoning',
+            state: 'streaming' as const,
+          },
+        ],
+      },
+    ];
+
+    const { getAllByRole } = render(
+      <Fragment>
+        {messages.map((message) => (
+          <ChatMessage
+            key={message.id}
+            indexUiState={{}}
+            setIndexUiState={jest.fn()}
+            message={message}
+            messages={messages}
+            status="streaming"
+            tools={{}}
+            onClose={jest.fn()}
+            showReasoning={true}
+          />
+        ))}
+      </Fragment>
+    );
+
+    const disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
+    expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+  });
+
   test('preserves an open disclosure while reasoning text streams', () => {
     const renderMessage = (text: string) => (
       <ChatMessage

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -256,6 +256,58 @@ describe('ChatMessage', () => {
     expect(queryByText('Private reasoning')).not.toBeInTheDocument();
   });
 
+  test.each([
+    ['stopped', 'ready' as const, ''],
+    ['disconnected', 'error' as const, ''],
+    ['finished with only whitespace', 'ready' as const, ' \n '],
+  ])(
+    'does not render blank reasoning after a response is %s',
+    (_responseState, status, text) => {
+      const { queryByRole } = render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={{
+            role: 'assistant',
+            id: '1',
+            parts: [{ type: 'reasoning', text, state: 'done' }],
+          }}
+          status={status}
+          tools={{}}
+          onClose={jest.fn()}
+          showReasoning={true}
+        />
+      );
+
+      expect(
+        queryByRole('group', { name: 'Reasoning' })
+      ).not.toBeInTheDocument();
+    }
+  );
+
+  test('renders empty reasoning while the response is active', () => {
+    const { getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'reasoning', text: '', state: 'streaming' }],
+        }}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+  });
+
   test('keeps reasoning disclosures in message part order', () => {
     const { container, getAllByRole, getByText } = render(
       <ChatMessage

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -236,6 +236,44 @@ describe('ChatMessage', () => {
     expect(getByText('I should search the catalog first.')).toBeInTheDocument();
   });
 
+  test('makes overflowing reasoning keyboard reachable', () => {
+    const { getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: Array.from(
+                { length: 20 },
+                (_, index) => `Reasoning paragraph ${index + 1}.`
+              ).join('\n\n'),
+              state: 'done',
+            },
+          ],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    const disclosure = getByRole('group', { name: 'Reasoning' });
+    const summary = disclosure.querySelector('summary')!;
+    userEvent.click(summary);
+
+    const body = getByRole('region', { name: 'Reasoning' });
+    expect(body).toHaveAttribute('tabindex', '0');
+
+    summary.focus();
+    userEvent.tab();
+    expect(body).toHaveFocus();
+  });
+
   test('does not render reasoning unless it is enabled', () => {
     const { queryByRole, queryByText } = render(
       <ChatMessage

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -237,7 +237,7 @@ describe('ChatMessage', () => {
   });
 
   test('makes overflowing reasoning keyboard reachable', () => {
-    const { getByRole } = render(
+    const { getByRole, queryByRole } = render(
       <ChatMessage
         indexUiState={{}}
         setIndexUiState={jest.fn()}
@@ -266,8 +266,9 @@ describe('ChatMessage', () => {
     const summary = disclosure.querySelector('summary')!;
     userEvent.click(summary);
 
-    const body = getByRole('region', { name: 'Reasoning' });
+    const body = disclosure.querySelector('.ais-ChatMessageReasoning-body')!;
     expect(body).toHaveAttribute('tabindex', '0');
+    expect(queryByRole('region', { hidden: true })).not.toBeInTheDocument();
 
     summary.focus();
     userEvent.tab();
@@ -347,7 +348,7 @@ describe('ChatMessage', () => {
   });
 
   test('keeps reasoning disclosures in message part order', () => {
-    const { container, getAllByRole, getByText } = render(
+    const { container, getAllByRole, getByText, queryAllByRole } = render(
       <ChatMessage
         indexUiState={{}}
         setIndexUiState={jest.fn()}
@@ -389,6 +390,7 @@ describe('ChatMessage', () => {
     expect(children[1]).toContainElement(getByText('Tool result'));
     expect(children[2]).toBe(disclosures[1]);
     expect(children[3]).toContainElement(getByText('Final answer'));
+    expect(queryAllByRole('region')).toHaveLength(0);
   });
 
   test('marks only the streaming reasoning disclosure as busy', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -425,6 +425,17 @@ describe('ChatMessage', () => {
     let disclosures = getAllByRole('group', { name: 'Reasoning' });
     expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
     expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+    expect(
+      disclosures[0].querySelector('.ais-ChatMessageReasoning-label')
+    ).toHaveTextContent(/^Reasoning$/);
+    expect(
+      disclosures[1].querySelector('.ais-ChatMessageReasoning-label')
+    ).toHaveTextContent(/^Reasoning…$/);
+    expect(
+      disclosures[1].querySelector(
+        '.ais-ChatMessageReasoning-label [aria-hidden="true"]'
+      )
+    ).toHaveTextContent('…');
 
     rerender(
       <ChatMessage
@@ -444,6 +455,14 @@ describe('ChatMessage', () => {
     disclosures = getAllByRole('group', { name: 'Reasoning' });
     expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
     expect(disclosures[1]).toHaveAttribute('aria-busy', 'false');
+    expect(
+      disclosures[1].querySelector('.ais-ChatMessageReasoning-label')
+    ).toHaveTextContent(/^Reasoning$/);
+    expect(
+      disclosures[1].querySelector(
+        '.ais-ChatMessageReasoning-label [aria-hidden="true"]'
+      )
+    ).not.toBeInTheDocument();
   });
 
   test('marks only the latest unfinished reasoning block as busy', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -354,6 +354,45 @@ describe('ChatMessage', () => {
     expect(disclosures[1]).toHaveAttribute('aria-busy', 'false');
   });
 
+  test('marks only the latest unfinished reasoning block as busy', () => {
+    const { getAllByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Compare the candidates',
+              state: 'streaming',
+            },
+            {
+              type: 'reasoning',
+              text: 'Check one candidate',
+              state: 'streaming',
+            },
+          ],
+        }}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    const disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
+    expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+    expect(
+      disclosures[0].querySelector('.ais-ChatMessageReasoning-label--streaming')
+    ).not.toBeInTheDocument();
+    expect(
+      disclosures[1].querySelector('.ais-ChatMessageReasoning-label--streaming')
+    ).toBeInTheDocument();
+  });
+
   test('marks reasoning as busy only on the active response', () => {
     const messages = [
       {
@@ -401,6 +440,74 @@ describe('ChatMessage', () => {
     const disclosures = getAllByRole('group', { name: 'Reasoning' });
     expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
     expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+  });
+
+  test('does not mark reasoning as busy after answer text starts streaming', () => {
+    const { getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Checking the catalog',
+              state: 'streaming',
+            },
+            {
+              type: 'text',
+              text: 'Here is what I found',
+              state: 'streaming',
+            },
+          ],
+        }}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    const disclosure = getByRole('group', { name: 'Reasoning' });
+    expect(disclosure).toHaveAttribute('aria-busy', 'false');
+    expect(
+      disclosure.querySelector('.ais-ChatMessageReasoning-label--streaming')
+    ).not.toBeInTheDocument();
+  });
+
+  test('marks an earlier unfinished reasoning block as busy after a later block ends', () => {
+    const { getAllByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Compare the candidates',
+              state: 'streaming',
+            },
+            {
+              type: 'reasoning',
+              text: 'Check one candidate',
+              state: 'done',
+            },
+          ],
+        }}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    const disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'true');
+    expect(disclosures[1]).toHaveAttribute('aria-busy', 'false');
   });
 
   test('preserves an open disclosure while reasoning text streams', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -4,6 +4,7 @@
 /** @jsx createElement */
 import { render, screen } from '@testing-library/preact';
 import { Fragment, createElement } from 'preact';
+import { useMemo } from 'preact/hooks';
 
 import { createChatMessageErrorComponent } from '../ChatMessageError';
 import { createChatMessagesComponent } from '../ChatMessages';
@@ -14,6 +15,11 @@ const ChatMessages = createChatMessagesComponent({
   createElement,
   Fragment,
   useMemo: (factory) => factory(),
+});
+const MemoizedChatMessages = createChatMessagesComponent({
+  createElement,
+  Fragment,
+  useMemo,
 });
 const ChatMessageError = createChatMessageErrorComponent({ createElement });
 
@@ -306,6 +312,69 @@ describe('ChatMessages', () => {
       screen.getAllByRole('group', { name: 'Reasoning' })[0]
     ).toHaveAttribute('aria-busy', 'true');
     expect(container.querySelector('.ais-ChatMessageLoader')).toBeNull();
+  });
+
+  test('updates nested reasoning labels for every completed message', () => {
+    const firstMessage = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Checking the catalog.',
+          state: 'done' as const,
+        },
+      ],
+    };
+    const secondMessage = {
+      role: 'assistant' as const,
+      id: '2',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Comparing the results.',
+          state: 'done' as const,
+        },
+      ],
+    };
+    const { rerender } = render(
+      <MemoizedChatMessages
+        messages={[firstMessage, secondMessage]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        assistantMessageProps={{
+          showReasoning: true,
+          translations: { reasoningLabel: 'Reasoning' },
+        }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.getAllByRole('group', { name: 'Reasoning' })).toHaveLength(2);
+
+    rerender(
+      <MemoizedChatMessages
+        messages={[firstMessage, { ...secondMessage }]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        assistantMessageProps={{
+          showReasoning: true,
+          translations: { reasoningLabel: 'Raisonnement' },
+        }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole('group', { name: 'Reasoning' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByRole('group', { name: 'Raisonnement' })
+    ).toHaveLength(2);
   });
 
   describe('parseMarkdown', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -271,6 +271,43 @@ describe('ChatMessages', () => {
     expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
   });
 
+  test('does not show the loader while an earlier reasoning part is still active', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Checking the catalog.',
+                state: 'streaming',
+              },
+              {
+                type: 'reasoning',
+                text: 'Comparing the results.',
+                state: 'done',
+              },
+            ],
+          },
+        ]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        status="streaming"
+        assistantMessageProps={{ showReasoning: true }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getAllByRole('group', { name: 'Reasoning' })[0]
+    ).toHaveAttribute('aria-busy', 'true');
+    expect(container.querySelector('.ais-ChatMessageLoader')).toBeNull();
+  });
+
   describe('parseMarkdown', () => {
     test('parses user message text as markdown by default', () => {
       const { container } = render(

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -144,6 +144,69 @@ describe('ChatMessages', () => {
     `);
   });
 
+  test('shows the loader while streaming reasoning is hidden', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Checking the catalog.',
+                state: 'streaming',
+              },
+            ],
+          },
+        ]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        status="streaming"
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole('group', { name: 'Reasoning' })
+    ).not.toBeInTheDocument();
+    expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
+  });
+
+  test('does not show the loader below visible streaming reasoning', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Checking the catalog.',
+                state: 'streaming',
+              },
+            ],
+          },
+        ]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        status="streaming"
+        assistantMessageProps={{ showReasoning: true }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('group', { name: 'Reasoning' })
+    ).toBeInTheDocument();
+    expect(container.querySelector('.ais-ChatMessageLoader')).toBeNull();
+  });
+
   describe('parseMarkdown', () => {
     test('parses user message text as markdown by default', () => {
       const { container } = render(

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -207,6 +207,38 @@ describe('ChatMessages', () => {
     expect(container.querySelector('.ais-ChatMessageLoader')).toBeNull();
   });
 
+  test('shows the loader after empty reasoning finishes while the response continues', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [
+              {
+                type: 'reasoning',
+                text: '',
+                state: 'done',
+              },
+            ],
+          },
+        ]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        status="streaming"
+        assistantMessageProps={{ showReasoning: true }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole('group', { name: 'Reasoning' })
+    ).not.toBeInTheDocument();
+    expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
+  });
+
   describe('parseMarkdown', () => {
     test('parses user message text as markdown by default', () => {
       const { container } = render(

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -239,6 +239,38 @@ describe('ChatMessages', () => {
     expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
   });
 
+  test('shows the loader after visible reasoning finishes while the response continues', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Checking the catalog.',
+                state: 'done',
+              },
+            ],
+          },
+        ]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        status="streaming"
+        assistantMessageProps={{ showReasoning: true }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('group', { name: 'Reasoning' })
+    ).toBeInTheDocument();
+    expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
+  });
+
   describe('parseMarkdown', () => {
     test('parses user message text as markdown by default', () => {
       const { container } = render(
@@ -314,9 +346,7 @@ describe('ChatMessages', () => {
 
       const messages = container.querySelectorAll('.ais-ChatMessage-message');
       // User message: plain text, no emphasis.
-      expect(
-        messages[0].querySelector('.ais-ChatMessage-text')
-      ).not.toBeNull();
+      expect(messages[0].querySelector('.ais-ChatMessage-text')).not.toBeNull();
       expect(messages[0].querySelector('em')).toBeNull();
       // Assistant message: still parsed as markdown.
       expect(messages[1].querySelector('em')).not.toBeNull();
@@ -346,7 +376,9 @@ describe('ChatMessages', () => {
       );
 
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(2);
     });
 
@@ -364,7 +396,9 @@ describe('ChatMessages', () => {
       );
 
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(0);
     });
 
@@ -386,7 +420,9 @@ describe('ChatMessages', () => {
         container.querySelector('.ais-ChatMessage-feedbackSpinner')
       ).not.toBeNull();
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(0);
     });
 
@@ -436,7 +472,9 @@ describe('ChatMessages', () => {
       );
 
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(0);
     });
   });

--- a/packages/instantsearch-ui-components/src/components/chat/icons.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/icons.tsx
@@ -265,6 +265,30 @@ export function ThumbsDownIcon({ createElement }: IconProps) {
   );
 }
 
+export function BrainIcon({ createElement }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 18V5" />
+      <path d="M15 13a4.17 4.17 0 0 1-3-4 4.17 4.17 0 0 1-3 4" />
+      <path d="M17.598 6.5A3 3 0 1 0 12 5a3 3 0 1 0-5.598 1.5" />
+      <path d="M17.997 5.125a4 4 0 0 1 2.526 5.77" />
+      <path d="M18 18a4 4 0 0 0 2-7.464" />
+      <path d="M19.967 17.483A4 4 0 1 1 12 18a4 4 0 1 1-7.967-.517" />
+      <path d="M6 18a4 4 0 0 1-2-7.464" />
+      <path d="M6.003 5.125a4 4 0 0 0-2.526 5.77" />
+    </svg>
+  );
+}
+
 export function ChevronLeftIcon({ createElement }: IconProps) {
   return (
     <svg

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -351,6 +351,13 @@ export interface ChatTransport<TUIMessage extends UIMessage> {
     messageId?: string;
   }) => Promise<ReadableStream<unknown>>;
 
+  /**
+   * Reconnects to an interrupted response.
+   *
+   * The returned stream must replay the full buffered assistant response in
+   * its original part order. Stream chunk boundaries may differ between
+   * connections.
+   */
   reconnectToStream: (options: {
     chatId: string;
   }) => Promise<ReadableStream<unknown> | null>;

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -14,7 +14,7 @@ const SearchIndexToolType = 'algolia_search_index';
 
 export const getTextContent = (message: ChatMessageBase) => {
   return message.parts
-    .map((part) => ('text' in part ? part.text : ''))
+    .map((part) => (part.type === 'text' ? part.text : ''))
     .join('');
 };
 

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -34,6 +34,24 @@ export const isPartTool = (
   return startsWith(part.type, 'tool-');
 };
 
+export function isReasoningPartActive(
+  parts: ChatMessageBase['parts'],
+  index: number
+): boolean {
+  const part = parts[index];
+
+  return (
+    part?.type === 'reasoning' &&
+    part.state === 'streaming' &&
+    !parts
+      .slice(index + 1)
+      .some(
+        (laterPart) =>
+          laterPart.type !== 'reasoning' || laterPart.state === 'streaming'
+      )
+  );
+}
+
 export const findTool = (
   partType: string,
   tools: ClientSideTools

--- a/packages/instantsearch.css/src/components/chat.scss
+++ b/packages/instantsearch.css/src/components/chat.scss
@@ -11,6 +11,7 @@
 @use 'chat/chat-header';
 @use 'chat/chat-messages';
 @use 'chat/chat-message';
+@use 'chat/chat-message-reasoning';
 @use 'chat/chat-message-loader';
 @use 'chat/chat-greeting';
 @use 'chat/chat-prompt';

--- a/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
@@ -1,7 +1,21 @@
+.ais-ChatMessage:has(.ais-ChatMessageReasoning) {
+  .ais-ChatMessage-content {
+    flex-grow: 1;
+  }
+
+  .ais-ChatMessage-message {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--ais-spacing) * 0.5);
+    width: 100%;
+  }
+}
+
 .ais-ChatMessageReasoning {
-  margin-block-end: calc(var(--ais-spacing) * 0.5);
+  box-sizing: border-box;
+  width: 100%;
   border: 1px solid rgba(var(--ais-muted-color-rgb), 0.25);
-  border-radius: var(--ais-border-radius-md);
+  border-radius: var(--ais-border-radius-sm);
   background-color: var(--ais-background-color);
   overflow: hidden;
 }
@@ -10,9 +24,9 @@
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  gap: calc(var(--ais-spacing) * 0.375);
+  gap: calc(var(--ais-spacing) * 0.25);
   width: 100%;
-  padding: calc(var(--ais-spacing) * 0.375) calc(var(--ais-spacing) * 0.5);
+  padding: calc(var(--ais-spacing) * 0.125) calc(var(--ais-spacing) * 0.5);
   cursor: pointer;
   list-style: none;
   user-select: none;
@@ -35,11 +49,10 @@
   }
 }
 
-.ais-ChatMessageReasoning-icon,
-.ais-ChatMessageReasoning-chevron {
+.ais-ChatMessageReasoning-icon {
   display: inline-flex;
-  width: calc(var(--ais-icon-size) * 0.85);
-  height: calc(var(--ais-icon-size) * 0.85);
+  width: calc(var(--ais-icon-size) * 0.8);
+  height: calc(var(--ais-icon-size) * 0.8);
   color: rgba(var(--ais-muted-color-rgb), 0.9);
   flex-shrink: 0;
 
@@ -53,19 +66,30 @@
   flex: 1;
   min-width: 0;
   color: rgba(var(--ais-muted-color-rgb), 0.95);
-  font-size: calc(var(--ais-spacing) * 0.8125);
+  font-size: calc(var(--ais-spacing) * 0.75);
+  line-height: var(--ais-spacing);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .ais-ChatMessageReasoning-label--streaming {
-  animation: ais-chat-reasoning-pulse 2s ease-in-out infinite;
+  animation: ais-chat-reasoning-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
 .ais-ChatMessageReasoning-chevron {
+  display: inline-flex;
+  width: var(--ais-icon-size);
+  height: var(--ais-icon-size);
+  color: rgba(var(--ais-muted-color-rgb), 0.9);
+  flex-shrink: 0;
   transition: transform var(--ais-transition-duration)
     var(--ais-transition-timing-function);
+
+  svg {
+    width: 100%;
+    height: 100%;
+  }
 }
 
 .ais-ChatMessageReasoning[open] .ais-ChatMessageReasoning-chevron {
@@ -78,8 +102,8 @@
   border-block-start: 1px solid rgba(var(--ais-muted-color-rgb), 0.2);
   background-color: rgba(var(--ais-muted-color-rgb), 0.06);
   color: rgba(var(--ais-text-color-rgb), 0.7);
-  font-size: calc(var(--ais-spacing) * 0.8125);
-  line-height: 1.5;
+  font-size: calc(var(--ais-spacing) * 0.875);
+  line-height: calc(var(--ais-spacing) * 1.25);
   overflow-y: auto;
 }
 

--- a/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
@@ -1,0 +1,110 @@
+.ais-ChatMessageReasoning {
+  margin-block-end: calc(var(--ais-spacing) * 0.5);
+  border: 1px solid rgba(var(--ais-muted-color-rgb), 0.25);
+  border-radius: var(--ais-border-radius-md);
+  background-color: var(--ais-background-color);
+  overflow: hidden;
+}
+
+.ais-ChatMessageReasoning-header {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: calc(var(--ais-spacing) * 0.375);
+  width: 100%;
+  padding: calc(var(--ais-spacing) * 0.375) calc(var(--ais-spacing) * 0.5);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &::marker {
+    content: '';
+  }
+
+  &:hover {
+    background-color: rgba(var(--ais-muted-color-rgb), 0.06);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgba(var(--ais-primary-color-rgb), 0.5);
+    outline-offset: -2px;
+  }
+}
+
+.ais-ChatMessageReasoning-icon,
+.ais-ChatMessageReasoning-chevron {
+  display: inline-flex;
+  width: calc(var(--ais-icon-size) * 0.85);
+  height: calc(var(--ais-icon-size) * 0.85);
+  color: rgba(var(--ais-muted-color-rgb), 0.9);
+  flex-shrink: 0;
+
+  svg {
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.ais-ChatMessageReasoning-label {
+  flex: 1;
+  min-width: 0;
+  color: rgba(var(--ais-muted-color-rgb), 0.95);
+  font-size: calc(var(--ais-spacing) * 0.8125);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ais-ChatMessageReasoning-label--streaming {
+  animation: ais-chat-reasoning-pulse 2s ease-in-out infinite;
+}
+
+.ais-ChatMessageReasoning-chevron {
+  transition: transform var(--ais-transition-duration)
+    var(--ais-transition-timing-function);
+}
+
+.ais-ChatMessageReasoning[open] .ais-ChatMessageReasoning-chevron {
+  transform: rotate(180deg);
+}
+
+.ais-ChatMessageReasoning-body {
+  max-height: 9rem;
+  padding: calc(var(--ais-spacing) * 0.5) calc(var(--ais-spacing) * 0.75);
+  border-block-start: 1px solid rgba(var(--ais-muted-color-rgb), 0.2);
+  background-color: rgba(var(--ais-muted-color-rgb), 0.06);
+  color: rgba(var(--ais-text-color-rgb), 0.7);
+  font-size: calc(var(--ais-spacing) * 0.8125);
+  line-height: 1.5;
+  overflow-y: auto;
+}
+
+.ais-ChatMessageReasoning-text {
+  overflow-wrap: anywhere;
+
+  > :first-child {
+    margin-block-start: 0;
+  }
+
+  > :last-child {
+    margin-block-end: 0;
+  }
+}
+
+@keyframes ais-chat-reasoning-pulse {
+  50% {
+    opacity: 0.5;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ais-ChatMessageReasoning-label,
+  .ais-ChatMessageReasoning-chevron {
+    animation: none;
+    transition: none;
+  }
+}

--- a/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
@@ -16,7 +16,10 @@
   width: 100%;
   border: 1px solid rgba(var(--ais-muted-color-rgb), 0.25);
   border-radius: var(--ais-border-radius-sm);
-  background-color: var(--ais-background-color);
+  background-color: rgba(
+    var(--ais-background-color-rgb),
+    var(--ais-background-color-alpha)
+  );
   overflow: hidden;
 }
 
@@ -44,7 +47,8 @@
   }
 
   &:focus-visible {
-    outline: 2px solid rgba(var(--ais-primary-color-rgb), 0.5);
+    outline: 2px solid
+      rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
     outline-offset: -2px;
   }
 }
@@ -121,7 +125,7 @@
 
 @keyframes ais-chat-reasoning-pulse {
   50% {
-    opacity: 0.5;
+    opacity: 0.85;
   }
 }
 

--- a/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
@@ -109,6 +109,12 @@
   font-size: calc(var(--ais-spacing) * 0.875);
   line-height: calc(var(--ais-spacing) * 1.25);
   overflow-y: auto;
+
+  &:focus-visible {
+    outline: 2px solid
+      rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
+    outline-offset: -2px;
+  }
 }
 
 .ais-ChatMessageReasoning-text {

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -211,6 +211,290 @@ function messageById(
 }
 
 describe('AbstractChat.processStreamWithCallbacks', () => {
+  describe('reasoning lifecycle', () => {
+    function createReasoningStreamSetup({
+      onError,
+      onFinish,
+    }: {
+      onError?: ChatOnErrorCallback;
+      onFinish?: ChatOnFinishCallback<UIMessage>;
+    } = {}) {
+      const reasoningStarted = deferred<void>();
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+
+      state['~registerMessagesCallback'](() => {
+        const reasoningPart = assistantPart(state);
+        if (
+          reasoningPart?.type === 'reasoning' &&
+          reasoningPart.state === 'streaming' &&
+          reasoningPart.text === 'Checking the catalog'
+        ) {
+          reasoningStarted.resolve();
+        }
+      });
+
+      const setup = createTestSetup({
+        state,
+        onError,
+        onFinish,
+        streamFactory: () =>
+          new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              streamController = controller;
+              controller.enqueue(startChunk());
+              controller.enqueue({
+                type: 'reasoning-start',
+                id: 'reasoning-1',
+              });
+              controller.enqueue({
+                type: 'reasoning-delta',
+                id: 'reasoning-1',
+                delta: 'Checking the catalog',
+              });
+            },
+          }),
+      });
+
+      return {
+        ...setup,
+        reasoningStarted: reasoningStarted.promise,
+        closeStream: () => streamController.close(),
+        failStream: (error: Error) => streamController.error(error),
+      };
+    }
+
+    it('completes unfinished reasoning when the response is stopped', async () => {
+      const setup = createReasoningStreamSetup();
+      const send = setup.chat.sendMessage({ text: 'Find a product' });
+      await setup.reasoningStarted;
+
+      await setup.chat.stop();
+
+      expect(setup.state.status).toBe('ready');
+      expect(assistantPart(setup.state)).toMatchObject({
+        type: 'reasoning',
+        text: 'Checking the catalog',
+        state: 'done',
+      });
+
+      setup.closeStream();
+      await send;
+    });
+
+    it('completes unfinished reasoning when the stream fails', async () => {
+      const onError = jest.fn();
+      const setup = createReasoningStreamSetup({ onError });
+      const send = setup.chat.sendMessage({ text: 'Find a product' });
+      await setup.reasoningStarted;
+
+      setup.failStream(new Error('disconnected'));
+      await send;
+
+      expect(setup.state.status).toBe('error');
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(assistantPart(setup.state)).toMatchObject({
+        type: 'reasoning',
+        text: 'Checking the catalog',
+        state: 'done',
+      });
+    });
+
+    it('completes unfinished reasoning when the stream closes', async () => {
+      const onFinish = jest.fn();
+      const setup = createReasoningStreamSetup({ onFinish });
+      const send = setup.chat.sendMessage({ text: 'Find a product' });
+      await setup.reasoningStarted;
+
+      setup.closeStream();
+      await send;
+
+      expect(setup.state.status).toBe('ready');
+      expect(assistantPart(setup.state)).toMatchObject({
+        type: 'reasoning',
+        text: 'Checking the catalog',
+        state: 'done',
+      });
+      expect(onFinish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({
+            parts: [
+              expect.objectContaining({
+                type: 'reasoning',
+                state: 'done',
+              }),
+            ],
+          }),
+        })
+      );
+    });
+
+    it('only completes reasoning owned by the terminal response when message ids are reused', async () => {
+      const oldReasoningStarted = deferred<void>();
+      const newReasoningStarted = deferred<void>();
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      let oldStreamController!: ReadableStreamDefaultController<UIMessageChunk>;
+      let newStreamController!: ReadableStreamDefaultController<UIMessageChunk>;
+
+      state['~registerMessagesCallback'](() => {
+        const reasoningParts =
+          state.messages
+            .find((message) => message.id === 'assistant-shared')
+            ?.parts.filter((part) => part.type === 'reasoning') ?? [];
+
+        if (
+          reasoningParts.some(
+            (part) =>
+              part.type === 'reasoning' &&
+              part.text === 'Old response' &&
+              part.state === 'streaming'
+          )
+        ) {
+          oldReasoningStarted.resolve();
+        }
+        if (
+          reasoningParts.some(
+            (part) =>
+              part.type === 'reasoning' &&
+              part.text === 'New response' &&
+              part.state === 'streaming'
+          )
+        ) {
+          newReasoningStarted.resolve();
+        }
+      });
+
+      const chat = new ConcurrentTestChat({
+        state,
+        onError: jest.fn(),
+      });
+      const oldResponse = chat.startResponse(
+        new ReadableStream<UIMessageChunk>({
+          start(controller) {
+            oldStreamController = controller;
+            controller.enqueue(startChunk('assistant-shared'));
+            controller.enqueue({
+              type: 'reasoning-start',
+              id: 'reasoning-old',
+            });
+            controller.enqueue({
+              type: 'reasoning-delta',
+              id: 'reasoning-old',
+              delta: 'Old response',
+            });
+          },
+        })
+      );
+      await oldReasoningStarted.promise;
+
+      const newResponse = chat.startResponse(
+        new ReadableStream<UIMessageChunk>({
+          start(controller) {
+            newStreamController = controller;
+            controller.enqueue(startChunk('assistant-shared'));
+            controller.enqueue({
+              type: 'reasoning-start',
+              id: 'reasoning-new',
+            });
+            controller.enqueue({
+              type: 'reasoning-delta',
+              id: 'reasoning-new',
+              delta: 'New response',
+            });
+          },
+        })
+      );
+      await newReasoningStarted.promise;
+
+      expect(
+        messageById(state, 'assistant-shared').parts.filter(
+          (part) => part.type === 'reasoning'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          text: 'Old response',
+          state: 'done',
+        }),
+        expect.objectContaining({
+          text: 'New response',
+          state: 'streaming',
+        }),
+      ]);
+
+      oldStreamController.error(new Error('old response disconnected'));
+      await oldResponse;
+
+      expect(state.status).toBe('streaming');
+      expect(
+        messageById(state, 'assistant-shared').parts.filter(
+          (part) => part.type === 'reasoning'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          text: 'Old response',
+          state: 'done',
+        }),
+        expect.objectContaining({
+          text: 'New response',
+          state: 'streaming',
+        }),
+      ]);
+
+      newStreamController.close();
+      await newResponse;
+
+      expect(state.status).toBe('ready');
+      expect(
+        messageById(state, 'assistant-shared').parts.filter(
+          (part) => part.type === 'reasoning'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          text: 'Old response',
+          state: 'done',
+        }),
+        expect.objectContaining({
+          text: 'New response',
+          state: 'done',
+        }),
+      ]);
+    });
+
+    it('completes unfinished reasoning when a tool callback rejects', async () => {
+      const onError = jest.fn();
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          { type: 'reasoning-start', id: 'reasoning-1' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-1',
+            delta: 'Checking the catalog',
+          },
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: () => Promise.reject(new Error('tool failed')),
+        onError,
+      });
+
+      await setup.chat.sendMessage({ text: 'Find a product' });
+
+      expect(setup.state.status).toBe('error');
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(assistantPart(setup.state)).toMatchObject({
+        type: 'reasoning',
+        text: 'Checking the catalog',
+        state: 'done',
+      });
+    });
+  });
+
   describe('guardrail violations', () => {
     it('replaces partial assistant content with the fallback and finishes ready', async () => {
       const fallbackResponse =

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -785,57 +785,115 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
   });
 
   describe('guardrail violations', () => {
-    it('replaces partial assistant content with the fallback and finishes ready', async () => {
-      const fallbackResponse =
-        "I can't help with that request, but I can help with product questions.";
-      const onFinish = jest.fn();
-      const onError = jest.fn();
-      const { chat, state } = createTestSetup({
-        chunks: [
-          startChunk(),
+    it.each<{
+      name: string;
+      openChunks: UIMessageChunk[];
+      trailingChunk: UIMessageChunk;
+    }>([
+      {
+        name: 'a text end',
+        openChunks: [
           { type: 'text-start', id: 'text-1' },
           {
             type: 'text-delta',
             id: 'text-1',
             delta: 'Unsafe partial content',
           },
-          {
-            type: 'data-guardrail-violation',
-            data: {
-              category: 'blocked',
-              guardrailType: 'output',
-              fallbackResponse,
-            },
-          },
-          finishChunk(),
         ],
-        onError,
-        onFinish,
-      });
+        trailingChunk: { type: 'text-end', id: 'text-1' },
+      },
+      {
+        name: 'a text delta',
+        openChunks: [{ type: 'text-start', id: 'text-1' }],
+        trailingChunk: {
+          type: 'text-delta',
+          id: 'text-1',
+          delta: 'Unsafe trailing content',
+        },
+      },
+      {
+        name: 'a reasoning end',
+        openChunks: [
+          { type: 'reasoning-start', id: 'reasoning-1' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-1',
+            delta: 'Unsafe partial reasoning',
+          },
+        ],
+        trailingChunk: { type: 'reasoning-end', id: 'reasoning-1' },
+      },
+      {
+        name: 'a reasoning delta',
+        openChunks: [{ type: 'reasoning-start', id: 'reasoning-1' }],
+        trailingChunk: {
+          type: 'reasoning-delta',
+          id: 'reasoning-1',
+          delta: 'Unsafe trailing reasoning',
+        },
+      },
+      {
+        name: 'a new text part',
+        openChunks: [{ type: 'text-start', id: 'text-1' }],
+        trailingChunk: { type: 'text-start', id: 'text-2' },
+      },
+      {
+        name: 'a new reasoning part',
+        openChunks: [{ type: 'reasoning-start', id: 'reasoning-1' }],
+        trailingChunk: { type: 'reasoning-start', id: 'reasoning-2' },
+      },
+    ])(
+      'keeps the guardrail fallback after $name',
+      async ({ openChunks, trailingChunk }) => {
+        const fallbackResponse =
+          "I can't help with that request, but I can help with product questions.";
+        const onFinish = jest.fn();
+        const onError = jest.fn();
+        const { chat, state } = createTestSetup({
+          chunks: [
+            startChunk(),
+            { type: 'start-step' },
+            ...openChunks,
+            {
+              type: 'data-guardrail-violation',
+              data: {
+                category: 'blocked',
+                guardrailType: 'output',
+                fallbackResponse,
+              },
+            },
+            trailingChunk,
+            {
+              type: 'finish',
+              messageMetadata: { finishReason: 'stop' },
+            },
+          ],
+          onError,
+          onFinish,
+        });
 
-      await chat.sendMessage({ text: 'blocked request' });
+        await chat.sendMessage({ text: 'blocked request' });
 
-      const assistant = state.messages.find((m) => m.role === 'assistant')!;
+        const assistant = state.messages.find((m) => m.role === 'assistant')!;
 
-      expect(state.status).toBe('ready');
-      expect(state.error).toBeUndefined();
-      expect(onError).not.toHaveBeenCalled();
-      expect(assistant).toMatchObject({
-        id: 'msg-1',
-        role: 'assistant',
-        parts: [{ type: 'text', text: fallbackResponse, state: 'done' }],
-      });
-      expect(JSON.stringify(assistant.parts)).not.toContain(
-        'Unsafe partial content'
-      );
-      expect(onFinish).toHaveBeenCalledWith({
-        message: assistant,
-        messages: state.messages,
-        isAbort: false,
-        isDisconnect: false,
-        isError: false,
-      });
-    });
+        expect(state.status).toBe('ready');
+        expect(state.error).toBeUndefined();
+        expect(onError).not.toHaveBeenCalled();
+        expect(assistant).toMatchObject({
+          id: 'msg-1',
+          role: 'assistant',
+          metadata: { finishReason: 'stop' },
+          parts: [{ type: 'text', text: fallbackResponse, state: 'done' }],
+        });
+        expect(onFinish).toHaveBeenCalledWith({
+          message: assistant,
+          messages: state.messages,
+          isAbort: false,
+          isDisconnect: false,
+          isError: false,
+        });
+      }
+    );
 
     it('creates a fallback assistant message when violation arrives before an assistant message starts', async () => {
       const onFinish = jest.fn();

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -4,6 +4,7 @@
 import { ChatState as RuntimeChatState } from '../../chat/chat';
 import { AbstractChat } from '../abstract-chat';
 import { parseJsonEventStream } from '../stream-parser';
+import { DefaultChatTransport } from '../transport';
 
 import type {
   ChatOnErrorCallback,
@@ -358,7 +359,7 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       ]);
     });
 
-    it('keeps resumed reasoning separate from an unfinished stored part', async () => {
+    it('keeps new reasoning separate outside a resumed stream', async () => {
       const state = new RuntimeChatState<UIMessage>(
         'test-chat',
         [
@@ -376,35 +377,25 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         ],
         false
       );
-      const sendMessages = jest.fn();
-      const reconnectToStream = jest.fn(() =>
-        Promise.resolve(
-          chunksToStream([
-            startChunk(),
-            { type: 'reasoning-start', id: 'reasoning-after-reconnect' },
-            {
-              type: 'reasoning-delta',
-              id: 'reasoning-after-reconnect',
-              delta: 'After reconnect',
-            },
-            { type: 'reasoning-end', id: 'reasoning-after-reconnect' },
-            finishChunk(),
-          ])
-        )
-      );
-      const chat = new TestChat({
+      const chat = new ConcurrentTestChat({
         id: 'test-chat',
         state,
-        transport: {
-          sendMessages: sendMessages as any,
-          reconnectToStream: reconnectToStream as any,
-        },
       });
 
-      await chat.resumeStream();
+      await chat.startResponse(
+        chunksToStream([
+          startChunk(),
+          { type: 'reasoning-start', id: 'reasoning-after-reconnect' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-after-reconnect',
+            delta: 'After reconnect',
+          },
+          { type: 'reasoning-end', id: 'reasoning-after-reconnect' },
+          finishChunk(),
+        ])
+      );
 
-      expect(sendMessages).not.toHaveBeenCalled();
-      expect(reconnectToStream).toHaveBeenCalledTimes(1);
       expect(
         messageById(state, 'msg-1').parts.filter(
           (part) => part.type === 'reasoning'
@@ -420,6 +411,144 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
           text: 'After reconnect',
           state: 'done',
           providerMetadata: undefined,
+        },
+      ]);
+    });
+
+    it('reuses unfinished reasoning when a resumed stream replays it', async () => {
+      const state = new RuntimeChatState<UIMessage>(
+        'test-chat',
+        [
+          {
+            id: 'msg-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Already buffered',
+                state: 'streaming',
+              },
+            ],
+          },
+        ],
+        false
+      );
+      const replayedChunks: UIMessageChunk[] = [
+        startChunk(),
+        { type: 'reasoning-start', id: 'reasoning-1' },
+        {
+          type: 'reasoning-delta',
+          id: 'reasoning-1',
+          delta: 'Already ',
+        },
+        {
+          type: 'reasoning-delta',
+          id: 'reasoning-1',
+          delta: 'buffered',
+        },
+        {
+          type: 'reasoning-delta',
+          id: 'reasoning-1',
+          delta: ' and completed',
+        },
+        { type: 'reasoning-end', id: 'reasoning-1' },
+        finishChunk(),
+      ];
+      const replayedBody =
+        replayedChunks
+          .map((chunk) => `data: ${JSON.stringify(chunk)}\n`)
+          .join('') + 'data: [DONE]\n';
+      const fetch = jest.fn(() =>
+        Promise.resolve(
+          new Response(replayedBody, {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+          })
+        )
+      ) as typeof globalThis.fetch;
+      const transport = new DefaultChatTransport<UIMessage>({
+        api: 'https://example.test/api/chat',
+        fetch,
+      });
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        transport,
+      });
+
+      await chat.resumeStream();
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://example.test/api/chat?chatId=test-chat',
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(state.status).toBe('ready');
+      expect(
+        messageById(state, 'msg-1').parts.filter(
+          (part) => part.type === 'reasoning'
+        )
+      ).toEqual([
+        {
+          type: 'reasoning',
+          text: 'Already buffered and completed',
+          state: 'done',
+          providerMetadata: undefined,
+        },
+      ]);
+    });
+
+    it('continues one unfinished reasoning part from resume suffix chunks', async () => {
+      const state = new RuntimeChatState<UIMessage>(
+        'test-chat',
+        [
+          {
+            id: 'msg-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Already buffered',
+                state: 'streaming',
+              },
+            ],
+          },
+        ],
+        false
+      );
+      const reconnectToStream = jest.fn(() =>
+        Promise.resolve(
+          chunksToStream([
+            startChunk(),
+            {
+              type: 'reasoning-delta',
+              id: 'reasoning-1',
+              delta: ' and completed',
+            },
+            { type: 'reasoning-end', id: 'reasoning-1' },
+            finishChunk(),
+          ])
+        )
+      );
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        transport: {
+          sendMessages: jest.fn() as any,
+          reconnectToStream: reconnectToStream as any,
+        },
+      });
+
+      await chat.resumeStream();
+
+      expect(
+        messageById(state, 'msg-1').parts.filter(
+          (part) => part.type === 'reasoning'
+        )
+      ).toEqual([
+        {
+          type: 'reasoning',
+          text: 'Already buffered and completed',
+          state: 'done',
         },
       ]);
     });

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -945,6 +945,37 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       ]);
     });
 
+    it('waits for split replay deltas to identify the matching reasoning block', async () => {
+      const { chat, state } = createResumeSetup(
+        [
+          { type: 'reasoning', text: 'Search', state: 'done' },
+          {
+            type: 'reasoning',
+            text: 'Search catalog',
+            state: 'streaming',
+          },
+        ],
+        [
+          { type: 'reasoning-start', id: 'reasoning-b' },
+          { type: 'reasoning-delta', id: 'reasoning-b', delta: 'Search' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-b',
+            delta: ' catalog completed',
+          },
+          { type: 'reasoning-end', id: 'reasoning-b' },
+          finishChunk(),
+        ]
+      );
+
+      await chat.resumeStream();
+
+      expect(getReasoningText(state)).toEqual([
+        'Search',
+        'Search catalog completed',
+      ]);
+    });
+
     it.each(['close', 'error', 'stop'] as const)(
       'does not restore a cleared message when a pending replay ends with %s',
       async (termination) => {
@@ -1102,6 +1133,123 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         state: 'done',
       });
     });
+
+    it.each([
+      {
+        suffixId: 'reasoning-1',
+        expectedText: 'Already and completed',
+        description: 'continues the matching reasoning block',
+        replaceTranscript: false,
+      },
+      {
+        suffixId: 'reasoning-2',
+        expectedText: 'Already',
+        description: 'ignores a suffix owned by another reasoning block',
+        replaceTranscript: false,
+      },
+      {
+        suffixId: 'reasoning-1',
+        expectedText: 'Already',
+        description: 'ignores retired ownership after replacing the transcript',
+        replaceTranscript: true,
+      },
+    ])(
+      '$description when the same chat resumes after a disconnect',
+      async ({ suffixId, expectedText, replaceTranscript }) => {
+        const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+        const reasoningStarted = deferred<void>();
+        let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+
+        state['~registerMessagesCallback'](() => {
+          const reasoningPart = messageById(state, 'msg-1')?.parts.find(
+            (part) => part.type === 'reasoning'
+          );
+          if (
+            reasoningPart?.type === 'reasoning' &&
+            reasoningPart.text === 'Already'
+          ) {
+            reasoningStarted.resolve();
+          }
+        });
+
+        const chat = new TestChat({
+          id: 'test-chat',
+          state,
+          onError: jest.fn(),
+          transport: {
+            sendMessages: jest.fn(() =>
+              Promise.resolve(
+                new ReadableStream<UIMessageChunk>({
+                  start(controller) {
+                    streamController = controller;
+                    controller.enqueue(startChunk());
+                    controller.enqueue({
+                      type: 'reasoning-start',
+                      id: 'reasoning-1',
+                    });
+                    controller.enqueue({
+                      type: 'reasoning-delta',
+                      id: 'reasoning-1',
+                      delta: 'Already',
+                    });
+                  },
+                })
+              )
+            ) as any,
+            reconnectToStream: jest.fn(() =>
+              Promise.resolve(
+                chunksToStream([
+                  startChunk(),
+                  {
+                    type: 'reasoning-delta',
+                    id: suffixId,
+                    delta: ' and completed',
+                  },
+                  { type: 'reasoning-end', id: suffixId },
+                  finishChunk(),
+                ])
+              )
+            ) as any,
+          },
+        });
+
+        const send = chat.sendMessage({ text: 'Find a product' });
+        await reasoningStarted.promise;
+        streamController.error(new Error('disconnected'));
+        await send;
+
+        expect(chat.status).toBe('error');
+        expect(getReasoningText(state)).toEqual(['Already']);
+
+        if (replaceTranscript) {
+          chat.messages = chat.messages.map((message) =>
+            message.id === 'msg-1'
+              ? {
+                  id: 'msg-1',
+                  role: 'assistant',
+                  parts: [
+                    {
+                      type: 'reasoning',
+                      text: 'Already',
+                      state: 'done',
+                    },
+                    {
+                      type: 'text',
+                      text: 'Replacement answer',
+                      state: 'done',
+                    },
+                  ],
+                }
+              : message
+          );
+        }
+
+        await chat.resumeStream();
+
+        expect(chat.status).toBe('ready');
+        expect(getReasoningText(state)).toEqual([expectedText]);
+      }
+    );
 
     it('completes unfinished reasoning when the stream closes', async () => {
       const onFinish = jest.fn();

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -93,6 +93,22 @@ function chunksToStream(
   });
 }
 
+function chunksToErrorStream(
+  chunks: UIMessageChunk[],
+  error: Error
+): ReadableStream<UIMessageChunk> {
+  let index = 0;
+  return new ReadableStream<UIMessageChunk>({
+    pull(controller) {
+      if (index < chunks.length) {
+        controller.enqueue(chunks[index++]);
+      } else {
+        controller.error(error);
+      }
+    },
+  });
+}
+
 /**
  * Parses raw SSE text the same way the production transport does
  * (`parseJsonEventStream`). Reserved for the verbatim-capture test, which is
@@ -1069,9 +1085,7 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
           )[0].parts.flatMap((part) =>
             part.type === 'reasoning' ? [part.text] : []
           )
-        ).toEqual(
-          termination === 'close' ? expectedMemory : ['Already buffered']
-        );
+        ).toEqual(expectedMemory);
       }
     );
 
@@ -2009,6 +2023,139 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       ]);
     });
 
+    it('reuses the unfinished assistant message when a replay start has no message id', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const toolCallDispatched = deferred<void>();
+      let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+      const onToolCall = jest.fn(() => {
+        toolCallDispatched.resolve();
+      });
+      const replayedChunks: UIMessageChunk[] = [
+        { type: 'start' },
+        {
+          type: 'tool-input-available',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: { query: 'headphones' },
+        },
+        { type: 'text-start', id: 'text-1' },
+        {
+          type: 'text-delta',
+          id: 'text-1',
+          delta: 'Here are the results.',
+        },
+      ];
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        generateId: (() => {
+          let index = 0;
+          return () => `gen-${++index}`;
+        })(),
+        onError: jest.fn(),
+        onToolCall,
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(
+              new ReadableStream<UIMessageChunk>({
+                start(controller) {
+                  streamController = controller;
+                  replayedChunks.forEach((chunk) =>
+                    controller.enqueue(chunk)
+                  );
+                },
+              })
+            )
+          ) as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([
+                ...replayedChunks,
+                { type: 'text-end', id: 'text-1' },
+                finishChunk(),
+              ])
+            )
+          ) as any,
+        },
+      });
+
+      const send = chat.sendMessage({ text: 'Find headphones' });
+      await toolCallDispatched.promise;
+      streamController.error(new Error('disconnected'));
+      await send;
+      await chat.resumeStream();
+
+      expect(
+        state.messages.filter((message) => message.role === 'assistant')
+      ).toEqual([
+        expect.objectContaining({
+          id: 'gen-2',
+          parts: expect.arrayContaining([
+            expect.objectContaining({
+              type: 'tool-search',
+              toolCallId: 'call-1',
+            }),
+            expect.objectContaining({
+              type: 'text',
+              text: 'Here are the results.',
+            }),
+          ]),
+        }),
+      ]);
+      expect(onToolCall).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not restore an idless replay cleared before its stream is available', async () => {
+      const state = new RuntimeChatState<UIMessage>(
+        'test-chat',
+        [
+          {
+            id: 'msg-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Already buffered',
+                state: 'streaming',
+              },
+            ],
+          },
+        ],
+        false
+      );
+      const replayStreamAvailable =
+        deferred<ReadableStream<UIMessageChunk> | null>();
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        transport: {
+          sendMessages: jest.fn() as any,
+          reconnectToStream: jest.fn(
+            () => replayStreamAvailable.promise
+          ) as any,
+        },
+      });
+
+      const resume = chat.resumeStream();
+      chat.messages = [];
+      replayStreamAvailable.resolve(
+        chunksToStream([
+          { type: 'start' },
+          { type: 'reasoning-start', id: 'reasoning-1' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-1',
+            delta: 'Replayed reasoning',
+          },
+          finishChunk(),
+        ])
+      );
+      await resume;
+
+      expect(chat.messages).toEqual([]);
+      expect(chat.status).toBe('ready');
+    });
+
     it('does not repeat a tool callback during a same-instance full replay', async () => {
       const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
       state.snapshot = <T>(value: T): T => value;
@@ -2157,7 +2304,7 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
 
       await chat.sendMessage({ text: 'Find headphones' });
-      await chat.resumeStream();
+      const resume = chat.resumeStream();
       await chat.addToolResult({
         tool: 'search',
         toolCallId: 'call-1',
@@ -2165,6 +2312,7 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
       releaseToolResult.resolve();
       await releaseToolResult.promise;
+      await resume;
 
       expect(onToolCall).toHaveBeenCalledTimes(1);
       expect(sendMessages).toHaveBeenCalledTimes(2);
@@ -2173,6 +2321,347 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         output: { hits: [] },
       });
     });
+
+    it('waits for a pending tool callback before completing a replay', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const releaseToolResult = deferred<void>();
+      const callbackStarted = deferred<void>();
+      const onFinish = jest.fn();
+      let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+      let callback!: Promise<void>;
+      let chat!: TestChat;
+      const replayedToolChunks: UIMessageChunk[] = [
+        startChunk(),
+        {
+          type: 'tool-input-available',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: { query: 'headphones' },
+        },
+      ];
+
+      chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError: jest.fn(),
+        onFinish,
+        onToolCall: () => {
+          callbackStarted.resolve();
+          callback = releaseToolResult.promise.then(() =>
+            chat.addToolResult({
+              tool: 'search',
+              toolCallId: 'call-1',
+              output: { hits: [] },
+            })
+          );
+          return callback;
+        },
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(
+              new ReadableStream<UIMessageChunk>({
+                start(controller) {
+                  streamController = controller;
+                  replayedToolChunks.forEach((chunk) =>
+                    controller.enqueue(chunk)
+                  );
+                },
+              })
+            )
+          ) as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([...replayedToolChunks, finishChunk()])
+            )
+          ) as any,
+        },
+      });
+
+      const send = chat.sendMessage({ text: 'Find headphones' });
+      await callbackStarted.promise;
+      streamController.error(new Error('disconnected'));
+      await send;
+
+      const resume = chat.resumeStream();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(onFinish).toHaveBeenCalledTimes(1);
+
+      releaseToolResult.resolve();
+      await callback;
+      await resume;
+
+      expect(onFinish).toHaveBeenCalledTimes(2);
+      expect(onFinish).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isDisconnect: false,
+          isError: false,
+          message: expect.objectContaining({
+            parts: [
+              expect.objectContaining({
+                toolCallId: 'call-1',
+                state: 'output-available',
+                output: { hits: [] },
+              }),
+            ],
+          }),
+        })
+      );
+    });
+
+    it.each(['original first', 'replayed first'] as const)(
+      'keeps one continuation owner when $resultOrder tool results settle',
+      async (resultOrder) => {
+        const state = new RuntimeChatState<UIMessage>(
+          'test-chat',
+          [],
+          false
+        );
+        const releaseOriginalResult = deferred<void>();
+        const replayedToolAvailable = deferred<void>();
+        let originalCallback!: Promise<void>;
+        let sendCount = 0;
+        let chat!: TestChat;
+        const replayedPrefix: UIMessageChunk[] = [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-original',
+            input: { query: 'headphones' },
+          },
+        ];
+        const sendMessages = jest.fn(() => {
+          sendCount++;
+          if (sendCount === 1) {
+            return Promise.resolve(
+              chunksToErrorStream(replayedPrefix, new Error('disconnected'))
+            );
+          }
+          return Promise.resolve(
+            chunksToStream([startChunk('msg-2'), finishChunk()])
+          );
+        });
+
+        chat = new TestChat({
+          id: 'test-chat',
+          state,
+          onError: jest.fn(),
+          onToolCall: (
+            { toolCall }: { toolCall: any },
+            addToolResult?: TestChat['addToolResult']
+          ) => {
+            if (toolCall.toolCallId === 'call-original') {
+              originalCallback = releaseOriginalResult.promise.then(() =>
+                addToolResult!({
+                  tool: 'search',
+                  toolCallId: 'call-original',
+                  output: { hits: ['original'] },
+                })
+              );
+              return originalCallback;
+            }
+            replayedToolAvailable.resolve();
+            return undefined;
+          },
+          sendAutomaticallyWhen: ({ messages }) => {
+            const toolParts = messages
+              .find((message) => message.id === 'msg-1')
+              ?.parts.filter((part) => 'toolCallId' in part);
+            return Boolean(
+              toolParts?.length === 2 &&
+                toolParts.every((part) => part.state === 'output-available')
+            );
+          },
+          transport: {
+            sendMessages: sendMessages as any,
+            reconnectToStream: jest.fn(() =>
+              Promise.resolve(
+                chunksToStream([
+                  ...replayedPrefix,
+                  {
+                    type: 'tool-input-available',
+                    toolName: 'search',
+                    toolCallId: 'call-replayed',
+                    input: { query: 'earbuds' },
+                  },
+                  finishChunk(),
+                ])
+              )
+            ) as any,
+          },
+        });
+
+        await chat.sendMessage({ text: 'Find headphones' });
+        const resume = chat.resumeStream();
+        await replayedToolAvailable.promise;
+
+        const submitReplayedResult = () => {
+          const message = chat.messages.find(
+            (candidate) => candidate.id === 'msg-1'
+          )!;
+          return chat['~addToolResultForMessage'](message, {
+            tool: 'search',
+            toolCallId: 'call-replayed',
+            output: { hits: ['replayed'] },
+          });
+        };
+
+        if (resultOrder === 'original first') {
+          releaseOriginalResult.resolve();
+          await originalCallback;
+          await submitReplayedResult();
+        } else {
+          await submitReplayedResult();
+          releaseOriginalResult.resolve();
+          await originalCallback;
+        }
+        await resume;
+
+        expect(sendMessages).toHaveBeenCalledTimes(2);
+        expect(assistantToolPart(state, 'call-original')).toMatchObject({
+          state: 'output-available',
+          output: { hits: ['original'] },
+        });
+        expect(assistantToolPart(state, 'call-replayed')).toMatchObject({
+          state: 'output-available',
+          output: { hits: ['replayed'] },
+        });
+      }
+    );
+
+    it('continues after a pending tool callback settles through a null reconnect', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const releaseToolResult = deferred<void>();
+      const reconnectResult =
+        deferred<ReadableStream<UIMessageChunk> | null>();
+      let callback!: Promise<void>;
+      let sendCount = 0;
+      let chat!: TestChat;
+      const toolChunks: UIMessageChunk[] = [
+        startChunk(),
+        {
+          type: 'tool-input-available',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: { query: 'headphones' },
+        },
+      ];
+      const sendMessages = jest.fn(() => {
+        sendCount++;
+        return Promise.resolve(
+          sendCount === 1
+            ? chunksToErrorStream(toolChunks, new Error('disconnected'))
+            : chunksToStream([startChunk('msg-2'), finishChunk()])
+        );
+      });
+      chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError: jest.fn(),
+        onToolCall: (
+          _options: { toolCall: any },
+          addToolResult?: TestChat['addToolResult']
+        ) => {
+          callback = releaseToolResult.promise.then(() =>
+            addToolResult!({
+              tool: 'search',
+              toolCallId: 'call-1',
+              output: { hits: [] },
+            })
+          );
+          return callback;
+        },
+        sendAutomaticallyWhen: ({ messages }) =>
+          messages.some((message) =>
+            message.parts.some(
+              (part) =>
+                'toolCallId' in part &&
+                part.toolCallId === 'call-1' &&
+                part.state === 'output-available'
+            )
+          ),
+        transport: {
+          sendMessages: sendMessages as any,
+          reconnectToStream: jest.fn(() => reconnectResult.promise) as any,
+        },
+      });
+
+      await chat.sendMessage({ text: 'Find headphones' });
+      const resume = chat.resumeStream();
+      reconnectResult.resolve(null);
+      await Promise.resolve();
+      releaseToolResult.resolve();
+      await callback;
+      await resume;
+
+      expect(sendMessages).toHaveBeenCalledTimes(2);
+      expect(chat.status).toBe('ready');
+      expect(assistantToolPart(state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { hits: [] },
+      });
+    });
+
+    it.each(['before', 'after'] as const)(
+      'reports a tool callback failure that settles $settlementOrder a null reconnect',
+      async (settlementOrder) => {
+        const state = new RuntimeChatState<UIMessage>(
+          'test-chat',
+          [],
+          false
+        );
+        const callback = deferred<void>();
+        const reconnectResult =
+          deferred<ReadableStream<UIMessageChunk> | null>();
+        const onError = jest.fn();
+        const chat = new TestChat({
+          id: 'test-chat',
+          state,
+          onError,
+          onToolCall: () => callback.promise,
+          transport: {
+            sendMessages: jest.fn(() =>
+              Promise.resolve(
+                chunksToErrorStream(
+                  [
+                    startChunk(),
+                    {
+                      type: 'tool-input-available',
+                      toolName: 'search',
+                      toolCallId: 'call-1',
+                      input: { query: 'headphones' },
+                    },
+                  ],
+                  new Error('disconnected')
+                )
+              )
+            ) as any,
+            reconnectToStream: jest.fn(() => reconnectResult.promise) as any,
+          },
+        });
+
+        await chat.sendMessage({ text: 'Find headphones' });
+        const resume = chat.resumeStream();
+        if (settlementOrder === 'before') {
+          callback.reject(new Error('tool failed'));
+          await callback.promise.catch(() => undefined);
+          reconnectResult.resolve(null);
+        } else {
+          reconnectResult.resolve(null);
+          await Promise.resolve();
+          callback.reject(new Error('tool failed'));
+          await callback.promise.catch(() => undefined);
+        }
+        await resume;
+
+        expect(onError).toHaveBeenCalledTimes(2);
+        expect(onError).toHaveBeenLastCalledWith(
+          expect.objectContaining({ message: 'tool failed' })
+        );
+        expect(chat.status).toBe('error');
+      }
+    );
 
     it('continues when a pending tool result settles before the replay stream is available', async () => {
       const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
@@ -2514,12 +3003,11 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       await callbackStarted.promise;
       streamController.error(new Error('disconnected'));
       await send;
-      await chat.resumeStream();
-      await chat.resumeStream();
 
+      const resume = chat.resumeStream();
       callback.reject(new Error('tool failed'));
       await callback.promise.catch(() => undefined);
-      await Promise.resolve();
+      await resume;
 
       expect(onError).toHaveBeenCalledTimes(2);
       expect(onError).toHaveBeenLastCalledWith(
@@ -2673,10 +3161,11 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(chat.status).toBe('ready');
     });
 
-    it('ignores a pending tool callback failure after the replayed message is cleared', async () => {
+    it('ignores a pending tool callback failure when the message is cleared before replay starts', async () => {
       const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
       const callback = deferred<void>();
       const callbackStarted = deferred<void>();
+      const replayStarted = deferred<void>();
       const onError = jest.fn();
       let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
       const replayedToolChunks: UIMessageChunk[] = [
@@ -2715,11 +3204,12 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
               })
             )
           ) as any,
-          reconnectToStream: jest.fn(() =>
-            Promise.resolve(
+          reconnectToStream: jest.fn(() => {
+            replayStarted.resolve();
+            return Promise.resolve(
               chunksToStream([...replayedToolChunks, finishChunk()])
-            )
-          ) as any,
+            );
+          }) as any,
         },
       });
 
@@ -2727,17 +3217,18 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       await callbackStarted.promise;
       streamController.error(new Error('disconnected'));
       await send;
-      await chat.resumeStream();
 
-      const errorCountAfterReplay = onError.mock.calls.length;
+      const resume = chat.resumeStream();
+      await replayStarted.promise;
+      const errorCountBeforeReplay = onError.mock.calls.length;
       chat.messages = [];
       callback.reject(new Error('tool failed after clear'));
       await callback.promise.catch(() => undefined);
-      await Promise.resolve();
+      await resume;
 
       expect(chat.messages).toEqual([]);
       expect(chat.status).toBe('ready');
-      expect(onError).toHaveBeenCalledTimes(errorCountAfterReplay);
+      expect(onError).toHaveBeenCalledTimes(errorCountBeforeReplay);
     });
 
     it('does not transfer replay ownership across messages sharing a tool call id', async () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -1,7 +1,11 @@
 /**
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
-import { ChatState as RuntimeChatState } from '../../chat/chat';
+import {
+  CACHE_KEY,
+  Chat as RuntimeChat,
+  ChatState as RuntimeChatState,
+} from '../../chat/chat';
 import { AbstractChat } from '../abstract-chat';
 import { parseJsonEventStream } from '../stream-parser';
 import { DefaultChatTransport } from '../transport';
@@ -265,6 +269,33 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       };
     }
 
+    function createResumeSetup(
+      parts: UIMessage['parts'],
+      chunks: UIMessageChunk[]
+    ) {
+      const state = new RuntimeChatState<UIMessage>(
+        'test-chat',
+        [{ id: 'msg-1', role: 'assistant', parts }],
+        false
+      );
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        transport: {
+          sendMessages: jest.fn() as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(chunksToStream([startChunk(), ...chunks]))
+          ) as any,
+        },
+      });
+      return { chat, state };
+    }
+
+    const getReasoningText = (state: ChatState<UIMessage>): string[] =>
+      messageById(state, 'msg-1').parts.flatMap((part) =>
+        part.type === 'reasoning' ? [part.text] : []
+      );
+
     it('keeps overlapping reasoning blocks associated with their stream ids', async () => {
       const { chat, state } = createTestSetup({
         chunks: [
@@ -497,6 +528,35 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       ]);
     });
 
+    it('keeps saved reasoning when a replay diverges before catching up', async () => {
+      const { chat, state } = createResumeSetup(
+        [
+          {
+            type: 'reasoning',
+            text: 'Already buffered',
+            state: 'streaming',
+          },
+        ],
+        [
+          { type: 'reasoning-start', id: 'reasoning-1' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-1',
+            delta: 'Different reasoning',
+          },
+          { type: 'reasoning-end', id: 'reasoning-1' },
+          finishChunk(),
+        ]
+      );
+
+      await chat.resumeStream();
+
+      expect(getReasoningText(state)).toEqual([
+        'Already buffered',
+        'Different reasoning',
+      ]);
+    });
+
     it('continues one unfinished reasoning part from resume suffix chunks', async () => {
       const state = new RuntimeChatState<UIMessage>(
         'test-chat',
@@ -551,6 +611,460 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
           state: 'done',
         },
       ]);
+    });
+
+    it.each([
+      {
+        termination: 'close',
+        replayedText: undefined,
+        expectedStatus: 'ready',
+        expectedMemory: ['Already buffered'],
+      },
+      {
+        termination: 'error',
+        replayedText: undefined,
+        expectedStatus: 'error',
+        expectedMemory: ['Already buffered'],
+      },
+      {
+        termination: 'close',
+        replayedText: 'Already',
+        expectedStatus: 'ready',
+        expectedMemory: ['Already buffered'],
+      },
+      {
+        termination: 'error',
+        replayedText: 'Already',
+        expectedStatus: 'error',
+        expectedMemory: ['Already buffered'],
+      },
+      {
+        termination: 'close',
+        replayedText: 'Different reasoning',
+        expectedStatus: 'ready',
+        expectedMemory: ['Already buffered', 'Different reasoning'],
+      },
+      {
+        termination: 'error',
+        replayedText: 'Different reasoning',
+        expectedStatus: 'error',
+        expectedMemory: ['Already buffered', 'Different reasoning'],
+      },
+    ] as const)(
+      'preserves saved reasoning when a replay ends with $termination after replaying $replayedText',
+      async ({ termination, replayedText, expectedStatus, expectedMemory }) => {
+        const agentId = `resume-${termination}-${replayedText ?? 'empty'}`;
+        const storageKey = `${CACHE_KEY}-${agentId}`;
+        const initialMessages: UIMessage[] = [
+          {
+            id: 'msg-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Already buffered',
+                state: 'streaming',
+              },
+            ],
+          },
+        ];
+        sessionStorage.setItem(storageKey, JSON.stringify(initialMessages));
+
+        let streamController!: ReadableStreamDefaultController<Uint8Array>;
+        const responseBody = new ReadableStream<Uint8Array>({
+          start(controller) {
+            streamController = controller;
+            const encoder = new TextEncoder();
+            controller.enqueue(
+              encoder.encode(
+                [
+                  startChunk(),
+                  { type: 'reasoning-start', id: 'reasoning-1' } as const,
+                  ...(replayedText
+                    ? ([
+                        {
+                          type: 'reasoning-delta',
+                          id: 'reasoning-1',
+                          delta: replayedText,
+                        },
+                      ] as const)
+                    : []),
+                  {
+                    type: 'message-metadata',
+                    messageMetadata: { replayProcessed: true },
+                  } as UIMessageChunk,
+                ]
+                  .map((chunk) => `data: ${JSON.stringify(chunk)}\n`)
+                  .join('')
+              )
+            );
+          },
+        });
+        const transport = new DefaultChatTransport<UIMessage>({
+          api: 'https://example.test/api/chat',
+          fetch: jest.fn(() =>
+            Promise.resolve(
+              new Response(responseBody, {
+                status: 200,
+                headers: { 'content-type': 'text/event-stream' },
+              })
+            )
+          ) as typeof globalThis.fetch,
+        });
+        const chat = new RuntimeChat<UIMessage>({
+          id: agentId,
+          agentId,
+          transport,
+          onError: jest.fn(),
+        });
+        const replayStarted = deferred<void>();
+        const getReplayMessage = () =>
+          chat.messages.find((message) => message.id === 'msg-1')!;
+        chat['~registerMessagesCallback'](() => {
+          const metadata = getReplayMessage().metadata as
+            | { replayProcessed?: boolean }
+            | undefined;
+          if (metadata?.replayProcessed) {
+            replayStarted.resolve();
+          }
+        });
+
+        const resume = chat.resumeStream();
+        await replayStarted.promise;
+        if (termination === 'close') {
+          streamController.close();
+        } else {
+          streamController.error(new Error('replay disconnected'));
+        }
+        await resume;
+
+        expect(chat.status).toBe(expectedStatus);
+        expect(
+          getReplayMessage().parts.flatMap((part) =>
+            part.type === 'reasoning' ? [part.text] : []
+          )
+        ).toEqual(expectedMemory);
+        expect(
+          (
+            JSON.parse(sessionStorage.getItem(storageKey)!) as UIMessage[]
+          )[0].parts.flatMap((part) =>
+            part.type === 'reasoning' ? [part.text] : []
+          )
+        ).toEqual(
+          termination === 'close' ? expectedMemory : ['Already buffered']
+        );
+      }
+    );
+
+    it('keeps completed reasoning before a suffix resume and a new block', async () => {
+      const { chat, state } = createResumeSetup(
+        [
+          {
+            type: 'reasoning',
+            text: 'First completed block',
+            state: 'done',
+          },
+          {
+            type: 'reasoning',
+            text: 'Second partial block',
+            state: 'streaming',
+          },
+        ],
+        [
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-2',
+            delta: ' completed',
+          },
+          { type: 'reasoning-end', id: 'reasoning-2' },
+          { type: 'reasoning-start', id: 'reasoning-3' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-3',
+            delta: 'Third new block',
+          },
+          { type: 'reasoning-end', id: 'reasoning-3' },
+          finishChunk(),
+        ]
+      );
+
+      await chat.resumeStream();
+
+      expect(getReasoningText(state)).toEqual([
+        'First completed block',
+        'Second partial block completed',
+        'Third new block',
+      ]);
+    });
+
+    it.each([
+      {
+        firstBlock: 'First completed block',
+        secondBlock: 'Second partial block',
+        replayedBlock: 'Second partial block completed',
+      },
+      {
+        firstBlock: 'Same',
+        secondBlock: 'Same partial',
+        replayedBlock: 'Same partial completed',
+      },
+    ])(
+      'reuses the matching later reasoning block when replay resumes from it',
+      async ({ firstBlock, secondBlock, replayedBlock }) => {
+        const { chat, state } = createResumeSetup(
+          [
+            {
+              type: 'reasoning',
+              text: firstBlock,
+              state: 'done',
+            },
+            {
+              type: 'reasoning',
+              text: secondBlock,
+              state: 'streaming',
+            },
+          ],
+          [
+            { type: 'reasoning-start', id: 'reasoning-2' },
+            {
+              type: 'reasoning-delta',
+              id: 'reasoning-2',
+              delta: replayedBlock,
+            },
+            { type: 'reasoning-end', id: 'reasoning-2' },
+            finishChunk(),
+          ]
+        );
+
+        await chat.resumeStream();
+
+        expect(getReasoningText(state)).toEqual([firstBlock, replayedBlock]);
+      }
+    );
+
+    it.each([
+      {
+        savedBlock: 'Search the catalog',
+        resumedBlock: 'Search',
+        expectedBlocks: ['Search the catalog', 'Search'],
+      },
+      {
+        savedBlock: 'Search',
+        resumedBlock: 'Search more',
+        expectedBlocks: ['Search', 'Search more'],
+      },
+    ])(
+      'preserves saved reasoning for an ambiguous replay prefix',
+      async ({ savedBlock, resumedBlock, expectedBlocks }) => {
+        const { chat, state } = createResumeSetup(
+          [
+            {
+              type: 'reasoning',
+              text: savedBlock,
+              state: 'done',
+            },
+          ],
+          [
+            { type: 'reasoning-start', id: 'reasoning-2' },
+            {
+              type: 'reasoning-delta',
+              id: 'reasoning-2',
+              delta: resumedBlock,
+            },
+            { type: 'reasoning-end', id: 'reasoning-2' },
+            finishChunk(),
+          ]
+        );
+
+        await chat.resumeStream();
+
+        expect(getReasoningText(state)).toEqual(expectedBlocks);
+      }
+    );
+
+    it('keeps overlapping resumed reasoning associated with its stream id', async () => {
+      const { chat, state } = createResumeSetup(
+        [
+          { type: 'reasoning', text: 'A1', state: 'streaming' },
+          { type: 'reasoning', text: 'B1', state: 'streaming' },
+        ],
+        [
+          { type: 'reasoning-start', id: 'reasoning-a' },
+          { type: 'reasoning-start', id: 'reasoning-b' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-b',
+            delta: 'B1 B2',
+          },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-a',
+            delta: 'A1 A2',
+          },
+          { type: 'reasoning-end', id: 'reasoning-b' },
+          { type: 'reasoning-end', id: 'reasoning-a' },
+          finishChunk(),
+        ]
+      );
+
+      await chat.resumeStream();
+
+      expect(getReasoningText(state)).toEqual(['A1 A2', 'B1 B2']);
+    });
+
+    it('reuses full replay blocks that share a prefix', async () => {
+      const { chat, state } = createResumeSetup(
+        [
+          { type: 'reasoning', text: 'Search', state: 'done' },
+          {
+            type: 'reasoning',
+            text: 'Search catalog',
+            state: 'streaming',
+          },
+        ],
+        [
+          { type: 'reasoning-start', id: 'reasoning-a' },
+          { type: 'reasoning-delta', id: 'reasoning-a', delta: 'Search' },
+          { type: 'reasoning-end', id: 'reasoning-a' },
+          { type: 'reasoning-start', id: 'reasoning-b' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-b',
+            delta: 'Search catalog completed',
+          },
+          { type: 'reasoning-end', id: 'reasoning-b' },
+          finishChunk(),
+        ]
+      );
+
+      await chat.resumeStream();
+
+      expect(getReasoningText(state)).toEqual([
+        'Search',
+        'Search catalog completed',
+      ]);
+    });
+
+    it.each(['close', 'error', 'stop'] as const)(
+      'does not restore a cleared message when a pending replay ends with %s',
+      async (termination) => {
+        const state = new RuntimeChatState<UIMessage>(
+          'test-chat',
+          [
+            {
+              id: 'msg-1',
+              role: 'assistant',
+              parts: [
+                {
+                  type: 'reasoning',
+                  text: 'Saved reasoning',
+                  state: 'streaming',
+                },
+              ],
+            },
+          ],
+          false
+        );
+        let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+        const replayUpdated = deferred<void>();
+        state['~registerMessagesCallback'](() => {
+          if (
+            state.messages
+              .flatMap((message) => message.parts)
+              .some(
+                (part) =>
+                  part.type === 'reasoning' &&
+                  part.text === 'Different reasoning'
+              )
+          ) {
+            replayUpdated.resolve();
+          }
+        });
+        const chat = new TestChat({
+          id: 'test-chat',
+          state,
+          transport: {
+            sendMessages: jest.fn() as any,
+            reconnectToStream: jest.fn(() =>
+              Promise.resolve(
+                new ReadableStream<UIMessageChunk>({
+                  start(controller) {
+                    streamController = controller;
+                    controller.enqueue(startChunk());
+                    controller.enqueue({
+                      type: 'reasoning-start',
+                      id: 'reasoning-1',
+                    });
+                    controller.enqueue({
+                      type: 'reasoning-delta',
+                      id: 'reasoning-1',
+                      delta: 'Different reasoning',
+                    });
+                  },
+                })
+              )
+            ) as any,
+          },
+        });
+
+        const resume = chat.resumeStream();
+        await replayUpdated.promise;
+        chat.messages = [];
+        if (termination === 'error') {
+          streamController.error(new Error('replay disconnected'));
+        } else {
+          if (termination === 'stop') {
+            await chat.stop();
+          }
+          streamController.close();
+        }
+        await resume;
+
+        expect(chat.messages).toEqual([]);
+      }
+    );
+
+    it('treats reasoning after a text suffix as a new block', async () => {
+      const { chat, state } = createResumeSetup(
+        [
+          {
+            type: 'reasoning',
+            text: 'Search the catalog',
+            state: 'done',
+          },
+          {
+            type: 'text',
+            text: 'Partial answer',
+            state: 'streaming',
+          },
+        ],
+        [
+          {
+            type: 'text-delta',
+            id: 'text-1',
+            delta: ' completed',
+          },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'reasoning-start', id: 'reasoning-2' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-2',
+            delta: 'Search',
+          },
+          { type: 'reasoning-end', id: 'reasoning-2' },
+          finishChunk(),
+        ]
+      );
+
+      await chat.resumeStream();
+
+      expect(getReasoningText(state)).toEqual(['Search the catalog', 'Search']);
+      expect(
+        messageById(state, 'msg-1').parts.find((part) => part.type === 'text')
+      ).toMatchObject({
+        text: 'Partial answer completed',
+        state: 'done',
+      });
     });
 
     it('completes unfinished reasoning when the response is stopped', async () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -2025,6 +2025,12 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
           toolCallId: 'call-1',
         },
         {
+          type: 'tool-input-delta',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          inputTextDelta: '{"query":"headphones"}',
+        },
+        {
           type: 'tool-input-available',
           toolName: 'search',
           toolCallId: 'call-1',
@@ -2068,7 +2074,12 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         messageById(state, 'msg-1').parts.filter(
           (part) => 'toolCallId' in part && part.toolCallId === 'call-1'
         )
-      ).toHaveLength(1);
+      ).toEqual([
+        expect.objectContaining({
+          state: 'input-available',
+          input: { query: 'headphones' },
+        }),
+      ]);
     });
 
     it('continues once when a pending tool callback resolves after replay', async () => {
@@ -2161,6 +2172,218 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         state: 'output-available',
         output: { hits: [] },
       });
+    });
+
+    it('continues when a pending tool result settles before the replay stream is available', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const callbackStarted = deferred<void>();
+      const releaseToolResult = deferred<void>();
+      const toolResultSubmitted = deferred<void>();
+      const replayStreamAvailable =
+        deferred<ReadableStream<UIMessageChunk> | null>();
+      let initialStreamController!: ReadableStreamDefaultController<UIMessageChunk>;
+      let sendIndex = 0;
+
+      const sendMessages = jest.fn(() => {
+        if (sendIndex++ === 0) {
+          return Promise.resolve(
+            new ReadableStream<UIMessageChunk>({
+              start(controller) {
+                initialStreamController = controller;
+                controller.enqueue(startChunk());
+                controller.enqueue({
+                  type: 'tool-input-start',
+                  toolName: 'search',
+                  toolCallId: 'call-1',
+                });
+                controller.enqueue({
+                  type: 'tool-input-available',
+                  toolName: 'search',
+                  toolCallId: 'call-1',
+                  input: { query: 'headphones' },
+                });
+              },
+            })
+          );
+        }
+
+        return Promise.resolve(
+          chunksToStream([
+            startChunk('msg-2'),
+            { type: 'text-start', id: 'text-2' },
+            {
+              type: 'text-delta',
+              id: 'text-2',
+              delta: 'Here are the results.',
+            },
+            { type: 'text-end', id: 'text-2' },
+            finishChunk(),
+          ])
+        );
+      });
+      const onToolCall = jest.fn(
+        (
+          _options: { toolCall: any },
+          addToolResult?: TestChat['addToolResult']
+        ) => {
+          callbackStarted.resolve();
+          return releaseToolResult.promise
+            .then(() =>
+              addToolResult!({
+                tool: 'search',
+                toolCallId: 'call-1',
+                output: { hits: [] },
+              })
+            )
+            .then(() => {
+              toolResultSubmitted.resolve();
+            });
+        }
+      );
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError: jest.fn(),
+        onToolCall,
+        sendAutomaticallyWhen: ({ messages }) =>
+          messages.some((message) =>
+            message.parts.some(
+              (part) =>
+                'toolCallId' in part &&
+                part.toolCallId === 'call-1' &&
+                part.state === 'output-available'
+            )
+          ),
+        transport: {
+          sendMessages: sendMessages as any,
+          reconnectToStream: jest.fn(
+            () => replayStreamAvailable.promise
+          ) as any,
+        },
+      });
+
+      const send = chat.sendMessage({ text: 'Find headphones' });
+      await callbackStarted.promise;
+      initialStreamController.error(new Error('disconnected'));
+      await send;
+
+      const resume = chat.resumeStream();
+      releaseToolResult.resolve();
+      await toolResultSubmitted.promise;
+
+      replayStreamAvailable.resolve(
+        chunksToStream([
+          startChunk(),
+          {
+            type: 'tool-input-start',
+            toolName: 'search',
+            toolCallId: 'call-1',
+          },
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { query: 'headphones' },
+          },
+          finishChunk(),
+        ])
+      );
+      await resume;
+
+      expect(onToolCall).toHaveBeenCalledTimes(1);
+      expect(sendMessages).toHaveBeenCalledTimes(2);
+      expect(
+        messageById(state, 'msg-1').parts.filter(
+          (part) => 'toolCallId' in part && part.toolCallId === 'call-1'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          state: 'output-available',
+          output: { hits: [] },
+        }),
+      ]);
+    });
+
+    it('reports a pending tool callback failure before the replay stream is available', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const callback = deferred<void>();
+      const callbackStarted = deferred<void>();
+      const replayStreamAvailable =
+        deferred<ReadableStream<UIMessageChunk> | null>();
+      const onError = jest.fn();
+      let initialStreamController!: ReadableStreamDefaultController<UIMessageChunk>;
+
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError,
+        onToolCall: jest.fn(() => {
+          callbackStarted.resolve();
+          return callback.promise;
+        }),
+        sendAutomaticallyWhen: () => true,
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(
+              new ReadableStream<UIMessageChunk>({
+                start(controller) {
+                  initialStreamController = controller;
+                  controller.enqueue(startChunk());
+                  controller.enqueue({
+                    type: 'tool-input-start',
+                    toolName: 'search',
+                    toolCallId: 'call-1',
+                  });
+                  controller.enqueue({
+                    type: 'tool-input-available',
+                    toolName: 'search',
+                    toolCallId: 'call-1',
+                    input: { query: 'headphones' },
+                  });
+                },
+              })
+            )
+          ) as any,
+          reconnectToStream: jest.fn(
+            () => replayStreamAvailable.promise
+          ) as any,
+        },
+      });
+
+      const send = chat.sendMessage({ text: 'Find headphones' });
+      await callbackStarted.promise;
+      initialStreamController.error(new Error('disconnected'));
+      await send;
+
+      const resume = chat.resumeStream();
+      callback.reject(new Error('tool failed'));
+      await callback.promise.catch(() => undefined);
+      await Promise.resolve();
+
+      replayStreamAvailable.resolve(
+        chunksToStream([
+          startChunk(),
+          {
+            type: 'tool-input-start',
+            toolName: 'search',
+            toolCallId: 'call-1',
+          },
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { query: 'headphones' },
+          },
+          finishChunk(),
+        ])
+      );
+      await resume;
+
+      expect(onError).toHaveBeenCalledTimes(2);
+      expect(onError).toHaveBeenLastCalledWith(
+        expect.objectContaining({ message: 'tool failed' })
+      );
+      expect(chat.status).toBe('error');
     });
 
     it.each([1, 2])(
@@ -2303,6 +2526,218 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         expect.objectContaining({ message: 'tool failed' })
       );
       expect(chat.status).toBe('error');
+    });
+
+    it('reports a pending tool callback failure after an interrupted replay', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const callback = deferred<void>();
+      const callbackStarted = deferred<void>();
+      const onError = jest.fn();
+      let initialStreamController!: ReadableStreamDefaultController<UIMessageChunk>;
+      let replayCount = 0;
+      const replayedToolChunks: UIMessageChunk[] = [
+        startChunk(),
+        {
+          type: 'tool-input-start',
+          toolName: 'search',
+          toolCallId: 'call-1',
+        },
+        {
+          type: 'tool-input-available',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: { query: 'headphones' },
+        },
+      ];
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError,
+        onToolCall: jest.fn(() => {
+          callbackStarted.resolve();
+          return callback.promise;
+        }),
+        sendAutomaticallyWhen: () => true,
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(
+              new ReadableStream<UIMessageChunk>({
+                start(controller) {
+                  initialStreamController = controller;
+                  replayedToolChunks.forEach((chunk) =>
+                    controller.enqueue(chunk)
+                  );
+                },
+              })
+            )
+          ) as any,
+          reconnectToStream: jest.fn(() => {
+            replayCount++;
+            if (replayCount === 1) {
+              let readCount = 0;
+              return Promise.resolve(
+                new ReadableStream<UIMessageChunk>({
+                  pull(controller) {
+                    if (readCount++ === 0) {
+                      controller.enqueue(startChunk());
+                    } else {
+                      controller.error(new Error('replay disconnected'));
+                    }
+                  },
+                })
+              );
+            }
+            return Promise.resolve(
+              chunksToStream([...replayedToolChunks, finishChunk()])
+            );
+          }) as any,
+        },
+      });
+
+      const send = chat.sendMessage({ text: 'Find headphones' });
+      await callbackStarted.promise;
+      initialStreamController.error(new Error('disconnected'));
+      await send;
+
+      await chat.resumeStream();
+
+      callback.reject(new Error('tool failed'));
+      await callback.promise.catch(() => undefined);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      await chat.resumeStream();
+
+      expect(onError).toHaveBeenCalledTimes(3);
+      expect(onError).toHaveBeenLastCalledWith(
+        expect.objectContaining({ message: 'tool failed' })
+      );
+      expect(chat.status).toBe('error');
+    });
+
+    it('ignores a stopped tool callback failure during replay', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const callback = deferred<void>();
+      const callbackStarted = deferred<void>();
+      const replayStreamAvailable =
+        deferred<ReadableStream<UIMessageChunk> | null>();
+      const onError = jest.fn();
+      const replayedToolChunks: UIMessageChunk[] = [
+        startChunk(),
+        {
+          type: 'tool-input-start',
+          toolName: 'search',
+          toolCallId: 'call-1',
+        },
+        {
+          type: 'tool-input-available',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: { query: 'headphones' },
+        },
+      ];
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError,
+        onToolCall: jest.fn(() => {
+          callbackStarted.resolve();
+          return callback.promise;
+        }),
+        sendAutomaticallyWhen: () => true,
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(chunksToStream(replayedToolChunks))
+          ) as any,
+          reconnectToStream: jest.fn(
+            () => replayStreamAvailable.promise
+          ) as any,
+        },
+      });
+
+      const send = chat.sendMessage({ text: 'Find headphones' });
+      await callbackStarted.promise;
+      await chat.stop();
+
+      const resume = chat.resumeStream();
+      callback.reject(new Error('tool failed after stop'));
+      await callback.promise.catch(() => undefined);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await send;
+
+      replayStreamAvailable.resolve(
+        chunksToStream([...replayedToolChunks, finishChunk()])
+      );
+      await resume;
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(chat.status).toBe('ready');
+    });
+
+    it('ignores a pending tool callback failure after the replayed message is cleared', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const callback = deferred<void>();
+      const callbackStarted = deferred<void>();
+      const onError = jest.fn();
+      let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+      const replayedToolChunks: UIMessageChunk[] = [
+        startChunk(),
+        {
+          type: 'tool-input-start',
+          toolName: 'search',
+          toolCallId: 'call-1',
+        },
+        {
+          type: 'tool-input-available',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: { query: 'headphones' },
+        },
+      ];
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError,
+        onToolCall: jest.fn(() => {
+          callbackStarted.resolve();
+          return callback.promise;
+        }),
+        sendAutomaticallyWhen: () => true,
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(
+              new ReadableStream<UIMessageChunk>({
+                start(controller) {
+                  streamController = controller;
+                  replayedToolChunks.forEach((chunk) =>
+                    controller.enqueue(chunk)
+                  );
+                },
+              })
+            )
+          ) as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([...replayedToolChunks, finishChunk()])
+            )
+          ) as any,
+        },
+      });
+
+      const send = chat.sendMessage({ text: 'Find headphones' });
+      await callbackStarted.promise;
+      streamController.error(new Error('disconnected'));
+      await send;
+      await chat.resumeStream();
+
+      const errorCountAfterReplay = onError.mock.calls.length;
+      chat.messages = [];
+      callback.reject(new Error('tool failed after clear'));
+      await callback.promise.catch(() => undefined);
+      await Promise.resolve();
+
+      expect(chat.messages).toEqual([]);
+      expect(chat.status).toBe('ready');
+      expect(onError).toHaveBeenCalledTimes(errorCountAfterReplay);
     });
 
     it('does not transfer replay ownership across messages sharing a tool call id', async () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -1686,6 +1686,526 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
     });
   });
 
+  describe('full response replay', () => {
+    function createFullReplaySetup(
+      parts: UIMessage['parts'],
+      chunks: UIMessageChunk[],
+      onData?: (dataPart: any) => void
+    ) {
+      const state = new RuntimeChatState<UIMessage>(
+        'test-chat',
+        [{ id: 'msg-1', role: 'assistant', parts }],
+        false
+      );
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        transport: {
+          sendMessages: jest.fn() as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(chunksToStream([startChunk(), ...chunks]))
+          ) as any,
+        },
+        onData,
+      });
+
+      return { chat, state };
+    }
+
+    it('reuses an interrupted tool call before automatic continuation', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const toolStarted = deferred<void>();
+      let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+      let chat!: TestChat;
+
+      state['~registerMessagesCallback'](() => {
+        if (assistantToolPart(state, 'call-1')?.state === 'input-streaming') {
+          toolStarted.resolve();
+        }
+      });
+
+      const onToolCall = jest.fn(
+        ({ toolCall }: { toolCall: any }, addToolResult = chat.addToolResult) =>
+          addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            output: { hits: [] },
+          })
+      );
+      const setup = createTestSetup({
+        state,
+        streamFactory: (index) => {
+          if (index === 0) {
+            return new ReadableStream<UIMessageChunk>({
+              start(controller) {
+                streamController = controller;
+                controller.enqueue(startChunk());
+                controller.enqueue({
+                  type: 'tool-input-start',
+                  toolName: 'search',
+                  toolCallId: 'call-1',
+                });
+              },
+            });
+          }
+
+          return chunksToStream([
+            startChunk('msg-2'),
+            { type: 'text-start', id: 'text-2' },
+            {
+              type: 'text-delta',
+              id: 'text-2',
+              delta: 'Here are the results.',
+            },
+            { type: 'text-end', id: 'text-2' },
+            finishChunk(),
+          ]);
+        },
+        onError: jest.fn(),
+        onToolCall,
+        sendAutomaticallyWhen: ({ messages }) =>
+          messages.some((message) =>
+            message.parts.some(
+              (part) =>
+                'toolCallId' in part &&
+                part.toolCallId === 'call-1' &&
+                part.state === 'output-available'
+            )
+          ),
+      });
+      chat = setup.chat;
+      setup.transport.reconnectToStream = jest.fn(() =>
+        Promise.resolve(
+          chunksToStream([
+            startChunk(),
+            {
+              type: 'tool-input-start',
+              toolName: 'search',
+              toolCallId: 'call-1',
+            },
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: { query: 'headphones' },
+            },
+            finishChunk(),
+          ])
+        )
+      ) as any;
+
+      const send = chat.sendMessage({ text: 'Find headphones' });
+      await toolStarted.promise;
+      streamController.error(new Error('disconnected'));
+      await send;
+      await chat.resumeStream();
+
+      const replayedToolParts = messageById(state, 'msg-1').parts.filter(
+        (part) => 'toolCallId' in part && part.toolCallId === 'call-1'
+      );
+      const continuationMessages = setup.sendMessages.mock.calls[1][0]
+        .messages as UIMessage[];
+      const continuationToolCallIds = continuationMessages.flatMap((message) =>
+        message.parts.flatMap((part) =>
+          'toolCallId' in part ? [part.toolCallId] : []
+        )
+      );
+
+      expect(replayedToolParts).toEqual([
+        expect.objectContaining({
+          type: 'tool-search',
+          toolCallId: 'call-1',
+          state: 'output-available',
+          output: { hits: [] },
+        }),
+      ]);
+      expect(continuationToolCallIds).toEqual(['call-1']);
+      expect(onToolCall).toHaveBeenCalledTimes(1);
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps partial tool input when replay starts with a shorter prefix', async () => {
+      const { chat, state } = createFullReplaySetup(
+        [
+          {
+            type: 'tool-search',
+            toolCallId: 'call-1',
+            state: 'input-streaming',
+            input: { query: 'head' },
+            rawInput: '{"query":"head',
+          },
+        ],
+        [
+          {
+            type: 'tool-input-start',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { query: 'he' },
+          },
+        ]
+      );
+
+      await chat.resumeStream();
+
+      expect(assistantToolPart(state, 'call-1')).toMatchObject({
+        type: 'tool-search',
+        toolCallId: 'call-1',
+        state: 'input-streaming',
+        input: { query: 'head' },
+        rawInput: '{"query":"head',
+      });
+    });
+
+    it('does not repeat a tool callback during a same-instance full replay', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      state.snapshot = <T>(value: T): T => value;
+      const toolCallDispatched = deferred<void>();
+      let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+      const onToolCall = jest.fn(() => {
+        toolCallDispatched.resolve();
+      });
+      const replayedToolChunks: UIMessageChunk[] = [
+        startChunk(),
+        {
+          type: 'tool-input-start',
+          toolName: 'search',
+          toolCallId: 'call-1',
+        },
+        {
+          type: 'tool-input-available',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: { query: 'headphones' },
+        },
+      ];
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError: jest.fn(),
+        onToolCall,
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(
+              new ReadableStream<UIMessageChunk>({
+                start(controller) {
+                  streamController = controller;
+                  replayedToolChunks.forEach((chunk) =>
+                    controller.enqueue(chunk)
+                  );
+                },
+              })
+            )
+          ) as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([...replayedToolChunks, finishChunk()])
+            )
+          ) as any,
+        },
+      });
+
+      const send = chat.sendMessage({ text: 'Find headphones' });
+      await toolCallDispatched.promise;
+      streamController.error(new Error('disconnected after tool callback'));
+      await send;
+      await chat.resumeStream();
+
+      expect(onToolCall).toHaveBeenCalledTimes(1);
+      expect(
+        messageById(state, 'msg-1').parts.filter(
+          (part) => 'toolCallId' in part && part.toolCallId === 'call-1'
+        )
+      ).toHaveLength(1);
+    });
+
+    it('continues once when a pending tool callback resolves after replay', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const releaseToolResult = deferred<void>();
+      let sendIndex = 0;
+      let submitToolResult!: (options: any) => Promise<void>;
+      const replayedToolChunks: UIMessageChunk[] = [
+        startChunk(),
+        {
+          type: 'tool-input-start',
+          toolName: 'search',
+          toolCallId: 'call-1',
+        },
+        {
+          type: 'tool-input-available',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: { query: 'headphones' },
+        },
+      ];
+      const sendMessages = jest.fn(() => {
+        if (sendIndex++ === 0) {
+          let chunkIndex = 0;
+          return Promise.resolve(
+            new ReadableStream<UIMessageChunk>({
+              pull(controller) {
+                if (chunkIndex < replayedToolChunks.length) {
+                  controller.enqueue(replayedToolChunks[chunkIndex++]);
+                } else {
+                  controller.error(
+                    new Error('disconnected while tool callback was pending')
+                  );
+                }
+              },
+            })
+          );
+        }
+        return Promise.resolve(
+          chunksToStream([
+            startChunk('msg-2'),
+            { type: 'text-start', id: 'text-2' },
+            {
+              type: 'text-delta',
+              id: 'text-2',
+              delta: 'Here are the results.',
+            },
+            { type: 'text-end', id: 'text-2' },
+            finishChunk(),
+          ])
+        );
+      });
+      const onToolCall = jest.fn(
+        (
+          _options: { toolCall: any },
+          addToolResult?: (options: any) => Promise<void>
+        ) => {
+          submitToolResult = addToolResult!;
+          return releaseToolResult.promise;
+        }
+      );
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError: jest.fn(),
+        onToolCall,
+        sendAutomaticallyWhen: ({ messages }) =>
+          messages.some((message) =>
+            message.parts.some(
+              (part) =>
+                'toolCallId' in part &&
+                part.toolCallId === 'call-1' &&
+                part.state === 'output-available'
+            )
+          ),
+        transport: {
+          sendMessages: sendMessages as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([...replayedToolChunks, finishChunk()])
+            )
+          ) as any,
+        },
+      });
+
+      await chat.sendMessage({ text: 'Find headphones' });
+      await chat.resumeStream();
+      await submitToolResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { hits: [] },
+      });
+      releaseToolResult.resolve();
+      await releaseToolResult.promise;
+
+      expect(onToolCall).toHaveBeenCalledTimes(1);
+      expect(sendMessages).toHaveBeenCalledTimes(2);
+      expect(assistantToolPart(state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { hits: [] },
+      });
+    });
+
+    it('does not repeat a tool callback restored at input-available', async () => {
+      const state = new RuntimeChatState<UIMessage>(
+        'test-chat',
+        [
+          {
+            id: 'msg-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-search',
+                toolCallId: 'call-1',
+                state: 'input-available',
+                input: { query: 'headphones' },
+              },
+            ],
+          },
+        ],
+        false
+      );
+      const onToolCall = jest.fn();
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onToolCall,
+        transport: {
+          sendMessages: jest.fn() as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([
+                startChunk(),
+                {
+                  type: 'tool-input-start',
+                  toolName: 'search',
+                  toolCallId: 'call-1',
+                },
+                {
+                  type: 'tool-input-available',
+                  toolName: 'search',
+                  toolCallId: 'call-1',
+                  input: { query: 'headphones' },
+                },
+                finishChunk(),
+              ])
+            )
+          ) as any,
+        },
+      });
+
+      await chat.resumeStream();
+
+      expect(onToolCall).not.toHaveBeenCalled();
+      expect(assistantToolPart(state, 'call-1')).toMatchObject({
+        state: 'input-available',
+        input: { query: 'headphones' },
+      });
+    });
+
+    it('reconciles replayed tool output deltas without duplicating the saved prefix', async () => {
+      const { chat, state } = createFullReplaySetup(
+        [
+          {
+            type: 'tool-search',
+            toolCallId: 'call-1',
+            state: 'output-available',
+            input: { query: 'headphones' },
+            output: { hits: [] },
+            rawOutput: '{"hits":[',
+            preliminary: true,
+            providerExecuted: true,
+          } as any,
+        ],
+        [
+          {
+            type: 'tool-input-start',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { query: 'headphones' },
+            providerExecuted: true,
+          },
+          {
+            type: 'data-tool-output-delta',
+            data: {
+              toolCallId: 'call-1',
+              toolName: 'search',
+              delta: '{"hits":[',
+            },
+          } as UIMessageChunk,
+          {
+            type: 'data-tool-output-delta',
+            data: {
+              toolCallId: 'call-1',
+              toolName: 'search',
+              delta: ']}',
+            },
+          } as UIMessageChunk,
+          finishChunk(),
+        ]
+      );
+
+      await chat.resumeStream();
+
+      expect(assistantToolPart(state, 'call-1')).toMatchObject({
+        state: 'output-available',
+        output: { hits: [] },
+        rawOutput: '{"hits":[]}',
+      });
+    });
+
+    it('reuses structural parts while replayed data remains observable', async () => {
+      const onData = jest.fn();
+      const structuralParts: UIMessage['parts'] = [
+        {
+          type: 'source-url',
+          sourceId: 'source-1',
+          url: 'https://example.test/source',
+          title: 'Source',
+        },
+        {
+          type: 'source-document',
+          sourceId: 'document-1',
+          mediaType: 'text/plain',
+          title: 'Document',
+        },
+        {
+          type: 'file',
+          url: 'https://example.test/file.pdf',
+          mediaType: 'application/pdf',
+        },
+        { type: 'step-start' },
+        {
+          type: 'data-progress',
+          id: 'progress-1',
+          data: { value: 1 },
+        },
+        {
+          type: 'data-status',
+          data: { label: 'Searching' },
+        },
+      ];
+      const { chat, state } = createFullReplaySetup(
+        structuralParts,
+        [
+          {
+            type: 'source-url',
+            sourceId: 'source-1',
+            url: 'https://example.test/source',
+            title: 'Source',
+          },
+          {
+            type: 'source-document',
+            sourceId: 'document-1',
+            mediaType: 'text/plain',
+            title: 'Document',
+          },
+          {
+            type: 'file',
+            url: 'https://example.test/file.pdf',
+            mediaType: 'application/pdf',
+          },
+          { type: 'start-step' },
+          {
+            type: 'data-progress',
+            id: 'progress-1',
+            data: { value: 1 },
+          } as UIMessageChunk,
+          {
+            type: 'data-status',
+            data: { label: 'Searching' },
+          } as UIMessageChunk,
+          finishChunk(),
+        ],
+        onData
+      );
+
+      await chat.resumeStream();
+
+      expect(messageById(state, 'msg-1').parts).toEqual(structuralParts);
+      expect(onData).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('tool-input lifecycle (existing chunks)', () => {
     it('settles when onToolCall returns addToolResult and commits the output', async () => {
       let chat!: TestChat;

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -264,6 +264,166 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       };
     }
 
+    it('keeps overlapping reasoning blocks associated with their stream ids', async () => {
+      const { chat, state } = createTestSetup({
+        chunks: [
+          startChunk(),
+          { type: 'reasoning-start', id: 'reasoning-a' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-a',
+            delta: 'A1 ',
+          },
+          { type: 'reasoning-start', id: 'reasoning-b' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-b',
+            delta: 'B1 ',
+          },
+          { type: 'reasoning-end', id: 'reasoning-b' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-a',
+            delta: 'A2',
+          },
+          { type: 'reasoning-end', id: 'reasoning-a' },
+          finishChunk(),
+        ],
+      });
+
+      await chat.sendMessage({ text: 'Compare two options' });
+
+      expect(
+        messageById(state, 'msg-1').parts.filter(
+          (part) => part.type === 'reasoning'
+        )
+      ).toEqual([
+        {
+          type: 'reasoning',
+          text: 'A1 A2',
+          state: 'done',
+          providerMetadata: undefined,
+        },
+        {
+          type: 'reasoning',
+          text: 'B1 ',
+          state: 'done',
+          providerMetadata: undefined,
+        },
+      ]);
+    });
+
+    it('keeps text and reasoning separate when their stream ids match', async () => {
+      const { chat, state } = createTestSetup({
+        chunks: [
+          startChunk(),
+          { type: 'reasoning-start', id: 'msg-1' },
+          {
+            type: 'reasoning-delta',
+            id: 'msg-1',
+            delta: 'Check the catalog. ',
+          },
+          { type: 'text-start', id: 'msg-1' },
+          {
+            type: 'text-delta',
+            id: 'msg-1',
+            delta: 'Here is what I found.',
+          },
+          {
+            type: 'reasoning-delta',
+            id: 'msg-1',
+            delta: 'Compare the results.',
+          },
+          { type: 'reasoning-end', id: 'msg-1' },
+          { type: 'text-end', id: 'msg-1' },
+          finishChunk(),
+        ],
+      });
+
+      await chat.sendMessage({ text: 'Find a product' });
+
+      expect(messageById(state, 'msg-1').parts).toEqual([
+        {
+          type: 'reasoning',
+          text: 'Check the catalog. Compare the results.',
+          state: 'done',
+          providerMetadata: undefined,
+        },
+        {
+          type: 'text',
+          text: 'Here is what I found.',
+          state: 'done',
+          providerMetadata: undefined,
+        },
+      ]);
+    });
+
+    it('keeps resumed reasoning separate from an unfinished stored part', async () => {
+      const state = new RuntimeChatState<UIMessage>(
+        'test-chat',
+        [
+          {
+            id: 'msg-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Before reconnect',
+                state: 'streaming',
+              },
+            ],
+          },
+        ],
+        false
+      );
+      const sendMessages = jest.fn();
+      const reconnectToStream = jest.fn(() =>
+        Promise.resolve(
+          chunksToStream([
+            startChunk(),
+            { type: 'reasoning-start', id: 'reasoning-after-reconnect' },
+            {
+              type: 'reasoning-delta',
+              id: 'reasoning-after-reconnect',
+              delta: 'After reconnect',
+            },
+            { type: 'reasoning-end', id: 'reasoning-after-reconnect' },
+            finishChunk(),
+          ])
+        )
+      );
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        transport: {
+          sendMessages: sendMessages as any,
+          reconnectToStream: reconnectToStream as any,
+        },
+      });
+
+      await chat.resumeStream();
+
+      expect(sendMessages).not.toHaveBeenCalled();
+      expect(reconnectToStream).toHaveBeenCalledTimes(1);
+      expect(
+        messageById(state, 'msg-1').parts.filter(
+          (part) => part.type === 'reasoning'
+        )
+      ).toEqual([
+        {
+          type: 'reasoning',
+          text: 'Before reconnect',
+          state: 'done',
+        },
+        {
+          type: 'reasoning',
+          text: 'After reconnect',
+          state: 'done',
+          providerMetadata: undefined,
+        },
+      ]);
+    });
+
     it('completes unfinished reasoning when the response is stopped', async () => {
       const setup = createReasoningStreamSetup();
       const send = setup.chat.sendMessage({ text: 'Find a product' });

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -528,6 +528,321 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       ]);
     });
 
+    it('reuses a disconnected reasoning block when full replay coalesces its text', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const reasoningStarted = deferred<void>();
+      let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+
+      state['~registerMessagesCallback'](() => {
+        const reasoningPart = messageById(state, 'msg-1')?.parts.find(
+          (part) => part.type === 'reasoning'
+        );
+        if (
+          reasoningPart?.type === 'reasoning' &&
+          reasoningPart.text === 'Already'
+        ) {
+          reasoningStarted.resolve();
+        }
+      });
+
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError: jest.fn(),
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(
+              new ReadableStream<UIMessageChunk>({
+                start(controller) {
+                  streamController = controller;
+                  controller.enqueue(startChunk());
+                  controller.enqueue({
+                    type: 'reasoning-start',
+                    id: 'reasoning-1',
+                  });
+                  controller.enqueue({
+                    type: 'reasoning-delta',
+                    id: 'reasoning-1',
+                    delta: 'Already',
+                  });
+                },
+              })
+            )
+          ) as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([
+                startChunk(),
+                { type: 'reasoning-start', id: 'reasoning-1' },
+                {
+                  type: 'reasoning-delta',
+                  id: 'reasoning-1',
+                  delta: 'Already and completed',
+                },
+                { type: 'reasoning-end', id: 'reasoning-1' },
+                finishChunk(),
+              ])
+            )
+          ) as any,
+        },
+      });
+
+      const send = chat.sendMessage({ text: 'Find a product' });
+      await reasoningStarted.promise;
+      streamController.error(new Error('disconnected'));
+      await send;
+      await chat.resumeStream();
+
+      expect(getReasoningText(state)).toEqual(['Already and completed']);
+    });
+
+    it('marks reused reasoning active while a full replay catches up', async () => {
+      const state = new RuntimeChatState<UIMessage>(
+        'test-chat',
+        [
+          {
+            id: 'msg-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Already',
+                state: 'done',
+              },
+            ],
+          },
+        ],
+        false
+      );
+      let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+      const replayStarted = deferred<void>();
+      const replayCaughtUp = deferred<void>();
+      state['~registerMessagesCallback'](() => {
+        const metadata = messageById(state, 'msg-1').metadata as
+          | { replayPhase?: 'started' | 'caught-up' }
+          | undefined;
+        if (metadata?.replayPhase === 'started') {
+          replayStarted.resolve();
+        }
+        if (metadata?.replayPhase === 'caught-up') {
+          replayCaughtUp.resolve();
+        }
+      });
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        transport: {
+          sendMessages: jest.fn() as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              new ReadableStream<UIMessageChunk>({
+                start(controller) {
+                  streamController = controller;
+                  controller.enqueue(startChunk());
+                  controller.enqueue({
+                    type: 'reasoning-start',
+                    id: 'reasoning-1',
+                  });
+                  controller.enqueue({
+                    type: 'message-metadata',
+                    messageMetadata: { replayPhase: 'started' },
+                  });
+                },
+              })
+            )
+          ) as any,
+        },
+      });
+
+      const resume = chat.resumeStream();
+      await replayStarted.promise;
+
+      expect(messageById(state, 'msg-1').parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Already',
+        state: 'streaming',
+      });
+
+      streamController.enqueue({
+        type: 'reasoning-delta',
+        id: 'reasoning-1',
+        delta: 'Already',
+      });
+      streamController.enqueue({
+        type: 'message-metadata',
+        messageMetadata: { replayPhase: 'caught-up' },
+      });
+      await replayCaughtUp.promise;
+
+      expect(messageById(state, 'msg-1').parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Already',
+        state: 'streaming',
+        providerMetadata: undefined,
+      });
+
+      streamController.close();
+      await resume;
+
+      expect(messageById(state, 'msg-1').parts[0]).toEqual({
+        type: 'reasoning',
+        text: 'Already',
+        state: 'done',
+        providerMetadata: undefined,
+      });
+    });
+
+    it('reuses text and reasoning blocks from a full replay in order', async () => {
+      const state = new RuntimeChatState<UIMessage>(
+        'test-chat',
+        [
+          {
+            id: 'msg-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Search the catalog',
+                state: 'done',
+              },
+              {
+                type: 'text',
+                text: 'A partial answer',
+                state: 'streaming',
+              },
+            ],
+          },
+        ],
+        false
+      );
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        transport: {
+          sendMessages: jest.fn() as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([
+                startChunk(),
+                { type: 'reasoning-start', id: 'reasoning-1' },
+                {
+                  type: 'reasoning-delta',
+                  id: 'reasoning-1',
+                  delta: 'Search the catalog',
+                },
+                { type: 'reasoning-end', id: 'reasoning-1' },
+                { type: 'text-start', id: 'text-1' },
+                {
+                  type: 'text-delta',
+                  id: 'text-1',
+                  delta: 'A partial answer completed',
+                },
+                { type: 'text-end', id: 'text-1' },
+                finishChunk(),
+              ])
+            )
+          ) as any,
+        },
+      });
+
+      await chat.resumeStream();
+
+      expect(messageById(state, 'msg-1').parts).toEqual([
+        {
+          type: 'reasoning',
+          text: 'Search the catalog',
+          state: 'done',
+          providerMetadata: undefined,
+        },
+        {
+          type: 'text',
+          text: 'A partial answer completed',
+          state: 'done',
+          providerMetadata: undefined,
+        },
+      ]);
+    });
+
+    it('preserves identical reasoning around a tool during full replay', async () => {
+      const { chat, state } = createResumeSetup(
+        [
+          {
+            type: 'reasoning',
+            text: 'Search the catalog',
+            state: 'done',
+          },
+          {
+            type: 'tool-search',
+            toolCallId: 'call-1',
+            state: 'output-available',
+            input: { query: 'headphones' },
+            output: { hits: [] },
+            providerExecuted: true,
+          },
+          {
+            type: 'reasoning',
+            text: 'Search the catalog',
+            state: 'streaming',
+          },
+        ],
+        [
+          { type: 'reasoning-start', id: 'reasoning-before-tool' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-before-tool',
+            delta: 'Search the catalog',
+          },
+          { type: 'reasoning-end', id: 'reasoning-before-tool' },
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { query: 'headphones' },
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-output-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            output: { hits: [] },
+          },
+          { type: 'reasoning-start', id: 'reasoning-after-tool' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-after-tool',
+            delta: 'Search the catalog',
+          },
+          { type: 'reasoning-end', id: 'reasoning-after-tool' },
+          finishChunk(),
+        ]
+      );
+
+      await chat.resumeStream();
+
+      expect(messageById(state, 'msg-1').parts).toEqual([
+        {
+          type: 'reasoning',
+          text: 'Search the catalog',
+          state: 'done',
+          providerMetadata: undefined,
+        },
+        {
+          type: 'tool-search',
+          toolCallId: 'call-1',
+          state: 'output-available',
+          input: { query: 'headphones' },
+          output: { hits: [] },
+          providerExecuted: true,
+        },
+        {
+          type: 'reasoning',
+          text: 'Search the catalog',
+          state: 'done',
+          providerMetadata: undefined,
+        },
+      ]);
+    });
+
     it('keeps saved reasoning when a replay diverges before catching up', async () => {
       const { chat, state } = createResumeSetup(
         [
@@ -797,91 +1112,6 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       ]);
     });
 
-    it.each([
-      {
-        firstBlock: 'First completed block',
-        secondBlock: 'Second partial block',
-        replayedBlock: 'Second partial block completed',
-      },
-      {
-        firstBlock: 'Same',
-        secondBlock: 'Same partial',
-        replayedBlock: 'Same partial completed',
-      },
-    ])(
-      'reuses the matching later reasoning block when replay resumes from it',
-      async ({ firstBlock, secondBlock, replayedBlock }) => {
-        const { chat, state } = createResumeSetup(
-          [
-            {
-              type: 'reasoning',
-              text: firstBlock,
-              state: 'done',
-            },
-            {
-              type: 'reasoning',
-              text: secondBlock,
-              state: 'streaming',
-            },
-          ],
-          [
-            { type: 'reasoning-start', id: 'reasoning-2' },
-            {
-              type: 'reasoning-delta',
-              id: 'reasoning-2',
-              delta: replayedBlock,
-            },
-            { type: 'reasoning-end', id: 'reasoning-2' },
-            finishChunk(),
-          ]
-        );
-
-        await chat.resumeStream();
-
-        expect(getReasoningText(state)).toEqual([firstBlock, replayedBlock]);
-      }
-    );
-
-    it.each([
-      {
-        savedBlock: 'Search the catalog',
-        resumedBlock: 'Search',
-        expectedBlocks: ['Search the catalog', 'Search'],
-      },
-      {
-        savedBlock: 'Search',
-        resumedBlock: 'Search more',
-        expectedBlocks: ['Search', 'Search more'],
-      },
-    ])(
-      'preserves saved reasoning for an ambiguous replay prefix',
-      async ({ savedBlock, resumedBlock, expectedBlocks }) => {
-        const { chat, state } = createResumeSetup(
-          [
-            {
-              type: 'reasoning',
-              text: savedBlock,
-              state: 'done',
-            },
-          ],
-          [
-            { type: 'reasoning-start', id: 'reasoning-2' },
-            {
-              type: 'reasoning-delta',
-              id: 'reasoning-2',
-              delta: resumedBlock,
-            },
-            { type: 'reasoning-end', id: 'reasoning-2' },
-            finishChunk(),
-          ]
-        );
-
-        await chat.resumeStream();
-
-        expect(getReasoningText(state)).toEqual(expectedBlocks);
-      }
-    );
-
     it('keeps overlapping resumed reasoning associated with its stream id', async () => {
       const { chat, state } = createResumeSetup(
         [
@@ -931,37 +1161,6 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
             type: 'reasoning-delta',
             id: 'reasoning-b',
             delta: 'Search catalog completed',
-          },
-          { type: 'reasoning-end', id: 'reasoning-b' },
-          finishChunk(),
-        ]
-      );
-
-      await chat.resumeStream();
-
-      expect(getReasoningText(state)).toEqual([
-        'Search',
-        'Search catalog completed',
-      ]);
-    });
-
-    it('waits for split replay deltas to identify the matching reasoning block', async () => {
-      const { chat, state } = createResumeSetup(
-        [
-          { type: 'reasoning', text: 'Search', state: 'done' },
-          {
-            type: 'reasoning',
-            text: 'Search catalog',
-            state: 'streaming',
-          },
-        ],
-        [
-          { type: 'reasoning-start', id: 'reasoning-b' },
-          { type: 'reasoning-delta', id: 'reasoning-b', delta: 'Search' },
-          {
-            type: 'reasoning-delta',
-            id: 'reasoning-b',
-            delta: ' catalog completed',
           },
           { type: 'reasoning-end', id: 'reasoning-b' },
           finishChunk(),
@@ -1133,123 +1332,6 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         state: 'done',
       });
     });
-
-    it.each([
-      {
-        suffixId: 'reasoning-1',
-        expectedText: 'Already and completed',
-        description: 'continues the matching reasoning block',
-        replaceTranscript: false,
-      },
-      {
-        suffixId: 'reasoning-2',
-        expectedText: 'Already',
-        description: 'ignores a suffix owned by another reasoning block',
-        replaceTranscript: false,
-      },
-      {
-        suffixId: 'reasoning-1',
-        expectedText: 'Already',
-        description: 'ignores retired ownership after replacing the transcript',
-        replaceTranscript: true,
-      },
-    ])(
-      '$description when the same chat resumes after a disconnect',
-      async ({ suffixId, expectedText, replaceTranscript }) => {
-        const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
-        const reasoningStarted = deferred<void>();
-        let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
-
-        state['~registerMessagesCallback'](() => {
-          const reasoningPart = messageById(state, 'msg-1')?.parts.find(
-            (part) => part.type === 'reasoning'
-          );
-          if (
-            reasoningPart?.type === 'reasoning' &&
-            reasoningPart.text === 'Already'
-          ) {
-            reasoningStarted.resolve();
-          }
-        });
-
-        const chat = new TestChat({
-          id: 'test-chat',
-          state,
-          onError: jest.fn(),
-          transport: {
-            sendMessages: jest.fn(() =>
-              Promise.resolve(
-                new ReadableStream<UIMessageChunk>({
-                  start(controller) {
-                    streamController = controller;
-                    controller.enqueue(startChunk());
-                    controller.enqueue({
-                      type: 'reasoning-start',
-                      id: 'reasoning-1',
-                    });
-                    controller.enqueue({
-                      type: 'reasoning-delta',
-                      id: 'reasoning-1',
-                      delta: 'Already',
-                    });
-                  },
-                })
-              )
-            ) as any,
-            reconnectToStream: jest.fn(() =>
-              Promise.resolve(
-                chunksToStream([
-                  startChunk(),
-                  {
-                    type: 'reasoning-delta',
-                    id: suffixId,
-                    delta: ' and completed',
-                  },
-                  { type: 'reasoning-end', id: suffixId },
-                  finishChunk(),
-                ])
-              )
-            ) as any,
-          },
-        });
-
-        const send = chat.sendMessage({ text: 'Find a product' });
-        await reasoningStarted.promise;
-        streamController.error(new Error('disconnected'));
-        await send;
-
-        expect(chat.status).toBe('error');
-        expect(getReasoningText(state)).toEqual(['Already']);
-
-        if (replaceTranscript) {
-          chat.messages = chat.messages.map((message) =>
-            message.id === 'msg-1'
-              ? {
-                  id: 'msg-1',
-                  role: 'assistant',
-                  parts: [
-                    {
-                      type: 'reasoning',
-                      text: 'Already',
-                      state: 'done',
-                    },
-                    {
-                      type: 'text',
-                      text: 'Replacement answer',
-                      state: 'done',
-                    },
-                  ],
-                }
-              : message
-          );
-        }
-
-        await chat.resumeStream();
-
-        expect(chat.status).toBe('ready');
-        expect(getReasoningText(state)).toEqual([expectedText]);
-      }
-    );
 
     it('completes unfinished reasoning when the stream closes', async () => {
       const onFinish = jest.fn();

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -2163,6 +2163,148 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
     });
 
+    it.each([1, 2])(
+      'keeps one continuation owner after $replayCount replay(s)',
+      async (replayCount) => {
+        const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+        let submitLateResult!: TestChat['addToolResult'];
+        const replayedToolChunks: UIMessageChunk[] = [
+          startChunk(),
+          {
+            type: 'tool-input-start',
+            toolName: 'search',
+            toolCallId: 'call-1',
+          },
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { query: 'headphones' },
+          },
+        ];
+        const setup = createTestSetup({
+          state,
+          onError: jest.fn(),
+          onToolCall: (_options, addToolResult) => {
+            submitLateResult = addToolResult!;
+          },
+          sendAutomaticallyWhen: ({ messages }) =>
+            messages.some((message) =>
+              message.parts.some(
+                (part) =>
+                  'toolCallId' in part &&
+                  part.toolCallId === 'call-1' &&
+                  part.state === 'output-available'
+              )
+            ),
+          streamFactory: (index) => {
+            return index === 0
+              ? chunksToStream([...replayedToolChunks, finishChunk()])
+              : chunksToStream([
+                  startChunk(`continuation-${index}`),
+                  { type: 'text-start', id: `text-${index}` },
+                  {
+                    type: 'text-delta',
+                    id: `text-${index}`,
+                    delta: `continuation ${index}`,
+                  },
+                  { type: 'text-end', id: `text-${index}` },
+                  finishChunk(),
+                ]);
+          },
+        });
+        setup.transport.reconnectToStream = jest.fn(() =>
+          Promise.resolve(
+            chunksToStream([...replayedToolChunks, finishChunk()])
+          )
+        );
+
+        await setup.chat.sendMessage({ text: 'Find headphones' });
+        for (let replay = 0; replay < replayCount; replay++) {
+          await setup.chat.resumeStream();
+        }
+        await submitLateResult({
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { hits: [] },
+        });
+
+        expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+        expect(assistantToolPart(state, 'call-1')).toMatchObject({
+          state: 'output-available',
+          output: { hits: [] },
+        });
+      }
+    );
+
+    it('reports a pending tool callback failure to the resumed response', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const callback = deferred<void>();
+      const callbackStarted = deferred<void>();
+      const onError = jest.fn();
+      let streamController!: ReadableStreamDefaultController<UIMessageChunk>;
+      const replayedToolChunks: UIMessageChunk[] = [
+        startChunk(),
+        {
+          type: 'tool-input-start',
+          toolName: 'search',
+          toolCallId: 'call-1',
+        },
+        {
+          type: 'tool-input-available',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: { query: 'headphones' },
+        },
+      ];
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError,
+        onToolCall: jest.fn(() => {
+          callbackStarted.resolve();
+          return callback.promise;
+        }),
+        sendAutomaticallyWhen: () => true,
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(
+              new ReadableStream<UIMessageChunk>({
+                start(controller) {
+                  streamController = controller;
+                  replayedToolChunks.forEach((chunk) =>
+                    controller.enqueue(chunk)
+                  );
+                },
+              })
+            )
+          ) as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([...replayedToolChunks, finishChunk()])
+            )
+          ) as any,
+        },
+      });
+
+      const send = chat.sendMessage({ text: 'Find headphones' });
+      await callbackStarted.promise;
+      streamController.error(new Error('disconnected'));
+      await send;
+      await chat.resumeStream();
+      await chat.resumeStream();
+
+      callback.reject(new Error('tool failed'));
+      await callback.promise.catch(() => undefined);
+      await Promise.resolve();
+
+      expect(onError).toHaveBeenCalledTimes(2);
+      expect(onError).toHaveBeenLastCalledWith(
+        expect.objectContaining({ message: 'tool failed' })
+      );
+      expect(chat.status).toBe('error');
+    });
+
     it('does not transfer replay ownership across messages sharing a tool call id', async () => {
       const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
       const onError = jest.fn();

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -11,6 +11,7 @@ import { parseJsonEventStream } from '../stream-parser';
 import { DefaultChatTransport } from '../transport';
 
 import type {
+  ChatOnDataCallback,
   ChatOnErrorCallback,
   ChatOnFinishCallback,
   ChatState,
@@ -111,6 +112,7 @@ function createTestSetup(
     streamFactory,
     sendMessagesFactory,
     onToolCall,
+    onData,
     onFinish,
     onError,
     sendAutomaticallyWhen,
@@ -128,6 +130,7 @@ function createTestSetup(
       options: { toolCall: any },
       addToolResult?: TestChat['addToolResult']
     ) => void | Promise<void>;
+    onData?: ChatOnDataCallback<UIMessage>;
     onFinish?: ChatOnFinishCallback<UIMessage>;
     onError?: ChatOnErrorCallback;
     sendAutomaticallyWhen?: (options: {
@@ -167,6 +170,7 @@ function createTestSetup(
       return () => `gen-${++i}`;
     })(),
     onError,
+    onData,
     onFinish,
     onToolCall,
     sendAutomaticallyWhen,
@@ -1639,6 +1643,73 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       }
     );
 
+    it.each<{
+      name: string;
+      trailingChunk: UIMessageChunk;
+    }>([
+      {
+        name: 'data',
+        trailingChunk: {
+          type: 'data-custom',
+          data: { unsafe: true },
+        } as UIMessageChunk,
+      },
+      {
+        name: 'source',
+        trailingChunk: {
+          type: 'source-url',
+          sourceId: 'source-1',
+          url: 'https://example.test/unsafe',
+          title: 'Unsafe source',
+        },
+      },
+      {
+        name: 'tool',
+        trailingChunk: {
+          type: 'tool-input-available',
+          toolName: 'search',
+          toolCallId: 'call-1',
+          input: { query: 'unsafe' },
+        },
+      },
+    ])(
+      'ignores trailing $name content after a guardrail violation',
+      async ({ trailingChunk }) => {
+        const fallbackResponse = 'This response was blocked.';
+        const onData = jest.fn();
+        const onToolCall = jest.fn();
+        const { chat, state } = createTestSetup({
+          chunks: [
+            startChunk(),
+            {
+              type: 'data-guardrail-violation',
+              data: {
+                category: 'blocked',
+                guardrailType: 'output',
+                fallbackResponse,
+              },
+            },
+            trailingChunk,
+            finishChunk(),
+          ],
+          onData,
+          onToolCall,
+        });
+
+        await chat.sendMessage({ text: 'blocked request' });
+
+        expect(messageById(state, 'msg-1').parts).toEqual([
+          {
+            type: 'text',
+            text: fallbackResponse,
+            state: 'done',
+          },
+        ]);
+        expect(onData).not.toHaveBeenCalled();
+        expect(onToolCall).not.toHaveBeenCalled();
+      }
+    );
+
     it('creates a fallback assistant message when violation arrives before an assistant message starts', async () => {
       const onFinish = jest.fn();
       const onError = jest.fn();
@@ -1856,6 +1927,88 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
     });
 
+    it('keeps divergent reasoning before replayed tools and text', async () => {
+      const { chat, state } = createFullReplaySetup(
+        [
+          {
+            type: 'reasoning',
+            text: 'Use the saved plan.',
+            state: 'done',
+          },
+          {
+            type: 'tool-search',
+            toolCallId: 'call-1',
+            state: 'output-available',
+            input: { query: 'headphones' },
+            output: { hits: [] },
+            providerExecuted: true,
+          },
+          {
+            type: 'text',
+            text: 'Here are the results.',
+            state: 'done',
+          },
+        ],
+        [
+          { type: 'reasoning-start', id: 'reasoning-1' },
+          {
+            type: 'reasoning-delta',
+            id: 'reasoning-1',
+            delta: 'Use a different plan.',
+          },
+          { type: 'reasoning-end', id: 'reasoning-1' },
+          {
+            type: 'tool-input-start',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { query: 'headphones' },
+            providerExecuted: true,
+          },
+          {
+            type: 'tool-output-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            output: { hits: [] },
+          },
+          { type: 'text-start', id: 'text-1' },
+          {
+            type: 'text-delta',
+            id: 'text-1',
+            delta: 'Here are the results.',
+          },
+          { type: 'text-end', id: 'text-1' },
+          finishChunk(),
+        ]
+      );
+
+      await chat.resumeStream();
+
+      expect(messageById(state, 'msg-1').parts).toEqual([
+        expect.objectContaining({
+          type: 'reasoning',
+          text: 'Use the saved plan.',
+        }),
+        expect.objectContaining({
+          type: 'reasoning',
+          text: 'Use a different plan.',
+        }),
+        expect.objectContaining({
+          type: 'tool-search',
+          toolCallId: 'call-1',
+        }),
+        expect.objectContaining({
+          type: 'text',
+          text: 'Here are the results.',
+        }),
+      ]);
+    });
+
     it('does not repeat a tool callback during a same-instance full replay', async () => {
       const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
       state.snapshot = <T>(value: T): T => value;
@@ -1922,7 +2075,6 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
       const releaseToolResult = deferred<void>();
       let sendIndex = 0;
-      let submitToolResult!: (options: any) => Promise<void>;
       const replayedToolChunks: UIMessageChunk[] = [
         startChunk(),
         {
@@ -1968,15 +2120,7 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
           ])
         );
       });
-      const onToolCall = jest.fn(
-        (
-          _options: { toolCall: any },
-          addToolResult?: (options: any) => Promise<void>
-        ) => {
-          submitToolResult = addToolResult!;
-          return releaseToolResult.promise;
-        }
-      );
+      const onToolCall = jest.fn(() => releaseToolResult.promise);
       const chat = new TestChat({
         id: 'test-chat',
         state,
@@ -2003,7 +2147,7 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
 
       await chat.sendMessage({ text: 'Find headphones' });
       await chat.resumeStream();
-      await submitToolResult({
+      await chat.addToolResult({
         tool: 'search',
         toolCallId: 'call-1',
         output: { hits: [] },
@@ -2019,7 +2163,99 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
     });
 
-    it('does not repeat a tool callback restored at input-available', async () => {
+    it('does not transfer replay ownership across messages sharing a tool call id', async () => {
+      const state = new RuntimeChatState<UIMessage>('test-chat', [], false);
+      const onError = jest.fn();
+      let submitOldResult!: TestChat['addToolResult'];
+      const onToolCall = jest.fn(
+        (
+          _options: { toolCall: any },
+          addToolResult?: TestChat['addToolResult']
+        ) => {
+          submitOldResult = addToolResult!;
+        }
+      );
+      const chat = new TestChat({
+        id: 'test-chat',
+        state,
+        onError,
+        onToolCall,
+        sendAutomaticallyWhen: () => false,
+        transport: {
+          sendMessages: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([
+                startChunk('assistant-old'),
+                {
+                  type: 'tool-input-available',
+                  toolName: 'search',
+                  toolCallId: 'call-1',
+                  input: { owner: 'old' },
+                },
+                finishChunk(),
+              ])
+            )
+          ) as any,
+          reconnectToStream: jest.fn(() =>
+            Promise.resolve(
+              chunksToStream([
+                startChunk('assistant-new'),
+                {
+                  type: 'tool-input-start',
+                  toolName: 'search',
+                  toolCallId: 'call-1',
+                },
+                {
+                  type: 'tool-input-available',
+                  toolName: 'search',
+                  toolCallId: 'call-1',
+                  input: { owner: 'new' },
+                },
+                finishChunk(),
+              ])
+            )
+          ) as any,
+        },
+      });
+
+      await chat.sendMessage({ text: 'first request' });
+      chat.messages = [
+        ...chat.messages,
+        {
+          id: 'assistant-new',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { owner: 'new' },
+            },
+          ],
+        },
+      ];
+
+      await chat.resumeStream();
+      await submitOldResult({
+        tool: 'search',
+        toolCallId: 'call-1',
+        output: { owner: 'old' },
+      });
+
+      expect(onToolCall).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(chat.status).toBe('error');
+      expect(messageById(state, 'assistant-old').parts[0]).toMatchObject({
+        state: 'output-available',
+        output: { owner: 'old' },
+      });
+      expect(messageById(state, 'assistant-new').parts[0]).toMatchObject({
+        state: 'input-available',
+        input: { owner: 'new' },
+      });
+    });
+
+    it('executes a restored input-available tool when no callback owner exists', async () => {
       const state = new RuntimeChatState<UIMessage>(
         'test-chat',
         [
@@ -2038,13 +2274,32 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         ],
         false
       );
-      const onToolCall = jest.fn();
-      const chat = new TestChat({
+      const sendMessages = jest.fn(() =>
+        Promise.resolve(chunksToStream([startChunk('msg-2'), finishChunk()]))
+      );
+      let chat!: TestChat;
+      const onToolCall = jest.fn(({ toolCall }: { toolCall: any }) =>
+        chat.addToolResult({
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          output: { hits: [] },
+        })
+      );
+      chat = new TestChat({
         id: 'test-chat',
         state,
         onToolCall,
+        sendAutomaticallyWhen: ({ messages }) =>
+          messages.some((message) =>
+            message.parts.some(
+              (part) =>
+                'toolCallId' in part &&
+                part.toolCallId === 'call-1' &&
+                part.state === 'output-available'
+            )
+          ),
         transport: {
-          sendMessages: jest.fn() as any,
+          sendMessages: sendMessages as any,
           reconnectToStream: jest.fn(() =>
             Promise.resolve(
               chunksToStream([
@@ -2069,10 +2324,12 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
 
       await chat.resumeStream();
 
-      expect(onToolCall).not.toHaveBeenCalled();
+      expect(onToolCall).toHaveBeenCalledTimes(1);
+      expect(sendMessages).toHaveBeenCalledTimes(1);
       expect(assistantToolPart(state, 'call-1')).toMatchObject({
-        state: 'input-available',
+        state: 'output-available',
         input: { query: 'headphones' },
+        output: { hits: [] },
       });
     });
 

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -538,6 +538,37 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     return canonicalMessage;
   }
 
+  private completeReasoningParts(
+    response: ResponseRecord
+  ): TUIMessage | undefined {
+    const messageIndex = this.messages.findIndex(
+      (message) => this.responseByMessage.get(message) === response
+    );
+    if (messageIndex === -1) return undefined;
+
+    const message = this.messages[messageIndex];
+    if (
+      !message.parts.some(
+        (part) => part.type === 'reasoning' && part.state === 'streaming'
+      )
+    ) {
+      return message;
+    }
+
+    return this.replaceMessage(
+      messageIndex,
+      {
+        ...message,
+        parts: message.parts.map((part) =>
+          part.type === 'reasoning' && part.state === 'streaming'
+            ? { ...part, state: 'done' as const }
+            : part
+        ),
+      } as TUIMessage,
+      response
+    );
+  }
+
   private commit(
     toolCallId: string,
     output: unknown,
@@ -643,6 +674,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     response.didEvaluateContinuation = true;
 
     if (this.activeResponse === response) {
+      this.completeReasoningParts(response);
       response.outcome = 'aborted';
       this.activeResponse = null;
       response.abortController.abort();
@@ -806,6 +838,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   stop = (): Promise<void> => {
     if (this.activeResponse) {
       const response = this.activeResponse;
+      this.completeReasoningParts(response);
       response.outcome = 'aborted';
       this.activeResponse = null;
       response.abortController.abort();
@@ -848,6 +881,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     ) => Promise<ReadableStream<InferUIMessageChunk<TUIMessage>> | null>
   ): Promise<void> {
     if (this.activeResponse) {
+      this.completeReasoningParts(this.activeResponse);
       this.activeResponse.outcome = 'aborted';
       this.activeResponse.abortController.abort();
     }
@@ -969,7 +1003,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     };
     const failToolCall = (reason: unknown): void => {
       if (response.outcome !== 'active') return;
-      const message = getCanonicalMessage();
+      const message =
+        this.completeReasoningParts(response) ?? getCanonicalMessage();
       const wasRetired = response.isRetired;
       const error =
         reason instanceof Error ? reason : new Error(String(reason));
@@ -1001,6 +1036,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           return;
         }
 
+        this.completeReasoningParts(response);
         isAbort ||=
           response.outcome === 'aborted' ||
           (!!error && error.name === 'AbortError');

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -945,8 +945,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const toolRawOutputByCallId: Record<string, string> = {};
     const streamPartIndexById = new Map<string, number>();
     const reusableReasoningPartIndexes: number[] = [];
+    const terminalContentMessageIds = new Set<string>();
     const streamPartKey = (type: 'text' | 'reasoning', id: string): string =>
       `${type}:${id}`;
+    const invalidateStreamParts = (): void => {
+      streamPartIndexById.clear();
+      reusableReasoningPartIndexes.length = 0;
+    };
     const findUnambiguousUnfinishedPart = (
       type: 'text' | 'reasoning'
     ): number | undefined => {
@@ -1096,8 +1101,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
           switch (chunk.type) {
             case 'start': {
-              streamPartIndexById.clear();
-              reusableReasoningPartIndexes.length = 0;
+              invalidateStreamParts();
               currentMessageId = chunk.messageId || this.generateId();
               response.messageId = currentMessageId;
 
@@ -1144,7 +1148,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
             case 'text-start':
             case 'reasoning-start': {
-              if (!currentMessage) break;
+              if (
+                !currentMessage ||
+                terminalContentMessageIds.has(currentMessage.id)
+              ) {
+                break;
+              }
               const type = chunk.type === 'text-start' ? 'text' : 'reasoning';
               const reusablePartIndex =
                 type === 'reasoning'
@@ -1165,7 +1174,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             case 'text-delta':
             case 'reasoning-delta': {
               const type = chunk.type === 'text-delta' ? 'text' : 'reasoning';
-              if (!currentMessage) break;
+              if (
+                !currentMessage ||
+                terminalContentMessageIds.has(currentMessage.id)
+              ) {
+                break;
+              }
 
               const partKey = streamPartKey(type, chunk.id);
               let partIndex = streamPartIndexById.get(partKey);
@@ -1177,19 +1191,29 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               }
               if (partIndex === undefined) break;
 
-              const part = currentMessage.parts[partIndex] as {
-                type: 'text' | 'reasoning';
-                text: string;
-                state?: 'streaming' | 'done';
-              };
-              if (part.type !== type || part.state !== 'streaming') break;
+              const part = currentMessage.parts[partIndex] as
+                | {
+                    type: 'text' | 'reasoning';
+                    text: string;
+                    state?: 'streaming' | 'done';
+                  }
+                | undefined;
+              if (!part || part.type !== type || part.state !== 'streaming') {
+                streamPartIndexById.delete(partKey);
+                break;
+              }
               setPart(partIndex, { ...part, text: part.text + chunk.delta });
               break;
             }
 
             case 'text-end':
             case 'reasoning-end': {
-              if (!currentMessage) break;
+              if (
+                !currentMessage ||
+                terminalContentMessageIds.has(currentMessage.id)
+              ) {
+                break;
+              }
               const type = chunk.type === 'text-end' ? 'text' : 'reasoning';
 
               const partKey = streamPartKey(type, chunk.id);
@@ -1203,7 +1227,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               if (partIndex === undefined) break;
 
               const part = currentMessage.parts[partIndex];
-              if (part.type !== type || part.state !== 'streaming') {
+              if (!part || part.type !== type || part.state !== 'streaming') {
                 streamPartIndexById.delete(partKey);
                 break;
               }
@@ -1679,6 +1703,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               const fallbackText =
                 fallbackResponse || defaultGuardrailFallbackResponse;
 
+              invalidateStreamParts();
+
               // The stream closes after a guardrail violation; keep the
               // fallback as the current message so the normal finish path runs.
               currentMessage = {
@@ -1706,6 +1732,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               }
 
               currentMessageId = currentMessage.id;
+              terminalContentMessageIds.add(currentMessage.id);
               break;
             }
 

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -44,6 +44,13 @@ type ResponseRecord = {
   pendingToolCallbacks: number;
   didNotifyFinish: boolean;
   didEvaluateContinuation: boolean;
+  resumableReasoningPartsByKey: Map<string, ResumableReasoningPart>;
+};
+
+type ResumableReasoningPart = {
+  messageId: string;
+  partIndex: number;
+  text: string;
 };
 
 type ToolResultSubmission<TUIMessage extends UIMessage> = <
@@ -332,6 +339,9 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     });
     if (this.activeResponse) {
       responses.add(this.activeResponse);
+    }
+    if (this.latestResponse) {
+      responses.add(this.latestResponse);
     }
     detachedResponses.forEach((response) => {
       responses.add(response);
@@ -675,6 +685,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
     response.isRetired = true;
     response.didEvaluateContinuation = true;
+    response.resumableReasoningPartsByKey.clear();
 
     if (this.activeResponse === response) {
       this.completeReasoningParts(response);
@@ -900,6 +911,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       pendingToolCallbacks: 0,
       didNotifyFinish: false,
       didEvaluateContinuation: false,
+      resumableReasoningPartsByKey:
+        isResume && this.latestResponse?.outcome === 'failed'
+          ? new Map(this.latestResponse.resumableReasoningPartsByKey)
+          : new Map(),
     };
     this.activeResponse = response;
     this.latestResponse = response;
@@ -945,6 +960,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const toolRawOutputByCallId: Record<string, string> = {};
     const streamPartIndexById = new Map<string, number>();
     const reusableReasoningPartIndexes: number[] = [];
+    const resumableReasoningPartIndexByKey = new Map<string, number>();
     const reasoningReplayByPartKey = new Map<
       string,
       {
@@ -959,6 +975,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const invalidateStreamParts = (): void => {
       streamPartIndexById.clear();
       reusableReasoningPartIndexes.length = 0;
+      resumableReasoningPartIndexByKey.clear();
       reasoningReplayByPartKey.clear();
     };
     const findUnambiguousUnfinishedPart = (
@@ -970,9 +987,23 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       return partIndexes?.length === 1 ? partIndexes[0] : undefined;
     };
     const claimUnambiguousUnfinishedPart = (
-      type: 'text' | 'reasoning'
+      type: 'text' | 'reasoning',
+      partKey: string
     ): number | undefined => {
-      const partIndex = findUnambiguousUnfinishedPart(type);
+      let partIndex = findUnambiguousUnfinishedPart(type);
+      if (partIndex === undefined && type === 'reasoning') {
+        partIndex = resumableReasoningPartIndexByKey.get(partKey);
+        const part =
+          partIndex === undefined
+            ? undefined
+            : currentMessage?.parts[partIndex];
+        if (part?.type === 'reasoning' && partIndex !== undefined) {
+          setPart(partIndex, { ...part, state: 'streaming' });
+          resumableReasoningPartIndexByKey.delete(partKey);
+        } else {
+          partIndex = undefined;
+        }
+      }
       if (partIndex !== undefined) {
         reusableReasoningPartIndexes.length = 0;
       }
@@ -1004,7 +1035,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         });
     const findReusableReasoningPart = (
       partKey: string,
-      replayedText: string
+      replayedText: string,
+      allowExactPrefixMatch: boolean
     ): number | undefined => {
       const compatiblePartIndexes = getCompatibleReasoningPartIndexes(
         partKey,
@@ -1017,13 +1049,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           ? undefined
           : currentMessage?.parts[firstCandidateIndex];
       if (
-        firstCandidate?.type === 'reasoning' &&
-        firstCandidate.text === replayedText
-      ) {
-        return firstCandidateIndex;
-      }
-
-      if (
+        !allowExactPrefixMatch &&
         compatiblePartIndexes.some((partIndex) => {
           const part = currentMessage!.parts[partIndex];
           return (
@@ -1032,6 +1058,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         })
       ) {
         return undefined;
+      }
+
+      if (
+        firstCandidate?.type === 'reasoning' &&
+        firstCandidate.text === replayedText
+      ) {
+        return firstCandidateIndex;
       }
 
       const matchingPartIndexes = compatiblePartIndexes.filter((partIndex) => {
@@ -1058,6 +1091,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       return longestMatches.length === 1 ? longestMatches[0] : undefined;
     };
     const consumeReasoningPart = (partKey: string, partIndex: number): void => {
+      resumableReasoningPartIndexByKey.forEach(
+        (candidatePartIndex, candidatePartKey) => {
+          if (candidatePartIndex === partIndex) {
+            resumableReasoningPartIndexByKey.delete(candidatePartKey);
+          }
+        }
+      );
       const candidateIndex = reusableReasoningPartIndexes.indexOf(partIndex);
       if (candidateIndex !== -1) {
         reusableReasoningPartIndexes.splice(
@@ -1125,7 +1165,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
       const reusablePartIndex = findReusableReasoningPart(
         partKey,
-        reasoningReplay.replayedText
+        reasoningReplay.replayedText,
+        replayState !== 'streaming'
       );
       if (reusablePartIndex !== undefined) {
         const part = currentMessage.parts[reusablePartIndex];
@@ -1227,6 +1268,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       const error =
         reason instanceof Error ? reason : new Error(String(reason));
       response.outcome = 'failed';
+      response.resumableReasoningPartsByKey.clear();
       response.abortController.abort();
 
       if (this.activeResponse === response) {
@@ -1255,10 +1297,42 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         }
 
         completeReasoningReplays();
-        this.completeReasoningParts(response);
         isAbort ||=
           response.outcome === 'aborted' ||
           (!!error && error.name === 'AbortError');
+        const messageId = response.messageId;
+        if (messageId) {
+          if (error && !isAbort && !isError) {
+            const message = getCanonicalMessage();
+            const partIndexByKey = new Map(resumableReasoningPartIndexByKey);
+            streamPartIndexById.forEach((partIndex, partKey) => {
+              if (partKey.startsWith('reasoning:')) {
+                partIndexByKey.set(partKey, partIndex);
+              }
+            });
+            const resumableParts = Array.from(partIndexByKey).flatMap(
+              ([partKey, partIndex]) => {
+                const part = message?.parts[partIndex];
+                return part?.type === 'reasoning'
+                  ? [
+                      [
+                        partKey,
+                        {
+                          messageId,
+                          partIndex,
+                          text: part.text,
+                        },
+                      ] as const,
+                    ]
+                  : [];
+              }
+            );
+            response.resumableReasoningPartsByKey = new Map(resumableParts);
+          } else {
+            response.resumableReasoningPartsByKey.clear();
+          }
+        }
+        this.completeReasoningParts(response);
         response.outcome = isAbort ? 'aborted' : error ? 'failed' : 'succeeded';
         if (this.activeResponse === response) {
           this.activeResponse = null;
@@ -1328,6 +1402,21 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                       reusableReasoningPartIndexes.push(index);
                     }
                   });
+                  response.resumableReasoningPartsByKey.forEach(
+                    ({ messageId, partIndex, text }, partKey) => {
+                      const part = currentMessage!.parts[partIndex];
+                      if (
+                        messageId === currentMessageId &&
+                        part?.type === 'reasoning' &&
+                        part.text === text
+                      ) {
+                        resumableReasoningPartIndexByKey.set(
+                          partKey,
+                          partIndex
+                        );
+                      }
+                    }
+                  );
                 }
               } else {
                 currentMessage = {
@@ -1399,7 +1488,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
               let partIndex = streamPartIndexById.get(partKey);
               if (partIndex === undefined && response.isResume) {
-                partIndex = claimUnambiguousUnfinishedPart(type);
+                partIndex = claimUnambiguousUnfinishedPart(type, partKey);
                 if (partIndex !== undefined) {
                   streamPartIndexById.set(partKey, partIndex);
                 }
@@ -1443,7 +1532,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
               let partIndex = streamPartIndexById.get(partKey);
               if (partIndex === undefined && response.isResume) {
-                partIndex = claimUnambiguousUnfinishedPart(type);
+                partIndex = claimUnambiguousUnfinishedPart(type, partKey);
                 if (partIndex !== undefined) {
                   streamPartIndexById.set(partKey, partIndex);
                 }

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -44,13 +44,6 @@ type ResponseRecord = {
   pendingToolCallbacks: number;
   didNotifyFinish: boolean;
   didEvaluateContinuation: boolean;
-  resumableReasoningPartsByKey: Map<string, ResumableReasoningPart>;
-};
-
-type ResumableReasoningPart = {
-  messageId: string;
-  partIndex: number;
-  text: string;
 };
 
 type ToolResultSubmission<TUIMessage extends UIMessage> = <
@@ -339,9 +332,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     });
     if (this.activeResponse) {
       responses.add(this.activeResponse);
-    }
-    if (this.latestResponse) {
-      responses.add(this.latestResponse);
     }
     detachedResponses.forEach((response) => {
       responses.add(response);
@@ -685,8 +675,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
     response.isRetired = true;
     response.didEvaluateContinuation = true;
-    response.resumableReasoningPartsByKey.clear();
-
     if (this.activeResponse === response) {
       this.completeReasoningParts(response);
       response.outcome = 'aborted';
@@ -911,10 +899,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       pendingToolCallbacks: 0,
       didNotifyFinish: false,
       didEvaluateContinuation: false,
-      resumableReasoningPartsByKey:
-        isResume && this.latestResponse?.outcome === 'failed'
-          ? new Map(this.latestResponse.resumableReasoningPartsByKey)
-          : new Map(),
     };
     this.activeResponse = response;
     this.latestResponse = response;
@@ -959,14 +943,22 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const toolRawInputByCallId: Record<string, string> = {};
     const toolRawOutputByCallId: Record<string, string> = {};
     const streamPartIndexById = new Map<string, number>();
-    const reusableReasoningPartIndexes: number[] = [];
-    const resumableReasoningPartIndexByKey = new Map<string, number>();
-    const reasoningReplayByPartKey = new Map<
+    // A resumed stream replays buffered content in order. The persisted parts
+    // do not retain stream ids, so reuse them in order while the replay catches
+    // up without clearing text that is already visible.
+    const reusablePartIndexesByType = new Map<'text' | 'reasoning', number[]>([
+      ['text', []],
+      ['reasoning', []],
+    ]);
+    const replayByPartKey = new Map<
       string,
       {
+        type: 'text' | 'reasoning';
+        originalPartIndex: number;
+        originalText: string;
         replayedText: string;
         providerMetadata?: ProviderMetadata;
-        partIndex?: number;
+        replayPartIndex?: number;
       }
     >();
     const terminalContentMessageIds = new Set<string>();
@@ -974,137 +966,25 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       `${type}:${id}`;
     const invalidateStreamParts = (): void => {
       streamPartIndexById.clear();
-      reusableReasoningPartIndexes.length = 0;
-      resumableReasoningPartIndexByKey.clear();
-      reasoningReplayByPartKey.clear();
+      reusablePartIndexesByType.forEach((indexes) => {
+        indexes.length = 0;
+      });
+      replayByPartKey.clear();
     };
-    const findUnambiguousUnfinishedPart = (
-      type: 'text' | 'reasoning'
+    const claimUnfinishedPart = (
+      type: 'text' | 'reasoning',
+      partKey: string
     ): number | undefined => {
       const partIndexes = currentMessage?.parts.flatMap((part, index) =>
         part.type === type && part.state === 'streaming' ? [index] : []
       );
-      return partIndexes?.length === 1 ? partIndexes[0] : undefined;
-    };
-    const claimUnambiguousUnfinishedPart = (
-      type: 'text' | 'reasoning',
-      partKey: string
-    ): number | undefined => {
-      let partIndex = findUnambiguousUnfinishedPart(type);
-      if (partIndex === undefined && type === 'reasoning') {
-        partIndex = resumableReasoningPartIndexByKey.get(partKey);
-        const part =
-          partIndex === undefined
-            ? undefined
-            : currentMessage?.parts[partIndex];
-        if (part?.type === 'reasoning' && partIndex !== undefined) {
-          setPart(partIndex, { ...part, state: 'streaming' });
-          resumableReasoningPartIndexByKey.delete(partKey);
-        } else {
-          partIndex = undefined;
-        }
-      }
-      if (partIndex !== undefined) {
-        reusableReasoningPartIndexes.length = 0;
-      }
-      return partIndex;
-    };
-    const getEarlierPendingReplayCount = (partKey: string): number => {
-      const replayKeys = Array.from(reasoningReplayByPartKey.keys());
-      const replayIndex = replayKeys.indexOf(partKey);
-      return replayKeys
-        .slice(0, replayIndex)
-        .filter(
-          (key) => reasoningReplayByPartKey.get(key)?.partIndex === undefined
-        ).length;
-    };
-    const getCompatibleReasoningPartIndexes = (
-      partKey: string,
-      replayedText: string
-    ): number[] =>
-      reusableReasoningPartIndexes
-        .slice(getEarlierPendingReplayCount(partKey))
-        .filter((partIndex) => {
-          const part = currentMessage?.parts[partIndex];
-          return (
-            part?.type === 'reasoning' &&
-            (part.text.startsWith(replayedText) ||
-              (part.state === 'streaming' &&
-                replayedText.startsWith(part.text)))
-          );
-        });
-    const findReusableReasoningPart = (
-      partKey: string,
-      replayedText: string,
-      allowExactPrefixMatch: boolean
-    ): number | undefined => {
-      const compatiblePartIndexes = getCompatibleReasoningPartIndexes(
-        partKey,
-        replayedText
-      );
-      const firstCandidateIndex =
-        reusableReasoningPartIndexes[getEarlierPendingReplayCount(partKey)];
-      const firstCandidate =
-        firstCandidateIndex === undefined
-          ? undefined
-          : currentMessage?.parts[firstCandidateIndex];
-      if (
-        !allowExactPrefixMatch &&
-        compatiblePartIndexes.some((partIndex) => {
-          const part = currentMessage!.parts[partIndex];
-          return (
-            part.type === 'reasoning' && part.text.length > replayedText.length
-          );
-        })
-      ) {
-        return undefined;
-      }
+      if (partIndexes?.length !== 1) return undefined;
 
-      if (
-        firstCandidate?.type === 'reasoning' &&
-        firstCandidate.text === replayedText
-      ) {
-        return firstCandidateIndex;
-      }
-
-      const matchingPartIndexes = compatiblePartIndexes.filter((partIndex) => {
-        const part = currentMessage!.parts[partIndex];
-        return (
-          part.type === 'reasoning' &&
-          (replayedText === part.text ||
-            (part.state === 'streaming' && replayedText.startsWith(part.text)))
-        );
+      reusablePartIndexesByType.forEach((indexes) => {
+        indexes.length = 0;
       });
-      const longestMatchLength = Math.max(
-        ...matchingPartIndexes.map((partIndex) => {
-          const part = currentMessage!.parts[partIndex];
-          return part.type === 'reasoning' ? part.text.length : -1;
-        }),
-        -1
-      );
-      const longestMatches = matchingPartIndexes.filter((partIndex) => {
-        const part = currentMessage!.parts[partIndex];
-        return (
-          part.type === 'reasoning' && part.text.length === longestMatchLength
-        );
-      });
-      return longestMatches.length === 1 ? longestMatches[0] : undefined;
-    };
-    const consumeReasoningPart = (partKey: string, partIndex: number): void => {
-      resumableReasoningPartIndexByKey.forEach(
-        (candidatePartIndex, candidatePartKey) => {
-          if (candidatePartIndex === partIndex) {
-            resumableReasoningPartIndexByKey.delete(candidatePartKey);
-          }
-        }
-      );
-      const candidateIndex = reusableReasoningPartIndexes.indexOf(partIndex);
-      if (candidateIndex !== -1) {
-        reusableReasoningPartIndexes.splice(
-          getEarlierPendingReplayCount(partKey) > 0 ? candidateIndex : 0,
-          getEarlierPendingReplayCount(partKey) > 0 ? 1 : candidateIndex + 1
-        );
-      }
+      streamPartIndexById.set(partKey, partIndexes[0]);
+      return partIndexes[0];
     };
 
     const findToolPart = (toolCallId: string): number =>
@@ -1121,95 +1001,73 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         response
       );
     };
-    const appendReasoningReplay = (
-      reasoningReplay: {
-        replayedText: string;
-        providerMetadata?: ProviderMetadata;
-        partIndex?: number;
-      },
-      state: 'streaming' | 'done'
-    ): number => {
-      const partIndex = currentMessage!.parts.length;
-      setPart(-1, {
-        type: 'reasoning',
-        text: reasoningReplay.replayedText,
-        state,
-        providerMetadata: reasoningReplay.providerMetadata,
-      });
-      reasoningReplay.partIndex = partIndex;
-      reusableReasoningPartIndexes.length = 0;
-      return partIndex;
-    };
-    const reconcileReasoningReplay = (
+    const updateReplayPart = (
       partKey: string,
-      replayState: 'streaming' | 'done' | 'interrupted'
+      state: 'streaming' | 'done'
     ): void => {
-      const reasoningReplay = reasoningReplayByPartKey.get(partKey);
-      if (!reasoningReplay || !currentMessage) return;
-      const partState =
-        replayState === 'streaming' ? 'streaming' : ('done' as const);
+      const replay = replayByPartKey.get(partKey);
+      if (!replay || !currentMessage) return;
 
-      if (reasoningReplay.partIndex !== undefined) {
-        const part = currentMessage.parts[reasoningReplay.partIndex];
-        if (part?.type === 'reasoning') {
-          setPart(reasoningReplay.partIndex, {
-            ...part,
-            text: reasoningReplay.replayedText,
-            state: partState,
+      const originalPart = currentMessage.parts[replay.originalPartIndex];
+      if (originalPart?.type !== replay.type) return;
+
+      if (
+        replay.replayedText.length < replay.originalText.length &&
+        replay.originalText.startsWith(replay.replayedText)
+      ) {
+        if (state === 'done') {
+          setPart(replay.originalPartIndex, {
+            ...originalPart,
+            state,
             providerMetadata:
-              reasoningReplay.providerMetadata ?? part.providerMetadata,
+              replay.providerMetadata ?? originalPart.providerMetadata,
           });
         }
         return;
       }
 
-      const reusablePartIndex = findReusableReasoningPart(
-        partKey,
-        reasoningReplay.replayedText,
-        replayState !== 'streaming'
-      );
-      if (reusablePartIndex !== undefined) {
-        const part = currentMessage.parts[reusablePartIndex];
-        if (part?.type === 'reasoning') {
-          setPart(reusablePartIndex, {
-            ...part,
-            text: reasoningReplay.replayedText,
-            state: partState,
-            providerMetadata:
-              reasoningReplay.providerMetadata ?? part.providerMetadata,
-          });
-          reasoningReplay.partIndex = reusablePartIndex;
-          consumeReasoningPart(partKey, reusablePartIndex);
-        }
+      if (replay.replayedText.startsWith(replay.originalText)) {
+        setPart(replay.originalPartIndex, {
+          ...originalPart,
+          text: replay.replayedText,
+          state,
+          providerMetadata:
+            replay.providerMetadata ?? originalPart.providerMetadata,
+        });
+        streamPartIndexById.set(partKey, replay.originalPartIndex);
         return;
       }
 
-      const hasCompatiblePart =
-        getCompatibleReasoningPartIndexes(partKey, reasoningReplay.replayedText)
-          .length > 0;
-      if (!hasCompatiblePart && reasoningReplay.replayedText) {
-        appendReasoningReplay(reasoningReplay, partState);
-      } else if (replayState === 'done' && reasoningReplay.replayedText) {
-        appendReasoningReplay(reasoningReplay, partState);
+      // Divergent content cannot safely replace a persisted part without a
+      // durable stream id. Preserve it and render the new replay separately.
+      if (replay.replayPartIndex === undefined) {
+        replay.replayPartIndex = currentMessage.parts.length;
       }
+      setPart(replay.replayPartIndex, {
+        type: replay.type,
+        text: replay.replayedText,
+        state,
+        providerMetadata: replay.providerMetadata,
+      });
+      streamPartIndexById.set(partKey, replay.replayPartIndex);
     };
-    const completeReasoningReplays = (): void => {
-      const replayMessageIndex = this.messages.findIndex(
+    const completeReplays = (): void => {
+      const messageIndex = this.messages.findIndex(
         (message) =>
           message.id === response.messageId &&
           this.responseByMessage.get(message) === response
       );
-      if (response.isRetired || replayMessageIndex === -1) {
-        reasoningReplayByPartKey.clear();
+      if (response.isRetired || messageIndex === -1) {
+        replayByPartKey.clear();
         return;
       }
-      currentMessageIndex = replayMessageIndex;
-      currentMessage = this.messages[replayMessageIndex];
+      currentMessageIndex = messageIndex;
+      currentMessage = this.messages[messageIndex];
 
-      reasoningReplayByPartKey.forEach((_reasoningReplay, partKey) => {
-        reconcileReasoningReplay(partKey, 'interrupted');
+      replayByPartKey.forEach((_replay, partKey) => {
+        updateReplayPart(partKey, 'done');
       });
-      reasoningReplayByPartKey.clear();
+      replayByPartKey.clear();
     };
     const mergeCallProviderMetadata = (
       toolCallId: string,
@@ -1261,14 +1119,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     };
     const failToolCall = (reason: unknown): void => {
       if (response.outcome !== 'active') return;
-      completeReasoningReplays();
+      completeReplays();
       const message =
         this.completeReasoningParts(response) ?? getCanonicalMessage();
       const wasRetired = response.isRetired;
       const error =
         reason instanceof Error ? reason : new Error(String(reason));
       response.outcome = 'failed';
-      response.resumableReasoningPartsByKey.clear();
       response.abortController.abort();
 
       if (this.activeResponse === response) {
@@ -1296,42 +1153,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           return;
         }
 
-        completeReasoningReplays();
+        completeReplays();
         isAbort ||=
           response.outcome === 'aborted' ||
           (!!error && error.name === 'AbortError');
-        const messageId = response.messageId;
-        if (messageId) {
-          if (error && !isAbort && !isError) {
-            const message = getCanonicalMessage();
-            const partIndexByKey = new Map(resumableReasoningPartIndexByKey);
-            streamPartIndexById.forEach((partIndex, partKey) => {
-              if (partKey.startsWith('reasoning:')) {
-                partIndexByKey.set(partKey, partIndex);
-              }
-            });
-            const resumableParts = Array.from(partIndexByKey).flatMap(
-              ([partKey, partIndex]) => {
-                const part = message?.parts[partIndex];
-                return part?.type === 'reasoning'
-                  ? [
-                      [
-                        partKey,
-                        {
-                          messageId,
-                          partIndex,
-                          text: part.text,
-                        },
-                      ] as const,
-                    ]
-                  : [];
-              }
-            );
-            response.resumableReasoningPartsByKey = new Map(resumableParts);
-          } else {
-            response.resumableReasoningPartsByKey.clear();
-          }
-        }
         this.completeReasoningParts(response);
         response.outcome = isAbort ? 'aborted' : error ? 'failed' : 'succeeded';
         if (this.activeResponse === response) {
@@ -1398,25 +1223,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 );
                 if (response.isResume) {
                   currentMessage.parts.forEach((part, index) => {
-                    if (part.type === 'reasoning' && part.text) {
-                      reusableReasoningPartIndexes.push(index);
+                    if (part.type === 'text' || part.type === 'reasoning') {
+                      reusablePartIndexesByType.get(part.type)!.push(index);
                     }
                   });
-                  response.resumableReasoningPartsByKey.forEach(
-                    ({ messageId, partIndex, text }, partKey) => {
-                      const part = currentMessage!.parts[partIndex];
-                      if (
-                        messageId === currentMessageId &&
-                        part?.type === 'reasoning' &&
-                        part.text === text
-                      ) {
-                        resumableReasoningPartIndexByKey.set(
-                          partKey,
-                          partIndex
-                        );
-                      }
-                    }
-                  );
                 }
               } else {
                 currentMessage = {
@@ -1442,14 +1252,29 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               }
               const type = chunk.type === 'text-start' ? 'text' : 'reasoning';
               const partKey = streamPartKey(type, chunk.id);
+              const reusablePartIndex = response.isResume
+                ? reusablePartIndexesByType.get(type)?.shift()
+                : undefined;
+              const reusablePart =
+                reusablePartIndex === undefined
+                  ? undefined
+                  : currentMessage.parts[reusablePartIndex];
               if (
-                type === 'reasoning' &&
-                response.isResume &&
-                reusableReasoningPartIndexes.length > 0
+                reusablePartIndex !== undefined &&
+                reusablePart?.type === type
               ) {
-                reasoningReplayByPartKey.set(partKey, {
+                replayByPartKey.set(partKey, {
+                  type,
+                  originalPartIndex: reusablePartIndex,
+                  originalText: reusablePart.text,
                   replayedText: '',
                   providerMetadata: chunk.providerMetadata,
+                });
+                setPart(reusablePartIndex, {
+                  ...reusablePart,
+                  state: 'streaming',
+                  providerMetadata:
+                    chunk.providerMetadata ?? reusablePart.providerMetadata,
                 });
                 break;
               }
@@ -1476,23 +1301,18 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               }
 
               const partKey = streamPartKey(type, chunk.id);
-              const reasoningReplay = reasoningReplayByPartKey.get(partKey);
-              if (reasoningReplay) {
-                reasoningReplay.replayedText += chunk.delta;
-                reconcileReasoningReplay(partKey, 'streaming');
-                if (reasoningReplay.partIndex !== undefined) {
-                  streamPartIndexById.set(partKey, reasoningReplay.partIndex);
-                }
+              const replay = replayByPartKey.get(partKey);
+              if (replay) {
+                replay.replayedText += chunk.delta;
+                updateReplayPart(partKey, 'streaming');
                 break;
               }
 
-              let partIndex = streamPartIndexById.get(partKey);
-              if (partIndex === undefined && response.isResume) {
-                partIndex = claimUnambiguousUnfinishedPart(type, partKey);
-                if (partIndex !== undefined) {
-                  streamPartIndexById.set(partKey, partIndex);
-                }
-              }
+              const partIndex =
+                streamPartIndexById.get(partKey) ??
+                (response.isResume
+                  ? claimUnfinishedPart(type, partKey)
+                  : undefined);
               if (partIndex === undefined) break;
 
               const part = currentMessage.parts[partIndex] as
@@ -1522,21 +1342,18 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               const type = chunk.type === 'text-end' ? 'text' : 'reasoning';
 
               const partKey = streamPartKey(type, chunk.id);
-              const reasoningReplay = reasoningReplayByPartKey.get(partKey);
-              if (reasoningReplay) {
-                reconcileReasoningReplay(partKey, 'done');
-                reasoningReplayByPartKey.delete(partKey);
+              if (replayByPartKey.has(partKey)) {
+                updateReplayPart(partKey, 'done');
+                replayByPartKey.delete(partKey);
                 streamPartIndexById.delete(partKey);
                 break;
               }
 
-              let partIndex = streamPartIndexById.get(partKey);
-              if (partIndex === undefined && response.isResume) {
-                partIndex = claimUnambiguousUnfinishedPart(type, partKey);
-                if (partIndex !== undefined) {
-                  streamPartIndexById.set(partKey, partIndex);
-                }
-              }
+              const partIndex =
+                streamPartIndexById.get(partKey) ??
+                (response.isResume
+                  ? claimUnfinishedPart(type, partKey)
+                  : undefined);
               if (partIndex === undefined) break;
 
               const part = currentMessage.parts[partIndex];

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -1049,6 +1049,39 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         response
       );
     };
+    const insertPart = (index: number, part: any): void => {
+      const parts = [...currentMessage!.parts];
+      parts.splice(index, 0, part);
+
+      reusablePartIndexes.forEach((partIndex, reusableIndex) => {
+        if (partIndex >= index) {
+          reusablePartIndexes[reusableIndex] = partIndex + 1;
+        }
+      });
+      streamPartIndexById.forEach((partIndex, partKey) => {
+        if (partIndex >= index) {
+          streamPartIndexById.set(partKey, partIndex + 1);
+        }
+      });
+      replayByPartKey.forEach((replay) => {
+        if (replay.originalPartIndex >= index) {
+          replay.originalPartIndex++;
+        }
+        if (
+          replay.replayPartIndex !== undefined &&
+          replay.replayPartIndex >= index
+        ) {
+          replay.replayPartIndex++;
+        }
+      });
+
+      currentMessage = { ...currentMessage!, parts } as TUIMessage;
+      currentMessage = this.replaceMessage(
+        currentMessageIndex,
+        currentMessage,
+        response
+      );
+    };
     const updateReplayPart = (
       partKey: string,
       state: 'streaming' | 'done'
@@ -1089,14 +1122,23 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       // Divergent content cannot safely replace a persisted part without a
       // durable stream id. Preserve it and render the new replay separately.
       if (replay.replayPartIndex === undefined) {
-        replay.replayPartIndex = currentMessage.parts.length;
+        const replayPartIndex =
+          reusablePartIndexes[0] ?? currentMessage.parts.length;
+        insertPart(replayPartIndex, {
+          type: replay.type,
+          text: replay.replayedText,
+          state,
+          providerMetadata: replay.providerMetadata,
+        });
+        replay.replayPartIndex = replayPartIndex;
+      } else {
+        setPart(replay.replayPartIndex, {
+          type: replay.type,
+          text: replay.replayedText,
+          state,
+          providerMetadata: replay.providerMetadata,
+        });
       }
-      setPart(replay.replayPartIndex, {
-        type: replay.type,
-        text: replay.replayedText,
-        state,
-        providerMetadata: replay.providerMetadata,
-      });
       streamPartIndexById.set(partKey, replay.replayPartIndex);
     };
     const completeReplays = (): void => {
@@ -1243,6 +1285,17 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             this.responseByMessage.set(currentMessage, response);
           }
 
+          if (
+            currentMessage &&
+            terminalContentMessageIds.has(currentMessage.id) &&
+            chunk.type !== 'message-metadata' &&
+            chunk.type !== 'error' &&
+            chunk.type !== 'abort' &&
+            chunk.type !== 'finish'
+          ) {
+            return;
+          }
+
           switch (chunk.type) {
             case 'start': {
               invalidateStreamParts();
@@ -1256,9 +1309,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 lastMessage.role === 'assistant' &&
                 lastMessage.id === currentMessageId
               ) {
-                if (lastMessage.parts.some((part) => 'toolCallId' in part)) {
-                  this.acceptsIdentifierOnlyToolResults = false;
-                }
                 currentMessage = {
                   ...lastMessage,
                   parts: [...lastMessage.parts],
@@ -1273,6 +1323,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   currentMessage.parts.forEach((part, index) => {
                     reusablePartIndexes.push(index);
                     if ('toolCallId' in part) {
+                      const dispatchOwners = Array.from(
+                        this.responsesByToolCallId.get(part.toolCallId) ?? []
+                      ).filter(
+                        (owner) =>
+                          owner !== response &&
+                          owner.messageId === currentMessage!.id &&
+                          owner.requiredToolCallIds.has(part.toolCallId)
+                      );
                       if (
                         'rawInput' in part &&
                         typeof part.rawInput === 'string'
@@ -1294,7 +1352,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                       if (
                         part.state === 'input-available' &&
                         (!('providerExecuted' in part) ||
-                          !part.providerExecuted)
+                          !part.providerExecuted) &&
+                        dispatchOwners.length === 1
                       ) {
                         replayedDispatchedToolCallIds.add(part.toolCallId);
                       }
@@ -1628,8 +1687,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                       forwardedResponses
                     );
                   });
-                  owners.add(response);
-                  this.responsesByToolCallId.set(chunk.toolCallId, owners);
                   break;
                 }
                 if (existingOwners.length > 0) {

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -42,7 +42,8 @@ type ResponseRecord = {
   resolvedToolCallIds: Set<string>;
   returnedToolCallbacks: Array<Promise<void>>;
   pendingToolCallbacks: number;
-  forwardToolResultsTo: Map<string, Set<ResponseRecord>>;
+  forwardToolOutcomeTo: Map<string, ResponseRecord>;
+  failToolCall?: (reason: unknown, toolCallId?: string) => void;
   didNotifyFinish: boolean;
   didEvaluateContinuation: boolean;
 };
@@ -736,10 +737,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       if (!response) {
         return this.continueResponse();
       }
-      const resultOwners = [
-        response,
-        ...(response.forwardToolResultsTo.get(toolCallId) ?? []),
-      ];
+      const forwardedResponse = response.forwardToolOutcomeTo.get(toolCallId);
+      const resultOwners = forwardedResponse
+        ? [response, forwardedResponse]
+        : [response];
       resultOwners.forEach((owner) => {
         if (owner.requiredToolCallIds.has(toolCallId)) {
           owner.resolvedToolCallIds.add(toolCallId);
@@ -909,7 +910,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       resolvedToolCallIds: new Set(),
       returnedToolCallbacks: [],
       pendingToolCallbacks: 0,
-      forwardToolResultsTo: new Map(),
+      forwardToolOutcomeTo: new Map(),
       didNotifyFinish: false,
       didEvaluateContinuation: false,
     };
@@ -1207,8 +1208,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         });
       }
     };
-    const failToolCall = (reason: unknown): void => {
-      if (response.outcome !== 'active') return;
+    const failToolCall = (reason: unknown, toolCallId?: string): void => {
+      if (response.outcome === 'failed' || response.outcome === 'aborted') {
+        const forwardedResponse = toolCallId
+          ? response.forwardToolOutcomeTo.get(toolCallId)
+          : undefined;
+        forwardedResponse?.failToolCall?.(reason, toolCallId);
+        return;
+      }
       completeReplays();
       const message =
         this.completeReasoningParts(response) ?? getCanonicalMessage();
@@ -1220,8 +1227,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
       if (this.activeResponse === response) {
         this.activeResponse = null;
-        this.handleError(error);
       }
+      this.handleError(error, {
+        updateState: this.latestResponse === response,
+      });
       notifyFinish({
         isAbort: false,
         isDisconnect: false,
@@ -1230,6 +1239,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         allowRetired: !wasRetired,
       });
     };
+    response.failToolCall = failToolCall;
     const acceptServerToolResult = (toolCallId: string): void => {
       if (response.requiredToolCallIds.has(toolCallId)) {
         response.resolvedToolCallIds.add(toolCallId);
@@ -1678,14 +1688,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                     if (!owner.requiredToolCallIds.has(chunk.toolCallId)) {
                       return;
                     }
-                    const forwardedResponses =
-                      owner.forwardToolResultsTo.get(chunk.toolCallId) ??
-                      new Set<ResponseRecord>();
-                    forwardedResponses.add(response);
-                    owner.forwardToolResultsTo.set(
-                      chunk.toolCallId,
-                      forwardedResponses
-                    );
+                    owner.forwardToolOutcomeTo.set(chunk.toolCallId, response);
+                    owner.didEvaluateContinuation = true;
                   });
                   break;
                 }
@@ -1733,7 +1737,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   if (result) {
                     response.returnedToolCallbacks.push(
                       Promise.resolve(result)
-                        .catch(failToolCall)
+                        .catch((error) => failToolCall(error, chunk.toolCallId))
                         .then(() => {
                           response.pendingToolCallbacks--;
                           this.pruneDetachedResponse(response);
@@ -1745,7 +1749,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   }
                 } catch (error) {
                   response.pendingToolCallbacks--;
-                  failToolCall(error);
+                  failToolCall(error, chunk.toolCallId);
                   this.pruneDetachedResponse(response);
                 }
               }

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -36,6 +36,7 @@ type ResponseRecord = {
   abortController: AbortController;
   messageId?: string;
   outcome: ResponseOutcome;
+  isResume: boolean;
   isRetired: boolean;
   requiredToolCallIds: Set<string>;
   resolvedToolCallIds: Set<string>;
@@ -507,11 +508,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         );
       }
 
-      return this.consume(() =>
-        this.transport!.reconnectToStream({
-          chatId: this.id,
-          ...options,
-        })
+      return this.consume(
+        () =>
+          this.transport!.reconnectToStream({
+            chatId: this.id,
+            ...options,
+          }),
+        { isResume: true }
       );
     });
   };
@@ -878,7 +881,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   private consume(
     createStream: (
       abortSignal: AbortSignal
-    ) => Promise<ReadableStream<InferUIMessageChunk<TUIMessage>> | null>
+    ) => Promise<ReadableStream<InferUIMessageChunk<TUIMessage>> | null>,
+    { isResume = false }: { isResume?: boolean } = {}
   ): Promise<void> {
     if (this.activeResponse) {
       this.completeReasoningParts(this.activeResponse);
@@ -888,6 +892,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const response: ResponseRecord = {
       abortController: new AbortController(),
       outcome: 'active',
+      isResume,
       isRetired: false,
       requiredToolCallIds: new Set(),
       resolvedToolCallIds: new Set(),
@@ -939,8 +944,17 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const toolRawInputByCallId: Record<string, string> = {};
     const toolRawOutputByCallId: Record<string, string> = {};
     const streamPartIndexById = new Map<string, number>();
+    const reusableReasoningPartIndexes: number[] = [];
     const streamPartKey = (type: 'text' | 'reasoning', id: string): string =>
       `${type}:${id}`;
+    const findUnambiguousUnfinishedPart = (
+      type: 'text' | 'reasoning'
+    ): number | undefined => {
+      const partIndexes = currentMessage?.parts.flatMap((part, index) =>
+        part.type === type && part.state === 'streaming' ? [index] : []
+      );
+      return partIndexes?.length === 1 ? partIndexes[0] : undefined;
+    };
 
     const findToolPart = (toolCallId: string): number =>
       currentMessage!.parts.findIndex(
@@ -1083,6 +1097,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           switch (chunk.type) {
             case 'start': {
               streamPartIndexById.clear();
+              reusableReasoningPartIndexes.length = 0;
               currentMessageId = chunk.messageId || this.generateId();
               response.messageId = currentMessageId;
 
@@ -1106,6 +1121,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   currentMessage,
                   response
                 );
+                if (response.isResume) {
+                  currentMessage.parts.forEach((part, index) => {
+                    if (part.type === 'reasoning') {
+                      reusableReasoningPartIndexes.push(index);
+                    }
+                  });
+                }
               } else {
                 currentMessage = {
                   id: currentMessageId,
@@ -1124,8 +1146,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             case 'reasoning-start': {
               if (!currentMessage) break;
               const type = chunk.type === 'text-start' ? 'text' : 'reasoning';
-              const partIndex = currentMessage.parts.length;
-              setPart(-1, {
+              const reusablePartIndex =
+                type === 'reasoning'
+                  ? reusableReasoningPartIndexes.shift()
+                  : undefined;
+              const partIndex =
+                reusablePartIndex ?? currentMessage.parts.length;
+              setPart(reusablePartIndex ?? -1, {
                 type,
                 text: '',
                 state: 'streaming' as const,
@@ -1140,9 +1167,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               const type = chunk.type === 'text-delta' ? 'text' : 'reasoning';
               if (!currentMessage) break;
 
-              const partIndex = streamPartIndexById.get(
-                streamPartKey(type, chunk.id)
-              );
+              const partKey = streamPartKey(type, chunk.id);
+              let partIndex = streamPartIndexById.get(partKey);
+              if (partIndex === undefined && response.isResume) {
+                partIndex = findUnambiguousUnfinishedPart(type);
+                if (partIndex !== undefined) {
+                  streamPartIndexById.set(partKey, partIndex);
+                }
+              }
               if (partIndex === undefined) break;
 
               const part = currentMessage.parts[partIndex] as {
@@ -1161,7 +1193,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               const type = chunk.type === 'text-end' ? 'text' : 'reasoning';
 
               const partKey = streamPartKey(type, chunk.id);
-              const partIndex = streamPartIndexById.get(partKey);
+              let partIndex = streamPartIndexById.get(partKey);
+              if (partIndex === undefined && response.isResume) {
+                partIndex = findUnambiguousUnfinishedPart(type);
+                if (partIndex !== undefined) {
+                  streamPartIndexById.set(partKey, partIndex);
+                }
+              }
               if (partIndex === undefined) break;
 
               const part = currentMessage.parts[partIndex];

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -43,9 +43,27 @@ type ResponseRecord = {
   returnedToolCallbacks: Array<Promise<void>>;
   pendingToolCallbacks: number;
   forwardToolOutcomeTo: Map<string, ResponseRecord>;
+  pendingToolCallFailures: Map<string, unknown>;
   failToolCall?: (reason: unknown, toolCallId?: string) => void;
   didNotifyFinish: boolean;
   didEvaluateContinuation: boolean;
+};
+
+const getToolOutcomeOwnerChain = (
+  response: ResponseRecord,
+  toolCallId: string
+): ResponseRecord[] => {
+  const owners: ResponseRecord[] = [];
+  const visited = new Set<ResponseRecord>();
+  let owner: ResponseRecord | undefined = response;
+
+  while (owner && !visited.has(owner)) {
+    owners.push(owner);
+    visited.add(owner);
+    owner = owner.forwardToolOutcomeTo.get(toolCallId);
+  }
+
+  return owners;
 };
 
 type ToolResultSubmission<TUIMessage extends UIMessage> = <
@@ -911,6 +929,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       returnedToolCallbacks: [],
       pendingToolCallbacks: 0,
       forwardToolOutcomeTo: new Map(),
+      pendingToolCallFailures: new Map(),
       didNotifyFinish: false,
       didEvaluateContinuation: false,
     };
@@ -958,7 +977,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const toolRawOutputByCallId: Record<string, string> = {};
     const replayedToolOriginalRawInputByCallId = new Map<string, string>();
     const replayedToolOriginalRawOutputByCallId = new Map<string, string>();
-    const replayedDispatchedToolCallIds = new Set<string>();
     const streamPartIndexById = new Map<string, number>();
     // A resumed stream replays buffered content in order. The persisted parts
     // do not all retain stream ids, so reuse the saved part sequence while the
@@ -984,7 +1002,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       replayByPartKey.clear();
       replayedToolOriginalRawInputByCallId.clear();
       replayedToolOriginalRawOutputByCallId.clear();
-      replayedDispatchedToolCallIds.clear();
     };
     const consumeReusablePartsThrough = (partIndex: number): void => {
       const reusableIndex = reusablePartIndexes.indexOf(partIndex);
@@ -1209,11 +1226,23 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       }
     };
     const failToolCall = (reason: unknown, toolCallId?: string): void => {
-      if (response.outcome === 'failed' || response.outcome === 'aborted') {
+      if (response.isRetired) return;
+
+      if (response.outcome === 'aborted') return;
+
+      if (response.outcome === 'failed') {
         const forwardedResponse = toolCallId
           ? response.forwardToolOutcomeTo.get(toolCallId)
           : undefined;
-        forwardedResponse?.failToolCall?.(reason, toolCallId);
+        if (forwardedResponse) {
+          forwardedResponse.failToolCall?.(reason, toolCallId);
+        } else if (
+          toolCallId &&
+          response.requiredToolCallIds.has(toolCallId) &&
+          !response.resolvedToolCallIds.has(toolCallId)
+        ) {
+          response.pendingToolCallFailures.set(toolCallId, reason);
+        }
         return;
       }
       completeReplays();
@@ -1330,6 +1359,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   response
                 );
                 if (response.isResume) {
+                  const pendingToolFailures: Array<{
+                    reason: unknown;
+                    toolCallId: string;
+                  }> = [];
                   currentMessage.parts.forEach((part, index) => {
                     reusablePartIndexes.push(index);
                     if ('toolCallId' in part) {
@@ -1338,6 +1371,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                       ).filter(
                         (owner) =>
                           owner !== response &&
+                          !owner.isRetired &&
                           owner.messageId === currentMessage!.id &&
                           owner.requiredToolCallIds.has(part.toolCallId)
                       );
@@ -1360,14 +1394,54 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                         );
                       }
                       if (
-                        part.state === 'input-available' &&
                         (!('providerExecuted' in part) ||
                           !part.providerExecuted) &&
                         dispatchOwners.length === 1
                       ) {
-                        replayedDispatchedToolCallIds.add(part.toolCallId);
+                        const ownerChain = getToolOutcomeOwnerChain(
+                          dispatchOwners[0],
+                          part.toolCallId
+                        ).filter(
+                          (owner) =>
+                            !owner.isRetired &&
+                            owner.messageId === currentMessage!.id &&
+                            owner.requiredToolCallIds.has(part.toolCallId)
+                        );
+                        response.requiredToolCallIds.add(part.toolCallId);
+                        if (
+                          ownerChain.some((owner) =>
+                            owner.resolvedToolCallIds.has(part.toolCallId)
+                          )
+                        ) {
+                          response.resolvedToolCallIds.add(part.toolCallId);
+                        }
+                        ownerChain.forEach((owner) => {
+                          owner.forwardToolOutcomeTo.set(
+                            part.toolCallId,
+                            response
+                          );
+                          owner.didEvaluateContinuation = true;
+                          if (
+                            owner.pendingToolCallFailures.has(part.toolCallId)
+                          ) {
+                            const pendingFailure =
+                              owner.pendingToolCallFailures.get(
+                                part.toolCallId
+                              );
+                            owner.pendingToolCallFailures.delete(
+                              part.toolCallId
+                            );
+                            pendingToolFailures.push({
+                              reason: pendingFailure,
+                              toolCallId: part.toolCallId,
+                            });
+                          }
+                        });
                       }
                     }
+                  });
+                  pendingToolFailures.forEach(({ reason, toolCallId }) => {
+                    failToolCall(reason, toolCallId);
                   });
                 }
               } else {
@@ -1624,8 +1698,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             case 'tool-input-available': {
               if (!currentMessage) break;
 
-              if (response.requiredToolCallIds.has(chunk.toolCallId)) break;
-
               delete toolRawInputByCallId[chunk.toolCallId];
               replayedToolOriginalRawInputByCallId.delete(chunk.toolCallId);
 
@@ -1656,6 +1728,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
               setPart(existingIndex, toolPart);
 
+              if (response.requiredToolCallIds.has(chunk.toolCallId)) break;
+
               if (
                 this.messages.some(
                   (message) =>
@@ -1679,20 +1753,6 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 const existingOwners = Array.from(owners).filter(
                   (owner) => owner !== response
                 );
-                if (
-                  response.isResume &&
-                  replayedDispatchedToolCallIds.has(chunk.toolCallId)
-                ) {
-                  response.requiredToolCallIds.add(chunk.toolCallId);
-                  existingOwners.forEach((owner) => {
-                    if (!owner.requiredToolCallIds.has(chunk.toolCallId)) {
-                      return;
-                    }
-                    owner.forwardToolOutcomeTo.set(chunk.toolCallId, response);
-                    owner.didEvaluateContinuation = true;
-                  });
-                  break;
-                }
                 if (existingOwners.length > 0) {
                   this.acceptsIdentifierOnlyToolResults = false;
                   const conflictingOwner = existingOwners.find(

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -41,6 +41,7 @@ type ResponseRecord = {
   requiredToolCallIds: Set<string>;
   resolvedToolCallIds: Set<string>;
   returnedToolCallbacks: Array<Promise<void>>;
+  returnedToolCallbacksByCallId: Map<string, Promise<void>>;
   pendingToolCallbacks: number;
   forwardToolOutcomeTo: Map<string, ResponseRecord>;
   pendingToolCallFailures: Map<string, unknown>;
@@ -642,6 +643,94 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     return true;
   }
 
+  private transferReplayToolOwnership(
+    response: ResponseRecord,
+    message: TUIMessage,
+    toolCallId: string
+  ): {
+    didNotifyFinish: boolean;
+    pendingFailures: unknown[];
+  } {
+    const dispatchOwners = Array.from(
+      this.responsesByToolCallId.get(toolCallId) ?? []
+    ).filter(
+      (owner) =>
+        owner !== response &&
+        !owner.isRetired &&
+        owner.messageId === message.id &&
+        owner.requiredToolCallIds.has(toolCallId)
+    );
+    if (dispatchOwners.length !== 1) {
+      return { didNotifyFinish: false, pendingFailures: [] };
+    }
+
+    const ownerChain = getToolOutcomeOwnerChain(
+      dispatchOwners[0],
+      toolCallId
+    ).filter(
+      (owner) =>
+        owner !== response &&
+        !owner.isRetired &&
+        owner.messageId === message.id &&
+        owner.requiredToolCallIds.has(toolCallId)
+    );
+    response.requiredToolCallIds.add(toolCallId);
+    if (
+      ownerChain.some((owner) => owner.resolvedToolCallIds.has(toolCallId))
+    ) {
+      response.resolvedToolCallIds.add(toolCallId);
+    }
+
+    const returnedToolCallback = ownerChain
+      .map((owner) => owner.returnedToolCallbacksByCallId.get(toolCallId))
+      .find((callback) => callback !== undefined);
+    if (
+      returnedToolCallback &&
+      !response.returnedToolCallbacksByCallId.has(toolCallId)
+    ) {
+      response.returnedToolCallbacksByCallId.set(
+        toolCallId,
+        returnedToolCallback
+      );
+      response.returnedToolCallbacks.push(returnedToolCallback);
+    }
+
+    const pendingFailures: unknown[] = [];
+    ownerChain.forEach((owner) => {
+      owner.forwardToolOutcomeTo.set(toolCallId, response);
+      owner.didEvaluateContinuation = true;
+      if (owner.pendingToolCallFailures.has(toolCallId)) {
+        pendingFailures.push(owner.pendingToolCallFailures.get(toolCallId));
+        owner.pendingToolCallFailures.delete(toolCallId);
+      }
+    });
+
+    return {
+      didNotifyFinish: ownerChain.some((owner) => owner.didNotifyFinish),
+      pendingFailures,
+    };
+  }
+
+  private waitForToolCallbacks(response: ResponseRecord): Promise<void> {
+    if (
+      response.returnedToolCallbacks.length === 0 ||
+      response.abortController.signal.aborted
+    ) {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve) => {
+      const finish = () => {
+        response.abortController.signal.removeEventListener('abort', finish);
+        resolve();
+      };
+      response.abortController.signal.addEventListener('abort', finish, {
+        once: true,
+      });
+      Promise.all(response.returnedToolCallbacks).then(finish);
+    });
+  }
+
   private continueResponse(response?: ResponseRecord): Promise<void> {
     if (response) {
       this.pruneDetachedResponse(response);
@@ -746,8 +835,19 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     if (response?.isRetired) return Promise.resolve();
 
     const commitResult = (): Promise<void> => {
+      const resultOwners = response
+        ? getToolOutcomeOwnerChain(response, toolCallId)
+        : [];
+      const canonicalResponse =
+        resultOwners[resultOwners.length - 1] ?? response;
       if (
-        !this.commit(toolCallId, output, messageId, response, expectedMessage)
+        !this.commit(
+          toolCallId,
+          output,
+          messageId,
+          canonicalResponse,
+          expectedMessage
+        )
       ) {
         return Promise.resolve();
       }
@@ -755,18 +855,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       if (!response) {
         return this.continueResponse();
       }
-      const forwardedResponse = response.forwardToolOutcomeTo.get(toolCallId);
-      const resultOwners = forwardedResponse
-        ? [response, forwardedResponse]
-        : [response];
       resultOwners.forEach((owner) => {
         if (owner.requiredToolCallIds.has(toolCallId)) {
           owner.resolvedToolCallIds.add(toolCallId);
         }
       });
-      return Promise.all(
-        resultOwners.map((owner) => this.continueResponse(owner))
-      ).then(() => undefined);
+      return this.continueResponse(canonicalResponse);
     };
 
     if (
@@ -914,6 +1008,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     ) => Promise<ReadableStream<InferUIMessageChunk<TUIMessage>> | null>,
     { isResume = false }: { isResume?: boolean } = {}
   ): Promise<void> {
+    const resumeTargetMessage =
+      isResume && this.lastMessage?.role === 'assistant'
+        ? this.lastMessage
+        : undefined;
     if (this.activeResponse) {
       this.completeReasoningParts(this.activeResponse);
       this.activeResponse.outcome = 'aborted';
@@ -921,12 +1019,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     }
     const response: ResponseRecord = {
       abortController: new AbortController(),
+      messageId: resumeTargetMessage?.id,
       outcome: 'active',
       isResume,
       isRetired: false,
       requiredToolCallIds: new Set(),
       resolvedToolCallIds: new Set(),
       returnedToolCallbacks: [],
+      returnedToolCallbacksByCallId: new Map(),
       pendingToolCallbacks: 0,
       forwardToolOutcomeTo: new Map(),
       pendingToolCallFailures: new Map(),
@@ -941,9 +1041,63 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       (stream) => {
         if (this.activeResponse === response) {
           if (stream) return this.processStream(stream, response);
-          response.outcome = 'succeeded';
-          this.activeResponse = null;
-          this.setStatus({ status: 'ready' });
+          response.failToolCall = (reason) => {
+            if (
+              response.isRetired ||
+              response.outcome === 'aborted' ||
+              response.outcome === 'failed'
+            ) {
+              return;
+            }
+            response.outcome = 'failed';
+            response.abortController.abort();
+            if (this.activeResponse === response) {
+              this.activeResponse = null;
+            }
+            this.handleError(
+              reason instanceof Error ? reason : new Error(String(reason)),
+              { updateState: this.latestResponse === response }
+            );
+          };
+
+          if (resumeTargetMessage) {
+            const currentMessage = this.messages.find(
+              (message) => message.id === resumeTargetMessage.id
+            );
+            if (currentMessage) {
+              this.responseByMessage.set(currentMessage, response);
+              currentMessage.parts.forEach((part) => {
+                if (
+                  'toolCallId' in part &&
+                  (!('providerExecuted' in part) || !part.providerExecuted)
+                ) {
+                  const transfer = this.transferReplayToolOwnership(
+                    response,
+                    currentMessage,
+                    part.toolCallId
+                  );
+                  response.didNotifyFinish ||= transfer.didNotifyFinish;
+                  transfer.pendingFailures.forEach((reason) => {
+                    response.failToolCall?.(reason, part.toolCallId);
+                  });
+                }
+              });
+            }
+          }
+
+          return this.waitForToolCallbacks(response).then(() => {
+            if (
+              this.activeResponse !== response ||
+              response.isRetired ||
+              response.outcome !== 'active'
+            ) {
+              return undefined;
+            }
+            response.outcome = 'succeeded';
+            this.activeResponse = null;
+            this.setStatus({ status: 'ready' });
+            return this.continueResponse(response);
+          });
         }
         return undefined;
       },
@@ -1338,11 +1492,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           switch (chunk.type) {
             case 'start': {
               invalidateStreamParts();
-              currentMessageId = chunk.messageId || this.generateId();
+              const lastMessage = this.lastMessage;
+              currentMessageId =
+                chunk.messageId ?? response.messageId ?? this.generateId();
               response.messageId = currentMessageId;
 
               // Check if we're continuing an existing message or creating a new one
-              const lastMessage = this.lastMessage;
               if (
                 lastMessage &&
                 lastMessage.role === 'assistant' &&
@@ -1359,22 +1514,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   response
                 );
                 if (response.isResume) {
+                  const replayMessage = currentMessage;
                   const pendingToolFailures: Array<{
                     reason: unknown;
                     toolCallId: string;
                   }> = [];
-                  currentMessage.parts.forEach((part, index) => {
+                  replayMessage.parts.forEach((part, index) => {
                     reusablePartIndexes.push(index);
                     if ('toolCallId' in part) {
-                      const dispatchOwners = Array.from(
-                        this.responsesByToolCallId.get(part.toolCallId) ?? []
-                      ).filter(
-                        (owner) =>
-                          owner !== response &&
-                          !owner.isRetired &&
-                          owner.messageId === currentMessage!.id &&
-                          owner.requiredToolCallIds.has(part.toolCallId)
-                      );
                       if (
                         'rawInput' in part &&
                         typeof part.rawInput === 'string'
@@ -1395,47 +1542,18 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                       }
                       if (
                         (!('providerExecuted' in part) ||
-                          !part.providerExecuted) &&
-                        dispatchOwners.length === 1
+                          !part.providerExecuted)
                       ) {
-                        const ownerChain = getToolOutcomeOwnerChain(
-                          dispatchOwners[0],
+                        const transfer = this.transferReplayToolOwnership(
+                          response,
+                          replayMessage,
                           part.toolCallId
-                        ).filter(
-                          (owner) =>
-                            !owner.isRetired &&
-                            owner.messageId === currentMessage!.id &&
-                            owner.requiredToolCallIds.has(part.toolCallId)
                         );
-                        response.requiredToolCallIds.add(part.toolCallId);
-                        if (
-                          ownerChain.some((owner) =>
-                            owner.resolvedToolCallIds.has(part.toolCallId)
-                          )
-                        ) {
-                          response.resolvedToolCallIds.add(part.toolCallId);
-                        }
-                        ownerChain.forEach((owner) => {
-                          owner.forwardToolOutcomeTo.set(
-                            part.toolCallId,
-                            response
-                          );
-                          owner.didEvaluateContinuation = true;
-                          if (
-                            owner.pendingToolCallFailures.has(part.toolCallId)
-                          ) {
-                            const pendingFailure =
-                              owner.pendingToolCallFailures.get(
-                                part.toolCallId
-                              );
-                            owner.pendingToolCallFailures.delete(
-                              part.toolCallId
-                            );
-                            pendingToolFailures.push({
-                              reason: pendingFailure,
-                              toolCallId: part.toolCallId,
-                            });
-                          }
+                        transfer.pendingFailures.forEach((reason) => {
+                          pendingToolFailures.push({
+                            reason,
+                            toolCallId: part.toolCallId,
+                          });
                         });
                       }
                     }
@@ -1795,14 +1913,17 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                         : this.submitToolResult(response, options)
                   );
                   if (result) {
-                    response.returnedToolCallbacks.push(
-                      Promise.resolve(result)
-                        .catch((error) => failToolCall(error, chunk.toolCallId))
-                        .then(() => {
-                          response.pendingToolCallbacks--;
-                          this.pruneDetachedResponse(response);
-                        })
+                    const returnedToolCallback = Promise.resolve(result)
+                      .catch((error) => failToolCall(error, chunk.toolCallId))
+                      .then(() => {
+                        response.pendingToolCallbacks--;
+                        this.pruneDetachedResponse(response);
+                      });
+                    response.returnedToolCallbacksByCallId.set(
+                      chunk.toolCallId,
+                      returnedToolCallback
                     );
+                    response.returnedToolCallbacks.push(returnedToolCallback);
                   } else {
                     response.pendingToolCallbacks--;
                     this.pruneDetachedResponse(response);
@@ -2181,7 +2302,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             }
           }
         },
-        () => Promise.all(response.returnedToolCallbacks).then(() => finish()),
+        () => this.waitForToolCallbacks(response).then(() => finish()),
         (error) => finish(error)
       );
     });

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -938,6 +938,9 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
     const toolRawInputByCallId: Record<string, string> = {};
     const toolRawOutputByCallId: Record<string, string> = {};
+    const streamPartIndexById = new Map<string, number>();
+    const streamPartKey = (type: 'text' | 'reasoning', id: string): string =>
+      `${type}:${id}`;
 
     const findToolPart = (toolCallId: string): number =>
       currentMessage!.parts.findIndex(
@@ -1079,6 +1082,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
           switch (chunk.type) {
             case 'start': {
+              streamPartIndexById.clear();
               currentMessageId = chunk.messageId || this.generateId();
               response.messageId = currentMessageId;
 
@@ -1120,12 +1124,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             case 'reasoning-start': {
               if (!currentMessage) break;
               const type = chunk.type === 'text-start' ? 'text' : 'reasoning';
+              const partIndex = currentMessage.parts.length;
               setPart(-1, {
                 type,
                 text: '',
                 state: 'streaming' as const,
                 providerMetadata: chunk.providerMetadata,
               });
+              streamPartIndexById.set(streamPartKey(type, chunk.id), partIndex);
               break;
             }
 
@@ -1134,16 +1140,17 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               const type = chunk.type === 'text-delta' ? 'text' : 'reasoning';
               if (!currentMessage) break;
 
-              const partIndex = currentMessage.parts.findIndex(
-                (part) => part.type === type && part.state === 'streaming'
+              const partIndex = streamPartIndexById.get(
+                streamPartKey(type, chunk.id)
               );
-              if (partIndex === -1) break;
+              if (partIndex === undefined) break;
 
               const part = currentMessage.parts[partIndex] as {
                 type: 'text' | 'reasoning';
                 text: string;
                 state?: 'streaming' | 'done';
               };
+              if (part.type !== type || part.state !== 'streaming') break;
               setPart(partIndex, { ...part, text: part.text + chunk.delta });
               break;
             }
@@ -1153,15 +1160,21 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               if (!currentMessage) break;
               const type = chunk.type === 'text-end' ? 'text' : 'reasoning';
 
-              const partIndex = currentMessage.parts.findIndex(
-                (part) => part.type === type && part.state === 'streaming'
-              );
-              if (partIndex === -1) break;
+              const partKey = streamPartKey(type, chunk.id);
+              const partIndex = streamPartIndexById.get(partKey);
+              if (partIndex === undefined) break;
+
+              const part = currentMessage.parts[partIndex];
+              if (part.type !== type || part.state !== 'streaming') {
+                streamPartIndexById.delete(partKey);
+                break;
+              }
 
               setPart(partIndex, {
-                ...currentMessage.parts[partIndex],
+                ...part,
                 state: 'done',
               });
+              streamPartIndexById.delete(partKey);
               break;
             }
 

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -945,12 +945,21 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     const toolRawOutputByCallId: Record<string, string> = {};
     const streamPartIndexById = new Map<string, number>();
     const reusableReasoningPartIndexes: number[] = [];
+    const reasoningReplayByPartKey = new Map<
+      string,
+      {
+        replayedText: string;
+        providerMetadata?: ProviderMetadata;
+        partIndex?: number;
+      }
+    >();
     const terminalContentMessageIds = new Set<string>();
     const streamPartKey = (type: 'text' | 'reasoning', id: string): string =>
       `${type}:${id}`;
     const invalidateStreamParts = (): void => {
       streamPartIndexById.clear();
       reusableReasoningPartIndexes.length = 0;
+      reasoningReplayByPartKey.clear();
     };
     const findUnambiguousUnfinishedPart = (
       type: 'text' | 'reasoning'
@@ -959,6 +968,103 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         part.type === type && part.state === 'streaming' ? [index] : []
       );
       return partIndexes?.length === 1 ? partIndexes[0] : undefined;
+    };
+    const claimUnambiguousUnfinishedPart = (
+      type: 'text' | 'reasoning'
+    ): number | undefined => {
+      const partIndex = findUnambiguousUnfinishedPart(type);
+      if (partIndex !== undefined) {
+        reusableReasoningPartIndexes.length = 0;
+      }
+      return partIndex;
+    };
+    const getEarlierPendingReplayCount = (partKey: string): number => {
+      const replayKeys = Array.from(reasoningReplayByPartKey.keys());
+      const replayIndex = replayKeys.indexOf(partKey);
+      return replayKeys
+        .slice(0, replayIndex)
+        .filter(
+          (key) => reasoningReplayByPartKey.get(key)?.partIndex === undefined
+        ).length;
+    };
+    const getCompatibleReasoningPartIndexes = (
+      partKey: string,
+      replayedText: string
+    ): number[] =>
+      reusableReasoningPartIndexes
+        .slice(getEarlierPendingReplayCount(partKey))
+        .filter((partIndex) => {
+          const part = currentMessage?.parts[partIndex];
+          return (
+            part?.type === 'reasoning' &&
+            (part.text.startsWith(replayedText) ||
+              (part.state === 'streaming' &&
+                replayedText.startsWith(part.text)))
+          );
+        });
+    const findReusableReasoningPart = (
+      partKey: string,
+      replayedText: string
+    ): number | undefined => {
+      const compatiblePartIndexes = getCompatibleReasoningPartIndexes(
+        partKey,
+        replayedText
+      );
+      const firstCandidateIndex =
+        reusableReasoningPartIndexes[getEarlierPendingReplayCount(partKey)];
+      const firstCandidate =
+        firstCandidateIndex === undefined
+          ? undefined
+          : currentMessage?.parts[firstCandidateIndex];
+      if (
+        firstCandidate?.type === 'reasoning' &&
+        firstCandidate.text === replayedText
+      ) {
+        return firstCandidateIndex;
+      }
+
+      if (
+        compatiblePartIndexes.some((partIndex) => {
+          const part = currentMessage!.parts[partIndex];
+          return (
+            part.type === 'reasoning' && part.text.length > replayedText.length
+          );
+        })
+      ) {
+        return undefined;
+      }
+
+      const matchingPartIndexes = compatiblePartIndexes.filter((partIndex) => {
+        const part = currentMessage!.parts[partIndex];
+        return (
+          part.type === 'reasoning' &&
+          (replayedText === part.text ||
+            (part.state === 'streaming' && replayedText.startsWith(part.text)))
+        );
+      });
+      const longestMatchLength = Math.max(
+        ...matchingPartIndexes.map((partIndex) => {
+          const part = currentMessage!.parts[partIndex];
+          return part.type === 'reasoning' ? part.text.length : -1;
+        }),
+        -1
+      );
+      const longestMatches = matchingPartIndexes.filter((partIndex) => {
+        const part = currentMessage!.parts[partIndex];
+        return (
+          part.type === 'reasoning' && part.text.length === longestMatchLength
+        );
+      });
+      return longestMatches.length === 1 ? longestMatches[0] : undefined;
+    };
+    const consumeReasoningPart = (partKey: string, partIndex: number): void => {
+      const candidateIndex = reusableReasoningPartIndexes.indexOf(partIndex);
+      if (candidateIndex !== -1) {
+        reusableReasoningPartIndexes.splice(
+          getEarlierPendingReplayCount(partKey) > 0 ? candidateIndex : 0,
+          getEarlierPendingReplayCount(partKey) > 0 ? 1 : candidateIndex + 1
+        );
+      }
     };
 
     const findToolPart = (toolCallId: string): number =>
@@ -974,6 +1080,95 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         currentMessage,
         response
       );
+    };
+    const appendReasoningReplay = (
+      reasoningReplay: {
+        replayedText: string;
+        providerMetadata?: ProviderMetadata;
+        partIndex?: number;
+      },
+      state: 'streaming' | 'done'
+    ): number => {
+      const partIndex = currentMessage!.parts.length;
+      setPart(-1, {
+        type: 'reasoning',
+        text: reasoningReplay.replayedText,
+        state,
+        providerMetadata: reasoningReplay.providerMetadata,
+      });
+      reasoningReplay.partIndex = partIndex;
+      reusableReasoningPartIndexes.length = 0;
+      return partIndex;
+    };
+    const reconcileReasoningReplay = (
+      partKey: string,
+      replayState: 'streaming' | 'done' | 'interrupted'
+    ): void => {
+      const reasoningReplay = reasoningReplayByPartKey.get(partKey);
+      if (!reasoningReplay || !currentMessage) return;
+      const partState =
+        replayState === 'streaming' ? 'streaming' : ('done' as const);
+
+      if (reasoningReplay.partIndex !== undefined) {
+        const part = currentMessage.parts[reasoningReplay.partIndex];
+        if (part?.type === 'reasoning') {
+          setPart(reasoningReplay.partIndex, {
+            ...part,
+            text: reasoningReplay.replayedText,
+            state: partState,
+            providerMetadata:
+              reasoningReplay.providerMetadata ?? part.providerMetadata,
+          });
+        }
+        return;
+      }
+
+      const reusablePartIndex = findReusableReasoningPart(
+        partKey,
+        reasoningReplay.replayedText
+      );
+      if (reusablePartIndex !== undefined) {
+        const part = currentMessage.parts[reusablePartIndex];
+        if (part?.type === 'reasoning') {
+          setPart(reusablePartIndex, {
+            ...part,
+            text: reasoningReplay.replayedText,
+            state: partState,
+            providerMetadata:
+              reasoningReplay.providerMetadata ?? part.providerMetadata,
+          });
+          reasoningReplay.partIndex = reusablePartIndex;
+          consumeReasoningPart(partKey, reusablePartIndex);
+        }
+        return;
+      }
+
+      const hasCompatiblePart =
+        getCompatibleReasoningPartIndexes(partKey, reasoningReplay.replayedText)
+          .length > 0;
+      if (!hasCompatiblePart && reasoningReplay.replayedText) {
+        appendReasoningReplay(reasoningReplay, partState);
+      } else if (replayState === 'done' && reasoningReplay.replayedText) {
+        appendReasoningReplay(reasoningReplay, partState);
+      }
+    };
+    const completeReasoningReplays = (): void => {
+      const replayMessageIndex = this.messages.findIndex(
+        (message) =>
+          message.id === response.messageId &&
+          this.responseByMessage.get(message) === response
+      );
+      if (response.isRetired || replayMessageIndex === -1) {
+        reasoningReplayByPartKey.clear();
+        return;
+      }
+      currentMessageIndex = replayMessageIndex;
+      currentMessage = this.messages[replayMessageIndex];
+
+      reasoningReplayByPartKey.forEach((_reasoningReplay, partKey) => {
+        reconcileReasoningReplay(partKey, 'interrupted');
+      });
+      reasoningReplayByPartKey.clear();
     };
     const mergeCallProviderMetadata = (
       toolCallId: string,
@@ -1025,6 +1220,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     };
     const failToolCall = (reason: unknown): void => {
       if (response.outcome !== 'active') return;
+      completeReasoningReplays();
       const message =
         this.completeReasoningParts(response) ?? getCanonicalMessage();
       const wasRetired = response.isRetired;
@@ -1058,6 +1254,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           return;
         }
 
+        completeReasoningReplays();
         this.completeReasoningParts(response);
         isAbort ||=
           response.outcome === 'aborted' ||
@@ -1127,7 +1324,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 );
                 if (response.isResume) {
                   currentMessage.parts.forEach((part, index) => {
-                    if (part.type === 'reasoning') {
+                    if (part.type === 'reasoning' && part.text) {
                       reusableReasoningPartIndexes.push(index);
                     }
                   });
@@ -1155,19 +1352,27 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 break;
               }
               const type = chunk.type === 'text-start' ? 'text' : 'reasoning';
-              const reusablePartIndex =
-                type === 'reasoning'
-                  ? reusableReasoningPartIndexes.shift()
-                  : undefined;
-              const partIndex =
-                reusablePartIndex ?? currentMessage.parts.length;
-              setPart(reusablePartIndex ?? -1, {
+              const partKey = streamPartKey(type, chunk.id);
+              if (
+                type === 'reasoning' &&
+                response.isResume &&
+                reusableReasoningPartIndexes.length > 0
+              ) {
+                reasoningReplayByPartKey.set(partKey, {
+                  replayedText: '',
+                  providerMetadata: chunk.providerMetadata,
+                });
+                break;
+              }
+
+              const partIndex = currentMessage.parts.length;
+              setPart(-1, {
                 type,
                 text: '',
                 state: 'streaming' as const,
                 providerMetadata: chunk.providerMetadata,
               });
-              streamPartIndexById.set(streamPartKey(type, chunk.id), partIndex);
+              streamPartIndexById.set(partKey, partIndex);
               break;
             }
 
@@ -1182,9 +1387,19 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               }
 
               const partKey = streamPartKey(type, chunk.id);
+              const reasoningReplay = reasoningReplayByPartKey.get(partKey);
+              if (reasoningReplay) {
+                reasoningReplay.replayedText += chunk.delta;
+                reconcileReasoningReplay(partKey, 'streaming');
+                if (reasoningReplay.partIndex !== undefined) {
+                  streamPartIndexById.set(partKey, reasoningReplay.partIndex);
+                }
+                break;
+              }
+
               let partIndex = streamPartIndexById.get(partKey);
               if (partIndex === undefined && response.isResume) {
-                partIndex = findUnambiguousUnfinishedPart(type);
+                partIndex = claimUnambiguousUnfinishedPart(type);
                 if (partIndex !== undefined) {
                   streamPartIndexById.set(partKey, partIndex);
                 }
@@ -1202,6 +1417,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 streamPartIndexById.delete(partKey);
                 break;
               }
+
               setPart(partIndex, { ...part, text: part.text + chunk.delta });
               break;
             }
@@ -1217,9 +1433,17 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               const type = chunk.type === 'text-end' ? 'text' : 'reasoning';
 
               const partKey = streamPartKey(type, chunk.id);
+              const reasoningReplay = reasoningReplayByPartKey.get(partKey);
+              if (reasoningReplay) {
+                reconcileReasoningReplay(partKey, 'done');
+                reasoningReplayByPartKey.delete(partKey);
+                streamPartIndexById.delete(partKey);
+                break;
+              }
+
               let partIndex = streamPartIndexById.get(partKey);
               if (partIndex === undefined && response.isResume) {
-                partIndex = findUnambiguousUnfinishedPart(type);
+                partIndex = claimUnambiguousUnfinishedPart(type);
                 if (partIndex !== undefined) {
                   streamPartIndexById.set(partKey, partIndex);
                 }

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -42,6 +42,7 @@ type ResponseRecord = {
   resolvedToolCallIds: Set<string>;
   returnedToolCallbacks: Array<Promise<void>>;
   pendingToolCallbacks: number;
+  forwardToolResultsTo: Map<string, Set<ResponseRecord>>;
   didNotifyFinish: boolean;
   didEvaluateContinuation: boolean;
 };
@@ -732,10 +733,21 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
         return Promise.resolve();
       }
 
-      if (response?.requiredToolCallIds.has(toolCallId)) {
-        response.resolvedToolCallIds.add(toolCallId);
+      if (!response) {
+        return this.continueResponse();
       }
-      return this.continueResponse(response);
+      const resultOwners = [
+        response,
+        ...(response.forwardToolResultsTo.get(toolCallId) ?? []),
+      ];
+      resultOwners.forEach((owner) => {
+        if (owner.requiredToolCallIds.has(toolCallId)) {
+          owner.resolvedToolCallIds.add(toolCallId);
+        }
+      });
+      return Promise.all(
+        resultOwners.map((owner) => this.continueResponse(owner))
+      ).then(() => undefined);
     };
 
     if (
@@ -897,6 +909,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       resolvedToolCallIds: new Set(),
       returnedToolCallbacks: [],
       pendingToolCallbacks: 0,
+      forwardToolResultsTo: new Map(),
       didNotifyFinish: false,
       didEvaluateContinuation: false,
     };
@@ -942,14 +955,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
     const toolRawInputByCallId: Record<string, string> = {};
     const toolRawOutputByCallId: Record<string, string> = {};
+    const replayedToolOriginalRawInputByCallId = new Map<string, string>();
+    const replayedToolOriginalRawOutputByCallId = new Map<string, string>();
+    const replayedDispatchedToolCallIds = new Set<string>();
     const streamPartIndexById = new Map<string, number>();
     // A resumed stream replays buffered content in order. The persisted parts
-    // do not retain stream ids, so reuse them in order while the replay catches
-    // up without clearing text that is already visible.
-    const reusablePartIndexesByType = new Map<'text' | 'reasoning', number[]>([
-      ['text', []],
-      ['reasoning', []],
-    ]);
+    // do not all retain stream ids, so reuse the saved part sequence while the
+    // replay catches up without duplicating the message.
+    const reusablePartIndexes: number[] = [];
     const replayByPartKey = new Map<
       string,
       {
@@ -966,10 +979,47 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       `${type}:${id}`;
     const invalidateStreamParts = (): void => {
       streamPartIndexById.clear();
-      reusablePartIndexesByType.forEach((indexes) => {
-        indexes.length = 0;
-      });
+      reusablePartIndexes.length = 0;
       replayByPartKey.clear();
+      replayedToolOriginalRawInputByCallId.clear();
+      replayedToolOriginalRawOutputByCallId.clear();
+      replayedDispatchedToolCallIds.clear();
+    };
+    const consumeReusablePartsThrough = (partIndex: number): void => {
+      const reusableIndex = reusablePartIndexes.indexOf(partIndex);
+      if (reusableIndex >= 0) {
+        reusablePartIndexes.splice(0, reusableIndex + 1);
+      }
+    };
+    const claimNextReusablePart = (
+      predicate: (part: TUIMessage['parts'][number]) => boolean
+    ): number | undefined => {
+      if (!response.isResume || !currentMessage) return undefined;
+
+      const partIndex = reusablePartIndexes[0];
+      if (
+        partIndex === undefined ||
+        !predicate(currentMessage.parts[partIndex])
+      ) {
+        return undefined;
+      }
+
+      reusablePartIndexes.shift();
+      return partIndex;
+    };
+    const claimReusablePartByIdentity = (
+      predicate: (part: TUIMessage['parts'][number]) => boolean
+    ): number | undefined => {
+      if (!response.isResume || !currentMessage) return undefined;
+
+      const reusableIndex = reusablePartIndexes.findIndex((partIndex) =>
+        predicate(currentMessage!.parts[partIndex])
+      );
+      if (reusableIndex < 0) return undefined;
+
+      const partIndex = reusablePartIndexes[reusableIndex];
+      reusablePartIndexes.splice(0, reusableIndex + 1);
+      return partIndex;
     };
     const claimUnfinishedPart = (
       type: 'text' | 'reasoning',
@@ -980,9 +1030,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       );
       if (partIndexes?.length !== 1) return undefined;
 
-      reusablePartIndexesByType.forEach((indexes) => {
-        indexes.length = 0;
-      });
+      consumeReusablePartsThrough(partIndexes[0]);
       streamPartIndexById.set(partKey, partIndexes[0]);
       return partIndexes[0];
     };
@@ -1223,8 +1271,33 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 );
                 if (response.isResume) {
                   currentMessage.parts.forEach((part, index) => {
-                    if (part.type === 'text' || part.type === 'reasoning') {
-                      reusablePartIndexesByType.get(part.type)!.push(index);
+                    reusablePartIndexes.push(index);
+                    if ('toolCallId' in part) {
+                      if (
+                        'rawInput' in part &&
+                        typeof part.rawInput === 'string'
+                      ) {
+                        replayedToolOriginalRawInputByCallId.set(
+                          part.toolCallId,
+                          part.rawInput
+                        );
+                      }
+                      if (
+                        'rawOutput' in part &&
+                        typeof part.rawOutput === 'string'
+                      ) {
+                        replayedToolOriginalRawOutputByCallId.set(
+                          part.toolCallId,
+                          part.rawOutput
+                        );
+                      }
+                      if (
+                        part.state === 'input-available' &&
+                        (!('providerExecuted' in part) ||
+                          !part.providerExecuted)
+                      ) {
+                        replayedDispatchedToolCallIds.add(part.toolCallId);
+                      }
                     }
                   });
                 }
@@ -1252,9 +1325,9 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               }
               const type = chunk.type === 'text-start' ? 'text' : 'reasoning';
               const partKey = streamPartKey(type, chunk.id);
-              const reusablePartIndex = response.isResume
-                ? reusablePartIndexesByType.get(type)?.shift()
-                : undefined;
+              const reusablePartIndex = claimNextReusablePart(
+                (part) => part.type === type
+              );
               const reusablePart =
                 reusablePartIndex === undefined
                   ? undefined
@@ -1373,15 +1446,20 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
             case 'tool-input-start': {
               if (!currentMessage) break;
 
-              const completedPart = currentMessage.parts.find(
-                (part) =>
-                  'toolCallId' in part &&
-                  part.toolCallId === chunk.toolCallId &&
-                  'state' in part &&
-                  (part.state === 'output-available' ||
-                    part.state === 'output-error')
-              );
-              if (completedPart) break;
+              const existingIndex = findToolPart(chunk.toolCallId);
+              if (existingIndex >= 0) {
+                consumeReusablePartsThrough(existingIndex);
+              }
+              const existingPart =
+                existingIndex >= 0
+                  ? (currentMessage.parts[existingIndex] as any)
+                  : null;
+              if (
+                existingPart?.state === 'output-available' ||
+                existingPart?.state === 'output-error'
+              ) {
+                break;
+              }
 
               const initialRawInput =
                 typeof chunk.input === 'string'
@@ -1391,17 +1469,30 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                   : '';
 
               toolRawInputByCallId[chunk.toolCallId] = initialRawInput;
-
               const toolPart = {
+                ...(response.isResume ? existingPart : null),
                 type: `tool-${chunk.toolName}` as const,
                 toolCallId: chunk.toolCallId,
-                state: 'input-streaming' as const,
-                input: chunk.input,
-                rawInput: initialRawInput || undefined,
-                providerExecuted: chunk.providerExecuted,
+                state:
+                  response.isResume && existingPart?.state === 'input-available'
+                    ? ('input-available' as const)
+                    : ('input-streaming' as const),
+                input:
+                  response.isResume && existingPart
+                    ? existingPart.input
+                    : chunk.input,
+                rawInput:
+                  response.isResume && existingPart?.rawInput !== undefined
+                    ? existingPart.rawInput
+                    : initialRawInput || undefined,
+                providerExecuted:
+                  chunk.providerExecuted ??
+                  (response.isResume
+                    ? existingPart?.providerExecuted
+                    : undefined),
               };
 
-              setPart(-1, toolPart);
+              setPart(existingIndex, toolPart);
               break;
             }
 
@@ -1421,8 +1512,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 break;
               }
               const previousRawInput =
-                existingPart?.rawInput ??
                 toolRawInputByCallId[chunk.toolCallId] ??
+                existingPart?.rawInput ??
                 '';
               const nextRawInput = `${previousRawInput}${chunk.inputTextDelta}`;
               toolRawInputByCallId[chunk.toolCallId] = nextRawInput;
@@ -1446,6 +1537,17 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 rawInput: nextRawInput,
               };
 
+              const originalRawInput = replayedToolOriginalRawInputByCallId.get(
+                chunk.toolCallId
+              );
+              if (
+                originalRawInput !== undefined &&
+                nextRawInput.length < originalRawInput.length &&
+                originalRawInput.startsWith(nextRawInput)
+              ) {
+                break;
+              }
+              replayedToolOriginalRawInputByCallId.delete(chunk.toolCallId);
               setPart(toolIndex, nextToolPart);
               break;
             }
@@ -1456,9 +1558,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               if (response.requiredToolCallIds.has(chunk.toolCallId)) break;
 
               delete toolRawInputByCallId[chunk.toolCallId];
+              replayedToolOriginalRawInputByCallId.delete(chunk.toolCallId);
 
               // Find existing tool part or create new one
               const existingIndex = findToolPart(chunk.toolCallId);
+              if (existingIndex >= 0) {
+                consumeReusablePartsThrough(existingIndex);
+              }
               const existingPart =
                 existingIndex >= 0
                   ? (currentMessage.parts[existingIndex] as any)
@@ -1504,6 +1610,28 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 const existingOwners = Array.from(owners).filter(
                   (owner) => owner !== response
                 );
+                if (
+                  response.isResume &&
+                  replayedDispatchedToolCallIds.has(chunk.toolCallId)
+                ) {
+                  response.requiredToolCallIds.add(chunk.toolCallId);
+                  existingOwners.forEach((owner) => {
+                    if (!owner.requiredToolCallIds.has(chunk.toolCallId)) {
+                      return;
+                    }
+                    const forwardedResponses =
+                      owner.forwardToolResultsTo.get(chunk.toolCallId) ??
+                      new Set<ResponseRecord>();
+                    forwardedResponses.add(response);
+                    owner.forwardToolResultsTo.set(
+                      chunk.toolCallId,
+                      forwardedResponses
+                    );
+                  });
+                  owners.add(response);
+                  this.responsesByToolCallId.set(chunk.toolCallId, owners);
+                  break;
+                }
                 if (existingOwners.length > 0) {
                   this.acceptsIdentifierOnlyToolResults = false;
                   const conflictingOwner = existingOwners.find(
@@ -1583,12 +1711,24 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 toolIndex >= 0
                   ? (currentMessage.parts[toolIndex] as any)
                   : null;
-              const previousRawOutput =
-                existingPart?.rawOutput ??
-                toolRawOutputByCallId[toolCallId] ??
-                '';
+              const previousRawOutput = response.isResume
+                ? toolRawOutputByCallId[toolCallId] ?? ''
+                : existingPart?.rawOutput ??
+                  toolRawOutputByCallId[toolCallId] ??
+                  '';
               const nextRawOutput = `${previousRawOutput}${delta}`;
               toolRawOutputByCallId[toolCallId] = nextRawOutput;
+
+              const originalRawOutput =
+                replayedToolOriginalRawOutputByCallId.get(toolCallId);
+              if (
+                originalRawOutput !== undefined &&
+                nextRawOutput.length < originalRawOutput.length &&
+                originalRawOutput.startsWith(nextRawOutput)
+              ) {
+                break;
+              }
+              replayedToolOriginalRawOutputByCallId.delete(toolCallId);
 
               const parsedOutput = parseToolInputDelta(
                 nextRawOutput,
@@ -1618,6 +1758,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               if (toolIndex >= 0) {
                 delete toolRawInputByCallId[chunk.toolCallId];
                 delete toolRawOutputByCallId[chunk.toolCallId];
+                replayedToolOriginalRawInputByCallId.delete(chunk.toolCallId);
+                replayedToolOriginalRawOutputByCallId.delete(chunk.toolCallId);
 
                 const existingPart = currentMessage.parts[toolIndex] as any;
                 if (response.resolvedToolCallIds.has(chunk.toolCallId)) {
@@ -1655,6 +1797,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               }
               delete toolRawInputByCallId[chunk.toolCallId];
               delete toolRawOutputByCallId[chunk.toolCallId];
+              replayedToolOriginalRawInputByCallId.delete(chunk.toolCallId);
+              replayedToolOriginalRawOutputByCallId.delete(chunk.toolCallId);
 
               const toolIndex = findToolPart(chunk.toolCallId);
               const existingPart =
@@ -1706,6 +1850,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
               delete toolRawInputByCallId[chunk.toolCallId];
               delete toolRawOutputByCallId[chunk.toolCallId];
+              replayedToolOriginalRawInputByCallId.delete(chunk.toolCallId);
+              replayedToolOriginalRawOutputByCallId.delete(chunk.toolCallId);
 
               const existingPart = currentMessage.parts[toolIndex] as any;
               const {
@@ -1740,7 +1886,11 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 title: chunk.title,
               };
 
-              setPart(-1, sourcePart);
+              const reusablePartIndex = claimReusablePartByIdentity(
+                (part) =>
+                  part.type === 'source-url' && part.sourceId === chunk.sourceId
+              );
+              setPart(reusablePartIndex ?? -1, sourcePart);
               break;
             }
 
@@ -1756,7 +1906,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 providerMetadata: chunk.providerMetadata,
               };
 
-              setPart(-1, docPart);
+              const reusablePartIndex = claimReusablePartByIdentity(
+                (part) =>
+                  part.type === 'source-document' &&
+                  part.sourceId === chunk.sourceId
+              );
+              setPart(reusablePartIndex ?? -1, docPart);
               break;
             }
 
@@ -1769,14 +1924,23 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 mediaType: chunk.mediaType,
               };
 
-              setPart(-1, filePart);
+              const reusablePartIndex = claimNextReusablePart(
+                (part) =>
+                  part.type === 'file' &&
+                  part.url === chunk.url &&
+                  part.mediaType === chunk.mediaType
+              );
+              setPart(reusablePartIndex ?? -1, filePart);
               break;
             }
 
             case 'start-step': {
               if (!currentMessage) break;
 
-              setPart(-1, { type: 'step-start' });
+              const reusablePartIndex = claimNextReusablePart(
+                (part) => part.type === 'step-start'
+              );
+              setPart(reusablePartIndex ?? -1, { type: 'step-start' });
               break;
             }
 
@@ -1870,13 +2034,23 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
               // Handle generic data parts (data-*)
               const chunkType = (chunk as any).type as string;
               if (chunkType?.startsWith('data-') && currentMessage) {
+                const chunkId = (chunk as any).id as string | undefined;
                 const dataPart = {
                   type: chunkType,
-                  id: (chunk as any).id,
+                  id: chunkId,
                   data: (chunk as any).data,
                 };
 
-                setPart(-1, dataPart);
+                const reusablePartIndex =
+                  chunkId === undefined
+                    ? claimNextReusablePart((part) => part.type === chunkType)
+                    : claimReusablePartByIdentity(
+                        (part) =>
+                          part.type === chunkType &&
+                          'id' in part &&
+                          part.id === chunkId
+                      );
+                setPart(reusablePartIndex ?? -1, dataPart);
 
                 // Trigger onData callback
                 if (this.onData) {

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -429,6 +429,13 @@ export interface ChatTransport<UI_MESSAGE extends UIMessage> {
     } & ChatRequestOptions
   ) => Promise<ReadableStream<InferUIMessageChunk<UI_MESSAGE>>>;
 
+  /**
+   * Reconnects to an interrupted response.
+   *
+   * The returned stream must replay the full buffered assistant response in
+   * its original part order. Stream chunk boundaries may differ between
+   * connections.
+   */
   reconnectToStream: (
     options: {
       chatId: string;

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -434,7 +434,8 @@ export interface ChatTransport<UI_MESSAGE extends UIMessage> {
    *
    * The returned stream must replay the full buffered assistant response in
    * its original part order. Stream chunk boundaries may differ between
-   * connections.
+   * connections. Data callbacks observe replayed chunks and may run again
+   * after reconnecting.
    */
   reconnectToStream: (
     options: {

--- a/packages/instantsearch.js/src/lib/chat/__tests__/chat.test.ts
+++ b/packages/instantsearch.js/src/lib/chat/__tests__/chat.test.ts
@@ -114,7 +114,7 @@ describe('ChatState', () => {
     );
   });
 
-  it('should not save messages to sessionStorage when status is not ready', () => {
+  it('should save committed messages when status changes to error', () => {
     const agentId = 'agentID3';
     const chatState = new ChatState<any>(agentId);
     const message = { role: 'user', content: 'Hello' };
@@ -125,7 +125,9 @@ describe('ChatState', () => {
     chatState.status = 'streaming';
     expect(sessionStorage.getItem(`${CACHE_KEY}-${agentId}`)).toBe(null);
     chatState.status = 'error';
-    expect(sessionStorage.getItem(`${CACHE_KEY}-${agentId}`)).toBe(null);
+    expect(sessionStorage.getItem(`${CACHE_KEY}-${agentId}`)).toBe(
+      JSON.stringify([message])
+    );
   });
 
   it('should not save messages to sessionStorage when persistence is disabled', () => {

--- a/packages/instantsearch.js/src/lib/chat/chat.ts
+++ b/packages/instantsearch.js/src/lib/chat/chat.ts
@@ -61,7 +61,7 @@ export class ChatState<TUiMessage extends UIMessage>
     }
 
     const saveMessagesInLocalStorage = () => {
-      if (this.status === 'ready') {
+      if (this.status === 'ready' || this.status === 'error') {
         try {
           sessionStorage.setItem(
             CACHE_KEY + (id ? `-${id}` : ''),

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -139,6 +139,7 @@ type ChatWrapperProps = {
     assistantMessageProps: {
       leadingComponent: ChatMessageProps['leadingComponent'];
       footerComponent: ChatMessageProps['footerComponent'];
+      showReasoning: ChatMessageProps['showReasoning'];
     };
     userMessageProps: {
       leadingComponent: ChatMessageProps['leadingComponent'];
@@ -293,6 +294,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
   containerNode,
   templates,
   tools,
+  showReasoning,
 }: {
   containerNode: HTMLElement;
   cssClasses: ChatCSSClasses;
@@ -301,6 +303,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
   };
   templates: ChatTemplates<THit>;
   tools: UserClientSideToolsWithTemplate;
+  showReasoning: boolean;
 }): Renderer<ChatRenderState, Partial<ChatWidgetParams>> => {
   const state = createLocalState();
   const promptRef = { current: null as HTMLTextAreaElement | null };
@@ -645,6 +648,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
     const messageTranslations = getDefinedProperties({
       actionsLabel: templates.message?.actionsLabelText,
       messageLabel: templates.message?.messageLabelText,
+      reasoningLabel: templates.message?.reasoningLabelText,
     });
 
     userMessageTemplateRef.current = prepareTemplateProps({
@@ -719,6 +723,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
             assistantMessageProps: {
               leadingComponent: stableAssistantMessageLeadingComponent,
               footerComponent: stableAssistantMessageFooterComponent,
+              showReasoning,
             },
             userMessageProps: {
               leadingComponent: stableUserMessageLeadingComponent,
@@ -898,6 +903,10 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
        * Label for the message container
        */
       messageLabelText?: string;
+      /**
+       * Label for reasoning disclosures
+       */
+      reasoningLabelText?: string;
     }>;
 
     /**
@@ -1025,6 +1034,11 @@ type ChatWidgetParams<THit extends RecordWithObjectID = RecordWithObjectID> = {
    * Disable validation that requires either `chatTrigger` or AI mode.
    */
   disableTriggerValidation?: boolean;
+
+  /**
+   * Whether to render reasoning parts
+   */
+  showReasoning?: boolean;
 };
 
 export type ChatWidget = WidgetFactory<
@@ -1050,6 +1064,7 @@ export default (function chat<
     tools: userTools,
     getSearchPageURL,
     disableTriggerValidation = false,
+    showReasoning = false,
     ...options
   } = widgetParams || {};
 
@@ -1084,6 +1099,7 @@ export default (function chat<
     renderState: {},
     templates,
     tools,
+    showReasoning,
   });
 
   const makeWidget = connectChat(specializedRenderer, () =>

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -149,6 +149,10 @@ export type ChatProps<TObject, TUiMessage extends UIMessage = UIMessage> = Omit<
     userMessageLeadingComponent?: ChatMessageProps['leadingComponent'];
     userMessageFooterComponent?: ChatMessageProps['footerComponent'];
     suggestionsComponent?: ChatUiProps['suggestionsComponent'];
+    /**
+     * Whether to render reasoning parts
+     */
+    showReasoning?: boolean;
     translations?: Partial<{
       prompt: ChatUiProps['promptProps']['translations'];
       header: ChatUiProps['headerProps']['translations'];
@@ -196,6 +200,7 @@ function ChatInner<
     title,
     getSearchPageURL,
     disableTriggerValidation = false,
+    showReasoning,
     ...props
   }: ChatProps<TObject, TUiMessage>,
   ref: React.ForwardedRef<ChatHandle>
@@ -340,9 +345,13 @@ function ChatInner<
         errorComponent: messagesErrorComponent,
         emptyComponent: emptyComponent,
         actionsComponent,
+        translations: messagesTranslations,
+        messageTranslations,
+        ...messagesProps,
         assistantMessageProps: {
           leadingComponent: assistantMessageLeadingComponent,
           footerComponent: assistantMessageFooterComponent,
+          showReasoning,
           ...messagesProps?.assistantMessageProps,
         },
         userMessageProps: {
@@ -350,9 +359,6 @@ function ChatInner<
           footerComponent: userMessageFooterComponent,
           ...messagesProps?.userMessageProps,
         },
-        translations: messagesTranslations,
-        messageTranslations,
-        ...messagesProps,
         error,
       }}
       promptProps={{

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import { act, render, screen } from '@testing-library/react';
+import { Chat as ChatInstance } from 'instantsearch.js/es/lib/chat';
+import React from 'react';
+import { InstantSearch } from 'react-instantsearch-core';
+
+import { ChatInlineLayout } from '../../components/ChatInlineLayout';
+import { Chat } from '../Chat';
+
+import type { UIMessage } from 'instantsearch.js/es/lib/chat';
+
+function createChat() {
+  return new ChatInstance<UIMessage>({
+    persistence: false,
+    messages: [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Find a product' }],
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            text: 'Check the catalog.',
+            state: 'done',
+          },
+          { type: 'text', text: 'I found one option.' },
+        ],
+      },
+      {
+        id: 'user-2',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Find another' }],
+      },
+      {
+        id: 'assistant-2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            text: 'Compare the results.',
+            state: 'done',
+          },
+          { type: 'text', text: 'Here is another option.' },
+        ],
+      },
+    ],
+  });
+}
+
+function ChatUnderTest({
+  chat,
+  showReasoning,
+}: {
+  chat: ChatInstance<UIMessage>;
+  showReasoning: boolean;
+}) {
+  return (
+    <InstantSearch
+      searchClient={createSearchClient()}
+      indexName="indexName"
+      future={{ preserveSharedStateOnUnmount: true }}
+    >
+      <Chat
+        chat={chat}
+        transport={{ api: 'http://unused' }}
+        layoutComponent={ChatInlineLayout}
+        requiresSearch={false}
+        showReasoning={showReasoning}
+      />
+    </InstantSearch>
+  );
+}
+
+describe('Chat', () => {
+  test('shows reasoning on completed messages when enabled after rendering', async () => {
+    const chat = createChat();
+    const { rerender } = render(
+      <ChatUnderTest chat={chat} showReasoning={false} />
+    );
+    await act(async () => {
+      await wait(0);
+    });
+    expect(screen.queryAllByRole('group', { name: 'Reasoning' })).toHaveLength(
+      0
+    );
+
+    rerender(<ChatUnderTest chat={chat} showReasoning={true} />);
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(screen.getAllByRole('group', { name: 'Reasoning' })).toHaveLength(2);
+  });
+
+  test('hides reasoning on completed messages when disabled after rendering', async () => {
+    const chat = createChat();
+    const { rerender } = render(
+      <ChatUnderTest chat={chat} showReasoning={true} />
+    );
+    await act(async () => {
+      await wait(0);
+    });
+    expect(screen.getAllByRole('group', { name: 'Reasoning' })).toHaveLength(2);
+
+    rerender(<ChatUnderTest chat={chat} showReasoning={false} />);
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(screen.queryAllByRole('group', { name: 'Reasoning' })).toHaveLength(
+      0
+    );
+  });
+});

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
@@ -14,6 +14,8 @@ import { Chat } from '../Chat';
 
 import type { UIMessage } from 'instantsearch.js/es/lib/chat';
 
+const searchClient = createSearchClient();
+
 function createChat() {
   return new ChatInstance<UIMessage>({
     persistence: false,
@@ -59,13 +61,15 @@ function createChat() {
 function ChatUnderTest({
   chat,
   showReasoning,
+  reasoningLabel = 'Reasoning',
 }: {
   chat: ChatInstance<UIMessage>;
   showReasoning: boolean;
+  reasoningLabel?: string;
 }) {
   return (
     <InstantSearch
-      searchClient={createSearchClient()}
+      searchClient={searchClient}
       indexName="indexName"
       future={{ preserveSharedStateOnUnmount: true }}
     >
@@ -75,6 +79,7 @@ function ChatUnderTest({
         layoutComponent={ChatInlineLayout}
         requiresSearch={false}
         showReasoning={showReasoning}
+        translations={{ message: { reasoningLabel } }}
       />
     </InstantSearch>
   );
@@ -118,6 +123,39 @@ describe('Chat', () => {
 
     expect(screen.queryAllByRole('group', { name: 'Reasoning' })).toHaveLength(
       0
+    );
+  });
+
+  test('updates the reasoning label on completed messages', async () => {
+    const chat = createChat();
+    const { rerender } = render(
+      <ChatUnderTest
+        chat={chat}
+        showReasoning={true}
+        reasoningLabel="Reasoning"
+      />
+    );
+    await act(async () => {
+      await wait(0);
+    });
+    expect(screen.getAllByRole('group', { name: 'Reasoning' })).toHaveLength(2);
+
+    rerender(
+      <ChatUnderTest
+        chat={chat}
+        showReasoning={true}
+        reasoningLabel="Raisonnement"
+      />
+    );
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(screen.queryAllByRole('group', { name: 'Reasoning' })).toHaveLength(
+      0
+    );
+    expect(screen.getAllByRole('group', { name: 'Raisonnement' })).toHaveLength(
+      2
     );
   });
 });

--- a/tests/common/widgets/chat/index.ts
+++ b/tests/common/widgets/chat/index.ts
@@ -3,6 +3,7 @@ import { fakeAct, skippableDescribe } from '../../common';
 import { createGuardrailsTests } from './guardrails';
 import { createOptionsTests } from './options';
 import { createPersistenceTests } from './persistence';
+import { createReasoningTests } from './reasoning';
 import { createStreamingTests } from './streaming';
 import { createTemplatesTests } from './templates';
 import { createTranslationsTests } from './translations';
@@ -53,6 +54,7 @@ export function createChatWidgetTests(
     createGuardrailsTests(setup, { act, skippedTests, flavor });
     createOptionsTests(setup, { act, skippedTests, flavor });
     createPersistenceTests(setup, { act, skippedTests, flavor });
+    createReasoningTests(setup, { act, skippedTests, flavor });
     createStreamingTests(setup, { act, skippedTests, flavor });
     createTemplatesTests(setup, { act, skippedTests, flavor });
     createTranslationsTests(setup, { act, skippedTests, flavor });

--- a/tests/common/widgets/chat/persistence.ts
+++ b/tests/common/widgets/chat/persistence.ts
@@ -1,4 +1,5 @@
 import { createSearchClient } from '@instantsearch/mocks';
+import { within } from '@testing-library/dom';
 
 import { openChat } from './utils';
 
@@ -59,6 +60,59 @@ export function createPersistenceTests(
 
       expect(document.body).toHaveTextContent('Fresh greeting');
       expect(document.body).not.toHaveTextContent('Previous persisted answer');
+    });
+
+    test('renders restored unfinished reasoning as inactive when chat is ready', async () => {
+      sessionStorage.clear();
+      const searchClient = createSearchClient();
+      const cacheKey = 'instantsearch-chat-initial-messages';
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'previous',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'A stopped response.',
+              state: 'streaming',
+            },
+            { type: 'text', text: 'A saved answer.' },
+          ],
+        },
+      ];
+
+      sessionStorage.setItem(
+        `${cacheKey}-agentId`,
+        JSON.stringify(previousMessages)
+      );
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            agentId: 'agentId',
+            showReasoning: true,
+          },
+          react: {
+            agentId: 'agentId',
+            showReasoning: true,
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      const disclosure = within(document.body).getByRole('group', {
+        name: 'Reasoning',
+      });
+      expect(disclosure).toHaveAttribute('aria-busy', 'false');
+      expect(
+        disclosure.querySelector('.ais-ChatMessageReasoning-label--streaming')
+      ).not.toBeInTheDocument();
     });
   });
 }

--- a/tests/common/widgets/chat/reasoning.tsx
+++ b/tests/common/widgets/chat/reasoning.tsx
@@ -1,0 +1,145 @@
+import { createSearchClient } from '@instantsearch/mocks';
+import { within } from '@testing-library/dom';
+import { Chat } from 'instantsearch.js/es/lib/chat';
+
+import { createDefaultWidgetParams, openChat } from './utils';
+
+import type { ChatWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+
+function createChatWithReasoning() {
+  return new Chat({
+    messages: [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            text: 'Check the **catalog**.',
+            state: 'done',
+          },
+          {
+            type: 'reasoning',
+            text: 'Compare release dates.',
+            state: 'done',
+          },
+          { type: 'text', text: 'The answer is 2001.' },
+        ],
+      },
+    ],
+  });
+}
+
+export function createReasoningTests(
+  setup: ChatWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('reasoning', () => {
+    test('does not render reasoning by default', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: createDefaultWidgetParams(createChatWithReasoning()),
+          react: createDefaultWidgetParams(createChatWithReasoning()),
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        within(document.body).queryByRole('group', { name: 'Reasoning' })
+      ).not.toBeInTheDocument();
+      expect(document.body).not.toHaveTextContent('Check the catalog.');
+    });
+
+    test('renders each reasoning part in a collapsed disclosure when enabled', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: true,
+          },
+          react: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: true,
+            messagesProps: {
+              onClose: () => {},
+              onReload: () => {},
+              assistantMessageProps: {
+                autoHideActions: true,
+              },
+            },
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      const disclosures = within(document.body).getAllByRole('group', {
+        name: 'Reasoning',
+      });
+      expect(disclosures).toHaveLength(2);
+      expect(disclosures[0]).not.toHaveAttribute('open');
+      expect(disclosures[1]).not.toHaveAttribute('open');
+      expect(disclosures[0]).toHaveTextContent('Check the catalog.');
+      expect(disclosures[0].querySelector('strong')).toHaveTextContent(
+        'catalog'
+      );
+      expect(disclosures[1]).toHaveTextContent('Compare release dates.');
+    });
+
+    test('renders the translated reasoning label', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: true,
+            templates: {
+              message: {
+                reasoningLabelText: 'Raisonnement',
+              },
+            },
+          },
+          react: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: true,
+            translations: {
+              message: {
+                reasoningLabel: 'Raisonnement',
+              },
+            },
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        within(document.body).getAllByRole('group', {
+          name: 'Raisonnement',
+        })
+      ).toHaveLength(2);
+    });
+  });
+}

--- a/tests/common/widgets/chat/reasoning.tsx
+++ b/tests/common/widgets/chat/reasoning.tsx
@@ -1,5 +1,7 @@
 import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
 import { within } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 import { Chat } from 'instantsearch.js/es/lib/chat';
 
 import { createDefaultWidgetParams, openChat } from './utils';
@@ -59,6 +61,76 @@ export function createReasoningTests(
       expect(document.body).not.toHaveTextContent('Check the catalog.');
     });
 
+    test('copies only answer text when reasoning is hidden', async () => {
+      const searchClient = createSearchClient();
+      const writeText = jest.fn();
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: createDefaultWidgetParams(createChatWithReasoning()),
+          react: createDefaultWidgetParams(createChatWithReasoning()),
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      userEvent.click(
+        within(document.body).getByRole('button', {
+          name: 'Copy to clipboard',
+        })
+      );
+
+      expect(writeText).toHaveBeenCalledWith('The answer is 2001.');
+    });
+
+    test('does not offer Copy when hidden reasoning is the only content', async () => {
+      const searchClient = createSearchClient();
+      const chat = new Chat({
+        messages: [
+          {
+            id: 'assistant-reasoning-only',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'No answer was produced.',
+                state: 'done',
+              },
+            ],
+          },
+        ],
+      });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: createDefaultWidgetParams(chat),
+          react: createDefaultWidgetParams(chat),
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        within(document.body).queryByRole('button', {
+          name: 'Copy to clipboard',
+        })
+      ).not.toBeInTheDocument();
+    });
+
     test('renders each reasoning part in a collapsed disclosure when enabled', async () => {
       const searchClient = createSearchClient();
 
@@ -100,6 +172,74 @@ export function createReasoningTests(
         'catalog'
       );
       expect(disclosures[1]).toHaveTextContent('Compare release dates.');
+    });
+
+    test('moves the streaming state to a newly appended response', async () => {
+      const searchClient = createSearchClient();
+      const previousMessage = {
+        id: 'assistant-previous',
+        role: 'assistant' as const,
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Previous reasoning',
+            state: 'streaming' as const,
+          },
+        ],
+      };
+      const chat = new Chat({ messages: [previousMessage] });
+      chat._state.status = 'streaming';
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        within(document.body).getByRole('group', {
+          name: 'Reasoning',
+        })
+      ).toHaveAttribute('aria-busy', 'true');
+
+      await act(async () => {
+        chat.messages = [
+          previousMessage,
+          {
+            id: 'assistant-current',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Current reasoning',
+                state: 'streaming',
+              },
+            ],
+          },
+        ];
+        await wait(0);
+      });
+
+      const disclosures = within(document.body).getAllByRole('group', {
+        name: 'Reasoning',
+      });
+      expect(disclosures).toHaveLength(2);
+      expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
+      expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
     });
 
     test('renders the translated reasoning label', async () => {

--- a/tests/common/widgets/chat/reasoning.tsx
+++ b/tests/common/widgets/chat/reasoning.tsx
@@ -242,6 +242,55 @@ export function createReasoningTests(
       expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
     });
 
+    test('stops showing reasoning as busy when answer text starts streaming', async () => {
+      const searchClient = createSearchClient();
+      const chat = new Chat({
+        messages: [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Checking the catalog',
+                state: 'streaming',
+              },
+              {
+                type: 'text',
+                text: 'Here is what I found',
+                state: 'streaming',
+              },
+            ],
+          },
+        ],
+      });
+      chat._state.status = 'streaming';
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        within(document.body).getByRole('group', { name: 'Reasoning' })
+      ).toHaveAttribute('aria-busy', 'false');
+    });
+
     test('renders the translated reasoning label', async () => {
       const searchClient = createSearchClient();
 


### PR DESCRIPTION
**Summary**

Adds opt-in rendering for Chat reasoning parts so the Agent Studio Dashboard can preserve its existing reasoning disclosure when moving to InstantSearch Chat.

`showReasoning` defaults to `false`. When enabled, reasoning is rendered in its original message order around tool calls and the final answer, collapsed by default. Only the active reasoning part shows progress.

This also keeps restored conversations stable. Replayed text, reasoning, tools and structural parts are reconciled without duplication, output guardrails stop trailing content and restored client tools retain a single callback owner.

This narrows #7105 to the rendering and stream behavior required by [FX-3831]. It does not add summaries, PII heuristics, loading captions, additional visibility modes or a custom Dashboard chat implementation.

**Result**

Enable reasoning in React:

```tsx
<Chat showReasoning />
```

Or InstantSearch.js:

```js
chat({
  showReasoning: true,
});
```

Covered behavior includes:

- hidden by default and opt-in rendering in JavaScript and React
- reasoning order around tools and answers
- streaming, stop, error and reconnect states
- full response replay without duplicate parts
- restored tool callbacks and automatic continuation
- output guardrail fallback
- keyboard access for long reasoning
- one progress indicator while reasoning is active

### Reasoning parts

Each reasoning part is rendered as an independent disclosure and keeps its open state while the response streams.

https://github.com/user-attachments/assets/350dc263-a37a-43c2-9db3-cd95ed960a2b

[FX-3831]: https://algolia.atlassian.net/browse/FX-3831




[FX-3831]: https://algolia.atlassian.net/browse/FX-3831