### PR TITLE
feat(chat): render reasoning parts

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -2,8 +2,14 @@
 import { compiler } from 'markdown-to-jsx';
 
 import { cx, startsWith } from '../../lib';
+import { isReasoningPartActive } from '../../lib/utils/chat';
 import { createButtonComponent } from '../Button';
 
+import {
+  createChatMessageReasoningComponent,
+  type ChatMessageReasoningClassNames,
+  type ChatMessageReasoningTranslations,
+} from './ChatMessageReasoning';
 import { MenuIcon } from './icons';
 
 import type { ComponentProps, Renderer, VNode } from '../../types';
@@ -36,7 +42,7 @@ export type ChatMessageTranslations = {
    * The label for message actions
    */
   actionsLabel: string;
-};
+} & Partial<ChatMessageReasoningTranslations>;
 
 export type ChatMessageClassNames = {
   /**
@@ -67,7 +73,7 @@ export type ChatMessageClassNames = {
    * Class names to apply to the footer element
    */
   footer: string | string[];
-};
+} & Partial<ChatMessageReasoningClassNames>;
 
 export type ChatMessageActionProps = {
   /**
@@ -155,6 +161,10 @@ export type ChatMessageProps = ComponentProps<'article'> & {
    */
   suggestionsElement?: VNode;
   /**
+   * Whether to render reasoning parts
+   */
+  showReasoning?: boolean;
+  /**
    * Optional class names
    */
   classNames?: Partial<ChatMessageClassNames>;
@@ -163,14 +173,14 @@ export type ChatMessageProps = ComponentProps<'article'> & {
    */
   translations?: Partial<ChatMessageTranslations>;
   /**
-   * Whether to render text parts as markdown.
+   * Whether to render text and reasoning parts as markdown.
    *
-   * When `true` (default), text parts are compiled with `markdown-to-jsx`
-   * (links, code blocks, emphasis, …). When `false`, text parts render as
-   * plain text with newlines preserved — useful for user messages where the
-   * source is the human's literal input and incidental markdown syntax (`*`,
-   * `_`, …) shouldn't be transformed. Note that opting out means links in the
-   * output are no longer clickable.
+   * When `true` (default), they are compiled with `markdown-to-jsx` (links,
+   * code blocks, emphasis, …). When `false`, they render as plain text with
+   * newlines preserved — useful for user messages where the source is the
+   * human's literal input and incidental markdown syntax (`*`, `_`, …)
+   * shouldn't be transformed. Note that opting out means links in the output
+   * are no longer clickable.
    */
   parseMarkdown?: boolean;
 };
@@ -180,6 +190,9 @@ const SearchIndexToolType = 'algolia_search_index';
 
 export function createChatMessageComponent({ createElement }: Renderer) {
   const Button = createButtonComponent({ createElement });
+  const ChatMessageReasoning = createChatMessageReasoningComponent({
+    createElement,
+  });
 
   return function ChatMessage(userProps: ChatMessageProps) {
     const {
@@ -200,6 +213,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
       onClose,
       translations: userTranslations,
       suggestionsElement,
+      showReasoning = false,
       parseMarkdown = true,
       ...props
     } = userProps;
@@ -207,15 +221,19 @@ export function createChatMessageComponent({ createElement }: Renderer) {
     const translations: Required<ChatMessageTranslations> = {
       messageLabel: 'Message',
       actionsLabel: 'Message actions',
+      reasoningLabel: 'Reasoning',
       ...userTranslations,
     };
 
     const hasLeading = Boolean(LeadingComponent);
+    const isCurrentMessage =
+      messages === undefined ||
+      messages[messages.length - 1]?.id === message.id;
 
     const showActions =
       Boolean(actions.length > 0 || ActionsComponent) && status === 'ready';
 
-    const cssClasses: ChatMessageClassNames = {
+    const cssClasses: Required<ChatMessageClassNames> = {
       root: cx(
         'ais-ChatMessage',
         `ais-ChatMessage--${side}`,
@@ -229,6 +247,31 @@ export function createChatMessageComponent({ createElement }: Renderer) {
       message: cx('ais-ChatMessage-message', classNames.message),
       actions: cx('ais-ChatMessage-actions', classNames.actions),
       footer: cx('ais-ChatMessage-footer', classNames.footer),
+      reasoning: cx('ais-ChatMessageReasoning', classNames.reasoning),
+      reasoningHeader: cx(
+        'ais-ChatMessageReasoning-header',
+        classNames.reasoningHeader
+      ),
+      reasoningIcon: cx(
+        'ais-ChatMessageReasoning-icon',
+        classNames.reasoningIcon
+      ),
+      reasoningLabel: cx(
+        'ais-ChatMessageReasoning-label',
+        classNames.reasoningLabel
+      ),
+      reasoningChevron: cx(
+        'ais-ChatMessageReasoning-chevron',
+        classNames.reasoningChevron
+      ),
+      reasoningBody: cx(
+        'ais-ChatMessageReasoning-body',
+        classNames.reasoningBody
+      ),
+      reasoningText: cx(
+        'ais-ChatMessageReasoning-text',
+        classNames.reasoningText
+      ),
     };
 
     function renderMessagePart(
@@ -237,6 +280,39 @@ export function createChatMessageComponent({ createElement }: Renderer) {
     ) {
       if (part.type === 'step-start') {
         return null;
+      }
+      if (part.type === 'reasoning') {
+        if (!showReasoning) {
+          return null;
+        }
+
+        const isReasoningStreaming =
+          status === 'streaming' &&
+          isCurrentMessage &&
+          isReasoningPartActive(message.parts, index);
+
+        if (!isReasoningStreaming && part.text.trim().length === 0) {
+          return null;
+        }
+
+        return (
+          <ChatMessageReasoning
+            key={`${message.id}-${index}`}
+            part={part}
+            isStreaming={isReasoningStreaming}
+            parseMarkdown={parseMarkdown}
+            translations={translations}
+            classNames={{
+              ...cssClasses,
+              reasoningLabel: cx(
+                'ais-ChatMessageReasoning-label',
+                isReasoningStreaming &&
+                  'ais-ChatMessageReasoning-label--streaming',
+                classNames.reasoningLabel
+              ),
+            }}
+          />
+        );
       }
       if (part.type === 'text') {
         // Back-compat shim for sessions started before the move from a

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
@@ -1,0 +1,122 @@
+/** @jsx createElement */
+import { compiler } from 'markdown-to-jsx';
+
+import { cx } from '../../lib';
+
+import { BrainIcon, ChevronDownIcon } from './icons';
+
+import type { Renderer } from '../../types';
+import type { ReasoningUIPart } from './types';
+
+export type ChatMessageReasoningTranslations = {
+  /**
+   * The label for a reasoning disclosure
+   */
+  reasoningLabel: string;
+};
+
+export type ChatMessageReasoningClassNames = {
+  /**
+   * Class names to apply to a reasoning disclosure
+   */
+  reasoning: string | string[];
+  /**
+   * Class names to apply to a reasoning disclosure header
+   */
+  reasoningHeader: string | string[];
+  /**
+   * Class names to apply to a reasoning disclosure icon
+   */
+  reasoningIcon: string | string[];
+  /**
+   * Class names to apply to a reasoning disclosure label
+   */
+  reasoningLabel: string | string[];
+  /**
+   * Class names to apply to a reasoning disclosure chevron
+   */
+  reasoningChevron: string | string[];
+  /**
+   * Class names to apply to a reasoning disclosure body
+   */
+  reasoningBody: string | string[];
+  /**
+   * Class names to apply to reasoning text
+   */
+  reasoningText: string | string[];
+};
+
+type ChatMessageReasoningProps = {
+  key?: string | number;
+  /**
+   * The reasoning part to render
+   */
+  part: ReasoningUIPart;
+  /**
+   * Whether this part is the one currently being produced
+   */
+  isStreaming: boolean;
+  /**
+   * Whether to parse the reasoning text as Markdown
+   */
+  parseMarkdown?: boolean;
+  translations: ChatMessageReasoningTranslations;
+  classNames: ChatMessageReasoningClassNames;
+};
+
+export function createChatMessageReasoningComponent({
+  createElement,
+}: Pick<Renderer, 'createElement'>) {
+  return function ChatMessageReasoning(userProps: ChatMessageReasoningProps) {
+    const {
+      part,
+      isStreaming,
+      parseMarkdown = true,
+      translations,
+      classNames,
+    } = userProps;
+    const body = parseMarkdown ? (
+      compiler(part.text, {
+        createElement: createElement as any,
+        disableParsingRawHTML: true,
+      })
+    ) : (
+      // `ais-ChatMessage-text` carries the `white-space: pre-wrap` that keeps the
+      // newlines markdown would otherwise collapse, as text parts do.
+      <p className="ais-ChatMessage-text">{part.text}</p>
+    );
+
+    return (
+      <details
+        className={cx(classNames.reasoning)}
+        aria-label={translations.reasoningLabel}
+        aria-busy={isStreaming}
+      >
+        <summary className={cx(classNames.reasoningHeader)}>
+          <span className={cx(classNames.reasoningIcon)} aria-hidden="true">
+            <BrainIcon createElement={createElement} />
+          </span>
+          {/* The indicator is a sibling of the label rather than part of its
+              text, so a translated label long enough to ellipsize truncates
+              before it. The chevron's auto margin takes the free space, keeping
+              the two adjacent without a wrapper.
+              Unclassed on purpose: the stylesheet reaches it as the unclassed
+              sibling of the streaming label, so no further `ais-*` name is
+              committed to. Being decorative it takes its type from the header, so
+              `reasoningHeader` styles it with the label. */}
+          <span className={cx(classNames.reasoningLabel)}>
+            {translations.reasoningLabel}
+          </span>
+          {isStreaming ? <span aria-hidden="true">…</span> : null}
+          <span className={cx(classNames.reasoningChevron)} aria-hidden="true">
+            <ChevronDownIcon createElement={createElement} />
+          </span>
+        </summary>
+
+        <div className={cx(classNames.reasoningBody)} tabIndex={0}>
+          <div className={cx(classNames.reasoningText)}>{body}</div>
+        </div>
+      </details>
+    );
+  };
+}

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
@@ -81,8 +81,8 @@ export function createChatMessageReasoningComponent({
         disableParsingRawHTML: true,
       })
     ) : (
-      // `ais-ChatMessage-text` carries the `white-space: pre-wrap` that keeps the
-      // newlines markdown would otherwise collapse, as text parts do.
+      // Borrowed from text parts for its `white-space: pre-wrap`, which keeps the
+      // newlines markdown would collapse.
       <p className="ais-ChatMessage-text">{part.text}</p>
     );
 
@@ -96,18 +96,9 @@ export function createChatMessageReasoningComponent({
           <span className={cx(classNames.reasoningIcon)} aria-hidden="true">
             <BrainIcon createElement={createElement} />
           </span>
-          {/* The indicator is a sibling of the label rather than part of its
-              text, so a translated label long enough to ellipsize truncates
-              before it. The chevron's auto margin takes the free space, keeping
-              the two adjacent without a wrapper.
-              Unclassed on purpose: the stylesheet reaches it as the unclassed
-              sibling of the streaming label, so no further `ais-*` name is
-              committed to. Being decorative it takes its type from the header, so
-              `reasoningHeader` styles it with the label. */}
           <span className={cx(classNames.reasoningLabel)}>
             {translations.reasoningLabel}
           </span>
-          {isStreaming ? <span aria-hidden="true">…</span> : null}
           <span className={cx(classNames.reasoningChevron)} aria-hidden="true">
             <ChevronDownIcon createElement={createElement} />
           </span>

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -248,8 +248,8 @@ const copyToClipboard = (message: ChatMessageBase) => {
   navigator.clipboard.writeText(getTextContent(message));
 };
 
-// Own-key presence, which is what a JSX spread copies — `in` would also answer
-// for inherited keys the spread leaves behind.
+// Own-key presence is what a JSX spread copies; `in` would also answer for
+// inherited keys the spread leaves behind.
 const hasOwnKey = (target: object | undefined, key: string) =>
   target !== undefined && Object.prototype.hasOwnProperty.call(target, key);
 
@@ -404,22 +404,17 @@ export function createChatMessagesComponent({
     props: Parameters<typeof DefaultMessageComponent>[0]
   ) {
     const messageFeedback = props.feedbackState?.[props.message.id];
-    // Resolve the per-role inputs below from the same side the row renders with
-    // (the `messageProps` selection in `DefaultMessage`), so a change to one
-    // role's props does not invalidate the other's completed rows, and a change
-    // to the row's own side is not missed.
+    // Read the row's own side, mirroring `DefaultMessage`, so one role's change
+    // neither invalidates the other's completed rows nor goes unnoticed here.
     const messageProps =
       props.message.role === 'user'
         ? props.userMessageProps
         : props.assistantMessageProps;
     const showReasoning = messageProps?.showReasoning;
     const parseMarkdown = messageProps?.parseMarkdown;
-    // Object-level fallback, matching the render: `{...messageProps}` replaces
-    // `translations` wholesale rather than merging it, so resolving key by key
-    // here would keep a stale label when a caller swaps the object. Own-key
-    // presence rather than nullishness for the same reason — the spread copies a
-    // key that is present but `undefined`, which replaces the shared object
-    // instead of deferring to it and leaves the built-in default to render.
+    // Object-level fallback, matching the render: the spread replaces
+    // `translations` wholesale, and it copies a key holding `undefined` too. Both
+    // are why this resolves by own-key presence rather than key by key.
     const reasoningTranslations = hasOwnKey(messageProps, 'translations')
       ? messageProps?.translations
       : props.messageTranslations;
@@ -434,8 +429,8 @@ export function createChatMessagesComponent({
     const reasoningChevronClassName = cx(reasoningClassNames?.reasoningChevron);
     const reasoningBodyClassName = cx(reasoningClassNames?.reasoningBody);
     const reasoningTextClassName = cx(reasoningClassNames?.reasoningText);
-    // This dependency list is the row comparator. Using the full props object
-    // would recompile every completed message on each streaming update.
+    // The row comparator. The full props object would recompile every completed
+    // message on each streaming update.
     return useMemo(
       () => <DefaultMessageComponent {...props} />,
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -531,9 +526,8 @@ export function createChatMessagesComponent({
 
     const lastMessage = messages[messages.length - 1];
     const lastPart = lastMessage?.parts?.[lastMessage.parts.length - 1];
-    // Only the loader consumes this, and only when reasoning is rendered, so
-    // skip the scan entirely while the opt-in is off — it walks the last
-    // message's parts and slices the remainder for each streaming reasoning part.
+    // The scan slices the remaining parts per candidate, and only the loader reads
+    // it, so skip it entirely while the opt-in is off.
     const hasActiveReasoning = assistantMessageProps?.showReasoning
       ? lastMessage?.parts?.some((_, index, parts) =>
           isReasoningPartActive(parts, index)
@@ -676,9 +670,8 @@ const getShowLoader = (
   if (status === 'submitted') return true;
 
   if (!lastPart) return true;
-  // An active reasoning disclosure carries its own progress affordance, so the
-  // loader would double it. Reasoning that has settled still shows the loader,
-  // because the answer has not started yet.
+  // An active disclosure carries its own progress affordance, so the loader would
+  // double it. Settled reasoning still shows it: the answer has not started.
   if (showReasoning && hasActiveReasoning) return false;
   if (isPartText(lastPart)) return false;
 

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -5,6 +5,7 @@ import {
   findTool,
   getTextContent,
   hasTextContent,
+  isReasoningPartActive,
   isPartText,
   isPartTool,
 } from '../../lib/utils/chat';
@@ -247,6 +248,11 @@ const copyToClipboard = (message: ChatMessageBase) => {
   navigator.clipboard.writeText(getTextContent(message));
 };
 
+// Own-key presence, which is what a JSX spread copies — `in` would also answer
+// for inherited keys the spread leaves behind.
+const hasOwnKey = (target: object | undefined, key: string) =>
+  target !== undefined && Object.prototype.hasOwnProperty.call(target, key);
+
 function createDefaultMessageComponent<
   TMessage extends ChatMessageBase = ChatMessageBase
 >({ createElement, Fragment }: Renderer) {
@@ -273,6 +279,7 @@ function createDefaultMessageComponent<
   }: {
     key: string;
     message: TMessage;
+    isCurrentMessage: boolean;
     status: ChatStatus;
     userMessageProps?: Partial<ChatMessageProps>;
     assistantMessageProps?: Partial<ChatMessageProps>;
@@ -397,13 +404,57 @@ export function createChatMessagesComponent({
     props: Parameters<typeof DefaultMessageComponent>[0]
   ) {
     const messageFeedback = props.feedbackState?.[props.message.id];
+    // Resolve the per-role inputs below from the same side the row renders with
+    // (the `messageProps` selection in `DefaultMessage`), so a change to one
+    // role's props does not invalidate the other's completed rows, and a change
+    // to the row's own side is not missed.
+    const messageProps =
+      props.message.role === 'user'
+        ? props.userMessageProps
+        : props.assistantMessageProps;
+    const showReasoning = messageProps?.showReasoning;
+    const parseMarkdown = messageProps?.parseMarkdown;
+    // Object-level fallback, matching the render: `{...messageProps}` replaces
+    // `translations` wholesale rather than merging it, so resolving key by key
+    // here would keep a stale label when a caller swaps the object. Own-key
+    // presence rather than nullishness for the same reason — the spread copies a
+    // key that is present but `undefined`, which replaces the shared object
+    // instead of deferring to it and leaves the built-in default to render.
+    const reasoningTranslations = hasOwnKey(messageProps, 'translations')
+      ? messageProps?.translations
+      : props.messageTranslations;
+    const reasoningLabel = reasoningTranslations?.reasoningLabel;
+    const reasoningClassNames = hasOwnKey(messageProps, 'classNames')
+      ? messageProps?.classNames
+      : props.classNames;
+    const reasoningClassName = cx(reasoningClassNames?.reasoning);
+    const reasoningHeaderClassName = cx(reasoningClassNames?.reasoningHeader);
+    const reasoningIconClassName = cx(reasoningClassNames?.reasoningIcon);
+    const reasoningLabelClassName = cx(reasoningClassNames?.reasoningLabel);
+    const reasoningChevronClassName = cx(reasoningClassNames?.reasoningChevron);
+    const reasoningBodyClassName = cx(reasoningClassNames?.reasoningBody);
+    const reasoningTextClassName = cx(reasoningClassNames?.reasoningText);
+    // This dependency list is the row comparator. Using the full props object
+    // would recompile every completed message on each streaming update.
     return useMemo(
       () => <DefaultMessageComponent {...props} />,
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [
         props.message,
+        props.isCurrentMessage,
         props.status,
         props.suggestionsElement,
         messageFeedback,
+        showReasoning,
+        parseMarkdown,
+        reasoningLabel,
+        reasoningClassName,
+        reasoningHeaderClassName,
+        reasoningIconClassName,
+        reasoningLabelClassName,
+        reasoningChevronClassName,
+        reasoningBodyClassName,
+        reasoningTextClassName,
       ]
     );
   }
@@ -480,7 +531,21 @@ export function createChatMessagesComponent({
 
     const lastMessage = messages[messages.length - 1];
     const lastPart = lastMessage?.parts?.[lastMessage.parts.length - 1];
-    const showLoader = getShowLoader(status, lastPart, tools);
+    // Only the loader consumes this, and only when reasoning is rendered, so
+    // skip the scan entirely while the opt-in is off — it walks the last
+    // message's parts and slices the remainder for each streaming reasoning part.
+    const hasActiveReasoning = assistantMessageProps?.showReasoning
+      ? lastMessage?.parts?.some((_, index, parts) =>
+          isReasoningPartActive(parts, index)
+        ) ?? false
+      : false;
+    const showLoader = getShowLoader(
+      status,
+      lastPart,
+      tools,
+      assistantMessageProps?.showReasoning,
+      hasActiveReasoning
+    );
 
     const showEmpty =
       messages.length === 0 && !showLoader && !isClearing && status !== 'error';
@@ -526,6 +591,7 @@ export function createChatMessagesComponent({
               <DefaultMessage
                 key={message.id}
                 message={message}
+                isCurrentMessage={index === messages.length - 1}
                 status={status}
                 userMessageProps={userMessageProps}
                 assistantMessageProps={assistantMessageProps}
@@ -602,12 +668,18 @@ export function createChatMessagesComponent({
 const getShowLoader = (
   status: ChatStatus,
   lastPart: ChatMessageBase['parts'][number] | undefined,
-  tools: ClientSideTools
+  tools: ClientSideTools,
+  showReasoning: boolean | undefined,
+  hasActiveReasoning: boolean
 ): boolean => {
   if (status !== 'submitted' && status !== 'streaming') return false;
   if (status === 'submitted') return true;
 
   if (!lastPart) return true;
+  // An active reasoning disclosure carries its own progress affordance, so the
+  // loader would double it. Reasoning that has settled still shows the loader,
+  // because the answer has not started yet.
+  if (showReasoning && hasActiveReasoning) return false;
   if (isPartText(lastPart)) return false;
 
   if (isPartTool(lastPart) && lastPart.state === 'input-streaming') {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -3,9 +3,14 @@
  */
 /** @jsx createElement */
 import { render } from '@testing-library/preact';
+import userEvent from '@testing-library/user-event';
 import { Fragment, createElement } from 'preact';
 
-import { createChatMessageComponent } from '../ChatMessage';
+import {
+  createChatMessageComponent,
+  type ChatMessageClassNames,
+  type ChatMessageTranslations,
+} from '../ChatMessage';
 
 import type { AddToolResult, ChatMessageBase, ClientSideTool } from '../types';
 
@@ -15,6 +20,38 @@ const ChatMessage = createChatMessageComponent({
 });
 
 describe('ChatMessage', () => {
+  test('accepts customization types without reasoning overrides', () => {
+    const classNames: ChatMessageClassNames = {
+      root: 'root',
+      container: 'container',
+      leading: 'leading',
+      content: 'content',
+      message: 'message',
+      actions: 'actions',
+      footer: 'footer',
+    };
+    const translations: ChatMessageTranslations = {
+      messageLabel: 'Message',
+      actionsLabel: 'Message actions',
+    };
+
+    expect({ classNames, translations }).toEqual({
+      classNames: {
+        root: 'root',
+        container: 'container',
+        leading: 'leading',
+        content: 'content',
+        message: 'message',
+        actions: 'actions',
+        footer: 'footer',
+      },
+      translations: {
+        messageLabel: 'Message',
+        actionsLabel: 'Message actions',
+      },
+    });
+  });
+
   test('renders with default props', () => {
     const { container } = render(
       <ChatMessage
@@ -206,6 +243,663 @@ describe('ChatMessage', () => {
         </div>
       </div>
     `);
+  });
+
+  test('renders reasoning in an accessible disclosure when enabled', () => {
+    const { getByRole, getByText } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'I should search the catalog first.',
+              state: 'done',
+            },
+          ],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    expect(getByRole('group', { name: 'Reasoning' })).toBeInTheDocument();
+    expect(getByText('I should search the catalog first.')).toBeInTheDocument();
+  });
+
+  test('makes overflowing reasoning keyboard reachable', () => {
+    const { getByRole, queryByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: Array.from(
+                { length: 20 },
+                (_, index) => `Reasoning paragraph ${index + 1}.`
+              ).join('\n\n'),
+              state: 'done',
+            },
+          ],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    const disclosure = getByRole('group', { name: 'Reasoning' });
+    const summary = disclosure.querySelector('summary')!;
+    userEvent.click(summary);
+
+    const body = disclosure.querySelector('.ais-ChatMessageReasoning-body')!;
+    expect(body).toHaveAttribute('tabindex', '0');
+    expect(queryByRole('region', { hidden: true })).not.toBeInTheDocument();
+
+    summary.focus();
+    userEvent.tab();
+    expect(body).toHaveFocus();
+  });
+
+  test('does not render reasoning unless it is enabled', () => {
+    const { queryByRole, queryByText } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'reasoning', text: 'Private reasoning' }],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(queryByRole('group', { name: 'Reasoning' })).not.toBeInTheDocument();
+    expect(queryByText('Private reasoning')).not.toBeInTheDocument();
+  });
+
+  test.each([
+    ['stopped', 'ready' as const, ''],
+    ['disconnected', 'error' as const, ''],
+    ['finished with only whitespace', 'ready' as const, ' \n '],
+  ])(
+    'does not render blank reasoning after a response is %s',
+    (_responseState, status, text) => {
+      const { queryByRole } = render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={{
+            role: 'assistant',
+            id: '1',
+            parts: [{ type: 'reasoning', text, state: 'done' }],
+          }}
+          status={status}
+          tools={{}}
+          onClose={jest.fn()}
+          showReasoning={true}
+        />
+      );
+
+      expect(
+        queryByRole('group', { name: 'Reasoning' })
+      ).not.toBeInTheDocument();
+    }
+  );
+
+  test('renders empty reasoning while the response is active', () => {
+    const { getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'reasoning', text: '', state: 'streaming' }],
+        }}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+  });
+
+  test('keeps reasoning disclosures in message part order', () => {
+    const { container, getAllByRole, getByText, queryAllByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            { type: 'reasoning', text: 'First thought', state: 'done' },
+            {
+              type: 'tool-test_tool',
+              toolCallId: '123',
+              input: {},
+              state: 'output-available',
+              output: { data: 'Tool result' },
+            },
+            { type: 'reasoning', text: 'Second thought', state: 'done' },
+            { type: 'text', text: 'Final answer' },
+          ],
+        }}
+        status="ready"
+        tools={{
+          test_tool: {
+            layoutComponent: () => <div>Tool result</div>,
+            addToolResult: jest.fn(),
+            applyFilters: jest.fn(),
+          },
+        }}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    const message = container.querySelector('.ais-ChatMessage-message')!;
+    const children = Array.from(message.children);
+    const disclosures = getAllByRole('group', { name: 'Reasoning' });
+
+    expect(children).toHaveLength(4);
+    expect(children[0]).toBe(disclosures[0]);
+    expect(children[1]).toContainElement(getByText('Tool result'));
+    expect(children[2]).toBe(disclosures[1]);
+    expect(children[3]).toContainElement(getByText('Final answer'));
+    expect(queryAllByRole('region')).toHaveLength(0);
+  });
+
+  test('marks only the streaming reasoning disclosure as busy', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'First thought',
+          state: 'done' as const,
+        },
+        {
+          type: 'reasoning' as const,
+          text: 'Second thought',
+          state: 'streaming' as const,
+        },
+      ],
+    };
+    const { getAllByRole, rerender } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={message}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    let disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
+    expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+    expect(disclosures[0]).not.toHaveAttribute('open');
+    expect(disclosures[1]).not.toHaveAttribute('open');
+    expect(
+      disclosures[0].querySelector('.ais-ChatMessageReasoning-label')
+    ).toHaveTextContent(/^Reasoning$/);
+    expect(
+      disclosures[1].querySelector('.ais-ChatMessageReasoning-label')
+    ).toHaveTextContent(/^Reasoning$/);
+    expect(
+      disclosures[1].querySelector('.ais-ChatMessageReasoning-label')!
+        .nextElementSibling
+    ).toHaveTextContent('…');
+
+    rerender(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          ...message,
+          parts: [message.parts[0], { ...message.parts[1], state: 'done' }],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
+    expect(disclosures[1]).toHaveAttribute('aria-busy', 'false');
+    expect(disclosures[0]).not.toHaveAttribute('open');
+    expect(disclosures[1]).not.toHaveAttribute('open');
+    expect(
+      disclosures[1].querySelector('.ais-ChatMessageReasoning-label')
+    ).toHaveTextContent(/^Reasoning$/);
+    // Nothing between the settled label and the chevron: the indicator is gone.
+    expect(
+      disclosures[1].querySelector('.ais-ChatMessageReasoning-label')!
+        .nextElementSibling
+    ).toHaveClass('ais-ChatMessageReasoning-chevron');
+  });
+
+  test('keeps the streaming indicator out of the truncating label', () => {
+    const { getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'reasoning', text: 'Working', state: 'streaming' }],
+        }}
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [{ type: 'reasoning', text: 'Working', state: 'streaming' }],
+          },
+        ]}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+        translations={{
+          reasoningLabel: 'Raisonnement de la demande en cours',
+        }}
+      />
+    );
+
+    const summary = getByRole('group', {
+      name: 'Raisonnement de la demande en cours',
+    }).querySelector('summary')!;
+    const label = summary.querySelector('.ais-ChatMessageReasoning-label')!;
+    const ellipsis = label.nextElementSibling!;
+
+    // The label carries `text-overflow: ellipsis`, so a long translated label
+    // truncates. The indicator has to live outside it to survive that, and
+    // directly between the label and the chevron: the chevron's auto margin is
+    // what takes the free space, keeping the indicator against the label.
+    expect(label).toHaveTextContent(/^Raisonnement de la demande en cours$/);
+    expect(label).toHaveClass('ais-ChatMessageReasoning-label--streaming');
+    expect(ellipsis).toHaveTextContent('…');
+    // Decorative, so it must stay out of the disclosure's accessible name.
+    expect(ellipsis).toHaveAttribute('aria-hidden', 'true');
+    expect(label.contains(ellipsis)).toBe(false);
+    expect(ellipsis.nextElementSibling).toBe(
+      summary.querySelector('.ais-ChatMessageReasoning-chevron')
+    );
+    // Unclassed on purpose. The stylesheet reaches it through the streaming
+    // label beside it, so the indicator adds no `ais-*` name to the public CSS
+    // surface — which is why that modifier is asserted above.
+    expect(ellipsis).not.toHaveAttribute('class');
+  });
+
+  test('styles the streaming indicator through the header, not the label', () => {
+    const { getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'reasoning', text: 'Working', state: 'streaming' }],
+        }}
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [{ type: 'reasoning', text: 'Working', state: 'streaming' }],
+          },
+        ]}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+        classNames={{
+          reasoningHeader: 'custom-header',
+          reasoningLabel: 'custom-label',
+        }}
+      />
+    );
+
+    const summary = getByRole('group', { name: 'Reasoning' }).querySelector(
+      'summary'
+    )!;
+    const label = summary.querySelector('.ais-ChatMessageReasoning-label')!;
+
+    // The indicator is a decorative sibling of the label, so it inherits the
+    // row's type from the header. `reasoningHeader` therefore restyles the label
+    // and the indicator together, while `reasoningLabel` reaches the label only —
+    // it must not be applied to a second, non-label element to widen its reach.
+    expect(summary).toHaveClass('custom-header');
+    expect(label).toHaveClass('custom-label');
+    expect(label.nextElementSibling).not.toHaveClass('custom-label');
+    expect(label.nextElementSibling).not.toHaveAttribute('class');
+  });
+
+  test('marks only the latest unfinished reasoning block as busy', () => {
+    const { getAllByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Compare the candidates',
+              state: 'streaming',
+            },
+            {
+              type: 'reasoning',
+              text: 'Check one candidate',
+              state: 'streaming',
+            },
+          ],
+        }}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    const disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
+    expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+    expect(
+      disclosures[0].querySelector('.ais-ChatMessageReasoning-label--streaming')
+    ).not.toBeInTheDocument();
+    expect(
+      disclosures[1].querySelector('.ais-ChatMessageReasoning-label--streaming')
+    ).toBeInTheDocument();
+  });
+
+  test('marks reasoning as busy only on the active response', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'previous',
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Stopped reasoning',
+            state: 'streaming' as const,
+          },
+        ],
+      },
+      {
+        role: 'assistant' as const,
+        id: 'current',
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Current reasoning',
+            state: 'streaming' as const,
+          },
+        ],
+      },
+    ];
+
+    const { getAllByRole } = render(
+      <Fragment>
+        {messages.map((message) => (
+          <ChatMessage
+            key={message.id}
+            indexUiState={{}}
+            setIndexUiState={jest.fn()}
+            message={message}
+            messages={messages}
+            status="streaming"
+            tools={{}}
+            onClose={jest.fn()}
+            showReasoning={true}
+          />
+        ))}
+      </Fragment>
+    );
+
+    const disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
+    expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+  });
+
+  test('does not mark reasoning as busy after answer text starts streaming', () => {
+    const { getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Checking the catalog',
+              state: 'streaming',
+            },
+            {
+              type: 'text',
+              text: 'Here is what I found',
+              state: 'streaming',
+            },
+          ],
+        }}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    const disclosure = getByRole('group', { name: 'Reasoning' });
+    expect(disclosure).toHaveAttribute('aria-busy', 'false');
+    expect(
+      disclosure.querySelector('.ais-ChatMessageReasoning-label--streaming')
+    ).not.toBeInTheDocument();
+  });
+
+  test('marks an earlier unfinished reasoning block as busy after a later block ends', () => {
+    const { getAllByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Compare the candidates',
+              state: 'streaming',
+            },
+            {
+              type: 'reasoning',
+              text: 'Check one candidate',
+              state: 'done',
+            },
+          ],
+        }}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+
+    const disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'true');
+    expect(disclosures[1]).toHaveAttribute('aria-busy', 'false');
+  });
+
+  test('preserves an open disclosure while reasoning text streams', () => {
+    const renderMessage = (text: string) => (
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'reasoning', text, state: 'streaming' }],
+        }}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+    const { getByRole, rerender } = render(renderMessage('First'));
+    const disclosure = getByRole('group', { name: 'Reasoning' });
+
+    userEvent.click(disclosure.querySelector('summary')!);
+    expect(disclosure).toHaveAttribute('open');
+
+    rerender(renderMessage('First second'));
+    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute('open');
+  });
+
+  test('keeps a reader-opened disclosure open once the answer starts and the response completes', () => {
+    const renderMessage = (
+      answer?: string,
+      status: 'streaming' | 'ready' = 'streaming'
+    ) => (
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Checking the catalog',
+              state: answer ? ('done' as const) : ('streaming' as const),
+            },
+            ...(answer
+              ? [
+                  {
+                    type: 'text' as const,
+                    text: answer,
+                    state:
+                      status === 'ready'
+                        ? ('done' as const)
+                        : ('streaming' as const),
+                  },
+                ]
+              : []),
+          ],
+        }}
+        status={status}
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+      />
+    );
+    const { getByRole, rerender } = render(renderMessage());
+    const disclosure = getByRole('group', { name: 'Reasoning' });
+
+    // Active reasoning stays collapsed until the reader opens it.
+    expect(disclosure).not.toHaveAttribute('open');
+    expect(disclosure).toHaveAttribute('aria-busy', 'true');
+
+    userEvent.click(disclosure.querySelector('summary')!);
+    expect(disclosure).toHaveAttribute('open');
+
+    // Reasoning ends and the answer starts mid-response.
+    rerender(renderMessage('The answer starts'));
+    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute('open');
+    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute(
+      'aria-busy',
+      'false'
+    );
+
+    // The response completes.
+    rerender(renderMessage('The answer starts', 'ready'));
+    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute('open');
+  });
+
+  test('renders reasoning as markdown with a translated label', () => {
+    const { container, getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Check the **release date**.',
+              state: 'done',
+            },
+          ],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+        translations={{ reasoningLabel: 'Raisonnement' }}
+      />
+    );
+
+    expect(getByRole('group', { name: 'Raisonnement' })).toBeInTheDocument();
+    expect(container.querySelector('strong')).toHaveTextContent('release date');
+  });
+
+  test('renders reasoning as plain text when parseMarkdown is false', () => {
+    const { container, getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Check the **release date**.\nThen compare.',
+              state: 'done',
+            },
+          ],
+        }}
+        status="ready"
+        tools={{}}
+        onClose={jest.fn()}
+        showReasoning={true}
+        parseMarkdown={false}
+      />
+    );
+
+    const body = getByRole('group', { name: 'Reasoning' }).querySelector(
+      '.ais-ChatMessageReasoning-text'
+    )!;
+    expect(container.querySelector('strong')).toBeNull();
+    expect(body.textContent).toBe('Check the **release date**.\nThen compare.');
+    // Same literal-text element as text parts use, so the newline survives.
+    expect(body.querySelector('.ais-ChatMessage-text')).not.toBeNull();
   });
 
   test('parses text parts as markdown by default', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -472,7 +472,7 @@ describe('ChatMessage', () => {
     expect(
       disclosures[1].querySelector('.ais-ChatMessageReasoning-label')!
         .nextElementSibling
-    ).toHaveTextContent('…');
+    ).toHaveClass('ais-ChatMessageReasoning-chevron');
 
     rerender(
       <ChatMessage
@@ -497,14 +497,13 @@ describe('ChatMessage', () => {
     expect(
       disclosures[1].querySelector('.ais-ChatMessageReasoning-label')
     ).toHaveTextContent(/^Reasoning$/);
-    // Nothing between the settled label and the chevron: the indicator is gone.
     expect(
       disclosures[1].querySelector('.ais-ChatMessageReasoning-label')!
         .nextElementSibling
     ).toHaveClass('ais-ChatMessageReasoning-chevron');
   });
 
-  test('keeps the streaming indicator out of the truncating label', () => {
+  test('signals activity on the label alone while streaming', () => {
     const { getByRole } = render(
       <ChatMessage
         indexUiState={{}}
@@ -531,32 +530,27 @@ describe('ChatMessage', () => {
       />
     );
 
-    const summary = getByRole('group', {
+    const disclosure = getByRole('group', {
       name: 'Raisonnement de la demande en cours',
-    }).querySelector('summary')!;
+    });
+    const summary = disclosure.querySelector('summary')!;
     const label = summary.querySelector('.ais-ChatMessageReasoning-label')!;
-    const ellipsis = label.nextElementSibling!;
 
-    // The label carries `text-overflow: ellipsis`, so a long translated label
-    // truncates. The indicator has to live outside it to survive that, and
-    // directly between the label and the chevron: the chevron's auto margin is
-    // what takes the free space, keeping the indicator against the label.
+    expect(disclosure).toHaveAttribute('aria-busy', 'true');
     expect(label).toHaveTextContent(/^Raisonnement de la demande en cours$/);
     expect(label).toHaveClass('ais-ChatMessageReasoning-label--streaming');
-    expect(ellipsis).toHaveTextContent('…');
-    // Decorative, so it must stay out of the disclosure's accessible name.
-    expect(ellipsis).toHaveAttribute('aria-hidden', 'true');
-    expect(label.contains(ellipsis)).toBe(false);
-    expect(ellipsis.nextElementSibling).toBe(
-      summary.querySelector('.ais-ChatMessageReasoning-chevron')
-    );
-    // Unclassed on purpose. The stylesheet reaches it through the streaming
-    // label beside it, so the indicator adds no `ais-*` name to the public CSS
-    // surface — which is why that modifier is asserted above.
-    expect(ellipsis).not.toHaveAttribute('class');
+
+    expect(
+      Array.from(summary.children).map((child) => child.className)
+    ).toEqual([
+      'ais-ChatMessageReasoning-icon',
+      'ais-ChatMessageReasoning-label ais-ChatMessageReasoning-label--streaming',
+      'ais-ChatMessageReasoning-chevron',
+    ]);
+    expect(summary).toHaveTextContent(/^Raisonnement de la demande en cours$/);
   });
 
-  test('styles the streaming indicator through the header, not the label', () => {
+  test('routes custom header and label class names to their own elements', () => {
     const { getByRole } = render(
       <ChatMessage
         indexUiState={{}}
@@ -589,14 +583,12 @@ describe('ChatMessage', () => {
     )!;
     const label = summary.querySelector('.ais-ChatMessageReasoning-label')!;
 
-    // The indicator is a decorative sibling of the label, so it inherits the
-    // row's type from the header. `reasoningHeader` therefore restyles the label
-    // and the indicator together, while `reasoningLabel` reaches the label only —
-    // it must not be applied to a second, non-label element to widen its reach.
     expect(summary).toHaveClass('custom-header');
     expect(label).toHaveClass('custom-label');
-    expect(label.nextElementSibling).not.toHaveClass('custom-label');
-    expect(label.nextElementSibling).not.toHaveAttribute('class');
+    expect(label).toHaveClass('ais-ChatMessageReasoning-label--streaming');
+    expect(
+      summary.querySelector('.ais-ChatMessageReasoning-chevron')
+    ).not.toHaveClass('custom-label');
   });
 
   test('marks only the latest unfinished reasoning block as busy', () => {
@@ -821,14 +813,12 @@ describe('ChatMessage', () => {
     const { getByRole, rerender } = render(renderMessage());
     const disclosure = getByRole('group', { name: 'Reasoning' });
 
-    // Active reasoning stays collapsed until the reader opens it.
     expect(disclosure).not.toHaveAttribute('open');
     expect(disclosure).toHaveAttribute('aria-busy', 'true');
 
     userEvent.click(disclosure.querySelector('summary')!);
     expect(disclosure).toHaveAttribute('open');
 
-    // Reasoning ends and the answer starts mid-response.
     rerender(renderMessage('The answer starts'));
     expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute('open');
     expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute(
@@ -836,7 +826,6 @@ describe('ChatMessage', () => {
       'false'
     );
 
-    // The response completes.
     rerender(renderMessage('The answer starts', 'ready'));
     expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute('open');
   });
@@ -898,7 +887,6 @@ describe('ChatMessage', () => {
     )!;
     expect(container.querySelector('strong')).toBeNull();
     expect(body.textContent).toBe('Check the **release date**.\nThen compare.');
-    // Same literal-text element as text parts use, so the newline survives.
     expect(body.querySelector('.ais-ChatMessage-text')).not.toBeNull();
   });
 

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -466,9 +466,8 @@ describe('ChatMessages', () => {
     }
   );
 
-  // The test above moves all seven keys together, so six of them could stop
-  // being row comparator dependencies without it noticing. One key at a time
-  // makes each dependency individually load-bearing.
+  // The test above moves all seven keys at once, so six could stop being
+  // dependencies unnoticed. One key at a time makes each individually load-bearing.
   const reasoningClassCases: Array<
     [string, 'messageClassNames' | 'assistantMessageProps']
   > = [
@@ -501,8 +500,8 @@ describe('ChatMessages', () => {
       const createProps = (suffix: string) => {
         const reasoningClassNames = { [key]: `${key}-${suffix}` };
         return {
-          // The same `message` reference in both renders, so the one class name
-          // is the only input the comparator can react to.
+          // Same `message` reference in both renders, so the class name is the
+          // only input the comparator can react to.
           messages: [message],
           indexUiState: {},
           setIndexUiState: jest.fn(),
@@ -573,9 +572,8 @@ describe('ChatMessages', () => {
       'Nested'
     );
 
-    // The nested object replaces `messageTranslations` wholesale rather than
-    // merging, so dropping its label falls back to the built-in default, not to
-    // the outer `messageTranslations` value.
+    // The nested object replaces `messageTranslations` wholesale, so dropping its
+    // label falls back to the built-in default, not to the outer value.
     rerender(
       <MemoizedChatMessages {...createProps({ messageLabel: 'Unrelated' })} />
     );
@@ -619,10 +617,8 @@ describe('ChatMessages', () => {
       'Nested'
     );
 
-    // The key is still there, holding `undefined`. Spreading it replaces
-    // `messageTranslations` rather than deferring to it, so the built-in default
-    // renders — and the comparator has to read presence, not nullishness, or the
-    // row keeps the label it can no longer be showing.
+    // The key is present holding `undefined`, which still replaces
+    // `messageTranslations`. The comparator has to read presence, not nullishness.
     rerender(<MemoizedChatMessages {...createProps(undefined)} />);
 
     expect(container.querySelector('details')).toHaveAttribute(
@@ -663,10 +659,8 @@ describe('ChatMessages', () => {
     );
     expect(container.querySelectorAll('.shared-reasoning')).toHaveLength(1);
 
-    // The mirror of the translations case, and the reason both fallbacks read
-    // own-key presence: the two surfaces hold the same value here, so a nullish
-    // fallback would compute an unchanged dependency and strand the class on a
-    // row that no longer renders it.
+    // Both surfaces hold the same value here, so a nullish fallback would compute
+    // an unchanged dependency and strand the class on a row that dropped it.
     rerender(<MemoizedChatMessages {...createProps(undefined)} />);
 
     expect(container.querySelectorAll('.shared-reasoning')).toHaveLength(0);
@@ -717,11 +711,9 @@ describe('ChatMessages', () => {
 
     rerender(<MemoizedChatMessages {...createProps('Raisonnement')} />);
 
-    // A user row renders with `userMessageProps`, so an assistant-only change
-    // must not invalidate it — that would recompile its markdown to produce
-    // exactly the same output.
+    // A user row renders with `userMessageProps`, so an assistant-only change must
+    // not invalidate it and recompile its markdown to the same output.
     expect(userRenders).toBe(baseline);
-    // The assistant row still has to pick the new label up.
     expect(screen.getAllByRole('group', { name: 'Raisonnement' })).toHaveLength(
       1
     );
@@ -760,9 +752,7 @@ describe('ChatMessages', () => {
       'Reasoning'
     );
 
-    // The mirror of the test above: reading the row's own side is what keeps a
-    // user-side change from going stale, which reading `assistantMessageProps`
-    // for every role would have missed.
+    // Reading `assistantMessageProps` for every role would strand this change.
     rerender(<MemoizedChatMessages {...createProps('Raisonnement')} />);
 
     expect(container.querySelector('details')).toHaveAttribute(
@@ -804,9 +794,8 @@ describe('ChatMessages', () => {
 
     const { unmount } = render(<ChatMessages {...props} />);
 
-    // Only the loader reads the result, and only when reasoning is rendered, so
-    // the scan — which slices the remaining parts per candidate — must not run
-    // while the opt-in is off.
+    // The scan slices the remaining parts per candidate, so it must not run while
+    // the opt-in is off.
     expect(isReasoningPartActive).not.toHaveBeenCalled();
 
     unmount();
@@ -848,8 +837,8 @@ describe('ChatMessages', () => {
     );
     expect(container.querySelector('details')).toBeNull();
 
-    // Completed rows have to react to the option itself, not only to reasoning
-    // labels and classes: a host app can flip it after the answer settled.
+    // A host app can flip the option after the answer settled, so completed rows
+    // have to react to the option itself, not only to labels and classes.
     rerender(<MemoizedChatMessages {...createProps(true)} />);
 
     expect(container.querySelector('details')).not.toBeNull();
@@ -899,8 +888,6 @@ describe('ChatMessages', () => {
       );
       expect(container.querySelector('em')).not.toBeNull();
 
-      // The completed row has to recompile when the option flips, so the row
-      // comparator needs it too.
       rerender(<MemoizedChatMessages {...createProps(false)} />);
 
       expect(container.querySelector('em')).toBeNull();

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -4,7 +4,9 @@
 /** @jsx createElement */
 import { render, screen } from '@testing-library/preact';
 import { Fragment, createElement } from 'preact';
+import { useMemo } from 'preact/hooks';
 
+import * as chatUtils from '../../../lib/utils/chat';
 import { createChatMessageErrorComponent } from '../ChatMessageError';
 import { createChatMessagesComponent } from '../ChatMessages';
 
@@ -14,6 +16,11 @@ const ChatMessages = createChatMessagesComponent({
   createElement,
   Fragment,
   useMemo: (factory) => factory(),
+});
+const MemoizedChatMessages = createChatMessagesComponent({
+  createElement,
+  Fragment,
+  useMemo,
 });
 const ChatMessageError = createChatMessageErrorComponent({ createElement });
 
@@ -144,6 +151,710 @@ describe('ChatMessages', () => {
     `);
   });
 
+  test('shows the loader while streaming reasoning is hidden', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Checking the catalog.',
+                state: 'streaming',
+              },
+            ],
+          },
+        ]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        status="streaming"
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole('group', { name: 'Reasoning' })
+    ).not.toBeInTheDocument();
+    expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
+  });
+
+  test('does not show the loader below visible streaming reasoning', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Checking the catalog.',
+                state: 'streaming',
+              },
+            ],
+          },
+        ]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        status="streaming"
+        assistantMessageProps={{ showReasoning: true }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('group', { name: 'Reasoning' })
+    ).toBeInTheDocument();
+    expect(container.querySelector('.ais-ChatMessageLoader')).toBeNull();
+  });
+
+  test('shows the loader after empty reasoning finishes while the response continues', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [
+              {
+                type: 'reasoning',
+                text: '',
+                state: 'done',
+              },
+            ],
+          },
+        ]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        status="streaming"
+        assistantMessageProps={{ showReasoning: true }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole('group', { name: 'Reasoning' })
+    ).not.toBeInTheDocument();
+    expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
+  });
+
+  test('shows the loader after visible reasoning finishes while the response continues', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Checking the catalog.',
+                state: 'done',
+              },
+            ],
+          },
+        ]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        status="streaming"
+        assistantMessageProps={{ showReasoning: true }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('group', { name: 'Reasoning' })
+    ).toBeInTheDocument();
+    expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
+  });
+
+  test('does not show the loader while an earlier reasoning part is still active', () => {
+    const { container } = render(
+      <ChatMessages
+        messages={[
+          {
+            role: 'assistant',
+            id: '1',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Checking the catalog.',
+                state: 'streaming',
+              },
+              {
+                type: 'reasoning',
+                text: 'Comparing the results.',
+                state: 'done',
+              },
+            ],
+          },
+        ]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        status="streaming"
+        assistantMessageProps={{ showReasoning: true }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getAllByRole('group', { name: 'Reasoning' })[0]
+    ).toHaveAttribute('aria-busy', 'true');
+    expect(container.querySelector('.ais-ChatMessageLoader')).toBeNull();
+  });
+
+  test('updates nested reasoning labels for every completed message', () => {
+    const firstMessage = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Checking the catalog.',
+          state: 'done' as const,
+        },
+      ],
+    };
+    const secondMessage = {
+      role: 'assistant' as const,
+      id: '2',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Comparing the results.',
+          state: 'done' as const,
+        },
+      ],
+    };
+    const { rerender } = render(
+      <MemoizedChatMessages
+        messages={[firstMessage, secondMessage]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        assistantMessageProps={{
+          showReasoning: true,
+          translations: { reasoningLabel: 'Reasoning' },
+        }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.getAllByRole('group', { name: 'Reasoning' })).toHaveLength(2);
+
+    rerender(
+      <MemoizedChatMessages
+        messages={[firstMessage, { ...secondMessage }]}
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        assistantMessageProps={{
+          showReasoning: true,
+          translations: { reasoningLabel: 'Raisonnement' },
+        }}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole('group', { name: 'Reasoning' })
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByRole('group', { name: 'Raisonnement' })).toHaveLength(
+      2
+    );
+  });
+
+  test.each(['messageClassNames', 'assistantMessageProps'] as const)(
+    'updates reasoning classes for every completed message through %s',
+    (classNameSource) => {
+      const firstMessage = {
+        role: 'assistant' as const,
+        id: '1',
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Checking the catalog.',
+            state: 'done' as const,
+          },
+        ],
+      };
+      const secondMessage = {
+        role: 'assistant' as const,
+        id: '2',
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Comparing the results.',
+            state: 'done' as const,
+          },
+        ],
+      };
+      const createReasoningClassNames = (suffix: string) => ({
+        reasoning: `reasoning-${suffix}`,
+        reasoningHeader: `reasoning-header-${suffix}`,
+        reasoningIcon: `reasoning-icon-${suffix}`,
+        reasoningLabel: `reasoning-label-${suffix}`,
+        reasoningChevron: `reasoning-chevron-${suffix}`,
+        reasoningBody: `reasoning-body-${suffix}`,
+        reasoningText: `reasoning-text-${suffix}`,
+      });
+      const createClassNameProps = (suffix: string) =>
+        classNameSource === 'messageClassNames'
+          ? {
+              messageClassNames: createReasoningClassNames(suffix),
+              assistantMessageProps: { showReasoning: true },
+            }
+          : {
+              assistantMessageProps: {
+                showReasoning: true,
+                classNames: createReasoningClassNames(suffix),
+              },
+            };
+      const { container, rerender } = render(
+        <MemoizedChatMessages
+          messages={[firstMessage, secondMessage]}
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          {...createClassNameProps('old')}
+          tools={{}}
+          onReload={jest.fn()}
+          onClose={jest.fn()}
+        />
+      );
+      const firstDisclosure = container.querySelector('details');
+      firstDisclosure!.open = true;
+      Object.values(createReasoningClassNames('old')).forEach((className) => {
+        expect(container.querySelectorAll(`.${className}`)).toHaveLength(2);
+      });
+
+      rerender(
+        <MemoizedChatMessages
+          messages={[firstMessage, { ...secondMessage }]}
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          {...createClassNameProps('new')}
+          tools={{}}
+          onReload={jest.fn()}
+          onClose={jest.fn()}
+        />
+      );
+
+      Object.values(createReasoningClassNames('old')).forEach((className) => {
+        expect(container.querySelectorAll(`.${className}`)).toHaveLength(0);
+      });
+      Object.values(createReasoningClassNames('new')).forEach((className) => {
+        expect(container.querySelectorAll(`.${className}`)).toHaveLength(2);
+      });
+      expect(container.querySelector('details')).toBe(firstDisclosure);
+      expect(firstDisclosure).toHaveProperty('open', true);
+      expect(firstDisclosure).toHaveAttribute('aria-label', 'Reasoning');
+      expect(firstDisclosure).toHaveAttribute('aria-busy', 'false');
+    }
+  );
+
+  // The test above moves all seven keys together, so six of them could stop
+  // being row comparator dependencies without it noticing. One key at a time
+  // makes each dependency individually load-bearing.
+  const reasoningClassCases: Array<
+    [string, 'messageClassNames' | 'assistantMessageProps']
+  > = [
+    'reasoning',
+    'reasoningHeader',
+    'reasoningIcon',
+    'reasoningLabel',
+    'reasoningChevron',
+    'reasoningBody',
+    'reasoningText',
+  ].flatMap((key) => [
+    [key, 'messageClassNames'],
+    [key, 'assistantMessageProps'],
+  ]);
+
+  test.each(reasoningClassCases)(
+    'updates the %s class on its own for completed messages through %s',
+    (key, classNameSource) => {
+      const message = {
+        role: 'assistant' as const,
+        id: '1',
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Checking the catalog.',
+            state: 'done' as const,
+          },
+        ],
+      };
+      const createProps = (suffix: string) => {
+        const reasoningClassNames = { [key]: `${key}-${suffix}` };
+        return {
+          // The same `message` reference in both renders, so the one class name
+          // is the only input the comparator can react to.
+          messages: [message],
+          indexUiState: {},
+          setIndexUiState: jest.fn(),
+          tools: {},
+          onReload: jest.fn(),
+          onClose: jest.fn(),
+          ...(classNameSource === 'messageClassNames'
+            ? {
+                messageClassNames: reasoningClassNames,
+                assistantMessageProps: { showReasoning: true },
+              }
+            : {
+                assistantMessageProps: {
+                  showReasoning: true,
+                  classNames: reasoningClassNames,
+                },
+              }),
+        };
+      };
+
+      const { container, rerender } = render(
+        <MemoizedChatMessages {...createProps('old')} />
+      );
+      const disclosure = container.querySelector('details')!;
+      disclosure.open = true;
+      expect(container.querySelectorAll(`.${key}-old`)).toHaveLength(1);
+
+      rerender(<MemoizedChatMessages {...createProps('new')} />);
+
+      expect(container.querySelectorAll(`.${key}-old`)).toHaveLength(0);
+      expect(container.querySelectorAll(`.${key}-new`)).toHaveLength(1);
+      // Updated in place rather than remounted, so reader state survives.
+      expect(container.querySelector('details')).toBe(disclosure);
+      expect(disclosure).toHaveProperty('open', true);
+    }
+  );
+
+  test('falls back to the default label when a nested override is removed', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Checking the catalog.',
+          state: 'done' as const,
+        },
+      ],
+    };
+    const createProps = (
+      translations: Record<string, string>
+    ): React.ComponentProps<typeof MemoizedChatMessages> => ({
+      messages: [message],
+      indexUiState: {},
+      setIndexUiState: jest.fn(),
+      messageTranslations: { reasoningLabel: 'Nested' },
+      assistantMessageProps: { showReasoning: true, translations },
+      tools: {},
+      onReload: jest.fn(),
+      onClose: jest.fn(),
+    });
+
+    const { container, rerender } = render(
+      <MemoizedChatMessages {...createProps({ reasoningLabel: 'Nested' })} />
+    );
+    expect(container.querySelector('details')).toHaveAttribute(
+      'aria-label',
+      'Nested'
+    );
+
+    // The nested object replaces `messageTranslations` wholesale rather than
+    // merging, so dropping its label falls back to the built-in default, not to
+    // the outer `messageTranslations` value.
+    rerender(
+      <MemoizedChatMessages {...createProps({ messageLabel: 'Unrelated' })} />
+    );
+
+    expect(container.querySelector('details')).toHaveAttribute(
+      'aria-label',
+      'Reasoning'
+    );
+  });
+
+  test('falls back to the default label when a nested override becomes undefined', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Checking the catalog.',
+          state: 'done' as const,
+        },
+      ],
+    };
+    const createProps = (
+      translations: Record<string, string> | undefined
+    ): React.ComponentProps<typeof MemoizedChatMessages> => ({
+      messages: [message],
+      indexUiState: {},
+      setIndexUiState: jest.fn(),
+      messageTranslations: { reasoningLabel: 'Nested' },
+      assistantMessageProps: { showReasoning: true, translations },
+      tools: {},
+      onReload: jest.fn(),
+      onClose: jest.fn(),
+    });
+
+    const { container, rerender } = render(
+      <MemoizedChatMessages {...createProps({ reasoningLabel: 'Nested' })} />
+    );
+    expect(container.querySelector('details')).toHaveAttribute(
+      'aria-label',
+      'Nested'
+    );
+
+    // The key is still there, holding `undefined`. Spreading it replaces
+    // `messageTranslations` rather than deferring to it, so the built-in default
+    // renders — and the comparator has to read presence, not nullishness, or the
+    // row keeps the label it can no longer be showing.
+    rerender(<MemoizedChatMessages {...createProps(undefined)} />);
+
+    expect(container.querySelector('details')).toHaveAttribute(
+      'aria-label',
+      'Reasoning'
+    );
+  });
+
+  test('drops a nested class override when it becomes undefined', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Checking the catalog.',
+          state: 'done' as const,
+        },
+      ],
+    };
+    const createProps = (
+      classNames: Record<string, string> | undefined
+    ): React.ComponentProps<typeof MemoizedChatMessages> => ({
+      messages: [message],
+      indexUiState: {},
+      setIndexUiState: jest.fn(),
+      messageClassNames: { reasoning: 'shared-reasoning' },
+      assistantMessageProps: { showReasoning: true, classNames },
+      tools: {},
+      onReload: jest.fn(),
+      onClose: jest.fn(),
+    });
+
+    const { container, rerender } = render(
+      <MemoizedChatMessages
+        {...createProps({ reasoning: 'shared-reasoning' })}
+      />
+    );
+    expect(container.querySelectorAll('.shared-reasoning')).toHaveLength(1);
+
+    // The mirror of the translations case, and the reason both fallbacks read
+    // own-key presence: the two surfaces hold the same value here, so a nullish
+    // fallback would compute an unchanged dependency and strand the class on a
+    // row that no longer renders it.
+    rerender(<MemoizedChatMessages {...createProps(undefined)} />);
+
+    expect(container.querySelectorAll('.shared-reasoning')).toHaveLength(0);
+  });
+
+  test('leaves completed user rows alone when assistant reasoning changes', () => {
+    const userMessage = {
+      role: 'user' as const,
+      id: '1',
+      parts: [{ type: 'text' as const, text: 'Show me sneakers.' }],
+    };
+    const assistantMessage = {
+      role: 'assistant' as const,
+      id: '2',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Checking the catalog.',
+          state: 'done' as const,
+        },
+      ],
+    };
+    let userRenders = 0;
+    const createProps = (reasoningLabel: string) => ({
+      messages: [userMessage, assistantMessage],
+      indexUiState: {},
+      setIndexUiState: jest.fn(),
+      userMessageProps: {
+        footerComponent: () => {
+          userRenders++;
+          return <span />;
+        },
+      },
+      assistantMessageProps: {
+        showReasoning: true,
+        translations: { reasoningLabel },
+      },
+      tools: {},
+      onReload: jest.fn(),
+      onClose: jest.fn(),
+    });
+
+    const { rerender } = render(
+      <MemoizedChatMessages {...createProps('Reasoning')} />
+    );
+    const baseline = userRenders;
+    expect(baseline).toBeGreaterThan(0);
+
+    rerender(<MemoizedChatMessages {...createProps('Raisonnement')} />);
+
+    // A user row renders with `userMessageProps`, so an assistant-only change
+    // must not invalidate it — that would recompile its markdown to produce
+    // exactly the same output.
+    expect(userRenders).toBe(baseline);
+    // The assistant row still has to pick the new label up.
+    expect(screen.getAllByRole('group', { name: 'Raisonnement' })).toHaveLength(
+      1
+    );
+  });
+
+  test('updates completed user rows when their own reasoning changes', () => {
+    const message = {
+      role: 'user' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Checking the catalog.',
+          state: 'done' as const,
+        },
+      ],
+    };
+    const createProps = (reasoningLabel: string) => ({
+      messages: [message],
+      indexUiState: {},
+      setIndexUiState: jest.fn(),
+      userMessageProps: {
+        showReasoning: true,
+        translations: { reasoningLabel },
+      },
+      tools: {},
+      onReload: jest.fn(),
+      onClose: jest.fn(),
+    });
+
+    const { container, rerender } = render(
+      <MemoizedChatMessages {...createProps('Reasoning')} />
+    );
+    expect(container.querySelector('details')).toHaveAttribute(
+      'aria-label',
+      'Reasoning'
+    );
+
+    // The mirror of the test above: reading the row's own side is what keeps a
+    // user-side change from going stale, which reading `assistantMessageProps`
+    // for every role would have missed.
+    rerender(<MemoizedChatMessages {...createProps('Raisonnement')} />);
+
+    expect(container.querySelector('details')).toHaveAttribute(
+      'aria-label',
+      'Raisonnement'
+    );
+  });
+
+  test('does not scan for active reasoning while the disclosure is off', () => {
+    const isReasoningPartActive = jest.spyOn(
+      chatUtils,
+      'isReasoningPartActive'
+    );
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'One.',
+          state: 'streaming' as const,
+        },
+        {
+          type: 'reasoning' as const,
+          text: 'Two.',
+          state: 'streaming' as const,
+        },
+      ],
+    };
+    const props = {
+      messages: [message],
+      indexUiState: {},
+      setIndexUiState: jest.fn(),
+      status: 'streaming' as const,
+      tools: {},
+      onReload: jest.fn(),
+      onClose: jest.fn(),
+    };
+
+    const { unmount } = render(<ChatMessages {...props} />);
+
+    // Only the loader reads the result, and only when reasoning is rendered, so
+    // the scan — which slices the remaining parts per candidate — must not run
+    // while the opt-in is off.
+    expect(isReasoningPartActive).not.toHaveBeenCalled();
+
+    unmount();
+    render(
+      <ChatMessages
+        {...props}
+        assistantMessageProps={{ showReasoning: true }}
+      />
+    );
+
+    expect(isReasoningPartActive).toHaveBeenCalled();
+    isReasoningPartActive.mockRestore();
+  });
+
+  test('toggles the disclosure on completed messages when the option changes', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Checking the catalog.',
+          state: 'done' as const,
+        },
+      ],
+    };
+    const createProps = (showReasoning: boolean) => ({
+      messages: [message],
+      indexUiState: {},
+      setIndexUiState: jest.fn(),
+      assistantMessageProps: { showReasoning },
+      tools: {},
+      onReload: jest.fn(),
+      onClose: jest.fn(),
+    });
+
+    const { container, rerender } = render(
+      <MemoizedChatMessages {...createProps(false)} />
+    );
+    expect(container.querySelector('details')).toBeNull();
+
+    // Completed rows have to react to the option itself, not only to reasoning
+    // labels and classes: a host app can flip it after the answer settled.
+    rerender(<MemoizedChatMessages {...createProps(true)} />);
+
+    expect(container.querySelector('details')).not.toBeNull();
+  });
+
   describe('parseMarkdown', () => {
     test('parses user message text as markdown by default', () => {
       const { container } = render(
@@ -165,6 +876,35 @@ describe('ChatMessages', () => {
 
       expect(container.querySelector('em')).not.toBeNull();
       expect(container.querySelector('.ais-ChatMessage-text')).toBeNull();
+    });
+
+    test('switches completed messages between markdown and plain text', () => {
+      const message = {
+        role: 'user' as const,
+        id: '1',
+        parts: [{ type: 'text' as const, text: 'a *b* c' }],
+      };
+      const createProps = (parseMarkdown: boolean) => ({
+        messages: [message],
+        indexUiState: {},
+        setIndexUiState: jest.fn(),
+        userMessageProps: { parseMarkdown },
+        tools: {},
+        onReload: jest.fn(),
+        onClose: jest.fn(),
+      });
+
+      const { container, rerender } = render(
+        <MemoizedChatMessages {...createProps(true)} />
+      );
+      expect(container.querySelector('em')).not.toBeNull();
+
+      // The completed row has to recompile when the option flips, so the row
+      // comparator needs it too.
+      rerender(<MemoizedChatMessages {...createProps(false)} />);
+
+      expect(container.querySelector('em')).toBeNull();
+      expect(container.querySelector('.ais-ChatMessage-text')).not.toBeNull();
     });
 
     test('renders user message text as plain text via userMessageProps', () => {
@@ -219,9 +959,7 @@ describe('ChatMessages', () => {
 
       const messages = container.querySelectorAll('.ais-ChatMessage-message');
       // User message: plain text, no emphasis.
-      expect(
-        messages[0].querySelector('.ais-ChatMessage-text')
-      ).not.toBeNull();
+      expect(messages[0].querySelector('.ais-ChatMessage-text')).not.toBeNull();
       expect(messages[0].querySelector('em')).toBeNull();
       // Assistant message: still parsed as markdown.
       expect(messages[1].querySelector('em')).not.toBeNull();
@@ -251,7 +989,9 @@ describe('ChatMessages', () => {
       );
 
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(2);
     });
 
@@ -269,7 +1009,9 @@ describe('ChatMessages', () => {
       );
 
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(0);
     });
 
@@ -291,7 +1033,9 @@ describe('ChatMessages', () => {
         container.querySelector('.ais-ChatMessage-feedbackSpinner')
       ).not.toBeNull();
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(0);
     });
 
@@ -341,7 +1085,9 @@ describe('ChatMessages', () => {
       );
 
       expect(
-        container.querySelectorAll('[aria-label="Like"], [aria-label="Dislike"]')
+        container.querySelectorAll(
+          '[aria-label="Like"], [aria-label="Dislike"]'
+        )
       ).toHaveLength(0);
     });
   });

--- a/packages/instantsearch-ui-components/src/components/chat/icons.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/icons.tsx
@@ -265,6 +265,29 @@ export function ThumbsDownIcon({ createElement }: IconProps) {
   );
 }
 
+export function BrainIcon({ createElement }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 18V5" />
+      <path d="M15 13a4.17 4.17 0 0 1-3-4 4.17 4.17 0 0 1-3 4" />
+      <path d="M17.598 6.5A3 3 0 1 0 12 5a3 3 0 1 0-5.598 1.5" />
+      <path d="M17.997 5.125a4 4 0 0 1 2.526 5.77" />
+      <path d="M18 18a4 4 0 0 0 2-7.464" />
+      <path d="M19.967 17.483A4 4 0 1 1 12 18a4 4 0 1 1-7.967-.517" />
+      <path d="M6 18a4 4 0 0 1-2-7.464" />
+      <path d="M6.003 5.125a4 4 0 0 0-2.526 5.77" />
+    </svg>
+  );
+}
+
 export function ChevronLeftIcon({ createElement }: IconProps) {
   return (
     <svg

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -14,7 +14,7 @@ const SearchIndexToolType = 'algolia_search_index';
 
 export const getTextContent = (message: ChatMessageBase) => {
   return message.parts
-    .map((part) => ('text' in part ? part.text : ''))
+    .map((part) => (part.type === 'text' ? part.text : ''))
     .join('');
 };
 
@@ -33,6 +33,24 @@ export const isPartTool = (
 ): part is ChatToolMessage => {
   return startsWith(part.type, 'tool-');
 };
+
+export function isReasoningPartActive(
+  parts: ChatMessageBase['parts'],
+  index: number
+): boolean {
+  const part = parts[index];
+
+  return (
+    part?.type === 'reasoning' &&
+    part.state === 'streaming' &&
+    !parts
+      .slice(index + 1)
+      .some(
+        (laterPart) =>
+          laterPart.type !== 'reasoning' || laterPart.state === 'streaming'
+      )
+  );
+}
 
 export const findTool = (
   partType: string,

--- a/packages/instantsearch.css/src/components/chat.scss
+++ b/packages/instantsearch.css/src/components/chat.scss
@@ -11,6 +11,7 @@
 @use 'chat/chat-header';
 @use 'chat/chat-messages';
 @use 'chat/chat-message';
+@use 'chat/chat-message-reasoning';
 @use 'chat/chat-message-loader';
 @use 'chat/chat-greeting';
 @use 'chat/chat-prompt';

--- a/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
@@ -34,11 +34,9 @@
   list-style: none;
   user-select: none;
 
-  // Declared here rather than on the label so the label and the streaming
-  // indicator beside it inherit one value: `reasoningHeader` restyles the row,
-  // while a `reasoningLabel` override reaches the label alone — the indicator is
-  // its sibling, not its descendant. The icon and chevron inherit the size too,
-  // but set their own colour and are sized in px.
+  // On the header rather than the label so `reasoningHeader` restyles the whole
+  // row while `reasoningLabel` reaches the label alone. The icon and chevron set
+  // their own colour and are sized in px.
   color: rgba(var(--ais-muted-color-rgb), 0.95);
   font-size: calc(var(--ais-spacing) * 0.75);
   line-height: var(--ais-spacing);
@@ -73,10 +71,9 @@
     width: 100%;
     height: 100%;
 
-    // The icon passes no `strokeWidth`, so the width has to come from CSS in both
-    // renderers. The cap and join are here because it does pass those as
-    // camelCase JSX props, which only React turns into standard attributes: bare
-    // Preact forwards them unchanged for SVG, where they are inert.
+    // Stroke presentation lives here because Preact forwards the icon's camelCase
+    // SVG props unchanged, where they are inert. React normalizes them; CSS covers
+    // both renderers.
     stroke-width: var(--ais-icon-stroke-width);
     stroke-linecap: round;
     stroke-linejoin: round;
@@ -92,28 +89,6 @@
 
 .ais-ChatMessageReasoning-label--streaming {
   animation: ais-chat-reasoning-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-
-  // The literal indicator beside it is already an ellipsis, so let the label
-  // clip rather than paint a second one. Settled labels keep `ellipsis`.
-  text-overflow: clip;
-}
-
-// The streaming indicator. Reached as the unclassed sibling of the streaming
-// label, so it needs no class of its own — one fewer `ais-*` name to commit to on
-// a new surface. `:not([class])` is what keeps this off the chevron, which is the
-// label's next sibling once the indicator stops rendering. Type comes from the
-// header above.
-.ais-ChatMessageReasoning-label--streaming + span:not([class]) {
-  // The label beside it truncates, so this must not be the thing that gives way.
-  flex-shrink: 0;
-
-  // Cancels the header's gap, so the indicator reads as part of the label
-  // instead of a detached glyph.
-  margin-inline-start: calc(var(--ais-spacing) * -0.25);
-
-  // Rendered only while streaming, beside a label that pulses, so it keeps the
-  // same animation.
-  animation: ais-chat-reasoning-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
 .ais-ChatMessageReasoning-chevron {
@@ -123,8 +98,8 @@
   color: rgba(var(--ais-muted-color-rgb), 0.9);
   flex-shrink: 0;
 
-  // The label is the only header item that shrinks, so this absorbs the free
-  // space and keeps the chevron at the end without wrapping the label pair.
+  // The label is the only header item that shrinks, so this absorbs the free space
+  // and keeps the chevron at the end.
   margin-inline-start: auto;
   transition: transform var(--ais-transition-duration)
     var(--ais-transition-timing-function);
@@ -133,9 +108,8 @@
     width: 100%;
     height: 100%;
 
-    // Same renderer caveat as the icon above. Stroke widths are in viewBox units
-    // and this box is 1.25x the icon's, so scaling the stroke by 1/1.25 makes the
-    // two draw at the same rendered width.
+    // Same renderer caveat as the icon. Stroke width is in viewBox units and this
+    // box is 1.25x the icon's, so 1/1.25 makes the two draw at the same width.
     stroke-width: calc(var(--ais-icon-stroke-width) * 0.8);
     stroke-linecap: round;
     stroke-linejoin: round;
@@ -166,15 +140,11 @@
 .ais-ChatMessageReasoning-text {
   overflow-wrap: anywhere;
 
-  // Block margins collapse up through every border- and padding-free ancestor,
-  // so the margin that ends up against the body's padding box can start at any
-  // depth: markdown-to-jsx wraps multi-block content in an extra `div`, and a
-  // loose list inside a quote reaches `div > blockquote > ul > li > p`. Reset the
-  // whole chain of leading (trailing) children rather than a fixed number of
-  // levels. The `:not()` excludes anything under a sibling that is not itself
-  // first (last), so gaps between list items and inside a blockquote are left
-  // alone. The `#{&}` interpolation is required: a literal `&` inside `:where()`
-  // makes Sass drop the parent prefix, and the selector then matches the document.
+  // Block margins collapse through padding-free ancestors, so the one meeting the
+  // body's padding box can sit at any depth. Reset the whole leading (trailing)
+  // chain; the `:not()` spares gaps between siblings that are not themselves first
+  // (last). `#{&}` is required: a literal `&` inside `:where()` makes Sass drop the
+  // parent prefix, and the selector then matches the document.
   :first-child:not(:where(#{&} :not(:first-child) *)) {
     margin-block-start: 0;
   }
@@ -186,13 +156,12 @@
 
 @keyframes ais-chat-reasoning-pulse {
   50% {
-    opacity: 0.85;
+    opacity: 0.5;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .ais-ChatMessageReasoning-label,
-  .ais-ChatMessageReasoning-label--streaming + span:not([class]),
   .ais-ChatMessageReasoning-chevron {
     animation: none;
     transition: none;

--- a/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
@@ -1,0 +1,200 @@
+.ais-ChatMessage:has(.ais-ChatMessageReasoning) {
+  .ais-ChatMessage-content {
+    flex-grow: 1;
+  }
+
+  .ais-ChatMessage-message {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--ais-spacing) * 0.5);
+    width: 100%;
+  }
+}
+
+.ais-ChatMessageReasoning {
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid rgba(var(--ais-muted-color-rgb), 0.25);
+  border-radius: var(--ais-border-radius-sm);
+  background-color: rgba(
+    var(--ais-background-color-rgb),
+    var(--ais-background-color-alpha)
+  );
+  overflow: hidden;
+}
+
+.ais-ChatMessageReasoning-header {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: calc(var(--ais-spacing) * 0.25);
+  width: 100%;
+  padding: calc(var(--ais-spacing) * 0.125) calc(var(--ais-spacing) * 0.5);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+
+  // Declared here rather than on the label so the label and the streaming
+  // indicator beside it inherit one value: `reasoningHeader` restyles the row,
+  // while a `reasoningLabel` override reaches the label alone — the indicator is
+  // its sibling, not its descendant. The icon and chevron inherit the size too,
+  // but set their own colour and are sized in px.
+  color: rgba(var(--ais-muted-color-rgb), 0.95);
+  font-size: calc(var(--ais-spacing) * 0.75);
+  line-height: var(--ais-spacing);
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &::marker {
+    content: '';
+  }
+
+  &:hover {
+    background-color: rgba(var(--ais-muted-color-rgb), 0.06);
+  }
+
+  &:focus-visible {
+    outline: 2px solid
+      rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
+    outline-offset: -2px;
+  }
+}
+
+.ais-ChatMessageReasoning-icon {
+  display: inline-flex;
+  width: calc(var(--ais-icon-size) * 0.8);
+  height: calc(var(--ais-icon-size) * 0.8);
+  color: rgba(var(--ais-muted-color-rgb), 0.9);
+  flex-shrink: 0;
+
+  svg {
+    width: 100%;
+    height: 100%;
+
+    // The icon passes no `strokeWidth`, so the width has to come from CSS in both
+    // renderers. The cap and join are here because it does pass those as
+    // camelCase JSX props, which only React turns into standard attributes: bare
+    // Preact forwards them unchanged for SVG, where they are inert.
+    stroke-width: var(--ais-icon-stroke-width);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+}
+
+.ais-ChatMessageReasoning-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ais-ChatMessageReasoning-label--streaming {
+  animation: ais-chat-reasoning-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+
+  // The literal indicator beside it is already an ellipsis, so let the label
+  // clip rather than paint a second one. Settled labels keep `ellipsis`.
+  text-overflow: clip;
+}
+
+// The streaming indicator. Reached as the unclassed sibling of the streaming
+// label, so it needs no class of its own — one fewer `ais-*` name to commit to on
+// a new surface. `:not([class])` is what keeps this off the chevron, which is the
+// label's next sibling once the indicator stops rendering. Type comes from the
+// header above.
+.ais-ChatMessageReasoning-label--streaming + span:not([class]) {
+  // The label beside it truncates, so this must not be the thing that gives way.
+  flex-shrink: 0;
+
+  // Cancels the header's gap, so the indicator reads as part of the label
+  // instead of a detached glyph.
+  margin-inline-start: calc(var(--ais-spacing) * -0.25);
+
+  // Rendered only while streaming, beside a label that pulses, so it keeps the
+  // same animation.
+  animation: ais-chat-reasoning-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.ais-ChatMessageReasoning-chevron {
+  display: inline-flex;
+  width: var(--ais-icon-size);
+  height: var(--ais-icon-size);
+  color: rgba(var(--ais-muted-color-rgb), 0.9);
+  flex-shrink: 0;
+
+  // The label is the only header item that shrinks, so this absorbs the free
+  // space and keeps the chevron at the end without wrapping the label pair.
+  margin-inline-start: auto;
+  transition: transform var(--ais-transition-duration)
+    var(--ais-transition-timing-function);
+
+  svg {
+    width: 100%;
+    height: 100%;
+
+    // Same renderer caveat as the icon above. Stroke widths are in viewBox units
+    // and this box is 1.25x the icon's, so scaling the stroke by 1/1.25 makes the
+    // two draw at the same rendered width.
+    stroke-width: calc(var(--ais-icon-stroke-width) * 0.8);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+}
+
+.ais-ChatMessageReasoning[open] .ais-ChatMessageReasoning-chevron {
+  transform: rotate(180deg);
+}
+
+.ais-ChatMessageReasoning-body {
+  max-height: 9rem;
+  padding: calc(var(--ais-spacing) * 0.5) calc(var(--ais-spacing) * 0.75);
+  border-block-start: 1px solid rgba(var(--ais-muted-color-rgb), 0.2);
+  background-color: rgba(var(--ais-muted-color-rgb), 0.06);
+  color: rgba(var(--ais-text-color-rgb), 0.7);
+  font-size: calc(var(--ais-spacing) * 0.875);
+  line-height: calc(var(--ais-spacing) * 1.25);
+  overflow-y: auto;
+
+  &:focus-visible {
+    outline: 2px solid
+      rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
+    outline-offset: -2px;
+  }
+}
+
+.ais-ChatMessageReasoning-text {
+  overflow-wrap: anywhere;
+
+  // Block margins collapse up through every border- and padding-free ancestor,
+  // so the margin that ends up against the body's padding box can start at any
+  // depth: markdown-to-jsx wraps multi-block content in an extra `div`, and a
+  // loose list inside a quote reaches `div > blockquote > ul > li > p`. Reset the
+  // whole chain of leading (trailing) children rather than a fixed number of
+  // levels. The `:not()` excludes anything under a sibling that is not itself
+  // first (last), so gaps between list items and inside a blockquote are left
+  // alone. The `#{&}` interpolation is required: a literal `&` inside `:where()`
+  // makes Sass drop the parent prefix, and the selector then matches the document.
+  :first-child:not(:where(#{&} :not(:first-child) *)) {
+    margin-block-start: 0;
+  }
+
+  :last-child:not(:where(#{&} :not(:last-child) *)) {
+    margin-block-end: 0;
+  }
+}
+
+@keyframes ais-chat-reasoning-pulse {
+  50% {
+    opacity: 0.85;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ais-ChatMessageReasoning-label,
+  .ais-ChatMessageReasoning-label--streaming + span:not([class]),
+  .ais-ChatMessageReasoning-chevron {
+    animation: none;
+    transition: none;
+  }
+}

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -139,6 +139,7 @@ type ChatWrapperProps = {
     assistantMessageProps: {
       leadingComponent: ChatMessageProps['leadingComponent'];
       footerComponent: ChatMessageProps['footerComponent'];
+      showReasoning: ChatMessageProps['showReasoning'];
     };
     userMessageProps: {
       leadingComponent: ChatMessageProps['leadingComponent'];
@@ -293,6 +294,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
   containerNode,
   templates,
   tools,
+  showReasoning,
 }: {
   containerNode: HTMLElement;
   cssClasses: ChatCSSClasses;
@@ -301,6 +303,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
   };
   templates: ChatTemplates<THit>;
   tools: UserClientSideToolsWithTemplate;
+  showReasoning: boolean;
 }): Renderer<ChatRenderState, Partial<ChatWidgetParams>> => {
   const state = createLocalState();
   const promptRef = { current: null as HTMLTextAreaElement | null };
@@ -645,6 +648,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
     const messageTranslations = getDefinedProperties({
       actionsLabel: templates.message?.actionsLabelText,
       messageLabel: templates.message?.messageLabelText,
+      reasoningLabel: templates.message?.reasoningLabelText,
     });
 
     userMessageTemplateRef.current = prepareTemplateProps({
@@ -719,6 +723,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
             assistantMessageProps: {
               leadingComponent: stableAssistantMessageLeadingComponent,
               footerComponent: stableAssistantMessageFooterComponent,
+              showReasoning,
             },
             userMessageProps: {
               leadingComponent: stableUserMessageLeadingComponent,
@@ -898,6 +903,10 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
        * Label for the message container
        */
       messageLabelText?: string;
+      /**
+       * Label for reasoning disclosures
+       */
+      reasoningLabelText?: string;
     }>;
 
     /**
@@ -1025,6 +1034,11 @@ type ChatWidgetParams<THit extends RecordWithObjectID = RecordWithObjectID> = {
    * Disable validation that requires either `chatTrigger` or AI mode.
    */
   disableTriggerValidation?: boolean;
+
+  /**
+   * Whether to render reasoning parts
+   */
+  showReasoning?: boolean;
 };
 
 export type ChatWidget = WidgetFactory<
@@ -1050,6 +1064,7 @@ export default (function chat<
     tools: userTools,
     getSearchPageURL,
     disableTriggerValidation = false,
+    showReasoning = false,
     ...options
   } = widgetParams || {};
 
@@ -1084,6 +1099,7 @@ export default (function chat<
     renderState: {},
     templates,
     tools,
+    showReasoning,
   });
 
   const makeWidget = connectChat(specializedRenderer, () =>

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -353,10 +353,9 @@ function ChatInner<
         actionsComponent,
         translations: messagesTranslations,
         messageTranslations,
-        // `assistantMessageProps` and `userMessageProps` merge key by key rather
-        // than replace, so the dedicated top-level props still apply for keys the
-        // caller's nested object leaves unset. Spread explicitly so that merge
-        // does not depend on where these keys sit in the literal.
+        // The message props merge key by key rather than replace, so the dedicated
+        // top-level props still apply for keys the caller leaves unset. Spread
+        // explicitly so the merge does not depend on key order in the literal.
         ...restMessagesProps,
         assistantMessageProps: {
           leadingComponent: assistantMessageLeadingComponent,

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -149,6 +149,10 @@ export type ChatProps<TObject, TUiMessage extends UIMessage = UIMessage> = Omit<
     userMessageLeadingComponent?: ChatMessageProps['leadingComponent'];
     userMessageFooterComponent?: ChatMessageProps['footerComponent'];
     suggestionsComponent?: ChatUiProps['suggestionsComponent'];
+    /**
+     * Whether to render reasoning parts
+     */
+    showReasoning?: boolean;
     translations?: Partial<{
       prompt: ChatUiProps['promptProps']['translations'];
       header: ChatUiProps['headerProps']['translations'];
@@ -196,6 +200,7 @@ function ChatInner<
     title,
     getSearchPageURL,
     disableTriggerValidation = false,
+    showReasoning,
     ...props
   }: ChatProps<TObject, TUiMessage>,
   ref: React.ForwardedRef<ChatHandle>
@@ -293,6 +298,12 @@ function ChatInner<
     throw error;
   }
 
+  const {
+    assistantMessageProps: callerAssistantMessageProps,
+    userMessageProps: callerUserMessageProps,
+    ...restMessagesProps
+  } = messagesProps ?? {};
+
   return (
     <ChatUiComponent
       title={title}
@@ -340,19 +351,24 @@ function ChatInner<
         errorComponent: messagesErrorComponent,
         emptyComponent: emptyComponent,
         actionsComponent,
+        translations: messagesTranslations,
+        messageTranslations,
+        // `assistantMessageProps` and `userMessageProps` merge key by key rather
+        // than replace, so the dedicated top-level props still apply for keys the
+        // caller's nested object leaves unset. Spread explicitly so that merge
+        // does not depend on where these keys sit in the literal.
+        ...restMessagesProps,
         assistantMessageProps: {
           leadingComponent: assistantMessageLeadingComponent,
           footerComponent: assistantMessageFooterComponent,
-          ...messagesProps?.assistantMessageProps,
+          showReasoning,
+          ...callerAssistantMessageProps,
         },
         userMessageProps: {
           leadingComponent: userMessageLeadingComponent,
           footerComponent: userMessageFooterComponent,
-          ...messagesProps?.userMessageProps,
+          ...callerUserMessageProps,
         },
-        translations: messagesTranslations,
-        messageTranslations,
-        ...messagesProps,
         error,
       }}
       promptProps={{

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
@@ -188,12 +188,11 @@ describe('Chat', () => {
       await wait(0);
     });
 
-    // The nested object sets one key, so the dedicated leading component and
-    // `showReasoning` both have to survive alongside it.
+    // The nested object sets one key; the dedicated props must survive alongside it.
     expect(screen.getAllByTestId('assistant-leading')).toHaveLength(2);
     expect(screen.getAllByRole('group', { name: 'Reasoning' })).toHaveLength(2);
     // And the caller's own key has to reach the message, or the merge is only
-    // being tested in one direction.
+    // tested in one direction.
     expect(
       container.querySelectorAll('.ais-ChatMessage--auto-hide-actions')
     ).toHaveLength(2);
@@ -311,8 +310,7 @@ describe('Chat', () => {
       await wait(0);
     });
 
-    // Every completed row has to re-render, not just the last one: earlier rows
-    // are memoized, so the prop has to take part in the comparator.
+    // Earlier rows are memoized, so the prop has to take part in the comparator.
     expect(container.querySelectorAll('strong')).toHaveLength(0);
   });
 });

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
@@ -1,0 +1,318 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import { act, render, screen } from '@testing-library/react';
+import { Chat as ChatInstance } from 'instantsearch.js/es/lib/chat';
+import React from 'react';
+import { InstantSearch } from 'react-instantsearch-core';
+
+import { ChatInlineLayout } from '../../components/ChatInlineLayout';
+import { Chat } from '../Chat';
+
+import type { UIMessage } from 'instantsearch.js/es/lib/chat';
+
+const searchClient = createSearchClient();
+
+function createChat() {
+  return new ChatInstance<UIMessage>({
+    persistence: false,
+    messages: [
+      {
+        id: 'user-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Find a product' }],
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            text: 'Check the catalog.',
+            state: 'done',
+          },
+          { type: 'text', text: 'I found one option.' },
+        ],
+      },
+      {
+        id: 'user-2',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Find another' }],
+      },
+      {
+        id: 'assistant-2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            text: 'Compare the results.',
+            state: 'done',
+          },
+          { type: 'text', text: 'Here is another option.' },
+        ],
+      },
+    ],
+  });
+}
+
+function ChatUnderTest({
+  chat,
+  showReasoning,
+  reasoningLabel = 'Reasoning',
+}: {
+  chat: ChatInstance<UIMessage>;
+  showReasoning: boolean;
+  reasoningLabel?: string;
+}) {
+  return (
+    <InstantSearch
+      searchClient={searchClient}
+      indexName="indexName"
+      future={{ preserveSharedStateOnUnmount: true }}
+    >
+      <Chat
+        chat={chat}
+        transport={{ api: 'http://unused' }}
+        layoutComponent={ChatInlineLayout}
+        requiresSearch={false}
+        showReasoning={showReasoning}
+        translations={{ message: { reasoningLabel } }}
+      />
+    </InstantSearch>
+  );
+}
+
+describe('Chat', () => {
+  test('shows reasoning on completed messages when enabled after rendering', async () => {
+    const chat = createChat();
+    const { rerender } = render(
+      <ChatUnderTest chat={chat} showReasoning={false} />
+    );
+    await act(async () => {
+      await wait(0);
+    });
+    expect(screen.queryAllByRole('group', { name: 'Reasoning' })).toHaveLength(
+      0
+    );
+
+    rerender(<ChatUnderTest chat={chat} showReasoning={true} />);
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(screen.getAllByRole('group', { name: 'Reasoning' })).toHaveLength(2);
+  });
+
+  test('hides reasoning on completed messages when disabled after rendering', async () => {
+    const chat = createChat();
+    const { rerender } = render(
+      <ChatUnderTest chat={chat} showReasoning={true} />
+    );
+    await act(async () => {
+      await wait(0);
+    });
+    expect(screen.getAllByRole('group', { name: 'Reasoning' })).toHaveLength(2);
+
+    rerender(<ChatUnderTest chat={chat} showReasoning={false} />);
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(screen.queryAllByRole('group', { name: 'Reasoning' })).toHaveLength(
+      0
+    );
+  });
+
+  test('updates the reasoning label on completed messages', async () => {
+    const chat = createChat();
+    const { rerender } = render(
+      <ChatUnderTest
+        chat={chat}
+        showReasoning={true}
+        reasoningLabel="Reasoning"
+      />
+    );
+    await act(async () => {
+      await wait(0);
+    });
+    expect(screen.getAllByRole('group', { name: 'Reasoning' })).toHaveLength(2);
+
+    rerender(
+      <ChatUnderTest
+        chat={chat}
+        showReasoning={true}
+        reasoningLabel="Raisonnement"
+      />
+    );
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(screen.queryAllByRole('group', { name: 'Reasoning' })).toHaveLength(
+      0
+    );
+    expect(screen.getAllByRole('group', { name: 'Raisonnement' })).toHaveLength(
+      2
+    );
+  });
+
+  test('merges messagesProps.assistantMessageProps with the dedicated props', async () => {
+    const chat = createChat();
+    const { container } = render(
+      <InstantSearch
+        searchClient={searchClient}
+        indexName="indexName"
+        future={{ preserveSharedStateOnUnmount: true }}
+      >
+        <Chat
+          chat={chat}
+          transport={{ api: 'http://unused' }}
+          layoutComponent={ChatInlineLayout}
+          requiresSearch={false}
+          showReasoning={true}
+          assistantMessageLeadingComponent={() => (
+            <span data-testid="assistant-leading" />
+          )}
+          messagesProps={{
+            onClose: () => {},
+            onReload: () => {},
+            assistantMessageProps: { autoHideActions: true },
+          }}
+        />
+      </InstantSearch>
+    );
+    await act(async () => {
+      await wait(0);
+    });
+
+    // The nested object sets one key, so the dedicated leading component and
+    // `showReasoning` both have to survive alongside it.
+    expect(screen.getAllByTestId('assistant-leading')).toHaveLength(2);
+    expect(screen.getAllByRole('group', { name: 'Reasoning' })).toHaveLength(2);
+    // And the caller's own key has to reach the message, or the merge is only
+    // being tested in one direction.
+    expect(
+      container.querySelectorAll('.ais-ChatMessage--auto-hide-actions')
+    ).toHaveLength(2);
+  });
+
+  test('routes parseMarkdown from messagesProps into reasoning', async () => {
+    const chat = new ChatInstance<UIMessage>({
+      persistence: false,
+      messages: [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Check the **catalog**.',
+              state: 'done',
+            },
+          ],
+        },
+      ],
+    });
+    const { container } = render(
+      <InstantSearch
+        searchClient={searchClient}
+        indexName="indexName"
+        future={{ preserveSharedStateOnUnmount: true }}
+      >
+        <Chat
+          chat={chat}
+          transport={{ api: 'http://unused' }}
+          layoutComponent={ChatInlineLayout}
+          requiresSearch={false}
+          showReasoning={true}
+          messagesProps={{
+            onClose: () => {},
+            onReload: () => {},
+            assistantMessageProps: { parseMarkdown: false },
+          }}
+        />
+      </InstantSearch>
+    );
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(container.querySelector('strong')).toBeNull();
+    expect(
+      screen.getByRole('group', { name: 'Reasoning' }).textContent
+    ).toContain('Check the **catalog**.');
+  });
+
+  test('updates reasoning on completed messages when parseMarkdown changes', async () => {
+    const chat = new ChatInstance<UIMessage>({
+      persistence: false,
+      messages: [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Check the **catalog**.',
+              state: 'done',
+            },
+            { type: 'text', text: 'I found one option.' },
+          ],
+        },
+        {
+          id: 'assistant-2',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'Compare the **results**.',
+              state: 'done',
+            },
+            { type: 'text', text: 'Here is another option.' },
+          ],
+        },
+      ],
+    });
+
+    function Subject({ parseMarkdown }: { parseMarkdown: boolean }) {
+      return (
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="indexName"
+          future={{ preserveSharedStateOnUnmount: true }}
+        >
+          <Chat
+            chat={chat}
+            transport={{ api: 'http://unused' }}
+            layoutComponent={ChatInlineLayout}
+            requiresSearch={false}
+            showReasoning={true}
+            messagesProps={{
+              onClose: () => {},
+              onReload: () => {},
+              assistantMessageProps: { parseMarkdown },
+            }}
+          />
+        </InstantSearch>
+      );
+    }
+
+    const { container, rerender } = render(<Subject parseMarkdown={true} />);
+    await act(async () => {
+      await wait(0);
+    });
+    expect(container.querySelectorAll('strong')).toHaveLength(2);
+
+    rerender(<Subject parseMarkdown={false} />);
+    await act(async () => {
+      await wait(0);
+    });
+
+    // Every completed row has to re-render, not just the last one: earlier rows
+    // are memoized, so the prop has to take part in the comparator.
+    expect(container.querySelectorAll('strong')).toHaveLength(0);
+  });
+});

