### PR TITLE
feat(chat): render v1 display results from tool input

### DIFF
--- a/packages/instantsearch-ui-components/src/components/Carousel.tsx
+++ b/packages/instantsearch-ui-components/src/components/Carousel.tsx
@@ -269,7 +269,7 @@ export function createCarouselComponent({ createElement, Fragment }: Renderer) {
         >
           {items.map((item, index) => (
             <li
-              key={item.objectID}
+              key={`${item.objectID}:${index}`}
               className={cx(cssClasses.item)}
               aria-roledescription="slide"
               aria-label={`${index + 1} of ${items.length}`}

--- a/packages/instantsearch-ui-components/src/components/Carousel.tsx
+++ b/packages/instantsearch-ui-components/src/components/Carousel.tsx
@@ -220,6 +220,8 @@ export function createCarouselComponent({ createElement, Fragment }: Renderer) {
       return null;
     }
 
+    const itemOccurrences = new Map<string, number>();
+
     return (
       <div {...props} className={cx(cssClasses.root)}>
         {HeaderComponent && (
@@ -267,22 +269,27 @@ export function createCarouselComponent({ createElement, Fragment }: Renderer) {
             }
           }}
         >
-          {items.map((item, index) => (
-            <li
-              key={`${item.objectID}:${index}`}
-              className={cx(cssClasses.item)}
-              aria-roledescription="slide"
-              aria-label={`${index + 1} of ${items.length}`}
-              onClick={() => {
-                sendEvent('click:internal', item, 'Item Clicked');
-              }}
-              onAuxClick={() => {
-                sendEvent('click:internal', item, 'Item Clicked');
-              }}
-            >
-              <ItemComponent item={item} sendEvent={sendEvent} />
-            </li>
-          ))}
+          {items.map((item, index) => {
+            const occurrence = itemOccurrences.get(item.objectID) ?? 0;
+            itemOccurrences.set(item.objectID, occurrence + 1);
+
+            return (
+              <li
+                key={JSON.stringify([item.objectID, occurrence])}
+                className={cx(cssClasses.item)}
+                aria-roledescription="slide"
+                aria-label={`${index + 1} of ${items.length}`}
+                onClick={() => {
+                  sendEvent('click:internal', item, 'Item Clicked');
+                }}
+                onAuxClick={() => {
+                  sendEvent('click:internal', item, 'Item Clicked');
+                }}
+              >
+                <ItemComponent item={item} sendEvent={sendEvent} />
+              </li>
+            );
+          })}
         </ol>
 
         {showNavigation && (

--- a/packages/instantsearch-ui-components/src/components/Carousel.tsx
+++ b/packages/instantsearch-ui-components/src/components/Carousel.tsx
@@ -14,6 +14,7 @@ import type {
 } from '../types';
 
 export type HeaderComponentProps = {
+  nbItems: number;
   canScrollLeft: boolean;
   canScrollRight: boolean;
   scrollLeft: () => void;
@@ -268,6 +269,7 @@ export function createCarouselComponent({
       <div {...props} className={cx(cssClasses.root)}>
         {HeaderComponent && (
           <HeaderComponent
+            nbItems={items.length}
             canScrollLeft={canScrollLeft}
             canScrollRight={canScrollRight}
             scrollLeft={scrollLeft}

--- a/packages/instantsearch-ui-components/src/components/Carousel.tsx
+++ b/packages/instantsearch-ui-components/src/components/Carousel.tsx
@@ -5,6 +5,7 @@ import { createDefaultItemComponent } from './recommend-shared';
 
 import type {
   ComponentProps,
+  Hooks,
   MutableRef,
   RecommendItemComponentProps,
   RecordWithObjectID,
@@ -44,6 +45,42 @@ export type CarouselProps<
   translations?: Partial<CarouselTranslations>;
   sendEvent: SendEventForHits;
 };
+
+type CarouselNavigationProps = Pick<
+  CarouselProps<unknown>,
+  | 'listRef'
+  | 'nextButtonRef'
+  | 'previousButtonRef'
+  | 'setCanScrollLeft'
+  | 'setCanScrollRight'
+>;
+
+function updateNavigationButtonsProps({
+  listRef,
+  nextButtonRef,
+  previousButtonRef,
+  setCanScrollLeft,
+  setCanScrollRight,
+}: CarouselNavigationProps) {
+  if (!listRef.current) {
+    return;
+  }
+
+  const isLeftHidden = listRef.current.scrollLeft <= 0;
+  const isRightHidden =
+    listRef.current.scrollLeft + listRef.current.clientWidth >=
+    listRef.current.scrollWidth;
+
+  setCanScrollLeft(!isLeftHidden);
+  setCanScrollRight(!isRightHidden);
+
+  if (previousButtonRef.current) {
+    previousButtonRef.current.hidden = isLeftHidden;
+  }
+  if (nextButtonRef.current) {
+    nextButtonRef.current.hidden = isRightHidden;
+  }
+}
 
 export type CarouselClassNames = {
   /**
@@ -131,7 +168,12 @@ function NextIconDefaultComponent({
   );
 }
 
-export function createCarouselComponent({ createElement, Fragment }: Renderer) {
+export function createCarouselComponent({
+  createElement,
+  Fragment,
+  useEffect,
+  useRef,
+}: Renderer & Pick<Hooks, 'useEffect' | 'useRef'>) {
   return function Carousel<TObject extends Record<string, unknown>>(
     userProps: CarouselProps<TObject>
   ) {
@@ -167,6 +209,7 @@ export function createCarouselComponent({ createElement, Fragment }: Renderer) {
       previousButtonTitle: 'Previous',
       ...userTranslations,
     };
+    const previousItemsLengthRef = useRef(items.length);
 
     const cssClasses: CarouselClassNames = {
       root: cx('ais-Carousel', classNames.root),
@@ -195,26 +238,25 @@ export function createCarouselComponent({ createElement, Fragment }: Renderer) {
       }
     }
 
-    function updateNavigationButtonsProps() {
-      if (!listRef.current) {
-        return;
+    useEffect(() => {
+      if (previousItemsLengthRef.current !== items.length) {
+        updateNavigationButtonsProps({
+          listRef,
+          nextButtonRef,
+          previousButtonRef,
+          setCanScrollLeft,
+          setCanScrollRight,
+        });
+        previousItemsLengthRef.current = items.length;
       }
-
-      const isLeftHidden = listRef.current.scrollLeft <= 0;
-      const isRightHidden =
-        listRef.current.scrollLeft + listRef.current.clientWidth >=
-        listRef.current.scrollWidth;
-
-      setCanScrollLeft(!isLeftHidden);
-      setCanScrollRight(!isRightHidden);
-
-      if (previousButtonRef.current) {
-        previousButtonRef.current.hidden = isLeftHidden;
-      }
-      if (nextButtonRef.current) {
-        nextButtonRef.current.hidden = isRightHidden;
-      }
-    }
+    }, [
+      items.length,
+      listRef,
+      nextButtonRef,
+      previousButtonRef,
+      setCanScrollLeft,
+      setCanScrollRight,
+    ]);
 
     if (items.length === 0) {
       return null;
@@ -258,7 +300,15 @@ export function createCarouselComponent({ createElement, Fragment }: Renderer) {
           aria-roledescription="carousel"
           aria-label={translations.listLabel}
           aria-live="polite"
-          onScroll={updateNavigationButtonsProps}
+          onScroll={() =>
+            updateNavigationButtonsProps({
+              listRef,
+              nextButtonRef,
+              previousButtonRef,
+              setCanScrollLeft,
+              setCanScrollRight,
+            })
+          }
           onKeyDown={(event) => {
             if (event.key === 'ArrowLeft') {
               event.preventDefault();

--- a/packages/instantsearch-ui-components/src/components/Carousel.tsx
+++ b/packages/instantsearch-ui-components/src/components/Carousel.tsx
@@ -174,58 +174,7 @@ export function createCarouselComponent({
   Fragment,
   useEffect,
   useRef,
-}: Renderer & Partial<Pick<Hooks, 'useEffect' | 'useRef'>>) {
-  // `useEffect` and `useRef` are optional so callers written against the
-  // pre-measurement signature keep compiling. Whether they were supplied is
-  // fixed when the component is created, so the branch below is stable for the
-  // component's whole lifetime and never changes hook order between renders.
-  const measurementHooks = useEffect && useRef ? { useEffect, useRef } : null;
-
-  /**
-   * Remeasures the list whenever the item count changes.
-   *
-   * Without the hooks this is inert, which is the behaviour callers had before
-   * item-count measurement existed: navigation state is then only recomputed on
-   * scroll.
-   */
-  const useItemCountMeasurement = measurementHooks
-    ? (itemCount: number, navigation: CarouselNavigationProps) => {
-        const previousItemCountRef = measurementHooks.useRef(itemCount);
-        // Destructured so the effect depends on the individually stable refs and
-        // setters rather than on the object literal, which is new every render.
-        const {
-          listRef,
-          nextButtonRef,
-          previousButtonRef,
-          setCanScrollLeft,
-          setCanScrollRight,
-        } = navigation;
-
-        measurementHooks.useEffect(() => {
-          if (previousItemCountRef.current !== itemCount) {
-            updateNavigationButtonsProps({
-              listRef,
-              nextButtonRef,
-              previousButtonRef,
-              setCanScrollLeft,
-              setCanScrollRight,
-            });
-            previousItemCountRef.current = itemCount;
-          }
-          // `previousItemCountRef` is a ref and therefore stable; it is listed
-          // only because the lint rule cannot see through `measurementHooks`.
-        }, [
-          itemCount,
-          listRef,
-          nextButtonRef,
-          previousButtonRef,
-          setCanScrollLeft,
-          setCanScrollRight,
-          previousItemCountRef,
-        ]);
-      }
-    : (_itemCount: number, _navigation: CarouselNavigationProps) => {};
-
+}: Renderer & Pick<Hooks, 'useEffect' | 'useRef'>) {
   return function Carousel<TObject extends Record<string, unknown>>(
     userProps: CarouselProps<TObject>
   ) {
@@ -261,6 +210,8 @@ export function createCarouselComponent({
       previousButtonTitle: 'Previous',
       ...userTranslations,
     };
+    const previousItemsLengthRef = useRef(items.length);
+
     const cssClasses: CarouselClassNames = {
       root: cx('ais-Carousel', classNames.root),
       list: cx('ais-Carousel-list', classNames.list),
@@ -288,13 +239,25 @@ export function createCarouselComponent({
       }
     }
 
-    useItemCountMeasurement(items.length, {
+    useEffect(() => {
+      if (previousItemsLengthRef.current !== items.length) {
+        updateNavigationButtonsProps({
+          listRef,
+          nextButtonRef,
+          previousButtonRef,
+          setCanScrollLeft,
+          setCanScrollRight,
+        });
+        previousItemsLengthRef.current = items.length;
+      }
+    }, [
+      items.length,
       listRef,
       nextButtonRef,
       previousButtonRef,
       setCanScrollLeft,
       setCanScrollRight,
-    });
+    ]);
 
     if (items.length === 0) {
       return null;

--- a/packages/instantsearch-ui-components/src/components/Carousel.tsx
+++ b/packages/instantsearch-ui-components/src/components/Carousel.tsx
@@ -174,7 +174,58 @@ export function createCarouselComponent({
   Fragment,
   useEffect,
   useRef,
-}: Renderer & Pick<Hooks, 'useEffect' | 'useRef'>) {
+}: Renderer & Partial<Pick<Hooks, 'useEffect' | 'useRef'>>) {
+  // `useEffect` and `useRef` are optional so callers written against the
+  // pre-measurement signature keep compiling. Whether they were supplied is
+  // fixed when the component is created, so the branch below is stable for the
+  // component's whole lifetime and never changes hook order between renders.
+  const measurementHooks = useEffect && useRef ? { useEffect, useRef } : null;
+
+  /**
+   * Remeasures the list whenever the item count changes.
+   *
+   * Without the hooks this is inert, which is the behaviour callers had before
+   * item-count measurement existed: navigation state is then only recomputed on
+   * scroll.
+   */
+  const useItemCountMeasurement = measurementHooks
+    ? (itemCount: number, navigation: CarouselNavigationProps) => {
+        const previousItemCountRef = measurementHooks.useRef(itemCount);
+        // Destructured so the effect depends on the individually stable refs and
+        // setters rather than on the object literal, which is new every render.
+        const {
+          listRef,
+          nextButtonRef,
+          previousButtonRef,
+          setCanScrollLeft,
+          setCanScrollRight,
+        } = navigation;
+
+        measurementHooks.useEffect(() => {
+          if (previousItemCountRef.current !== itemCount) {
+            updateNavigationButtonsProps({
+              listRef,
+              nextButtonRef,
+              previousButtonRef,
+              setCanScrollLeft,
+              setCanScrollRight,
+            });
+            previousItemCountRef.current = itemCount;
+          }
+          // `previousItemCountRef` is a ref and therefore stable; it is listed
+          // only because the lint rule cannot see through `measurementHooks`.
+        }, [
+          itemCount,
+          listRef,
+          nextButtonRef,
+          previousButtonRef,
+          setCanScrollLeft,
+          setCanScrollRight,
+          previousItemCountRef,
+        ]);
+      }
+    : (_itemCount: number, _navigation: CarouselNavigationProps) => {};
+
   return function Carousel<TObject extends Record<string, unknown>>(
     userProps: CarouselProps<TObject>
   ) {
@@ -210,8 +261,6 @@ export function createCarouselComponent({
       previousButtonTitle: 'Previous',
       ...userTranslations,
     };
-    const previousItemsLengthRef = useRef(items.length);
-
     const cssClasses: CarouselClassNames = {
       root: cx('ais-Carousel', classNames.root),
       list: cx('ais-Carousel-list', classNames.list),
@@ -239,25 +288,13 @@ export function createCarouselComponent({
       }
     }
 
-    useEffect(() => {
-      if (previousItemsLengthRef.current !== items.length) {
-        updateNavigationButtonsProps({
-          listRef,
-          nextButtonRef,
-          previousButtonRef,
-          setCanScrollLeft,
-          setCanScrollRight,
-        });
-        previousItemsLengthRef.current = items.length;
-      }
-    }, [
-      items.length,
+    useItemCountMeasurement(items.length, {
       listRef,
       nextButtonRef,
       previousButtonRef,
       setCanScrollLeft,
       setCanScrollRight,
-    ]);
+    });
 
     if (items.length === 0) {
       return null;

--- a/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
@@ -402,16 +402,24 @@ describe('Carousel', () => {
       await waitFor(() => expect(nextButton(container)).not.toBeVisible());
     });
 
-    test('keeps the next control when the items overflow', async () => {
+    test('reverses the next control from hidden to visible once the list overflows', async () => {
+      const third = { objectID: '3', __position: 3 };
       const { container, rerender } = render(
         <CarouselWithRefs items={items.slice(0, 1)} sendEvent={jest.fn()} />
       );
-      setGeometry(container.querySelector('.ais-Carousel-list')!, {
-        clientWidth: 200,
-        scrollWidth: 400,
-      });
+      const list = container.querySelector('.ais-Carousel-list')!;
 
+      setGeometry(list, { clientWidth: 400, scrollWidth: 400 });
       rerender(<CarouselWithRefs items={items} sendEvent={jest.fn()} />);
+
+      await waitFor(() => expect(nextButton(container)).not.toBeVisible());
+
+      // Same carousel instance, same node: only the measurement changed, so a
+      // list that starts fitting must hand its control back once it overflows.
+      setGeometry(list, { clientWidth: 200, scrollWidth: 400 });
+      rerender(
+        <CarouselWithRefs items={[...items, third]} sendEvent={jest.fn()} />
+      );
 
       await waitFor(() => expect(nextButton(container)).toBeVisible());
     });

--- a/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
@@ -14,6 +14,8 @@ import type { CarouselProps } from '../Carousel';
 const Carousel = createCarouselComponent({
   createElement: createElement as Pragma,
   Fragment,
+  useEffect,
+  useRef,
 });
 
 function CarouselWithRefs(

--- a/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
@@ -18,6 +18,14 @@ const Carousel = createCarouselComponent({
   useRef,
 });
 
+// Source-compatibility case: the pre-measurement call shape must keep compiling.
+// This is a type assertion as much as a runtime one; `yarn type-check` fails if
+// the hooks become required again.
+const LegacyCarousel = createCarouselComponent({
+  createElement: createElement as Pragma,
+  Fragment,
+});
+
 function CarouselWithRefs(
   props: Omit<
     CarouselProps<RecordWithObjectID>,
@@ -421,6 +429,73 @@ describe('Carousel', () => {
         <CarouselWithRefs items={[...items, third]} sendEvent={jest.fn()} />
       );
 
+      await waitFor(() => expect(nextButton(container)).toBeVisible());
+    });
+  });
+  describe('source compatibility with the pre-measurement signature', () => {
+    const items = [
+      { objectID: '1', __position: 1 },
+      { objectID: '2', __position: 2 },
+    ];
+    const nextButton = (container: Element) =>
+      container.querySelector<HTMLButtonElement>(
+        '.ais-Carousel-navigation--next'
+      )!;
+
+    function LegacyCarouselWithRefs(
+      props: Omit<
+        CarouselProps<RecordWithObjectID>,
+        | 'listRef'
+        | 'nextButtonRef'
+        | 'previousButtonRef'
+        | 'carouselIdRef'
+        | 'canScrollLeft'
+        | 'canScrollRight'
+        | 'setCanScrollLeft'
+        | 'setCanScrollRight'
+      >
+    ) {
+      return (
+        <LegacyCarousel
+          listRef={useRef(null)}
+          nextButtonRef={useRef(null)}
+          previousButtonRef={useRef(null)}
+          carouselIdRef={useRef(generateCarouselId())}
+          canScrollLeft={false}
+          canScrollRight={false}
+          setCanScrollLeft={() => {}}
+          setCanScrollRight={() => {}}
+          {...props}
+        />
+      );
+    }
+
+    test('renders without the measurement hooks', () => {
+      const { container } = render(
+        <LegacyCarouselWithRefs items={items} sendEvent={jest.fn()} />
+      );
+
+      expect(container.querySelector('.ais-Carousel')).toBeInTheDocument();
+      expect(container.querySelectorAll('.ais-Carousel-item')).toHaveLength(2);
+    });
+
+    test('stays inert on item changes, as it did before measurement existed', async () => {
+      const { container, rerender } = render(
+        <LegacyCarouselWithRefs
+          items={items.slice(0, 1)}
+          sendEvent={jest.fn()}
+        />
+      );
+      const list = container.querySelector('.ais-Carousel-list')!;
+
+      Object.defineProperties(list, {
+        clientWidth: { configurable: true, value: 400 },
+        scrollWidth: { configurable: true, value: 400 },
+      });
+      rerender(<LegacyCarouselWithRefs items={items} sendEvent={jest.fn()} />);
+
+      // The hook-enabled carousel hides this control here. Without the hooks no
+      // measurement runs, so the control keeps its unmeasured default.
       await waitFor(() => expect(nextButton(container)).toBeVisible());
     });
   });

--- a/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
@@ -369,8 +369,8 @@ describe('Carousel', () => {
     consoleError.mockRestore();
   });
   describe('built-in navigation on item count change', () => {
-    // jsdom reports zero dimensions, so both directions need explicit widths.
-    // Without them a test only proves the measurement ran, not what it decided.
+    // jsdom reports zero dimensions, so without explicit widths a test only
+    // proves the measurement ran, not what it decided.
     const setGeometry = (
       list: Element,
       { clientWidth, scrollWidth }: { clientWidth: number; scrollWidth: number }
@@ -414,8 +414,6 @@ describe('Carousel', () => {
 
       await waitFor(() => expect(nextButton(container)).not.toBeVisible());
 
-      // Same carousel instance, same node: only the measurement changed, so a
-      // list that starts fitting must hand its control back once it overflows.
       setGeometry(list, { clientWidth: 200, scrollWidth: 400 });
       rerender(
         <CarouselWithRefs items={[...items, third]} sendEvent={jest.fn()} />

--- a/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
@@ -315,7 +315,7 @@ describe('Carousel', () => {
       ({ item }) => {
         useEffect(() => {
           mounts.push(item.objectID);
-        }, []);
+        }, [item.objectID]);
 
         return <div>{item.objectID}</div>;
       };

--- a/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
@@ -18,14 +18,6 @@ const Carousel = createCarouselComponent({
   useRef,
 });
 
-// Source-compatibility case: the pre-measurement call shape must keep compiling.
-// This is a type assertion as much as a runtime one; `yarn type-check` fails if
-// the hooks become required again.
-const LegacyCarousel = createCarouselComponent({
-  createElement: createElement as Pragma,
-  Fragment,
-});
-
 function CarouselWithRefs(
   props: Omit<
     CarouselProps<RecordWithObjectID>,
@@ -429,73 +421,6 @@ describe('Carousel', () => {
         <CarouselWithRefs items={[...items, third]} sendEvent={jest.fn()} />
       );
 
-      await waitFor(() => expect(nextButton(container)).toBeVisible());
-    });
-  });
-  describe('source compatibility with the pre-measurement signature', () => {
-    const items = [
-      { objectID: '1', __position: 1 },
-      { objectID: '2', __position: 2 },
-    ];
-    const nextButton = (container: Element) =>
-      container.querySelector<HTMLButtonElement>(
-        '.ais-Carousel-navigation--next'
-      )!;
-
-    function LegacyCarouselWithRefs(
-      props: Omit<
-        CarouselProps<RecordWithObjectID>,
-        | 'listRef'
-        | 'nextButtonRef'
-        | 'previousButtonRef'
-        | 'carouselIdRef'
-        | 'canScrollLeft'
-        | 'canScrollRight'
-        | 'setCanScrollLeft'
-        | 'setCanScrollRight'
-      >
-    ) {
-      return (
-        <LegacyCarousel
-          listRef={useRef(null)}
-          nextButtonRef={useRef(null)}
-          previousButtonRef={useRef(null)}
-          carouselIdRef={useRef(generateCarouselId())}
-          canScrollLeft={false}
-          canScrollRight={false}
-          setCanScrollLeft={() => {}}
-          setCanScrollRight={() => {}}
-          {...props}
-        />
-      );
-    }
-
-    test('renders without the measurement hooks', () => {
-      const { container } = render(
-        <LegacyCarouselWithRefs items={items} sendEvent={jest.fn()} />
-      );
-
-      expect(container.querySelector('.ais-Carousel')).toBeInTheDocument();
-      expect(container.querySelectorAll('.ais-Carousel-item')).toHaveLength(2);
-    });
-
-    test('stays inert on item changes, as it did before measurement existed', async () => {
-      const { container, rerender } = render(
-        <LegacyCarouselWithRefs
-          items={items.slice(0, 1)}
-          sendEvent={jest.fn()}
-        />
-      );
-      const list = container.querySelector('.ais-Carousel-list')!;
-
-      Object.defineProperties(list, {
-        clientWidth: { configurable: true, value: 400 },
-        scrollWidth: { configurable: true, value: 400 },
-      });
-      rerender(<LegacyCarouselWithRefs items={items} sendEvent={jest.fn()} />);
-
-      // The hook-enabled carousel hides this control here. Without the hooks no
-      // measurement runs, so the control keeps its unmeasured default.
       await waitFor(() => expect(nextButton(container)).toBeVisible());
     });
   });

--- a/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
@@ -4,7 +4,7 @@
 /** @jsx createElement */
 import { render } from '@testing-library/preact';
 import { createElement, Fragment } from 'preact';
-import { useRef } from 'preact/hooks';
+import { useEffect, useRef } from 'preact/hooks';
 
 import { createCarouselComponent, generateCarouselId } from '../Carousel';
 
@@ -307,5 +307,63 @@ describe('Carousel', () => {
     expect(
       container.querySelector('.ais-Carousel-navigation--next')
     ).toHaveClass('NAVIGATION', 'NAVIGATION_NEXT');
+  });
+
+  test('keeps retained item components mounted when an item is inserted first', () => {
+    const mounts: string[] = [];
+    const TrackingItemComponent: CarouselProps<RecordWithObjectID>['itemComponent'] =
+      ({ item }) => {
+        useEffect(() => {
+          mounts.push(item.objectID);
+        }, []);
+
+        return <div>{item.objectID}</div>;
+      };
+    const initialItems = [
+      { objectID: '1', __position: 1 },
+      { objectID: '2', __position: 2 },
+    ];
+    const { rerender } = render(
+      <CarouselWithRefs
+        sendEvent={jest.fn()}
+        items={initialItems}
+        itemComponent={TrackingItemComponent}
+      />
+    );
+
+    expect(mounts).toEqual(['1', '2']);
+
+    rerender(
+      <CarouselWithRefs
+        sendEvent={jest.fn()}
+        items={[{ objectID: '0', __position: 1 }, ...initialItems]}
+        itemComponent={TrackingItemComponent}
+      />
+    );
+
+    expect(mounts).toEqual(['1', '2', '0']);
+  });
+
+  test('renders repeated and key-like object IDs without duplicate key warnings', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const { getAllByText } = render(
+      <CarouselWithRefs
+        sendEvent={jest.fn()}
+        items={[
+          { objectID: '1', __position: 1 },
+          { objectID: '1', __position: 2 },
+          { objectID: '1:0', __position: 3 },
+        ]}
+        itemComponent={ItemComponent}
+      />
+    );
+
+    expect(getAllByText('1')).toHaveLength(2);
+    expect(getAllByText('1:0')).toHaveLength(1);
+    expect(consoleError).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
   });
 });

--- a/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/__tests__/Carousel.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 /** @jsx createElement */
-import { render } from '@testing-library/preact';
+import { render, waitFor } from '@testing-library/preact';
 import { createElement, Fragment } from 'preact';
 import { useEffect, useRef } from 'preact/hooks';
 
@@ -367,5 +367,53 @@ describe('Carousel', () => {
     expect(consoleError).not.toHaveBeenCalled();
 
     consoleError.mockRestore();
+  });
+  describe('built-in navigation on item count change', () => {
+    // jsdom reports zero dimensions, so both directions need explicit widths.
+    // Without them a test only proves the measurement ran, not what it decided.
+    const setGeometry = (
+      list: Element,
+      { clientWidth, scrollWidth }: { clientWidth: number; scrollWidth: number }
+    ) =>
+      Object.defineProperties(list, {
+        clientWidth: { configurable: true, value: clientWidth },
+        scrollWidth: { configurable: true, value: scrollWidth },
+      });
+    const items = [
+      { objectID: '1', __position: 1 },
+      { objectID: '2', __position: 2 },
+    ];
+    const nextButton = (container: Element) =>
+      container.querySelector<HTMLButtonElement>(
+        '.ais-Carousel-navigation--next'
+      )!;
+
+    test('hides the next control when the items fit', async () => {
+      const { container, rerender } = render(
+        <CarouselWithRefs items={items.slice(0, 1)} sendEvent={jest.fn()} />
+      );
+      setGeometry(container.querySelector('.ais-Carousel-list')!, {
+        clientWidth: 400,
+        scrollWidth: 400,
+      });
+
+      rerender(<CarouselWithRefs items={items} sendEvent={jest.fn()} />);
+
+      await waitFor(() => expect(nextButton(container)).not.toBeVisible());
+    });
+
+    test('keeps the next control when the items overflow', async () => {
+      const { container, rerender } = render(
+        <CarouselWithRefs items={items.slice(0, 1)} sendEvent={jest.fn()} />
+      );
+      setGeometry(container.querySelector('.ais-Carousel-list')!, {
+        clientWidth: 200,
+        scrollWidth: 400,
+      });
+
+      rerender(<CarouselWithRefs items={items} sendEvent={jest.fn()} />);
+
+      await waitFor(() => expect(nextButton(container)).toBeVisible());
+    });
   });
 });

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -399,6 +399,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
             >
               <ToolLayoutComponent
                 message={toolMessage}
+                status={status}
                 indexUiState={indexUiState}
                 setIndexUiState={setIndexUiState}
                 messages={messages}

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/CarouselTool.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/CarouselTool.test.tsx
@@ -4,7 +4,7 @@
 /** @jsx createElement */
 import { render } from '@testing-library/preact';
 import { createElement, Fragment } from 'preact';
-import { useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import { createCarouselToolComponent } from '../tools/CarouselTool';
 
@@ -17,6 +17,7 @@ type InputHit = { objectID: string; name: string };
 const CarouselTool = createCarouselToolComponent<Hit>({
   createElement: createElement as Pragma,
   Fragment,
+  useEffect,
   useMemo,
   useRef,
   useState,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/CarouselTool.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/CarouselTool.test.tsx
@@ -23,6 +23,17 @@ const CarouselTool = createCarouselToolComponent<Hit>({
   useState,
 });
 
+// Source-compatibility case: the pre-measurement call shape, without
+// `useEffect`, must keep compiling. `yarn type-check` fails if it becomes
+// required again.
+createCarouselToolComponent<Hit>({
+  createElement: createElement as Pragma,
+  Fragment,
+  useMemo,
+  useRef,
+  useState,
+});
+
 type ItemComponentProps = NonNullable<
   Parameters<typeof CarouselTool>[0]['itemComponent']
 >;

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/CarouselTool.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/CarouselTool.test.tsx
@@ -23,17 +23,6 @@ const CarouselTool = createCarouselToolComponent<Hit>({
   useState,
 });
 
-// Source-compatibility case: the pre-measurement call shape, without
-// `useEffect`, must keep compiling. `yarn type-check` fails if it becomes
-// required again.
-createCarouselToolComponent<Hit>({
-  createElement: createElement as Pragma,
-  Fragment,
-  useMemo,
-  useRef,
-  useState,
-});
-
 type ItemComponentProps = NonNullable<
   Parameters<typeof CarouselTool>[0]['itemComponent']
 >;

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -1092,6 +1092,9 @@ describe('ChatMessage', () => {
   });
 
   test('renders with tools', () => {
+    const layoutComponent = jest.fn(({ message }) => (
+      <div className="wrapper">{JSON.stringify(message.output)}</div>
+    ));
     const { container } = render(
       <ChatMessage
         indexUiState={{}}
@@ -1112,9 +1115,7 @@ describe('ChatMessage', () => {
         status="ready"
         tools={{
           test_tool: {
-            layoutComponent: ({ message }) => (
-              <div className="wrapper">{JSON.stringify(message.output)}</div>
-            ),
+            layoutComponent,
             addToolResult: jest.fn(),
             onToolCall: jest.fn(),
             applyFilters: jest.fn(),
@@ -1122,6 +1123,9 @@ describe('ChatMessage', () => {
         }}
         onClose={jest.fn()}
       />
+    );
+    expect(layoutComponent.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ status: 'ready' })
     );
     expect(container).toMatchInlineSnapshot(`
       <div>

--- a/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
@@ -170,8 +170,6 @@ export function createCarouselToolComponent<
       addAbsolutePosition(hits, 0, hits.length),
       output?.queryID
     );
-    const nbItems = items.length;
-
     const [canScrollLeft, setCanScrollLeft] = useState(false);
     const [canScrollRight, setCanScrollRight] = useState(true);
 
@@ -208,7 +206,6 @@ export function createCarouselToolComponent<
             showViewAll={showViewAll}
             nbHits={output?.nbHits}
             input={input}
-            nbItems={nbItems}
             applyFilters={applyFilters}
             getSearchPageURL={getSearchPageURL}
             onClose={onClose}
@@ -222,7 +219,6 @@ export function createCarouselToolComponent<
           showViewAll={showViewAll}
           nbHits={output?.nbHits}
           input={input}
-          nbItems={nbItems}
           applyFilters={applyFilters}
           getSearchPageURL={getSearchPageURL}
           onClose={onClose}
@@ -234,7 +230,6 @@ export function createCarouselToolComponent<
       HeaderComponent,
       output?.nbHits,
       input,
-      nbItems,
       applyFilters,
       getSearchPageURL,
       onClose,

--- a/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
@@ -137,7 +137,11 @@ export function createCarouselToolComponent<
   useMemo,
   useRef,
   useState,
-}: Renderer & Pick<Hooks, 'useEffect' | 'useMemo' | 'useRef' | 'useState'>) {
+}: Renderer &
+  Pick<Hooks, 'useMemo' | 'useRef' | 'useState'> &
+  // Optional so callers written before item-count measurement keep compiling.
+  // Without it the carousel stays inert on item changes, as it was before.
+  Partial<Pick<Hooks, 'useEffect'>>) {
   const DefaultHeader = createHeaderComponent({ createElement, Fragment });
   const Carousel = createCarouselComponent({
     createElement,

--- a/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
@@ -11,10 +11,7 @@ import type {
   CarouselProps,
   HeaderComponentProps as CarouselHeaderComponentProps,
 } from '../../Carousel';
-import type {
-  ClientSideToolComponentProps,
-  SearchToolInput,
-} from '../types';
+import type { ClientSideToolComponentProps, SearchToolInput } from '../types';
 import type { SearchParameters } from 'algoliasearch-helper';
 
 type HeaderProps = {
@@ -136,12 +133,18 @@ export function createCarouselToolComponent<
 >({
   createElement,
   Fragment,
+  useEffect,
   useMemo,
   useRef,
   useState,
-}: Renderer & Pick<Hooks, 'useMemo' | 'useRef' | 'useState'>) {
+}: Renderer & Pick<Hooks, 'useEffect' | 'useMemo' | 'useRef' | 'useState'>) {
   const DefaultHeader = createHeaderComponent({ createElement, Fragment });
-  const Carousel = createCarouselComponent({ createElement, Fragment });
+  const Carousel = createCarouselComponent({
+    createElement,
+    Fragment,
+    useEffect,
+    useRef,
+  });
 
   return function CarouselTool(userProps: CarouselToolProps<TObject>) {
     const {

--- a/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
@@ -137,11 +137,7 @@ export function createCarouselToolComponent<
   useMemo,
   useRef,
   useState,
-}: Renderer &
-  Pick<Hooks, 'useMemo' | 'useRef' | 'useState'> &
-  // Optional so callers written before item-count measurement keep compiling.
-  // Without it the carousel stays inert on item changes, as it was before.
-  Partial<Pick<Hooks, 'useEffect'>>) {
+}: Renderer & Pick<Hooks, 'useEffect' | 'useMemo' | 'useRef' | 'useState'>) {
   const DefaultHeader = createHeaderComponent({ createElement, Fragment });
   const Carousel = createCarouselComponent({
     createElement,

--- a/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
@@ -8,7 +8,7 @@ import type { ClientSideToolComponentProps } from '../types';
 export type DisplayResultsTranslations = {
   /**
    * Caption shown under the groups while the tool is still streaming its
-   * output. Defaults to "Curating results…".
+   * input. Defaults to "Curating results…".
    */
   streamingLabel: string;
 };
@@ -19,10 +19,21 @@ type DisplayResultsGroup<THit> = {
   results?: Array<RecordWithObjectID<THit>>;
 };
 
-type DisplayResultsOutput<THit> = {
+type DisplayResultsPayload<THit> = {
   intro?: string;
   groups?: Array<DisplayResultsGroup<THit>>;
 };
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object';
+
+const hasOwn = (value: Record<string, unknown>, key: string) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const claimsDisplayResultsPayload = (
+  value: unknown
+): value is Record<string, unknown> =>
+  isObject(value) && (hasOwn(value, 'intro') || hasOwn(value, 'groups'));
 
 /**
  * An item handed to a group's carousel: the record (hydrated from the search
@@ -83,15 +94,79 @@ export function createDisplayResultsToolComponent<
       [messages, toolCallId]
     );
 
-    const output = message?.output as DisplayResultsOutput<TObject> | undefined;
-    const intro = typeof output?.intro === 'string' ? output.intro : undefined;
-    const groups = Array.isArray(output?.groups) ? output.groups : [];
-
-    const isStreaming =
+    const inputClaimsPayload = claimsDisplayResultsPayload(message?.input);
+    const legacyOutput =
       message?.state === 'output-available' &&
-      (message as { preliminary?: boolean }).preliminary === true;
+      (message as { preliminary?: boolean }).preliminary !== true &&
+      !inputClaimsPayload
+        ? message.output
+        : undefined;
+    const payload = (
+      inputClaimsPayload
+        ? message?.input
+        : claimsDisplayResultsPayload(legacyOutput)
+        ? legacyOutput
+        : undefined
+    ) as DisplayResultsPayload<TObject> | undefined;
+    const intro =
+      typeof payload?.intro === 'string' ? payload.intro : undefined;
+    const groups = Array.isArray(payload?.groups)
+      ? payload.groups.filter(isObject)
+      : [];
+    const isStreaming = message?.state === 'input-streaming';
 
-    if (!intro && groups.length === 0) {
+    const renderableGroups = groups.reduce<
+      Array<{
+        key: number;
+        title?: string;
+        why?: string;
+        items: Array<DisplayResultsItem<TObject>>;
+      }>
+    >((renderedGroups, group, groupIndex) => {
+      const results = Array.isArray(group.results)
+        ? group.results.filter(
+            (result): result is RecordWithObjectID<TObject> =>
+              isObject(result) &&
+              typeof result.objectID === 'string' &&
+              result.objectID !== ''
+          )
+        : [];
+
+      const items = results.reduce<Array<DisplayResultsItem<TObject>>>(
+        (renderedItems, result, resultIndex) => {
+          const hydrated = hitsByObjectID?.[result.objectID] as
+            | RecordWithObjectID<TObject>
+            | undefined;
+
+          if (!hydrated) {
+            return renderedItems;
+          }
+
+          renderedItems.push({
+            ...hydrated,
+            objectID: result.objectID,
+            __position: resultIndex + 1,
+            __displayToolResult: result,
+          });
+          return renderedItems;
+        },
+        []
+      );
+
+      if (items.length === 0) {
+        return renderedGroups;
+      }
+
+      renderedGroups.push({
+        key: groupIndex,
+        title: typeof group.title === 'string' ? group.title : undefined,
+        why: typeof group.why === 'string' ? group.why : undefined,
+        items,
+      });
+      return renderedGroups;
+    }, []);
+
+    if (!intro && renderableGroups.length === 0 && !isStreaming) {
       return <Fragment />;
     }
 
@@ -101,49 +176,21 @@ export function createDisplayResultsToolComponent<
           <div className="ais-ChatToolDisplayResults-intro">{intro}</div>
         )}
 
-        {groups.map((group, groupIndex) => {
-          const results = Array.isArray(group.results)
-            ? group.results.filter(
-                (r): r is RecordWithObjectID<TObject> =>
-                  Boolean(r) &&
-                  typeof r.objectID === 'string' &&
-                  r.objectID !== ''
-              )
-            : [];
-
-          if (results.length === 0) return null;
-
-          const items: Array<DisplayResultsItem<TObject>> = results.map(
-            (result, idx) => {
-              const hydrated = hitsByObjectID?.[result.objectID] as
-                | RecordWithObjectID<TObject>
-                | undefined;
-
-              return {
-                ...(hydrated as RecordWithObjectID<TObject>),
-                objectID: result.objectID,
-                __position: idx + 1,
-                __displayToolResult: result,
-              };
-            }
-          );
-
-          return (
-            <div key={groupIndex} className="ais-ChatToolDisplayResults-group">
-              {group.title && (
-                <div className="ais-ChatToolDisplayResults-groupTitle">
-                  {group.title}
-                </div>
-              )}
-              {group.why && (
-                <div className="ais-ChatToolDisplayResults-groupWhy">
-                  {group.why}
-                </div>
-              )}
-              {renderGroupCarousel({ items, sendEvent })}
-            </div>
-          );
-        })}
+        {renderableGroups.map((group) => (
+          <div key={group.key} className="ais-ChatToolDisplayResults-group">
+            {group.title && (
+              <div className="ais-ChatToolDisplayResults-groupTitle">
+                {group.title}
+              </div>
+            )}
+            {group.why && (
+              <div className="ais-ChatToolDisplayResults-groupWhy">
+                {group.why}
+              </div>
+            )}
+            {renderGroupCarousel({ items: group.items, sendEvent })}
+          </div>
+        ))}
 
         {isStreaming && (
           <div className="ais-ChatToolDisplayResults-streaming">

--- a/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
@@ -134,13 +134,13 @@ export function createDisplayResultsToolComponent<
 
       const items = results.reduce<Array<DisplayResultsItem<TObject>>>(
         (renderedItems, result, resultIndex) => {
-          const hydrated = hitsByObjectID?.[result.objectID] as
-            | RecordWithObjectID<TObject>
-            | undefined;
-
-          if (!hydrated) {
+          if (!hitsByObjectID || !hasOwn(hitsByObjectID, result.objectID)) {
             return renderedItems;
           }
+
+          const hydrated = hitsByObjectID[
+            result.objectID
+          ] as RecordWithObjectID<TObject>;
 
           renderedItems.push({
             ...hydrated,

--- a/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
@@ -81,7 +81,7 @@ export function createDisplayResultsToolComponent<
       groupCarouselComponent: renderGroupCarousel,
       translations: userTranslations,
     } = userProps;
-    const { message, messages, sendEvent } = toolProps;
+    const { message, messages, sendEvent, status } = toolProps;
 
     const translations: DisplayResultsTranslations = {
       ...DEFAULT_TRANSLATIONS,
@@ -112,7 +112,11 @@ export function createDisplayResultsToolComponent<
     const groups = Array.isArray(payload?.groups)
       ? payload.groups.filter(isObject)
       : [];
-    const isStreaming = message?.state === 'input-streaming';
+    const latestMessage = messages?.[messages.length - 1];
+    const isStreaming =
+      status === 'streaming' &&
+      message?.state === 'input-streaming' &&
+      latestMessage?.parts.some((part) => part === message) === true;
 
     const renderableGroups = groups.reduce<
       Array<{

--- a/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
@@ -88,10 +88,9 @@ export function createDisplayResultsToolComponent<
       ...userTranslations,
     };
 
-    const toolCallId = message?.toolCallId;
     const hitsByObjectID = useMemo(
-      () => (messages ? getHitsByObjectID(messages, toolCallId) : undefined),
-      [messages, toolCallId]
+      () => (messages ? getHitsByObjectID(messages, message) : undefined),
+      [messages, message]
     );
 
     const inputClaimsPayload = claimsDisplayResultsPayload(message?.input);

--- a/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
@@ -133,7 +133,7 @@ export function createDisplayResultsToolComponent<
         : [];
 
       const items = results.reduce<Array<DisplayResultsItem<TObject>>>(
-        (renderedItems, result, resultIndex) => {
+        (renderedItems, result) => {
           if (!hitsByObjectID || !hasOwn(hitsByObjectID, result.objectID)) {
             return renderedItems;
           }
@@ -145,7 +145,7 @@ export function createDisplayResultsToolComponent<
           renderedItems.push({
             ...hydrated,
             objectID: result.objectID,
-            __position: resultIndex + 1,
+            __position: renderedItems.length + 1,
             __displayToolResult: result,
           });
           return renderedItems;

--- a/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/DisplayResultsTool.tsx
@@ -35,6 +35,92 @@ const claimsDisplayResultsPayload = (
 ): value is Record<string, unknown> =>
   isObject(value) && (hasOwn(value, 'intro') || hasOwn(value, 'groups'));
 
+type JsonFrame = { key: string; lastKey: string; isObject: boolean };
+
+/**
+ * Decodes a raw property-key body with JSON string semantics, so an escaped
+ * spelling of `objectID` compares equal to the name `JSON.parse` produces.
+ * An undecodable key is kept verbatim: it matches no name below, and the
+ * document holding it cannot parse either.
+ */
+const decodeJsonKey = (rawKey: string) => {
+  if (rawKey.indexOf('\\') === -1) {
+    return rawKey;
+  }
+  try {
+    return JSON.parse(`"${rawKey}"`) as string;
+  } catch {
+    return rawKey;
+  }
+};
+
+/**
+ * Reports whether the raw input ends inside an unterminated
+ * `groups[].results[].objectID` value.
+ *
+ * Partial input is parsed with repair that closes an open string literal, so an
+ * identifier still mid-delta reaches `input` looking complete and can hydrate a
+ * different record whose identifier is a prefix of the real one.
+ */
+const endsInsideResultObjectId = (rawInput: string) => {
+  const frames: JsonFrame[] = [];
+  let inString = false;
+  let isEscaped = false;
+  let isKey = false;
+  let expectValue = false;
+  let stringStart = 0;
+
+  for (let index = 0; index < rawInput.length; index++) {
+    const char = rawInput[index];
+
+    if (inString) {
+      if (isEscaped) {
+        isEscaped = false;
+      } else if (char === '\\') {
+        isEscaped = true;
+      } else if (char === '"') {
+        inString = false;
+        if (isKey) {
+          frames[frames.length - 1].lastKey = decodeJsonKey(
+            rawInput.slice(stringStart, index)
+          );
+        } else {
+          expectValue = false;
+        }
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      stringStart = index + 1;
+      isKey = !expectValue && frames[frames.length - 1]?.isObject === true;
+    } else if (char === ':') {
+      expectValue = true;
+    } else if (char === ',') {
+      expectValue = false;
+    } else if (char === '{' || char === '[') {
+      frames.push({
+        key: expectValue ? frames[frames.length - 1]?.lastKey ?? '' : '',
+        lastKey: '',
+        isObject: char === '{',
+      });
+      expectValue = false;
+    } else if (char === '}' || char === ']') {
+      frames.pop();
+      expectValue = false;
+    }
+  }
+
+  return (
+    inString &&
+    !isKey &&
+    frames[frames.length - 1]?.lastKey === 'objectID' &&
+    frames[frames.length - 2]?.key === 'results' &&
+    frames[frames.length - 4]?.key === 'groups'
+  );
+};
+
 /**
  * An item handed to a group's carousel: the record (hydrated from the search
  * tool) augmented with the display tool's own result object under a separate
@@ -118,6 +204,14 @@ export function createDisplayResultsToolComponent<
       message?.state === 'input-streaming' &&
       latestMessage?.parts.some((part) => part === message) === true;
 
+    // Only the last result of the last group can still be mid-delta, so it is
+    // the only one ever withheld.
+    const rawInput =
+      message?.state === 'input-streaming' ? message.rawInput : undefined;
+    const withholdsTrailingResult =
+      typeof rawInput === 'string' && endsInsideResultObjectId(rawInput);
+    const lastGroupIndex = groups.length - 1;
+
     const renderableGroups = groups.reduce<
       Array<{
         key: number;
@@ -126,14 +220,17 @@ export function createDisplayResultsToolComponent<
         items: Array<DisplayResultsItem<TObject>>;
       }>
     >((renderedGroups, group, groupIndex) => {
-      const results = Array.isArray(group.results)
-        ? group.results.filter(
-            (result): result is RecordWithObjectID<TObject> =>
-              isObject(result) &&
-              typeof result.objectID === 'string' &&
-              result.objectID !== ''
-          )
+      const suppliedResults = Array.isArray(group.results)
+        ? withholdsTrailingResult && groupIndex === lastGroupIndex
+          ? group.results.slice(0, -1)
+          : group.results
         : [];
+      const results = suppliedResults.filter(
+        (result): result is RecordWithObjectID<TObject> =>
+          isObject(result) &&
+          typeof result.objectID === 'string' &&
+          result.objectID !== ''
+      );
 
       const items = results.reduce<Array<DisplayResultsItem<TObject>>>(
         (renderedItems, result) => {

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -122,6 +122,12 @@ export type ToolUIPart<TTools extends UITools = UITools> = ValueOf<{
     | {
         state: 'input-streaming';
         input: DeepPartial<TTools[NAME]['input']> | undefined;
+        /**
+         * The raw accumulated input text. `input` is parsed from it with
+         * partial-JSON repair, so a value still mid-delta can be exposed as a
+         * complete one. Consult this when completeness matters.
+         */
+        rawInput?: string;
         providerExecuted?: boolean;
         output?: never;
         errorText?: never;

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -495,6 +495,7 @@ export type ChatLayoutOwnProps<
 export type ClientSideToolComponentProps = {
   message: ChatToolMessage;
   messages?: ChatMessageBase[];
+  status?: ChatStatus;
   indexUiState: object;
   setIndexUiState: (state: object) => void;
   onClose: () => void;

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -324,6 +324,45 @@ describe('getHitsByObjectID', () => {
   });
 
   test('returns an empty map when there are no search outputs', () => {
-    expect(getHitsByObjectID([])).toEqual({});
+    const hits = getHitsByObjectID([]);
+
+    expect(hits).toEqual({});
+    expect(hits.constructor).toBeUndefined();
+    expect(hits.__proto__).toBeUndefined();
+  });
+
+  test('stores prototype-named object IDs as own hydrated records', () => {
+    const constructorHit = {
+      objectID: 'constructor',
+      name: 'Constructor record',
+    };
+    const protoHit = {
+      objectID: '__proto__',
+      name: 'Prototype record',
+    };
+    const messages = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: {},
+            output: { hits: [constructorHit, protoHit] },
+          },
+        ],
+      },
+    ] as ChatMessageBase[];
+
+    const hits = getHitsByObjectID(messages);
+
+    expect(Object.prototype.hasOwnProperty.call(hits, 'constructor')).toBe(
+      true
+    );
+    expect(Object.prototype.hasOwnProperty.call(hits, '__proto__')).toBe(true);
+    expect(hits.constructor).toEqual(constructorHit);
+    expect(hits.__proto__).toEqual(protoHit);
   });
 });

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -287,6 +287,42 @@ describe('getHitsByObjectID', () => {
     });
   });
 
+  test('ignores searches after `untilToolCallId` in the same message', () => {
+    const messages: ChatMessageBase[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search-before',
+            state: 'output-available',
+            input: { query: 'shoes' },
+            output: { hits: [{ objectID: '1', name: 'Runner' }] },
+          },
+          {
+            type: 'tool-algolia_display_results',
+            toolCallId: 'display',
+            state: 'output-available',
+            input: {},
+            output: {},
+          },
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search-after',
+            state: 'output-available',
+            input: { query: 'future search' },
+            output: { hits: [{ objectID: '1', name: 'Future Runner' }] },
+          },
+        ],
+      },
+    ] as ChatMessageBase[];
+
+    expect(getHitsByObjectID(messages, 'display')).toEqual({
+      1: { objectID: '1', name: 'Runner' },
+    });
+  });
+
   test('returns an empty map when there are no search outputs', () => {
     expect(getHitsByObjectID([])).toEqual({});
   });

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -1,6 +1,6 @@
 import { getFacetFiltersFromToolInput, getHitsByObjectID } from '../chat';
 
-import type { ChatMessageBase } from '../../../components';
+import type { ChatMessageBase, ChatToolMessage } from '../../../components';
 
 describe('getFacetFiltersFromToolInput', () => {
   test('returns undefined when input is undefined', () => {
@@ -206,7 +206,7 @@ describe('getHitsByObjectID', () => {
     });
   });
 
-  test('scopes collection to the turn containing `untilToolCallId`, ignoring later searches', () => {
+  test('scopes collection to the owning tool part, ignoring later searches', () => {
     const messages: ChatMessageBase[] = [
       {
         id: '1',
@@ -248,7 +248,9 @@ describe('getHitsByObjectID', () => {
     ] as ChatMessageBase[];
 
     // Scoped to the first turn: the later search (with `q2`) must not leak in.
-    expect(getHitsByObjectID(messages, 'display-1')).toEqual({
+    expect(
+      getHitsByObjectID(messages, messages[0].parts[1] as ChatToolMessage)
+    ).toEqual({
       1: { objectID: '1', name: 'Runner', __queryID: 'q1' },
     });
 
@@ -258,7 +260,7 @@ describe('getHitsByObjectID', () => {
     });
   });
 
-  test('includes the search in the same message as `untilToolCallId`', () => {
+  test('includes the search before the boundary in the same message', () => {
     const messages: ChatMessageBase[] = [
       {
         id: '1',
@@ -282,12 +284,14 @@ describe('getHitsByObjectID', () => {
       },
     ] as ChatMessageBase[];
 
-    expect(getHitsByObjectID(messages, 'display')).toEqual({
+    expect(
+      getHitsByObjectID(messages, messages[0].parts[1] as ChatToolMessage)
+    ).toEqual({
       1: { objectID: '1', name: 'Runner' },
     });
   });
 
-  test('ignores searches after `untilToolCallId` in the same message', () => {
+  test('ignores searches after the boundary in the same message', () => {
     const messages: ChatMessageBase[] = [
       {
         id: '1',
@@ -318,9 +322,38 @@ describe('getHitsByObjectID', () => {
       },
     ] as ChatMessageBase[];
 
-    expect(getHitsByObjectID(messages, 'display')).toEqual({
+    expect(
+      getHitsByObjectID(messages, messages[0].parts[1] as ChatToolMessage)
+    ).toEqual({
       1: { objectID: '1', name: 'Runner' },
     });
+  });
+
+  test('fails closed when the boundary is not in the messages', () => {
+    const boundary = {
+      type: 'tool-algolia_display_results',
+      toolCallId: 'missing-display',
+      state: 'output-available',
+      input: {},
+      output: {},
+    } as ChatToolMessage;
+    const messages = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: {},
+            output: { hits: [{ objectID: '1', name: 'Runner' }] },
+          },
+        ],
+      },
+    ] as ChatMessageBase[];
+
+    expect(getHitsByObjectID(messages, boundary)).toEqual({});
   });
 
   test('returns an empty map when there are no search outputs', () => {

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -150,10 +150,9 @@ const collectHitsFromPart = (
  * preceding search tool already fetched.
  *
  * Pass `untilToolCallId` (the display tool's own `toolCallId`) to scope
- * collection to the turn that produced it: hits are only gathered up to and
- * including the message that contains that tool call. This prevents a later
- * turn's search from overwriting an earlier display tool's records (and their
- * per-query metadata like `__queryID`).
+ * collection to the call that produced it: hits are only gathered before the
+ * matching tool part. This prevents later searches from overwriting an earlier
+ * display tool's records and per-query metadata like `__queryID`.
  */
 export const getHitsByObjectID = (
   messages: ChatMessageBase[],
@@ -164,20 +163,20 @@ export const getHitsByObjectID = (
   for (const message of messages) {
     let reachedBoundary = false;
 
-    message.parts.forEach((part) => {
+    for (const part of message.parts) {
       if (!isPartTool(part)) {
-        return;
+        continue;
       }
-      // Note the boundary but keep processing the rest of this message's parts:
-      // the search tool that fed this display tool lives in the same message,
-      // so its hits must still be collected before we stop.
+
       if (untilToolCallId && part.toolCallId === untilToolCallId) {
         reachedBoundary = true;
+        break;
       }
+
       if (isSearchToolPart(part)) {
         collectHitsFromPart(part, hitsByObjectID);
       }
-    });
+    }
 
     if (reachedBoundary) {
       break;

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -149,27 +149,27 @@ const collectHitsFromPart = (
  * relies on this map to hydrate each result with the full record that the
  * preceding search tool already fetched.
  *
- * Pass `untilToolCallId` (the display tool's own `toolCallId`) to scope
- * collection to the call that produced it: hits are only gathered before the
- * matching tool part. This prevents later searches from overwriting an earlier
- * display tool's records and per-query metadata like `__queryID`.
+ * Pass the display tool's own message part to scope collection to that exact
+ * occurrence. This prevents reused tool call IDs and later searches from
+ * changing another display tool's records or per-query metadata like
+ * `__queryID`.
  */
 export const getHitsByObjectID = (
   messages: ChatMessageBase[],
-  untilToolCallId?: string
+  untilToolPart?: ChatToolMessage
 ): Record<string, RecordWithObjectID> => {
   const hitsByObjectID = Object.create(null) as Record<
     string,
     RecordWithObjectID
   >;
 
-  messages.some((message) =>
+  const reachedBoundary = messages.some((message) =>
     message.parts.some((part) => {
       if (!isPartTool(part)) {
         return false;
       }
 
-      if (untilToolCallId && part.toolCallId === untilToolCallId) {
+      if (untilToolPart && part === untilToolPart) {
         return true;
       }
 
@@ -180,6 +180,10 @@ export const getHitsByObjectID = (
       return false;
     })
   );
+
+  if (untilToolPart && !reachedBoundary) {
+    return Object.create(null) as Record<string, RecordWithObjectID>;
+  }
 
   return hitsByObjectID;
 };

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -158,30 +158,28 @@ export const getHitsByObjectID = (
   messages: ChatMessageBase[],
   untilToolCallId?: string
 ): Record<string, RecordWithObjectID> => {
-  const hitsByObjectID: Record<string, RecordWithObjectID> = {};
+  const hitsByObjectID = Object.create(null) as Record<
+    string,
+    RecordWithObjectID
+  >;
 
-  for (const message of messages) {
-    let reachedBoundary = false;
-
-    for (const part of message.parts) {
+  messages.some((message) =>
+    message.parts.some((part) => {
       if (!isPartTool(part)) {
-        continue;
+        return false;
       }
 
       if (untilToolCallId && part.toolCallId === untilToolCallId) {
-        reachedBoundary = true;
-        break;
+        return true;
       }
 
       if (isSearchToolPart(part)) {
         collectHitsFromPart(part, hitsByObjectID);
       }
-    }
 
-    if (reachedBoundary) {
-      break;
-    }
-  }
+      return false;
+    })
+  );
 
   return hitsByObjectID;
 };

--- a/packages/instantsearch.js/src/templates/carousel/carousel.tsx
+++ b/packages/instantsearch.js/src/templates/carousel/carousel.tsx
@@ -7,7 +7,7 @@ import {
   generateCarouselId,
 } from 'instantsearch-ui-components';
 import { Fragment, h } from 'preact';
-import { useRef, useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 
 import type {
   CarouselProps as CarouselUiProps,
@@ -17,6 +17,8 @@ import type {
 const Carousel = createCarouselComponent({
   createElement: h,
   Fragment,
+  useEffect,
+  useRef,
 });
 
 function CarouselWithRefs<TObject extends Record<string, unknown>>(

--- a/packages/instantsearch.js/src/templates/carousel/carousel.tsx
+++ b/packages/instantsearch.js/src/templates/carousel/carousel.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 
 import type {
   CarouselProps as CarouselUiProps,
+  HeaderComponentProps,
   VNode,
 } from 'instantsearch-ui-components';
 
@@ -69,15 +70,7 @@ type CreateCarouselTemplateProps<TObject extends Record<string, unknown>> = {
   templates?: Partial<{
     previous: Exclude<Template, string>;
     next: Exclude<Template, string>;
-    header: Exclude<
-      Template<{
-        canScrollLeft: boolean;
-        canScrollRight: boolean;
-        scrollLeft: () => void;
-        scrollRight: () => void;
-      }>,
-      string
-    >;
+    header: Exclude<Template<HeaderComponentProps>, string>;
   }>;
   cssClasses?: Partial<CarouselUiProps<TObject>['classNames']>;
   showNavigation?: boolean;
@@ -100,34 +93,33 @@ export function carousel<TObject extends Record<string, unknown>>({
   templates = {},
   showNavigation = true,
 }: CreateCarouselTemplateProps<TObject> = {}) {
+  const { previous, next, header } = templates;
+  const HeaderComponent = (
+    header
+      ? (props: HeaderComponentProps) => header({ html, ...props })
+      : undefined
+  ) as CarouselUiProps<TObject>['headerComponent'];
+  const PreviousIconComponent = (
+    previous ? () => previous({ html }) : undefined
+  ) as CarouselUiProps<TObject>['previousIconComponent'];
+  const NextIconComponent = (
+    next ? () => next({ html }) : undefined
+  ) as CarouselUiProps<TObject>['nextIconComponent'];
+
   return function CarouselTemplate({
     items,
     templates: widgetTemplates,
     cssClasses: widgetCssClasses = {},
     sendEvent = () => {},
   }: CarouselTemplateProps<TObject>) {
-    const { previous, next, header } = templates;
-
     return (
       <CarouselWithRefs
         items={items}
         sendEvent={sendEvent}
         itemComponent={widgetTemplates.item}
-        headerComponent={
-          (header
-            ? (props) => header({ html, ...props })
-            : undefined) as CarouselUiProps<TObject>['headerComponent']
-        }
-        previousIconComponent={
-          (previous
-            ? () => previous({ html })
-            : undefined) as CarouselUiProps<TObject>['previousIconComponent']
-        }
-        nextIconComponent={
-          (next
-            ? () => next({ html })
-            : undefined) as CarouselUiProps<TObject>['nextIconComponent']
-        }
+        headerComponent={HeaderComponent}
+        previousIconComponent={PreviousIconComponent}
+        nextIconComponent={NextIconComponent}
         classNames={{
           ...cssClasses,
           ...{

--- a/packages/instantsearch.js/src/widgets/chat/__tests__/display-results-tool.test.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/__tests__/display-results-tool.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+/** @jsx h */
+import { fireEvent, screen } from '@testing-library/dom';
+import { h, render } from 'preact';
+
+import { createDisplayResultsTool } from '../display-results-tool';
+
+import type { ClientSideToolComponentProps } from 'instantsearch-ui-components';
+import type { ComponentType } from 'preact';
+
+describe('createDisplayResultsTool', () => {
+  test('keeps item state while tool input streams', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const tool = createDisplayResultsTool({
+      item: (_item, { html }) =>
+        html`<input
+          aria-label="Display result item"
+          value="Original item value"
+        />`,
+    });
+    const LayoutComponent = tool.templates
+      .layout as unknown as ComponentType<ClientSideToolComponentProps>;
+    const createToolProps = (intro: string): ClientSideToolComponentProps => {
+      const message = {
+        type: 'tool-algolia_display_results',
+        toolCallId: 'display',
+        state: 'input-streaming',
+        input: {
+          intro,
+          groups: [
+            {
+              title: 'Products',
+              results: [{ objectID: '1' }],
+            },
+          ],
+        },
+      } as ClientSideToolComponentProps['message'];
+
+      return {
+        message,
+        messages: [
+          {
+            id: 'assistant-message-id',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-algolia_search_index',
+                toolCallId: 'search',
+                state: 'output-available',
+                input: { query: 'products' },
+                output: {
+                  hits: [{ objectID: '1', name: 'Product 1' }],
+                },
+              },
+              message,
+            ],
+          },
+        ] as ClientSideToolComponentProps['messages'],
+        indexUiState: {},
+        setIndexUiState: jest.fn(),
+        onClose: jest.fn(),
+        addToolResult: jest.fn(),
+        applyFilters: jest.fn(),
+        sendEvent: jest.fn(),
+      };
+    };
+
+    render(
+      <LayoutComponent {...createToolProps('Original intro')} />,
+      container
+    );
+
+    const inputBefore = screen.getByLabelText<HTMLInputElement>(
+      'Display result item'
+    );
+
+    fireEvent.input(inputBefore, {
+      target: { value: 'Edited during stream' },
+    });
+    inputBefore.focus();
+
+    render(
+      <LayoutComponent {...createToolProps('Updated intro')} />,
+      container
+    );
+
+    const inputAfter = screen.getByLabelText<HTMLInputElement>(
+      'Display result item'
+    );
+
+    expect(screen.getByText('Updated intro')).toBeInTheDocument();
+    expect(inputAfter).toBe(inputBefore);
+    expect(inputAfter).toHaveValue('Edited during stream');
+    expect(document.activeElement).toBe(inputAfter);
+  });
+});

--- a/packages/instantsearch.js/src/widgets/chat/__tests__/display-results-tool.test.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/__tests__/display-results-tool.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 /** @jsx h */
-import { fireEvent, screen } from '@testing-library/dom';
+import { fireEvent, screen, within } from '@testing-library/dom';
 import { h, render } from 'preact';
 
 import { createDisplayResultsTool } from '../display-results-tool';
@@ -10,7 +10,62 @@ import { createDisplayResultsTool } from '../display-results-tool';
 import type { ClientSideToolComponentProps } from 'instantsearch-ui-components';
 import type { ComponentType } from 'preact';
 
+const createToolProps = (
+  intro: string,
+  objectIDs = ['1']
+): ClientSideToolComponentProps => {
+  const message = {
+    type: 'tool-algolia_display_results',
+    toolCallId: 'display',
+    state: 'input-streaming',
+    input: {
+      intro,
+      groups: [
+        {
+          title: 'Products',
+          results: objectIDs.map((objectID) => ({ objectID })),
+        },
+      ],
+    },
+  } as ClientSideToolComponentProps['message'];
+
+  return {
+    message,
+    messages: [
+      {
+        id: 'assistant-message-id',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search',
+            state: 'output-available',
+            input: { query: 'products' },
+            output: {
+              hits: objectIDs.map((objectID) => ({
+                objectID,
+                name: `Product ${objectID}`,
+              })),
+            },
+          },
+          message,
+        ],
+      },
+    ] as ClientSideToolComponentProps['messages'],
+    indexUiState: {},
+    setIndexUiState: jest.fn(),
+    onClose: jest.fn(),
+    addToolResult: jest.fn(),
+    applyFilters: jest.fn(),
+    sendEvent: jest.fn(),
+  };
+};
+
 describe('createDisplayResultsTool', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
   test('keeps item state while tool input streams', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -24,50 +79,6 @@ describe('createDisplayResultsTool', () => {
     });
     const LayoutComponent = tool.templates
       .layout as unknown as ComponentType<ClientSideToolComponentProps>;
-    const createToolProps = (intro: string): ClientSideToolComponentProps => {
-      const message = {
-        type: 'tool-algolia_display_results',
-        toolCallId: 'display',
-        state: 'input-streaming',
-        input: {
-          intro,
-          groups: [
-            {
-              title: 'Products',
-              results: [{ objectID: '1' }],
-            },
-          ],
-        },
-      } as ClientSideToolComponentProps['message'];
-
-      return {
-        message,
-        messages: [
-          {
-            id: 'assistant-message-id',
-            role: 'assistant',
-            parts: [
-              {
-                type: 'tool-algolia_search_index',
-                toolCallId: 'search',
-                state: 'output-available',
-                input: { query: 'products' },
-                output: {
-                  hits: [{ objectID: '1', name: 'Product 1' }],
-                },
-              },
-              message,
-            ],
-          },
-        ] as ClientSideToolComponentProps['messages'],
-        indexUiState: {},
-        setIndexUiState: jest.fn(),
-        onClose: jest.fn(),
-        addToolResult: jest.fn(),
-        applyFilters: jest.fn(),
-        sendEvent: jest.fn(),
-      };
-    };
 
     render(
       <LayoutComponent {...createToolProps('Original intro')} />,
@@ -96,5 +107,40 @@ describe('createDisplayResultsTool', () => {
     expect(inputAfter).toBe(inputBefore);
     expect(inputAfter).toHaveValue('Edited during stream');
     expect(document.activeElement).toBe(inputAfter);
+  });
+
+  test('keeps carousel controls focused while tool input streams', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const tool = createDisplayResultsTool({
+      item: (item, { html }) => html`<span>${item.objectID}</span>`,
+    });
+    const LayoutComponent = tool.templates
+      .layout as unknown as ComponentType<ClientSideToolComponentProps>;
+
+    render(
+      <LayoutComponent {...createToolProps('Original intro')} />,
+      container
+    );
+
+    const list = container.querySelector('.ais-Carousel-list')!;
+    Object.defineProperties(list, {
+      clientWidth: { configurable: true, value: 100 },
+      scrollWidth: { configurable: true, value: 200 },
+    });
+    const nextButtonBefore = within(container).getAllByRole('button')[1];
+    nextButtonBefore.focus();
+
+    render(
+      <LayoutComponent {...createToolProps('Updated intro', ['1', '2'])} />,
+      container
+    );
+
+    const nextButtonAfter = within(container).getAllByRole('button')[1];
+
+    expect(screen.getByText('2 results')).toBeInTheDocument();
+    expect(nextButtonAfter).toBe(nextButtonBefore);
+    expect(document.activeElement).toBe(nextButtonAfter);
   });
 });

--- a/packages/instantsearch.js/src/widgets/chat/__tests__/display-results-tool.test.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/__tests__/display-results-tool.test.tsx
@@ -143,4 +143,25 @@ describe('createDisplayResultsTool', () => {
     expect(nextButtonAfter).toBe(nextButtonBefore);
     expect(document.activeElement).toBe(nextButtonAfter);
   });
+
+  test('names the carousel scroll controls', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const tool = createDisplayResultsTool({
+      item: (item, { html }) => html`<span>${item.objectID}</span>`,
+    });
+    const LayoutComponent = tool.templates
+      .layout as unknown as ComponentType<ClientSideToolComponentProps>;
+
+    render(<LayoutComponent {...createToolProps('Curating')} />, container);
+
+    // Icon-only controls carry no text, so the name has to come from the label.
+    expect(
+      within(container).getByRole('button', { name: 'Previous' })
+    ).toHaveClass('ais-ChatToolDisplayResultsCarouselHeaderScrollButton');
+    expect(within(container).getByRole('button', { name: 'Next' })).toHaveClass(
+      'ais-ChatToolDisplayResultsCarouselHeaderScrollButton'
+    );
+  });
 });

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -80,6 +80,34 @@ function getDefinedProperties<T extends object>(obj: T): Partial<T> {
   ) as Partial<T>;
 }
 
+function mergeToolOptions<TTool extends { streamInput?: boolean }>(
+  defaultTools: Record<string, TTool>,
+  userTools?: Record<string, TTool>
+): Record<string, TTool> {
+  if (!userTools) {
+    return defaultTools;
+  }
+
+  const tools = { ...defaultTools, ...userTools };
+
+  Object.keys(userTools).forEach((toolName) => {
+    const userTool = userTools[toolName];
+    const defaultStreamInput = defaultTools[toolName]?.streamInput;
+
+    if (
+      userTool.streamInput === undefined &&
+      defaultStreamInput !== undefined
+    ) {
+      tools[toolName] = {
+        ...userTool,
+        streamInput: defaultStreamInput,
+      };
+    }
+  });
+
+  return tools;
+}
+
 function createDefaultTools<
   THit extends RecordWithObjectID = RecordWithObjectID
 >(
@@ -1081,7 +1109,7 @@ export default (function chat<
 
   const defaultTools = createDefaultTools(templates, getSearchPageURL);
 
-  const tools = { ...defaultTools, ...userTools };
+  const tools = mergeToolOptions(defaultTools, userTools);
 
   // Inline layouts are always visible, so they don't require a `chatTrigger`
   // (or AI mode) to be present. We detect this via a `$$inlineLayout` marker

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -80,7 +80,12 @@ function getDefinedProperties<T extends object>(obj: T): Partial<T> {
   ) as Partial<T>;
 }
 
-function mergeToolOptions<TTool extends { streamInput?: boolean }>(
+function mergeToolOptions<
+  TTool extends {
+    streamInput?: boolean;
+    templates?: { layout?: unknown };
+  }
+>(
   defaultTools: Record<string, TTool>,
   userTools?: Record<string, TTool>
 ): Record<string, TTool> {
@@ -95,6 +100,7 @@ function mergeToolOptions<TTool extends { streamInput?: boolean }>(
     const defaultStreamInput = defaultTools[toolName]?.streamInput;
 
     if (
+      userTool.templates?.layout !== undefined &&
       userTool.streamInput === undefined &&
       defaultStreamInput !== undefined
     ) {

--- a/packages/instantsearch.js/src/widgets/chat/display-results-tool.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/display-results-tool.tsx
@@ -98,5 +98,6 @@ export function createDisplayResultsTool<
 
   return {
     templates: { layout: DisplayResultsLayoutComponent },
+    streamInput: true,
   };
 }

--- a/packages/instantsearch.js/src/widgets/chat/display-results-tool.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/display-results-tool.tsx
@@ -17,7 +17,10 @@ import type {
   ClientSideToolTemplateData,
   Tool as UserClientSideToolWithTemplate,
 } from './chat';
-import type { RecordWithObjectID } from 'instantsearch-ui-components';
+import type {
+  CarouselProps,
+  RecordWithObjectID,
+} from 'instantsearch-ui-components';
 
 export function createDisplayResultsTool<
   THit extends RecordWithObjectID = RecordWithObjectID
@@ -32,6 +35,17 @@ export function createDisplayResultsTool<
 
   const Button = createButtonComponent({ createElement: h });
 
+  const itemComponent: NonNullable<
+    CarouselProps<RecordWithObjectID<THit>>['itemComponent']
+  > = ({ item }) => (
+    <TemplateComponent
+      templates={templates}
+      templateKey="item"
+      data={item}
+      rootTagName="fragment"
+    />
+  );
+
   function DisplayResultsLayoutComponent(
     toolProps: ClientSideToolTemplateData
   ) {
@@ -39,7 +53,7 @@ export function createDisplayResultsTool<
       <DisplayResultsUIComponent
         toolProps={toolProps}
         groupCarouselComponent={({ items, sendEvent }) =>
-          carousel({
+          carousel<RecordWithObjectID<THit>>({
             showNavigation: false,
             templates: {
               header: ({
@@ -80,14 +94,7 @@ export function createDisplayResultsTool<
           })({
             items,
             templates: {
-              item: ({ item }) => (
-                <TemplateComponent
-                  templates={templates}
-                  templateKey="item"
-                  data={item}
-                  rootTagName="fragment"
-                />
-              ),
+              item: itemComponent,
             },
             sendEvent,
           })

--- a/packages/instantsearch.js/src/widgets/chat/display-results-tool.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/display-results-tool.tsx
@@ -35,6 +35,47 @@ export function createDisplayResultsTool<
 
   const Button = createButtonComponent({ createElement: h });
 
+  const displayResultsCarousel = carousel<RecordWithObjectID<THit>>({
+    showNavigation: false,
+    templates: {
+      header: ({
+        nbItems,
+        canScrollLeft,
+        canScrollRight,
+        scrollLeft,
+        scrollRight,
+      }) => (
+        <div className="ais-ChatToolDisplayResultsCarouselHeader">
+          <div className="ais-ChatToolDisplayResultsCarouselHeaderCount">
+            {nbItems} result{nbItems > 1 ? 's' : ''}
+          </div>
+          <div className="ais-ChatToolDisplayResultsCarouselHeaderScrollButtons">
+            <Button
+              variant="outline"
+              size="sm"
+              iconOnly
+              onClick={scrollLeft}
+              disabled={!canScrollLeft}
+              className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
+            >
+              <ChevronLeftIcon createElement={h} />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              iconOnly
+              onClick={scrollRight}
+              disabled={!canScrollRight}
+              className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
+            >
+              <ChevronRightIcon createElement={h} />
+            </Button>
+          </div>
+        </div>
+      ),
+    },
+  });
+
   const itemComponent: NonNullable<
     CarouselProps<RecordWithObjectID<THit>>['itemComponent']
   > = ({ item }) => (
@@ -53,45 +94,7 @@ export function createDisplayResultsTool<
       <DisplayResultsUIComponent
         toolProps={toolProps}
         groupCarouselComponent={({ items, sendEvent }) =>
-          carousel<RecordWithObjectID<THit>>({
-            showNavigation: false,
-            templates: {
-              header: ({
-                canScrollLeft,
-                canScrollRight,
-                scrollLeft,
-                scrollRight,
-              }) => (
-                <div className="ais-ChatToolDisplayResultsCarouselHeader">
-                  <div className="ais-ChatToolDisplayResultsCarouselHeaderCount">
-                    {items.length} result{items.length > 1 ? 's' : ''}
-                  </div>
-                  <div className="ais-ChatToolDisplayResultsCarouselHeaderScrollButtons">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      iconOnly
-                      onClick={scrollLeft}
-                      disabled={!canScrollLeft}
-                      className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
-                    >
-                      <ChevronLeftIcon createElement={h} />
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      iconOnly
-                      onClick={scrollRight}
-                      disabled={!canScrollRight}
-                      className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
-                    >
-                      <ChevronRightIcon createElement={h} />
-                    </Button>
-                  </div>
-                </div>
-              ),
-            },
-          })({
+          displayResultsCarousel({
             items,
             templates: {
               item: itemComponent,

--- a/packages/instantsearch.js/src/widgets/chat/display-results-tool.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/display-results-tool.tsx
@@ -54,6 +54,7 @@ export function createDisplayResultsTool<
               variant="outline"
               size="sm"
               iconOnly
+              aria-label="Previous"
               onClick={scrollLeft}
               disabled={!canScrollLeft}
               className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
@@ -64,6 +65,7 @@ export function createDisplayResultsTool<
               variant="outline"
               size="sm"
               iconOnly
+              aria-label="Next"
               onClick={scrollRight}
               disabled={!canScrollRight}
               className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"

--- a/packages/instantsearch.js/src/widgets/chat/search-index-tool.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/search-index-tool.tsx
@@ -2,7 +2,7 @@
 
 import { createCarouselToolComponent } from 'instantsearch-ui-components';
 import { Fragment, h } from 'preact';
-import { useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 
 import TemplateComponent from '../../components/Template/Template';
 
@@ -26,6 +26,7 @@ export function createCarouselTool<
   const SearchLayoutUIComponent = createCarouselToolComponent<THit>({
     createElement: h,
     Fragment,
+    useEffect,
     useMemo,
     useRef,
     useState,

--- a/packages/react-instantsearch/src/components/Carousel.tsx
+++ b/packages/react-instantsearch/src/components/Carousel.tsx
@@ -2,7 +2,13 @@ import {
   createCarouselComponent,
   generateCarouselId,
 } from 'instantsearch-ui-components';
-import React, { createElement, Fragment, useRef, useState } from 'react';
+import React, {
+  createElement,
+  Fragment,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import type {
   CarouselProps as CarouselUiProps,
@@ -12,6 +18,8 @@ import type {
 const CarouselUiComponent = createCarouselComponent({
   createElement: createElement as Pragma,
   Fragment,
+  useEffect,
+  useRef,
 });
 
 export type CarouselProps<TObject extends Record<string, unknown>> = Omit<

--- a/packages/react-instantsearch/src/components/__tests__/Carousel.test.tsx
+++ b/packages/react-instantsearch/src/components/__tests__/Carousel.test.tsx
@@ -449,5 +449,4 @@ describe('Carousel', () => {
       ).not.toBeVisible()
     );
   });
-
 });

--- a/packages/react-instantsearch/src/components/__tests__/Carousel.test.tsx
+++ b/packages/react-instantsearch/src/components/__tests__/Carousel.test.tsx
@@ -438,9 +438,8 @@ describe('Carousel', () => {
       />
     );
 
-    // Only proves the flavor state wiring reaches the shared measurement. The
-    // fitting and overflowing decisions are covered in the shared Carousel suite,
-    // which sets explicit widths.
+    // Wiring only: jsdom has no geometry here, so the fitting and overflowing
+    // decisions live in the shared Carousel suite.
     await waitFor(() =>
       expect(
         container.querySelector<HTMLButtonElement>(

--- a/packages/react-instantsearch/src/components/__tests__/Carousel.test.tsx
+++ b/packages/react-instantsearch/src/components/__tests__/Carousel.test.tsx
@@ -2,8 +2,8 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 
-import { render } from '@testing-library/react';
-import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import React, { useState } from 'react';
 
 import { Carousel } from '../Carousel';
 
@@ -299,5 +299,117 @@ describe('Carousel', () => {
         </div>
       </div>
     `);
+  });
+
+  test('preserves duplicate item state when another item is prepended', () => {
+    function StatefulItem({
+      item,
+    }: {
+      item: { objectID: string; __position: number; name: string };
+    }) {
+      const [selected, setSelected] = useState(false);
+
+      return (
+        <button
+          aria-label={`Toggle ${item.name}`}
+          onClick={() => setSelected((value) => !value)}
+        >
+          {item.name}: {selected ? 'selected' : 'idle'}
+        </button>
+      );
+    }
+
+    const items = [
+      { objectID: '1', __position: 1, name: 'shoe' },
+      { objectID: '1', __position: 2, name: 'sock' },
+      { objectID: '2', __position: 3, name: 'hat' },
+    ];
+    const { getByRole, getAllByRole, rerender } = render(
+      <Carousel
+        sendEvent={jest.fn()}
+        items={items}
+        itemComponent={StatefulItem}
+      />
+    );
+
+    fireEvent.click(getByRole('button', { name: 'Toggle sock' }));
+    expect(getByRole('button', { name: 'Toggle sock' })).toHaveTextContent(
+      'sock: selected'
+    );
+
+    rerender(
+      <Carousel
+        sendEvent={jest.fn()}
+        items={[
+          { objectID: '9', __position: 1, name: 'new' },
+          ...items.map((item, index) => ({
+            ...item,
+            __position: index + 2,
+          })),
+        ]}
+        itemComponent={StatefulItem}
+      />
+    );
+
+    expect(getAllByRole('listitem')).toHaveLength(4);
+    expect(getByRole('button', { name: 'Toggle shoe' })).toHaveTextContent(
+      'shoe: idle'
+    );
+    expect(getByRole('button', { name: 'Toggle sock' })).toHaveTextContent(
+      'sock: selected'
+    );
+  });
+
+  test('updates navigation when items are appended', async () => {
+    function Header({ canScrollRight }: { canScrollRight: boolean }) {
+      return (
+        <button aria-label="Next results" disabled={!canScrollRight}>
+          Next
+        </button>
+      );
+    }
+
+    const items = [
+      { objectID: '1', __position: 1 },
+      { objectID: '2', __position: 2 },
+    ];
+    const { container, getByRole, rerender } = render(
+      <Carousel
+        sendEvent={jest.fn()}
+        items={items}
+        itemComponent={({ item }) => <p>{item.objectID}</p>}
+        headerComponent={Header}
+      />
+    );
+    const list = container.querySelector('.ais-Carousel-list')!;
+    let scrollWidth = 200;
+
+    Object.defineProperties(list, {
+      clientWidth: { configurable: true, value: 100 },
+      scrollWidth: {
+        configurable: true,
+        get: () => scrollWidth,
+      },
+    });
+    list.scrollLeft = 100;
+    fireEvent.scroll(list);
+
+    await waitFor(() =>
+      expect(getByRole('button', { name: 'Next results' })).toBeDisabled()
+    );
+
+    scrollWidth = 300;
+    rerender(
+      <Carousel
+        sendEvent={jest.fn()}
+        items={[...items, { objectID: '3', __position: 3 }]}
+        itemComponent={({ item }) => <p>{item.objectID}</p>}
+        headerComponent={Header}
+      />
+    );
+
+    await waitFor(() =>
+      expect(getByRole('button', { name: 'Next results' })).toBeEnabled()
+    );
   });
 });

--- a/packages/react-instantsearch/src/components/__tests__/Carousel.test.tsx
+++ b/packages/react-instantsearch/src/components/__tests__/Carousel.test.tsx
@@ -412,4 +412,42 @@ describe('Carousel', () => {
       expect(getByRole('button', { name: 'Next results' })).toBeEnabled()
     );
   });
+
+  test('wires the navigation measurement when items arrive after mount', async () => {
+    type Item = { objectID: string; __position: number };
+    const items: Array<Item> = [
+      { objectID: '1', __position: 1 },
+      { objectID: '2', __position: 2 },
+    ];
+    const noItems: Array<Item> = [];
+    const { container, rerender } = render(
+      <Carousel
+        sendEvent={jest.fn()}
+        items={noItems}
+        itemComponent={({ item }) => <p>{item.objectID}</p>}
+      />
+    );
+
+    expect(container.querySelector('.ais-Carousel')).toBeNull();
+
+    rerender(
+      <Carousel
+        sendEvent={jest.fn()}
+        items={items}
+        itemComponent={({ item }) => <p>{item.objectID}</p>}
+      />
+    );
+
+    // Only proves the flavor state wiring reaches the shared measurement. The
+    // fitting and overflowing decisions are covered in the shared Carousel suite,
+    // which sets explicit widths.
+    await waitFor(() =>
+      expect(
+        container.querySelector<HTMLButtonElement>(
+          '.ais-Carousel-navigation--next'
+        )
+      ).not.toBeVisible()
+    );
+  });
+
 });

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -75,6 +75,34 @@ export function createDefaultTools<TObject extends RecordWithObjectID>(
   };
 }
 
+function mergeToolOptions<TTool extends { streamInput?: boolean }>(
+  defaultTools: Record<string, TTool>,
+  userTools?: Record<string, TTool>
+): Record<string, TTool> {
+  if (!userTools) {
+    return defaultTools;
+  }
+
+  const tools = { ...defaultTools, ...userTools };
+
+  Object.keys(userTools).forEach((toolName) => {
+    const userTool = userTools[toolName];
+    const defaultStreamInput = defaultTools[toolName]?.streamInput;
+
+    if (
+      userTool.streamInput === undefined &&
+      defaultStreamInput !== undefined
+    ) {
+      tools[toolName] = {
+        ...userTool,
+        streamInput: defaultStreamInput,
+      };
+    }
+  });
+
+  return tools;
+}
+
 type ItemComponent<TObject> = RecommendComponentProps<TObject>['itemComponent'];
 
 type UiProps = Pick<
@@ -227,7 +255,7 @@ function ChatInner<
   const tools = useMemo(() => {
     const defaults = createDefaultTools(itemComponent, getSearchPageURL);
 
-    return { ...defaults, ...userTools };
+    return mergeToolOptions(defaults, userTools);
   }, [getSearchPageURL, itemComponent, userTools]);
 
   // Inline layouts are always visible, so they don't require a `<ChatTrigger />`

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -75,7 +75,12 @@ export function createDefaultTools<TObject extends RecordWithObjectID>(
   };
 }
 
-function mergeToolOptions<TTool extends { streamInput?: boolean }>(
+function mergeToolOptions<
+  TTool extends {
+    streamInput?: boolean;
+    layoutComponent?: unknown;
+  }
+>(
   defaultTools: Record<string, TTool>,
   userTools?: Record<string, TTool>
 ): Record<string, TTool> {
@@ -90,6 +95,7 @@ function mergeToolOptions<TTool extends { streamInput?: boolean }>(
     const defaultStreamInput = defaultTools[toolName]?.streamInput;
 
     if (
+      userTool.layoutComponent !== undefined &&
       userTool.streamInput === undefined &&
       defaultStreamInput !== undefined
     ) {

--- a/packages/react-instantsearch/src/widgets/chat/tools/DisplayResultsTool.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/DisplayResultsTool.tsx
@@ -27,7 +27,9 @@ function createDisplayResultsTool<TObject extends RecordWithObjectID>(
     useMemo,
   });
 
-  const Button = createButtonComponent({ createElement: createElement as Pragma });
+  const Button = createButtonComponent({
+    createElement: createElement as Pragma,
+  });
 
   const DisplayResultsLayoutComponent = (
     toolProps: ClientSideToolComponentProps
@@ -70,9 +72,7 @@ function createDisplayResultsTool<TObject extends RecordWithObjectID>(
                     disabled={!canScrollRight}
                     className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
                   >
-                    <ChevronRightIcon
-                      createElement={createElement as Pragma}
-                    />
+                    <ChevronRightIcon createElement={createElement as Pragma} />
                   </Button>
                 </div>
               </div>
@@ -85,6 +85,7 @@ function createDisplayResultsTool<TObject extends RecordWithObjectID>(
 
   return {
     layoutComponent: DisplayResultsLayoutComponent,
+    streamInput: true,
   };
 }
 

--- a/packages/react-instantsearch/src/widgets/chat/tools/DisplayResultsTool.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/DisplayResultsTool.tsx
@@ -10,6 +10,7 @@ import { Carousel } from '../../../components';
 
 import type {
   ClientSideToolComponentProps,
+  HeaderComponentProps,
   Pragma,
   RecommendComponentProps,
   RecordWithObjectID,
@@ -31,6 +32,42 @@ function createDisplayResultsTool<TObject extends RecordWithObjectID>(
     createElement: createElement as Pragma,
   });
 
+  const DisplayResultsCarouselHeader = ({
+    nbItems,
+    canScrollLeft,
+    canScrollRight,
+    scrollLeft,
+    scrollRight,
+  }: HeaderComponentProps) => (
+    <div className="ais-ChatToolDisplayResultsCarouselHeader">
+      <div className="ais-ChatToolDisplayResultsCarouselHeaderCount">
+        {nbItems} result{nbItems > 1 ? 's' : ''}
+      </div>
+      <div className="ais-ChatToolDisplayResultsCarouselHeaderScrollButtons">
+        <Button
+          variant="outline"
+          size="sm"
+          iconOnly
+          onClick={scrollLeft}
+          disabled={!canScrollLeft}
+          className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
+        >
+          <ChevronLeftIcon createElement={createElement as Pragma} />
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          iconOnly
+          onClick={scrollRight}
+          disabled={!canScrollRight}
+          className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
+        >
+          <ChevronRightIcon createElement={createElement as Pragma} />
+        </Button>
+      </div>
+    </div>
+  );
+
   const DisplayResultsLayoutComponent = (
     toolProps: ClientSideToolComponentProps
   ) => {
@@ -43,40 +80,7 @@ function createDisplayResultsTool<TObject extends RecordWithObjectID>(
             itemComponent={itemComponent}
             sendEvent={sendEvent}
             showNavigation={false}
-            headerComponent={({
-              canScrollLeft,
-              canScrollRight,
-              scrollLeft,
-              scrollRight,
-            }) => (
-              <div className="ais-ChatToolDisplayResultsCarouselHeader">
-                <div className="ais-ChatToolDisplayResultsCarouselHeaderCount">
-                  {items.length} result{items.length > 1 ? 's' : ''}
-                </div>
-                <div className="ais-ChatToolDisplayResultsCarouselHeaderScrollButtons">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    iconOnly
-                    onClick={scrollLeft}
-                    disabled={!canScrollLeft}
-                    className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
-                  >
-                    <ChevronLeftIcon createElement={createElement as Pragma} />
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    iconOnly
-                    onClick={scrollRight}
-                    disabled={!canScrollRight}
-                    className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
-                  >
-                    <ChevronRightIcon createElement={createElement as Pragma} />
-                  </Button>
-                </div>
-              </div>
-            )}
+            headerComponent={DisplayResultsCarouselHeader}
           />
         )}
       />

--- a/packages/react-instantsearch/src/widgets/chat/tools/DisplayResultsTool.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/DisplayResultsTool.tsx
@@ -48,6 +48,7 @@ function createDisplayResultsTool<TObject extends RecordWithObjectID>(
           variant="outline"
           size="sm"
           iconOnly
+          aria-label="Previous"
           onClick={scrollLeft}
           disabled={!canScrollLeft}
           className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"
@@ -58,6 +59,7 @@ function createDisplayResultsTool<TObject extends RecordWithObjectID>(
           variant="outline"
           size="sm"
           iconOnly
+          aria-label="Next"
           onClick={scrollRight}
           disabled={!canScrollRight}
           className="ais-ChatToolDisplayResultsCarouselHeaderScrollButton"

--- a/packages/react-instantsearch/src/widgets/chat/tools/SearchIndexTool.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/SearchIndexTool.tsx
@@ -1,6 +1,7 @@
 import { createCarouselToolComponent } from 'instantsearch-ui-components';
 import React, {
   createElement,
+  useEffect,
   useMemo,
   useState,
   useRef,
@@ -26,6 +27,7 @@ function createCarouselTool<TObject extends RecordWithObjectID>(
   const SearchLayoutUIComponent = createCarouselToolComponent<TObject>({
     createElement: createElement as Pragma,
     Fragment,
+    useEffect,
     useMemo,
     useRef,
     useState,

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.streaming.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.streaming.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ *
+ * Streamed-identifier completeness for the Display Results tool.
+ *
+ * Driven through the production `Chat` reducer rather than hand-built parts,
+ * because it is partial-JSON repair closing an open string literal that lets a
+ * mid-delta identifier reach `input` looking complete.
+ */
+import { render, screen } from '@testing-library/react';
+import { Chat } from 'instantsearch.js/es/lib/chat';
+import React from 'react';
+
+import { createDisplayResultsTool } from '../DisplayResultsTool';
+
+import type { ClientSideToolComponentProps } from 'instantsearch-ui-components';
+import type { UIMessageChunk } from 'instantsearch.js/es/lib/ai-lite';
+import type { UIMessage } from 'instantsearch.js/es/lib/chat';
+
+type TestResult = { objectID: string; name?: string; __position: number };
+
+const HITS = [
+  { objectID: '12', name: 'PREFIX-12' },
+  { objectID: '1234', name: 'FULL-1234' },
+  { objectID: 'AB"', name: 'PREFIX-ESCAPED' },
+  { objectID: 'AB"CD', name: 'FULL-ESCAPED' },
+];
+
+const itemComponent = ({ item }: { item: TestResult }) => (
+  <div data-testid={`item-${item.objectID}`}>{item.name}</div>
+);
+
+function chunkStream(chunks: UIMessageChunk[]) {
+  return new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      chunks.forEach((chunk) => controller.enqueue(chunk));
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Streams `deltas` as the display tool's input and returns every committed
+ * frame of its message part. No `tool-input-available` is sent, so the final
+ * frame is still `input-streaming`, the state that must already render.
+ */
+async function streamDisplayInput(deltas: string[]) {
+  const frames: Array<ClientSideToolComponentProps['message']> = [];
+  const chat = new Chat<UIMessage>({
+    persistence: false,
+    transport: {
+      sendMessages: () =>
+        Promise.resolve(
+          chunkStream([
+            { type: 'start', messageId: 'msg-1' },
+            {
+              type: 'tool-input-start',
+              toolName: 'algolia_display_results',
+              toolCallId: 'display',
+            },
+            ...deltas.map((inputTextDelta) => ({
+              type: 'tool-input-delta' as const,
+              toolName: 'algolia_display_results',
+              toolCallId: 'display',
+              inputTextDelta,
+            })),
+          ] as UIMessageChunk[])
+        ),
+      reconnectToStream: () => Promise.resolve(null),
+    },
+    // Mirrors what `connectChat` derives from the tool's `streamInput: true`.
+    shouldRepairToolInput: () => true,
+  });
+
+  chat._state._messagesCallbacks.add(() => {
+    const parts = chat.messages[chat.messages.length - 1]?.parts ?? [];
+    const part = parts.find((candidate) =>
+      candidate.type.startsWith('tool-algolia_display_results')
+    );
+    if (part) {
+      frames.push({ ...part } as ClientSideToolComponentProps['message']);
+    }
+  });
+
+  await chat.sendMessage({ text: 'show me shoes' });
+  return frames;
+}
+
+function renderFrame(part: ClientSideToolComponentProps['message']) {
+  const tool = createDisplayResultsTool<TestResult>(itemComponent);
+  const LayoutComponent = tool.layoutComponent!;
+  const messages = [
+    {
+      id: '1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-algolia_search_index',
+          toolCallId: 'search',
+          state: 'output-available',
+          input: {},
+          output: { hits: HITS },
+        },
+        part,
+      ],
+    },
+  ] as unknown as ClientSideToolComponentProps['messages'];
+
+  const { unmount } = render(
+    <LayoutComponent
+      message={part}
+      messages={messages}
+      status="streaming"
+      applyFilters={jest.fn()}
+      onClose={jest.fn()}
+      indexUiState={{}}
+      addToolResult={jest.fn()}
+      setIndexUiState={jest.fn()}
+      sendEvent={jest.fn()}
+    />
+  );
+  const visible = HITS.filter((hit) =>
+    screen.queryByTestId(`item-${hit.objectID}`)
+  ).map((hit) => hit.name);
+  unmount();
+  return visible;
+}
+
+const renderAllFrames = (
+  frames: Array<ClientSideToolComponentProps['message']>
+) => frames.map(renderFrame);
+
+describe('display results, streamed identifier completeness', () => {
+  test('a split identifier never renders the record its prefix matches', async () => {
+    const frames = await streamDisplayInput([
+      '{"intro":"Top picks","groups":[{"title":"Best value","results":[{"objectID":"12',
+      '34"}]}]}',
+    ]);
+
+    const midFrame = frames.find(
+      (frame) => (frame as any).input?.groups?.[0]?.results?.length
+    ) as any;
+    expect(midFrame.rawInput).toContain('"objectID":"12');
+    expect(midFrame.input.groups[0].results[0].objectID).toBe('12');
+
+    const rendered = renderAllFrames(frames);
+    expect(rendered.flat()).not.toContain('PREFIX-12');
+    expect(rendered[rendered.length - 1]).toEqual(['FULL-1234']);
+  });
+
+  test('a split escaped identifier never renders the record its decoded prefix matches', async () => {
+    const frames = await streamDisplayInput([
+      '{"groups":[{"results":[{"objectID":"AB\\"',
+      'CD"}]}]}',
+    ]);
+
+    // Repair decodes the escape, so `input` carries `AB"` while the raw text
+    // still carries the escape sequence.
+    const midFrame = frames.find(
+      (frame) => (frame as any).input?.groups?.[0]?.results?.length
+    ) as any;
+    expect(midFrame.input.groups[0].results[0].objectID).toBe('AB"');
+    expect(midFrame.rawInput).toContain('AB\\"');
+
+    const rendered = renderAllFrames(frames);
+    expect(rendered.flat()).not.toContain('PREFIX-ESCAPED');
+    expect(rendered[rendered.length - 1]).toEqual(['FULL-ESCAPED']);
+  });
+
+  test('a split identifier is withheld when every path key uses an escaped spelling', async () => {
+    // All three path keys decode to the names the payload is read by, so the
+    // renderer sees an ordinary group while the raw text spells none of them.
+    const frames = await streamDisplayInput([
+      '{"gro\\u0075ps":[{"res\\u0075lts":[{"object\\u0049D":"12',
+      '34"}]}]}',
+    ]);
+
+    const midFrame = frames.find(
+      (frame) => (frame as any).input?.groups?.[0]?.results?.length
+    ) as any;
+    expect(midFrame.input.groups[0].results[0].objectID).toBe('12');
+    expect(midFrame.rawInput).not.toContain('objectID');
+    expect(midFrame.rawInput).not.toContain('groups');
+    expect(midFrame.rawInput).not.toContain('results');
+
+    const rendered = renderAllFrames(frames);
+    expect(rendered.flat()).not.toContain('PREFIX-12');
+    expect(rendered[rendered.length - 1]).toEqual(['FULL-1234']);
+  });
+
+  test('a fully emitted single result renders while input is still streaming', async () => {
+    const frames = await streamDisplayInput([
+      '{"intro":"Top picks","groups":[{"title":"Best value","results":[{"objectID":"1234"}]}]}',
+    ]);
+    const last = frames[frames.length - 1];
+
+    expect(last.state).toBe('input-streaming');
+    expect(renderFrame(last)).toEqual(['FULL-1234']);
+  });
+
+  test('a completed result stays visible when a later truncated field repeats its identifier', async () => {
+    const frames = await streamDisplayInput([
+      '{"groups":[{"results":[{"objectID":"1234"}],"why":"1234',
+    ]);
+    const last = frames[frames.length - 1] as any;
+
+    // The open string is a `why` value whose text equals the identifier above it.
+    expect(last.state).toBe('input-streaming');
+    expect(last.input.groups[0].results[0].objectID).toBe('1234');
+    expect(renderFrame(last)).toEqual(['FULL-1234']);
+  });
+
+  test('a persisted intermediate frame cannot restore the record its prefix matches', async () => {
+    const frames = await streamDisplayInput([
+      '{"groups":[{"results":[{"objectID":"12',
+    ]);
+    const last = frames[frames.length - 1];
+
+    // `Chat` persists with `JSON.stringify(this.messages)`, so a stream aborted
+    // here is restored verbatim, `rawInput` included.
+    const restored = JSON.parse(
+      JSON.stringify(last)
+    ) as ClientSideToolComponentProps['message'];
+
+    expect((restored as any).input.groups[0].results[0].objectID).toBe('12');
+    expect(renderFrame(restored)).toEqual([]);
+  });
+});

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
@@ -237,6 +237,106 @@ describe('createDisplayResultsTool', () => {
     expect(screen.queryByText('Runners')).not.toBeInTheDocument();
   });
 
+  test('omits unresolved prototype-named object IDs', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+
+    const message: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {
+        groups: [
+          {
+            title: 'Runners',
+            results: [
+              { objectID: '1' },
+              { objectID: 'constructor' },
+              { objectID: '__proto__' },
+              { objectID: '2' },
+            ],
+          },
+          {
+            title: 'Unknown only',
+            results: [{ objectID: 'constructor' }],
+          },
+        ],
+      },
+      output: {
+        status: 'warning',
+        unknownObjectIds: ['constructor', '__proto__'],
+      },
+    };
+
+    render(
+      <LayoutComponent
+        message={message}
+        messages={createMessages(message, [
+          { objectID: '1', name: 'Air Runner' },
+          { objectID: '2', name: 'Trail Runner' },
+        ])}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(
+      screen
+        .getAllByTestId(/^item-/)
+        .map((element) => element.getAttribute('data-testid'))
+    ).toEqual(['item-1', 'item-2']);
+    expect(screen.queryByTestId('item-constructor')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('item-__proto__')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unknown only')).not.toBeInTheDocument();
+  });
+
+  test('renders hydrated prototype-named object IDs', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+
+    const message: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {
+        groups: [
+          {
+            title: 'Reserved names',
+            results: [{ objectID: 'constructor' }, { objectID: '__proto__' }],
+          },
+        ],
+      },
+      output: { status: 'success', unknownObjectIds: [] },
+    };
+
+    render(
+      <LayoutComponent
+        message={message}
+        messages={createMessages(message, [
+          { objectID: 'constructor', name: 'Constructor record' },
+          { objectID: '__proto__', name: 'Prototype record' },
+        ])}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('name-constructor')).toHaveTextContent(
+      'Constructor record'
+    );
+    expect(screen.getByTestId('name-__proto__')).toHaveTextContent(
+      'Prototype record'
+    );
+  });
+
   test('does not render preliminary legacy output', () => {
     const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
     const LayoutComponent = tool.layoutComponent!;

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
@@ -20,6 +20,7 @@ type TestResult = {
 const mockItemComponent = ({ item }: { item: TestResult }) => (
   <div data-testid={`item-${item.objectID}`}>
     <span>{item.objectID}</span>
+    <span data-testid={`position-${item.objectID}`}>{item.__position}</span>
     {item.name && (
       <strong data-testid={`name-${item.objectID}`}>{item.name}</strong>
     )}
@@ -31,8 +32,77 @@ const mockItemComponent = ({ item }: { item: TestResult }) => (
   </div>
 );
 
+const createMessages = (
+  message: ClientSideToolComponentProps['message'],
+  hits: Array<{ objectID: string; name?: string; why?: string }>
+): ClientSideToolComponentProps['messages'] =>
+  [
+    {
+      id: '1',
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-algolia_search_index',
+          toolCallId: 'search',
+          state: 'output-available',
+          input: {},
+          output: { hits },
+        },
+        message,
+      ],
+    },
+  ] as ClientSideToolComponentProps['messages'];
+
 describe('createDisplayResultsTool', () => {
-  test('renders intro and one carousel per group, passing results straight through', () => {
+  test('opts into tool input streaming', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+
+    expect(tool.streamInput).toBe(true);
+  });
+
+  test('renders hydrated groups while tool input is streaming', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+
+    const message: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'input-streaming',
+      toolCallId: 'display',
+      input: {
+        intro: 'Curating for you',
+        groups: [
+          {
+            title: 'Runners',
+            results: [{ objectID: '1', why: 'lightweight' }],
+          },
+        ],
+      },
+    };
+
+    const messages = createMessages(message, [
+      { objectID: '1', name: 'Air Runner' },
+    ]);
+
+    render(
+      <LayoutComponent
+        message={message}
+        messages={messages}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Curating for you')).toBeInTheDocument();
+    expect(screen.getByText('Runners')).toBeInTheDocument();
+    expect(screen.getByTestId('name-1')).toHaveTextContent('Air Runner');
+    expect(screen.getByText('Curating results…')).toBeInTheDocument();
+  });
+
+  test('renders completed legacy v1 output when input has no v1 fields', () => {
     const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
     const LayoutComponent = tool.layoutComponent!;
 
@@ -60,6 +130,10 @@ describe('createDisplayResultsTool', () => {
     render(
       <LayoutComponent
         message={message}
+        messages={createMessages(message, [
+          { objectID: '1', name: 'Air Runner' },
+          { objectID: '2', name: 'Street Runner' },
+        ])}
         applyFilters={jest.fn()}
         onClose={jest.fn()}
         indexUiState={{}}
@@ -85,8 +159,7 @@ describe('createDisplayResultsTool', () => {
       type: 'tool-algolia_display_results',
       state: 'output-available',
       toolCallId: 'display',
-      input: {},
-      output: {
+      input: {
         groups: [
           {
             title: 'Runners',
@@ -95,31 +168,15 @@ describe('createDisplayResultsTool', () => {
           },
         ],
       },
+      output: { status: 'success', unknownObjectIds: [] },
     };
 
     // The preceding search tool (same assistant message) carries the full
     // records; the display tool hydrates from them.
-    const messages: ClientSideToolComponentProps['messages'] = [
-      {
-        id: '1',
-        role: 'assistant',
-        parts: [
-          {
-            type: 'tool-algolia_search_index',
-            toolCallId: 'search',
-            state: 'output-available',
-            input: {},
-            output: {
-              hits: [
-                { objectID: '1', name: 'Air Runner', why: 'from search' },
-                { objectID: '2', name: 'Trail Runner' },
-              ],
-            },
-          },
-          message,
-        ],
-      },
-    ] as ClientSideToolComponentProps['messages'];
+    const messages = createMessages(message, [
+      { objectID: '1', name: 'Air Runner', why: 'from search' },
+      { objectID: '2', name: 'Trail Runner' },
+    ]);
 
     render(
       <LayoutComponent
@@ -142,7 +199,7 @@ describe('createDisplayResultsTool', () => {
     expect(screen.getByTestId('why-1')).toHaveTextContent('iconic');
   });
 
-  test('renders results untouched when no matching hit is available', () => {
+  test('omits results when no matching hit is available', () => {
     const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
     const LayoutComponent = tool.layoutComponent!;
 
@@ -150,30 +207,17 @@ describe('createDisplayResultsTool', () => {
       type: 'tool-algolia_display_results',
       state: 'output-available',
       toolCallId: 'display',
-      input: {},
-      output: {
+      input: {
         groups: [
           { title: 'Runners', results: [{ objectID: '1', why: 'iconic' }] },
         ],
       },
+      output: { status: 'success', unknownObjectIds: ['1'] },
     };
 
-    const messages: ClientSideToolComponentProps['messages'] = [
-      {
-        id: '1',
-        role: 'assistant',
-        parts: [
-          {
-            type: 'tool-algolia_search_index',
-            toolCallId: 'search',
-            state: 'output-available',
-            input: {},
-            output: { hits: [{ objectID: '99', name: 'Unrelated' }] },
-          },
-          message,
-        ],
-      },
-    ] as ClientSideToolComponentProps['messages'];
+    const messages = createMessages(message, [
+      { objectID: '99', name: 'Unrelated' },
+    ]);
 
     render(
       <LayoutComponent
@@ -188,16 +232,16 @@ describe('createDisplayResultsTool', () => {
       />
     );
 
-    expect(screen.getByTestId('item-1')).toBeInTheDocument();
-    expect(screen.getByTestId('why-1')).toHaveTextContent('iconic');
+    expect(screen.queryByTestId('item-1')).not.toBeInTheDocument();
     expect(screen.queryByTestId('name-1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Runners')).not.toBeInTheDocument();
   });
 
-  test('shows streaming caption while preliminary flag is true', () => {
+  test('does not render preliminary legacy output', () => {
     const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
     const LayoutComponent = tool.layoutComponent!;
 
-    render(
+    const { container } = render(
       <LayoutComponent
         message={
           {
@@ -212,6 +256,7 @@ describe('createDisplayResultsTool', () => {
             preliminary: true,
           } as ClientSideToolComponentProps['message']
         }
+        messages={[]}
         applyFilters={jest.fn()}
         onClose={jest.fn()}
         indexUiState={{}}
@@ -221,35 +266,34 @@ describe('createDisplayResultsTool', () => {
       />
     );
 
-    expect(screen.getByText('Curating')).toBeInTheDocument();
-    expect(screen.getByText('Runners')).toBeInTheDocument();
-    expect(screen.getByTestId('item-1')).toBeInTheDocument();
-    expect(screen.getByText('Curating results…')).toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
   test('drops results that are missing an objectID and skips groups with no valid results', () => {
     const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
     const LayoutComponent = tool.layoutComponent!;
+    const message = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {
+        groups: [
+          { title: 'Empty', results: [{}, { objectID: '' }] },
+          {
+            title: 'Full',
+            results: [{}, { objectID: '1', why: 'iconic' }],
+          },
+        ],
+      },
+      output: { status: 'success' },
+    } as ClientSideToolComponentProps['message'];
 
     render(
       <LayoutComponent
-        message={
-          {
-            type: 'tool-algolia_display_results',
-            state: 'output-available',
-            toolCallId: 'display',
-            input: {},
-            output: {
-              groups: [
-                { title: 'Empty', results: [{}, { objectID: '' }] },
-                {
-                  title: 'Full',
-                  results: [{}, { objectID: '1', why: 'iconic' }],
-                },
-              ],
-            },
-          } as ClientSideToolComponentProps['message']
-        }
+        message={message}
+        messages={createMessages(message, [
+          { objectID: '1', name: 'Air Runner' },
+        ])}
         applyFilters={jest.fn()}
         onClose={jest.fn()}
         indexUiState={{}}
@@ -289,5 +333,169 @@ describe('createDisplayResultsTool', () => {
     );
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  test('keeps input authoritative when output contains diagnostics', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+
+    const message: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {
+        intro: 'Input intro',
+        groups: [{ title: 'Input group', results: [{ objectID: '1' }] }],
+      },
+      output: {
+        status: 'warning',
+        unknownObjectIds: ['missing'],
+      },
+    };
+
+    render(
+      <LayoutComponent
+        message={message}
+        messages={createMessages(message, [
+          { objectID: '1', name: 'Air Runner' },
+        ])}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Input intro')).toBeInTheDocument();
+    expect(screen.getByText('Input group')).toBeInTheDocument();
+    expect(screen.getByTestId('name-1')).toHaveTextContent('Air Runner');
+    expect(screen.queryByText('warning')).not.toBeInTheDocument();
+  });
+
+  test('shows the streaming caption before a renderable input field arrives', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+
+    render(
+      <LayoutComponent
+        message={
+          {
+            type: 'tool-algolia_display_results',
+            state: 'input-streaming',
+            toolCallId: 'display',
+            input: {},
+          } as ClientSideToolComponentProps['message']
+        }
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Curating results…')).toBeInTheDocument();
+  });
+
+  test('does not expose legacy output when input claims malformed v1 fields', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+
+    const { container } = render(
+      <LayoutComponent
+        message={
+          {
+            type: 'tool-algolia_display_results',
+            state: 'output-available',
+            toolCallId: 'display',
+            input: { groups: 'invalid' },
+            output: { intro: 'Legacy output' },
+          } as ClientSideToolComponentProps['message']
+        }
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('preserves duplicate result order and uses the latest preceding hit', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+
+    const message: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {
+        groups: [
+          {
+            results: [
+              { objectID: '1', why: 'first' },
+              { objectID: '1', why: 'second' },
+            ],
+          },
+        ],
+      },
+      output: { status: 'success' },
+    };
+    const messages = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search-1',
+            state: 'output-available',
+            input: {},
+            output: { hits: [{ objectID: '1', name: 'Old Runner' }] },
+          },
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search-2',
+            state: 'output-available',
+            input: {},
+            output: { hits: [{ objectID: '1', name: 'New Runner' }] },
+          },
+          message,
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'search-after-display',
+            state: 'output-available',
+            input: {},
+            output: { hits: [{ objectID: '1', name: 'Future Runner' }] },
+          },
+        ],
+      },
+    ] as ClientSideToolComponentProps['messages'];
+
+    render(
+      <LayoutComponent
+        message={message}
+        messages={messages}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(screen.getAllByTestId('name-1')).toHaveLength(2);
+    expect(screen.getAllByTestId('name-1')[0]).toHaveTextContent('New Runner');
+    expect(screen.getAllByTestId('position-1')[0]).toHaveTextContent('1');
+    expect(screen.getAllByTestId('position-1')[1]).toHaveTextContent('2');
+    expect(screen.getAllByTestId('why-1')[0]).toHaveTextContent('first');
+    expect(screen.getAllByTestId('why-1')[1]).toHaveTextContent('second');
   });
 });

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { createDisplayResultsTool } from '../DisplayResultsTool';
@@ -292,6 +292,71 @@ describe('createDisplayResultsTool', () => {
     expect(screen.queryByTestId('item-constructor')).not.toBeInTheDocument();
     expect(screen.queryByTestId('item-__proto__')).not.toBeInTheDocument();
     expect(screen.queryByText('Unknown only')).not.toBeInTheDocument();
+  });
+
+  test('uses dense rendered positions for click analytics after omissions', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+    const sendEvent = jest.fn();
+
+    const message: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {
+        groups: [
+          {
+            results: [
+              { objectID: 'missing' },
+              { objectID: 'known' },
+              { objectID: 'known-2' },
+              { objectID: 'known' },
+            ],
+          },
+        ],
+      },
+      output: { status: 'warning', unknownObjectIds: ['missing'] },
+    };
+
+    render(
+      <LayoutComponent
+        message={message}
+        messages={createMessages(message, [
+          { objectID: 'known', name: 'Known record' },
+          { objectID: 'known-2', name: 'Second known record' },
+        ])}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={sendEvent}
+      />
+    );
+
+    const knownItems = screen.getAllByTestId('item-known');
+    fireEvent.click(knownItems[0]);
+    fireEvent.click(screen.getByTestId('item-known-2'));
+    fireEvent.click(knownItems[1]);
+
+    expect(sendEvent).toHaveBeenNthCalledWith(
+      1,
+      'click:internal',
+      expect.objectContaining({ objectID: 'known', __position: 1 }),
+      'Item Clicked'
+    );
+    expect(sendEvent).toHaveBeenNthCalledWith(
+      2,
+      'click:internal',
+      expect.objectContaining({ objectID: 'known-2', __position: 2 }),
+      'Item Clicked'
+    );
+    expect(sendEvent).toHaveBeenNthCalledWith(
+      3,
+      'click:internal',
+      expect.objectContaining({ objectID: 'known', __position: 3 }),
+      'Item Clicked'
+    );
   });
 
   test('renders hydrated prototype-named object IDs', () => {

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
@@ -663,4 +663,102 @@ describe('createDisplayResultsTool', () => {
     expect(screen.getAllByTestId('why-1')[0]).toHaveTextContent('first');
     expect(screen.getAllByTestId('why-1')[1]).toHaveTextContent('second');
   });
+
+  test('hydrates reused tool call IDs within their owning messages', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+    const firstDisplayMessage: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {
+        groups: [
+          { title: 'First turn', results: [{ objectID: 'old-product' }] },
+        ],
+      },
+      output: { status: 'success' },
+    };
+    const secondDisplayMessage: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'output-available',
+      toolCallId: 'display',
+      input: {
+        groups: [
+          { title: 'Second turn', results: [{ objectID: 'new-product' }] },
+        ],
+      },
+      output: { status: 'success' },
+    };
+    const messages = [
+      {
+        id: 'first-message',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'first-search',
+            state: 'output-available',
+            input: {},
+            output: {
+              hits: [{ objectID: 'old-product', name: 'Old product' }],
+            },
+          },
+          firstDisplayMessage,
+        ],
+      },
+      {
+        id: 'second-message',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-algolia_search_index',
+            toolCallId: 'second-search',
+            state: 'output-available',
+            input: {},
+            output: {
+              hits: [{ objectID: 'new-product', name: 'New product' }],
+            },
+          },
+          secondDisplayMessage,
+        ],
+      },
+    ] as ClientSideToolComponentProps['messages'];
+
+    const firstRender = render(
+      <LayoutComponent
+        message={firstDisplayMessage}
+        messages={messages}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('name-old-product')).toHaveTextContent(
+      'Old product'
+    );
+
+    firstRender.unmount();
+
+    render(
+      <LayoutComponent
+        message={secondDisplayMessage}
+        messages={messages}
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('name-new-product')).toHaveTextContent(
+      'New product'
+    );
+    expect(screen.queryByTestId('name-old-product')).not.toBeInTheDocument();
+  });
 });

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 
 import { createDisplayResultsTool } from '../DisplayResultsTool';
@@ -100,6 +100,64 @@ describe('createDisplayResultsTool', () => {
     expect(screen.getByText('Runners')).toBeInTheDocument();
     expect(screen.getByTestId('name-1')).toHaveTextContent('Air Runner');
     expect(screen.getByText('Curating results…')).toBeInTheDocument();
+  });
+
+  test('keeps carousel controls focused while tool input streams', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+    const createToolProps = (intro: string, objectIDs: string[]) => {
+      const message: ClientSideToolComponentProps['message'] = {
+        type: 'tool-algolia_display_results',
+        state: 'input-streaming',
+        toolCallId: 'display',
+        input: {
+          intro,
+          groups: [
+            {
+              title: 'Products',
+              results: objectIDs.map((objectID) => ({ objectID })),
+            },
+          ],
+        },
+      };
+
+      return {
+        message,
+        messages: createMessages(
+          message,
+          objectIDs.map((objectID) => ({
+            objectID,
+            name: `Product ${objectID}`,
+          }))
+        ),
+        applyFilters: jest.fn(),
+        onClose: jest.fn(),
+        indexUiState: {},
+        addToolResult: jest.fn(),
+        setIndexUiState: jest.fn(),
+        sendEvent: jest.fn(),
+      };
+    };
+    const { container, rerender } = render(
+      <LayoutComponent {...createToolProps('Original intro', ['1'])} />
+    );
+    const list = container.querySelector('.ais-Carousel-list')!;
+    Object.defineProperties(list, {
+      clientWidth: { configurable: true, value: 100 },
+      scrollWidth: { configurable: true, value: 200 },
+    });
+    const nextButtonBefore = within(container).getAllByRole('button')[1];
+
+    nextButtonBefore.focus();
+    rerender(
+      <LayoutComponent {...createToolProps('Updated intro', ['1', '2'])} />
+    );
+
+    const nextButtonAfter = within(container).getAllByRole('button')[1];
+
+    expect(screen.getByText('2 results')).toBeInTheDocument();
+    expect(nextButtonAfter).toBe(nextButtonBefore);
+    expect(document.activeElement).toBe(nextButtonAfter);
   });
 
   test('renders completed legacy v1 output when input has no v1 fields', () => {

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
@@ -87,6 +87,7 @@ describe('createDisplayResultsTool', () => {
       <LayoutComponent
         message={message}
         messages={messages}
+        status="streaming"
         applyFilters={jest.fn()}
         onClose={jest.fn()}
         indexUiState={{}}
@@ -130,6 +131,7 @@ describe('createDisplayResultsTool', () => {
             name: `Product ${objectID}`,
           }))
         ),
+        status: 'streaming' as const,
         applyFilters: jest.fn(),
         onClose: jest.fn(),
         indexUiState: {},
@@ -600,17 +602,18 @@ describe('createDisplayResultsTool', () => {
   test('shows the streaming caption before a renderable input field arrives', () => {
     const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
     const LayoutComponent = tool.layoutComponent!;
+    const message = {
+      type: 'tool-algolia_display_results',
+      state: 'input-streaming',
+      toolCallId: 'display',
+      input: {},
+    } as ClientSideToolComponentProps['message'];
 
     render(
       <LayoutComponent
-        message={
-          {
-            type: 'tool-algolia_display_results',
-            state: 'input-streaming',
-            toolCallId: 'display',
-            input: {},
-          } as ClientSideToolComponentProps['message']
-        }
+        message={message}
+        messages={createMessages(message, [])}
+        status="streaming"
         applyFilters={jest.fn()}
         onClose={jest.fn()}
         indexUiState={{}}

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
@@ -162,6 +162,41 @@ describe('createDisplayResultsTool', () => {
     expect(document.activeElement).toBe(nextButtonAfter);
   });
 
+  test('names the carousel scroll controls', () => {
+    const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
+    const LayoutComponent = tool.layoutComponent!;
+    const message: ClientSideToolComponentProps['message'] = {
+      type: 'tool-algolia_display_results',
+      state: 'input-streaming',
+      toolCallId: 'display',
+      input: {
+        intro: 'Curating',
+        groups: [{ title: 'Products', results: [{ objectID: '1' }] }],
+      },
+    };
+    const { container } = render(
+      <LayoutComponent
+        message={message}
+        messages={createMessages(message, [{ objectID: '1', name: 'Runner' }])}
+        status="streaming"
+        applyFilters={jest.fn()}
+        onClose={jest.fn()}
+        indexUiState={{}}
+        addToolResult={jest.fn()}
+        setIndexUiState={jest.fn()}
+        sendEvent={jest.fn()}
+      />
+    );
+
+    // Icon-only controls carry no text, so the name has to come from the label.
+    expect(
+      within(container).getByRole('button', { name: 'Previous' })
+    ).toHaveClass('ais-ChatToolDisplayResultsCarouselHeaderScrollButton');
+    expect(within(container).getByRole('button', { name: 'Next' })).toHaveClass(
+      'ais-ChatToolDisplayResultsCarouselHeaderScrollButton'
+    );
+  });
+
   test('renders completed legacy v1 output when input has no v1 fields', () => {
     const tool = createDisplayResultsTool<TestResult>(mockItemComponent);
     const LayoutComponent = tool.layoutComponent!;

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -386,7 +386,10 @@ export function createOptionsTests(
           searchClient,
         },
         widgetParams: {
-          javascript: { ...createDefaultWidgetParams(chat), context: contextValue },
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            context: contextValue,
+          },
           react: { ...createDefaultWidgetParams(chat), context: contextValue },
           vue: {},
         },
@@ -429,7 +432,10 @@ export function createOptionsTests(
           searchClient,
         },
         widgetParams: {
-          javascript: { ...createDefaultWidgetParams(chat), context: contextFn },
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            context: contextFn,
+          },
           react: { ...createDefaultWidgetParams(chat), context: contextFn },
           vue: {},
         },
@@ -461,15 +467,16 @@ export function createOptionsTests(
 
       const chat = new Chat({});
       jest.spyOn(chat, 'sendMessage').mockImplementation(async (message) => {
-        const text = (message as any).text;
+        const text = message && 'text' in message ? message.text : undefined;
+        const parts = message && 'parts' in message ? message.parts ?? [] : [];
+        const metadata =
+          message && 'metadata' in message ? message.metadata : undefined;
         chat.messages = [
           {
             id: '1',
             role: 'user',
-            parts: text
-              ? [{ type: 'text', text }]
-              : (message as any).parts ?? [],
-            metadata: (message as any).metadata,
+            parts: text ? [{ type: 'text', text }] : parts,
+            metadata,
           },
         ] as any;
       });
@@ -482,7 +489,10 @@ export function createOptionsTests(
           searchClient,
         },
         widgetParams: {
-          javascript: { ...createDefaultWidgetParams(chat), context: contextValue },
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            context: contextValue,
+          },
           react: { ...createDefaultWidgetParams(chat), context: contextValue },
           vue: {},
         },
@@ -1831,20 +1841,36 @@ export function createOptionsTests(
 
       describe('display results tool', () => {
         const displayResultsMessage = (
-          output: unknown,
-          { preliminary = false } = {}
+          input: unknown,
+          {
+            state = 'output-available',
+            output = { status: 'success' },
+          }: {
+            state?: 'input-streaming' | 'input-available' | 'output-available';
+            output?: unknown;
+          } = {}
         ) =>
           ({
             id: '1',
             role: 'assistant',
             parts: [
               {
-                type: `tool-${DisplayResultsToolType}`,
-                toolCallId: '1',
-                input: {},
+                type: `tool-${SearchIndexToolType}`,
+                toolCallId: 'search',
+                input: { query: 'test' },
                 state: 'output-available',
+                output: {
+                  hits: ['1', '2', '3', '4', '5'].map((objectID) => ({
+                    objectID,
+                  })),
+                },
+              },
+              {
+                type: `tool-${DisplayResultsToolType}`,
+                toolCallId: 'display',
+                input,
+                state,
                 output,
-                ...(preliminary ? { preliminary: true } : {}),
               },
             ],
           } as any);
@@ -1911,10 +1937,16 @@ export function createOptionsTests(
           expect(whys).toHaveLength(1);
           expect(whys[0].textContent).toBe('matches your stride');
 
-          expect(document.querySelectorAll('.ais-Carousel')).toHaveLength(2);
-          expect(document.querySelectorAll('.ais-Carousel-item')).toHaveLength(
-            5
-          );
+          expect(
+            document.querySelectorAll(
+              '.ais-ChatToolDisplayResults .ais-Carousel'
+            )
+          ).toHaveLength(2);
+          expect(
+            document.querySelectorAll(
+              '.ais-ChatToolDisplayResults .ais-Carousel-item'
+            )
+          ).toHaveLength(5);
 
           const counts = document.querySelectorAll(
             '.ais-ChatToolDisplayResultsCarouselHeaderCount'
@@ -1936,7 +1968,7 @@ export function createOptionsTests(
           });
         });
 
-        test('shows streaming caption while preliminary flag is true', async () => {
+        test('shows the streaming caption while tool input is streaming', async () => {
           const searchClient = createSearchClient();
 
           const chat = new Chat({
@@ -1944,11 +1976,9 @@ export function createOptionsTests(
               displayResultsMessage(
                 {
                   intro: 'Curating',
-                  groups: [
-                    { title: 'Runners', results: [{ objectID: '1' }] },
-                  ],
+                  groups: [{ title: 'Runners', results: [{ objectID: '1' }] }],
                 },
-                { preliminary: true }
+                { state: 'input-streaming', output: undefined }
               ),
             ],
             id: 'chat-id',
@@ -1973,7 +2003,7 @@ export function createOptionsTests(
           ).toBeInTheDocument();
         });
 
-        test('renders nothing when output has no intro and no groups', async () => {
+        test('renders nothing when input has no intro and no groups', async () => {
           const searchClient = createSearchClient();
 
           const chat = new Chat({
@@ -2020,13 +2050,13 @@ export function createOptionsTests(
                   {
                     type: `tool-${DisplayResultsToolType}`,
                     toolCallId: '2',
-                    input: {},
-                    state: 'output-available',
-                    output: {
+                    input: {
                       groups: [
                         { title: 'Picks', results: [{ objectID: '1' }] },
                       ],
                     },
+                    state: 'output-available',
+                    output: { status: 'success' },
                   },
                 ],
               },
@@ -2078,13 +2108,13 @@ export function createOptionsTests(
                   {
                     type: `tool-${DisplayResultsToolType}`,
                     toolCallId: '2',
-                    input: {},
-                    state: 'output-available',
-                    output: {
+                    input: {
                       groups: [
                         { title: 'Picks', results: [{ objectID: '1' }] },
                       ],
                     },
+                    state: 'output-available',
+                    output: { status: 'success' },
                   },
                 ],
               },
@@ -2122,9 +2152,7 @@ export function createOptionsTests(
           const chat = new Chat({
             messages: [
               displayResultsMessage({
-                groups: [
-                  { title: 'Runners', results: [{ objectID: '1' }] },
-                ],
+                groups: [{ title: 'Runners', results: [{ objectID: '1' }] }],
               }),
             ],
             id: 'chat-id',
@@ -2141,8 +2169,7 @@ export function createOptionsTests(
                 tools: {
                   [DisplayResultsToolType]: {
                     templates: {
-                      layout:
-                        '<div id="custom-display">custom display</div>',
+                      layout: '<div id="custom-display">custom display</div>',
                     },
                   },
                 },
@@ -2163,9 +2190,9 @@ export function createOptionsTests(
 
           await openChat(act);
 
-          expect(
-            document.querySelector('#custom-display')!.textContent
-          ).toBe('custom display');
+          expect(document.querySelector('#custom-display')!.textContent).toBe(
+            'custom display'
+          );
           expect(
             document.querySelector('.ais-ChatToolDisplayResults')
           ).not.toBeInTheDocument();
@@ -2263,8 +2290,7 @@ export function createOptionsTests(
                 layout: (props, { html }: any) =>
                   html`<div class="custom-layout">
                     <span class="custom-layout-title">My Custom Chat</span>
-                    ${props.templates.header()}
-                    ${props.templates.prompt()}
+                    ${props.templates.header()} ${props.templates.prompt()}
                   </div>`,
               },
             },
@@ -2318,7 +2344,7 @@ export function createOptionsTests(
                     <button
                       class="custom-send"
                       onclick="${() =>
-                      props.sendMessage({ text: 'hello from layout' })}"
+                        props.sendMessage({ text: 'hello from layout' })}"
                     >
                       Send
                     </button>
@@ -2394,18 +2420,18 @@ export function createOptionsTests(
 
         await openChat(act);
 
-        expect(
-          document.querySelector('.custom-status')!.textContent
-        ).toBe('ready');
+        expect(document.querySelector('.custom-status')!.textContent).toBe(
+          'ready'
+        );
 
         await act(async () => {
           chat._state.status = 'submitted';
           await wait(0);
         });
 
-        expect(
-          document.querySelector('.custom-status')!.textContent
-        ).toBe('submitted');
+        expect(document.querySelector('.custom-status')!.textContent).toBe(
+          'submitted'
+        );
       });
 
       test('renders with inline layout component', async () => {

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -2201,6 +2201,60 @@ export function createOptionsTests(
           ).not.toBeInTheDocument();
         });
 
+        test('shows the loader for a callback-only display results override', async () => {
+          const searchClient = createSearchClient();
+          const chat = new Chat({});
+
+          await setup({
+            instantSearchOptions: {
+              indexName: 'indexName',
+              searchClient,
+            },
+            widgetParams: {
+              javascript: {
+                ...createDefaultWidgetParams(chat),
+                tools: {
+                  [DisplayResultsToolType]: {
+                    templates: {},
+                    onToolCall: jest.fn(),
+                  },
+                },
+              },
+              react: {
+                ...createDefaultWidgetParams(chat),
+                tools: {
+                  [DisplayResultsToolType]: {
+                    onToolCall: jest.fn(),
+                  },
+                },
+              },
+              vue: {},
+            },
+          });
+
+          await openChat(act);
+
+          await act(async () => {
+            chat._state.messages = [
+              displayResultsMessage(
+                {
+                  groups: [{ title: 'Runners', results: [{ objectID: '1' }] }],
+                },
+                { state: 'input-streaming', output: undefined }
+              ),
+            ];
+            chat._state.status = 'streaming';
+            await wait(0);
+          });
+
+          expect(
+            document.querySelector('.ais-ChatToolDisplayResults')
+          ).not.toBeInTheDocument();
+          expect(
+            document.querySelector('.ais-ChatMessageLoader')
+          ).toBeInTheDocument();
+        });
+
         test('allows a display results override to disable input streaming', async () => {
           const searchClient = createSearchClient();
 
@@ -2250,6 +2304,11 @@ export function createOptionsTests(
 
           await openChat(act);
 
+          await act(async () => {
+            chat._state.status = 'streaming';
+            await wait(0);
+          });
+
           expect(document.querySelector('.ais-Chat')).toBeInTheDocument();
           expect(
             document.querySelector('#custom-display')
@@ -2257,6 +2316,9 @@ export function createOptionsTests(
           expect(
             document.querySelector('.ais-ChatToolDisplayResults')
           ).not.toBeInTheDocument();
+          expect(
+            document.querySelector('.ais-ChatMessageLoader')
+          ).toBeInTheDocument();
         });
       });
     });

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -2033,6 +2033,15 @@ export function createOptionsTests(
           );
 
           await act(async () => {
+            chat._state.status = 'streaming';
+            await wait(0);
+          });
+
+          expect(
+            document.querySelector('.ais-ChatToolDisplayResults-streaming')
+          ).toBeInTheDocument();
+
+          await act(async () => {
             chat._state.messages = [
               ...chat.messages,
               {
@@ -2041,7 +2050,6 @@ export function createOptionsTests(
                 parts: [{ type: 'text', text: 'Next answer' }],
               },
             ];
-            chat._state.status = 'streaming';
             await wait(0);
           });
 

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -2146,14 +2146,17 @@ export function createOptionsTests(
           ).not.toBeInTheDocument();
         });
 
-        test('allows overriding the display results tool via the tools option', async () => {
+        test('streams input with a layout-only display results override', async () => {
           const searchClient = createSearchClient();
 
           const chat = new Chat({
             messages: [
-              displayResultsMessage({
-                groups: [{ title: 'Runners', results: [{ objectID: '1' }] }],
-              }),
+              displayResultsMessage(
+                {
+                  groups: [{ title: 'Runners', results: [{ objectID: '1' }] }],
+                },
+                { state: 'input-streaming', output: undefined }
+              ),
             ],
             id: 'chat-id',
           });
@@ -2193,6 +2196,64 @@ export function createOptionsTests(
           expect(document.querySelector('#custom-display')!.textContent).toBe(
             'custom display'
           );
+          expect(
+            document.querySelector('.ais-ChatToolDisplayResults')
+          ).not.toBeInTheDocument();
+        });
+
+        test('allows a display results override to disable input streaming', async () => {
+          const searchClient = createSearchClient();
+
+          const chat = new Chat({
+            messages: [
+              displayResultsMessage(
+                {
+                  groups: [{ title: 'Runners', results: [{ objectID: '1' }] }],
+                },
+                { state: 'input-streaming', output: undefined }
+              ),
+            ],
+            id: 'chat-id',
+          });
+
+          await setup({
+            instantSearchOptions: {
+              indexName: 'indexName',
+              searchClient,
+            },
+            widgetParams: {
+              javascript: {
+                ...createDefaultWidgetParams(chat),
+                tools: {
+                  [DisplayResultsToolType]: {
+                    streamInput: false,
+                    templates: {
+                      layout: '<div id="custom-display">custom display</div>',
+                    },
+                  },
+                },
+              },
+              react: {
+                ...createDefaultWidgetParams(chat),
+                tools: {
+                  [DisplayResultsToolType]: {
+                    streamInput: false,
+                    layoutComponent: () => (
+                      <div id="custom-display">custom display</div>
+                    ),
+                  },
+                },
+              },
+              vue: {},
+            },
+          });
+
+          await openChat(act);
+
+          expect(document.querySelector('.ais-Chat')).toBeInTheDocument();
+          expect(
+            document.querySelector('#custom-display')
+          ).not.toBeInTheDocument();
           expect(
             document.querySelector('.ais-ChatToolDisplayResults')
           ).not.toBeInTheDocument();

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -2256,6 +2256,60 @@ export function createOptionsTests(
           ).not.toBeInTheDocument();
         });
 
+        test('hides the loader while the default tool streams its input', async () => {
+          const searchClient = createSearchClient();
+          const chat = new Chat({});
+
+          await setup({
+            instantSearchOptions: {
+              indexName: 'indexName',
+              searchClient,
+            },
+            widgetParams: {
+              javascript: createDefaultWidgetParams(chat),
+              react: createDefaultWidgetParams(chat),
+              vue: {},
+            },
+          });
+
+          await openChat(act);
+
+          await act(async () => {
+            chat._state.messages = [
+              displayResultsMessage(
+                {
+                  intro: 'Curating',
+                  groups: [{ title: 'Runners', results: [{ objectID: '1' }] }],
+                },
+                { state: 'input-streaming', output: undefined }
+              ),
+            ];
+            chat._state.status = 'streaming';
+            await wait(0);
+          });
+
+          // The default tool opts into input streaming, so it owns the waiting
+          // state: content and its caption are visible and the loader is not.
+          expect(
+            document.querySelector('.ais-ChatToolDisplayResults')
+          ).toBeInTheDocument();
+          expect(
+            document.querySelector('.ais-ChatToolDisplayResults-groupTitle')
+              ?.textContent
+          ).toBe('Runners');
+          expect(
+            document.querySelectorAll(
+              '.ais-ChatToolDisplayResults .ais-Carousel-item'
+            )
+          ).toHaveLength(1);
+          expect(
+            document.querySelector('.ais-ChatToolDisplayResults-streaming')
+          ).toBeInTheDocument();
+          expect(
+            document.querySelector('.ais-ChatMessageLoader')
+          ).not.toBeInTheDocument();
+        });
+
         test('shows the loader for a callback-only display results override', async () => {
           const searchClient = createSearchClient();
           const chat = new Chat({});

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -1968,7 +1968,7 @@ export function createOptionsTests(
           });
         });
 
-        test('shows the streaming caption while tool input is streaming', async () => {
+        test('shows the streaming caption only for the active response', async () => {
           const searchClient = createSearchClient();
 
           const chat = new Chat({
@@ -1981,7 +1981,7 @@ export function createOptionsTests(
                 { state: 'input-streaming', output: undefined }
               ),
             ],
-            id: 'chat-id',
+            agentId: 'chat-id',
           });
 
           await setup({
@@ -1999,8 +1999,55 @@ export function createOptionsTests(
           await openChat(act);
 
           expect(
+            document.querySelector('.ais-ChatToolDisplayResults')
+          ).toBeInTheDocument();
+          expect(
+            document.querySelector('.ais-ChatToolDisplayResults-streaming')
+          ).not.toBeInTheDocument();
+
+          await act(async () => {
+            chat._state.status = 'streaming';
+            await wait(0);
+          });
+
+          expect(
             document.querySelector('.ais-ChatToolDisplayResults-streaming')
           ).toBeInTheDocument();
+
+          await act(async () => {
+            await chat.stop();
+            await wait(0);
+          });
+
+          expect(chat.status).toBe('ready');
+          expect(
+            document.querySelector('.ais-ChatToolDisplayResults')
+          ).toBeInTheDocument();
+          expect(
+            document.querySelector('.ais-ChatToolDisplayResults-streaming')
+          ).not.toBeInTheDocument();
+
+          const restoredChat = new Chat({ agentId: 'chat-id' });
+          expect(restoredChat.messages[0].parts[1]).toEqual(
+            expect.objectContaining({ state: 'input-streaming' })
+          );
+
+          await act(async () => {
+            chat._state.messages = [
+              ...chat.messages,
+              {
+                id: '2',
+                role: 'assistant',
+                parts: [{ type: 'text', text: 'Next answer' }],
+              },
+            ];
+            chat._state.status = 'streaming';
+            await wait(0);
+          });
+
+          expect(
+            document.querySelector('.ais-ChatToolDisplayResults-streaming')
+          ).not.toBeInTheDocument();
         });
 
         test('renders nothing when input has no intro and no groups', async () => {

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -2288,8 +2288,6 @@ export function createOptionsTests(
             await wait(0);
           });
 
-          // The default tool opts into input streaming, so it owns the waiting
-          // state: content and its caption are visible and the loader is not.
           expect(
             document.querySelector('.ais-ChatToolDisplayResults')
           ).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Renders Display Results v1 from streamed tool input instead of completed diagnostic output allowing curated results to appear while the agent is responding.

[FX-3901]

## Implementation

- Enables input streaming for the default JavaScript and React tools.
- Preserves input streaming for layout only Display Results tool overrides. `streamInput: false` remains an explicit opt out.
- Uses valid v1 input as the display source and keeps completed output as diagnostics.
- Retains a narrow compatibility path for stored messages containing completed v1 output.
- Hydrates records only from searches before the owning Display Results call.
- Omits unresolved identifiers and empty groups.
- Preserves supplied result order and duplicates while keeping hydrated record fields canonical.
- Measures shared Carousel navigation when item count changes. This also reaches Recommend and Algolia Experiences consumers. Initial paint, resize handling and focus policy remain follow up work.

## Scope guard

This PR implements the v1 grouped schema only. It does not add v2 UI blocks, change the backend schema or introduce a new public option.

## Validation

- Focused renderer and hydration tests.
- Common Display Results tests across JavaScript and React.
- QA covering streamed input, completed diagnostics and legacy output fallback.

[FX-3901]: https://algolia.atlassian.net/browse/FX-3901