--- a/tests/common/widgets/chat/index.ts
+++ b/tests/common/widgets/chat/index.ts
@@ -3,6 +3,7 @@ import { fakeAct, skippableDescribe } from '../../common';
 import { createGuardrailsTests } from './guardrails';
 import { createOptionsTests } from './options';
 import { createPersistenceTests } from './persistence';
+import { createReasoningTests } from './reasoning';
 import { createStreamingTests } from './streaming';
 import { createTemplatesTests } from './templates';
 import { createTranslationsTests } from './translations';
@@ -53,6 +54,7 @@ export function createChatWidgetTests(
     createGuardrailsTests(setup, { act, skippedTests, flavor });
     createOptionsTests(setup, { act, skippedTests, flavor });
     createPersistenceTests(setup, { act, skippedTests, flavor });
+    createReasoningTests(setup, { act, skippedTests, flavor });
     createStreamingTests(setup, { act, skippedTests, flavor });
     createTemplatesTests(setup, { act, skippedTests, flavor });
     createTranslationsTests(setup, { act, skippedTests, flavor });

--- a/tests/common/widgets/chat/persistence.ts
+++ b/tests/common/widgets/chat/persistence.ts
@@ -1,4 +1,5 @@
 import { createSearchClient } from '@instantsearch/mocks';
+import { within } from '@testing-library/dom';
 
 import { openChat } from './utils';
 
@@ -59,6 +60,62 @@ export function createPersistenceTests(
 
       expect(document.body).toHaveTextContent('Fresh greeting');
       expect(document.body).not.toHaveTextContent('Previous persisted answer');
+    });
+
+    test('renders restored unfinished reasoning as inactive when chat is ready', async () => {
+      sessionStorage.clear();
+      const searchClient = createSearchClient();
+      const cacheKey = 'instantsearch-chat-initial-messages';
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'previous',
+          role: 'assistant',
+          // The reasoning part is last and never settled, which is what a
+          // response stopped mid-reasoning persists. A trailing part of any
+          // other type would make `isReasoningPartActive` false on its own,
+          // so this fixture is what pins the `status === 'streaming'` guard.
+          parts: [
+            {
+              type: 'reasoning',
+              text: 'A stopped response.',
+              state: 'streaming',
+            },
+          ],
+        },
+      ];
+
+      sessionStorage.setItem(
+        `${cacheKey}-agentId`,
+        JSON.stringify(previousMessages)
+      );
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            agentId: 'agentId',
+            showReasoning: true,
+          },
+          react: {
+            agentId: 'agentId',
+            showReasoning: true,
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      const disclosure = within(document.body).getByRole('group', {
+        name: 'Reasoning',
+      });
+      expect(disclosure).toHaveAttribute('aria-busy', 'false');
+      expect(
+        disclosure.querySelector('.ais-ChatMessageReasoning-label--streaming')
+      ).not.toBeInTheDocument();
     });
   });
 }

--- a/tests/common/widgets/chat/persistence.ts
+++ b/tests/common/widgets/chat/persistence.ts
@@ -70,10 +70,9 @@ export function createPersistenceTests(
         {
           id: 'previous',
           role: 'assistant',
-          // The reasoning part is last and never settled, which is what a
-          // response stopped mid-reasoning persists. A trailing part of any
-          // other type would make `isReasoningPartActive` false on its own,
-          // so this fixture is what pins the `status === 'streaming'` guard.
+          // A trailing unsettled reasoning part, which is what a response stopped
+          // mid-reasoning persists. Any other trailing type would make
+          // `isReasoningPartActive` false on its own and not reach the guard.
           parts: [
             {
               type: 'reasoning',

--- a/tests/common/widgets/chat/reasoning.tsx
+++ b/tests/common/widgets/chat/reasoning.tsx
@@ -1,0 +1,402 @@
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import { within } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+import { Chat } from 'instantsearch.js/es/lib/chat';
+
+import { createDefaultWidgetParams, openChat } from './utils';
+
+import type { ChatWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+import type { UIMessage } from 'instantsearch.js/es/lib/chat';
+
+function createChatWithReasoning() {
+  return new Chat({
+    messages: [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            text: 'Check the **catalog**.',
+            state: 'done',
+          },
+          {
+            type: 'reasoning',
+            text: 'Compare release dates.',
+            state: 'done',
+          },
+          { type: 'text', text: 'The answer is 2001.' },
+        ],
+      },
+    ],
+  });
+}
+
+export function createReasoningTests(
+  setup: ChatWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('reasoning', () => {
+    test('does not render reasoning by default', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: createDefaultWidgetParams(createChatWithReasoning()),
+          react: createDefaultWidgetParams(createChatWithReasoning()),
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        within(document.body).queryByRole('group', { name: 'Reasoning' })
+      ).not.toBeInTheDocument();
+      expect(document.body).not.toHaveTextContent('Check the catalog.');
+    });
+
+    test('copies only answer text when reasoning is hidden', async () => {
+      const searchClient = createSearchClient();
+      const writeText = jest.fn();
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: createDefaultWidgetParams(createChatWithReasoning()),
+          react: createDefaultWidgetParams(createChatWithReasoning()),
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      userEvent.click(
+        within(document.body).getByRole('button', {
+          name: 'Copy to clipboard',
+        })
+      );
+
+      expect(writeText).toHaveBeenCalledWith('The answer is 2001.');
+    });
+
+    test('does not offer Copy when hidden reasoning is the only content', async () => {
+      const searchClient = createSearchClient();
+      const chat = new Chat({
+        messages: [
+          {
+            id: 'assistant-reasoning-only',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'No answer was produced.',
+                state: 'done',
+              },
+            ],
+          },
+        ],
+      });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: createDefaultWidgetParams(chat),
+          react: createDefaultWidgetParams(chat),
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        within(document.body).queryByRole('button', {
+          name: 'Copy to clipboard',
+        })
+      ).not.toBeInTheDocument();
+    });
+
+    test('renders each reasoning part in a collapsed disclosure when enabled', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: true,
+          },
+          react: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: true,
+            messagesProps: {
+              onClose: () => {},
+              onReload: () => {},
+              assistantMessageProps: {
+                autoHideActions: true,
+              },
+            },
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      const disclosures = within(document.body).getAllByRole('group', {
+        name: 'Reasoning',
+      });
+      expect(disclosures).toHaveLength(2);
+      expect(disclosures[0]).not.toHaveAttribute('open');
+      expect(disclosures[1]).not.toHaveAttribute('open');
+      expect(disclosures[0]).toHaveTextContent('Check the catalog.');
+      expect(disclosures[0].querySelector('strong')).toHaveTextContent(
+        'catalog'
+      );
+      expect(disclosures[1]).toHaveTextContent('Compare release dates.');
+    });
+
+    test('keeps an active reasoning disclosure collapsed until the reader opens it', async () => {
+      const searchClient = createSearchClient();
+      const activeMessage: UIMessage = {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'reasoning',
+            text: 'Checking the catalog',
+            state: 'streaming',
+          },
+        ],
+      };
+      const answeringMessage: UIMessage = {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [
+          { type: 'reasoning', text: 'Checking the catalog', state: 'done' },
+          { type: 'text', text: 'The answer is 2001.', state: 'streaming' },
+        ],
+      };
+      const chat = new Chat({ messages: [activeMessage] });
+      chat._state.status = 'streaming';
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      const disclosure = within(document.body).getByRole('group', {
+        name: 'Reasoning',
+      });
+      expect(disclosure).not.toHaveAttribute('open');
+      expect(disclosure).toHaveAttribute('aria-busy', 'true');
+
+      userEvent.click(disclosure.querySelector('summary')!);
+      expect(disclosure).toHaveAttribute('open');
+
+      // Reasoning ending and the answer starting must not close a disclosure
+      // the reader opened.
+      await act(async () => {
+        chat.messages = [answeringMessage];
+        await wait(0);
+      });
+
+      const streamedDisclosure = within(document.body).getByRole('group', {
+        name: 'Reasoning',
+      });
+      expect(streamedDisclosure).toHaveAttribute('open');
+      expect(streamedDisclosure).toHaveAttribute('aria-busy', 'false');
+    });
+
+    test('moves the streaming state to a newly appended response', async () => {
+      const searchClient = createSearchClient();
+      const previousMessage = {
+        id: 'assistant-previous',
+        role: 'assistant' as const,
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Previous reasoning',
+            state: 'streaming' as const,
+          },
+        ],
+      };
+      const chat = new Chat({ messages: [previousMessage] });
+      chat._state.status = 'streaming';
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        within(document.body).getByRole('group', {
+          name: 'Reasoning',
+        })
+      ).toHaveAttribute('aria-busy', 'true');
+
+      await act(async () => {
+        chat.messages = [
+          previousMessage,
+          {
+            id: 'assistant-current',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Current reasoning',
+                state: 'streaming',
+              },
+            ],
+          },
+        ];
+        await wait(0);
+      });
+
+      const disclosures = within(document.body).getAllByRole('group', {
+        name: 'Reasoning',
+      });
+      expect(disclosures).toHaveLength(2);
+      expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
+      expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+    });
+
+    test('stops showing reasoning as busy when answer text starts streaming', async () => {
+      const searchClient = createSearchClient();
+      const chat = new Chat({
+        messages: [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'reasoning',
+                text: 'Checking the catalog',
+                state: 'streaming',
+              },
+              {
+                type: 'text',
+                text: 'Here is what I found',
+                state: 'streaming',
+              },
+            ],
+          },
+        ],
+      });
+      chat._state.status = 'streaming';
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        within(document.body).getByRole('group', { name: 'Reasoning' })
+      ).toHaveAttribute('aria-busy', 'false');
+    });
+
+    test('renders the translated reasoning label', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: true,
+            templates: {
+              message: {
+                reasoningLabelText: 'Raisonnement',
+              },
+            },
+          },
+          react: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: true,
+            translations: {
+              message: {
+                reasoningLabel: 'Raisonnement',
+              },
+            },
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        within(document.body).getAllByRole('group', {
+          name: 'Raisonnement',
+        })
+      ).toHaveLength(2);
+    });
+  });
+}


### PR DESCRIPTION
**Summary**

Adds opt-in rendering for Chat reasoning parts.

`showReasoning` defaults to `false`. When enabled, reasoning keeps its original position among tool calls and answer text, collapsed by default. Only the active reasoning part shows progress.

This PR does not change reconnect or reducer behavior.

**Result**

Enable reasoning in React:

    <Chat showReasoning />

Or InstantSearch.js:

    chat({ showReasoning: true });

Covered behavior:

- hidden by default, opt-in in InstantSearch.js and React
- reasoning order around tools and answers
- Markdown body with a translated label
- `parseMarkdown` applies consistently to text and reasoning parts
- keyboard access for long reasoning
- one progress indicator while reasoning is active
- reasoning text excluded from Copy

**Reasoning parts**

Each reasoning part is rendered as an independent, uncontrolled `<details>` disclosure. It is collapsed by default, including while that part is still streaming; activity is signaled by `aria-busy` and the pulsing label. Nothing opens or closes it automatically, so a reader's choice survives reasoning ending, the answer starting and the response completing. This matches the shipped Agent Studio accordion, which is uncontrolled for the same reason.

**Additional behavior changes**

- **Copy excludes reasoning text.** `getTextContent` previously matched any part with a top-level `text` field, including reasoning. Copy could therefore include reasoning text even when `showReasoning` was `false`. It now includes text parts only and reasoning-only messages no longer show Copy.
- **Nested message props now merge with dedicated props.** Providing `messagesProps.assistantMessageProps` or `messagesProps.userMessageProps` previously replaced the values assembled from the dedicated top-level leading and footer component props. They now merge key by key, so nested values override only matching keys while omitted dedicated components remain in effect.

**Scope**

This narrows #7105 to the rendering required by [FX-3831]. It does not add summaries, PII heuristics, loading captions, additional visibility modes or a custom chat implementation.

`vue-instantsearch` has no Chat component, so the cross-flavor suite runs JavaScript and React and skips Vue as it does for the rest of Chat.

**Known limit**

- Collapsed reasoning Markdown is still compiled on each streaming update. Lazy compilation is deferred to follow-up work.



## Demo

Real Agent Studio stream using reasoning → Algolia Search tool → reasoning → final response.

https://github.com/user-attachments/assets/e47ac079-be22-4814-b4a2-b9c6e171d9e7




[FX-3831]: https://algolia.atlassian.net/browse/FX-3831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
