### PR TITLE
feat(chat): accept any JSON in `context` and truncate at 10 KB

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1881,20 +1881,29 @@ data: [DONE]`,
       expect(sendMessageSpy.mock.calls[0][0]).toBeUndefined();
     });
 
-    it('forwards values verbatim and leaves payload validation to the server', async () => {
+    it('forwards any JSON values verbatim when the serialized context fits 10 KB', async () => {
       const chatInstance = createTestChat();
       const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
 
-      const longValue = 'x'.repeat(1025);
+      // Any JSON-serializable payload is allowed — nested objects, arrays,
+      // numbers, booleans, null — and keys the server may still reject are
+      // forwarded as-is: the client only enforces the size cap.
+      const context = {
+        'bad key!': 'kept as-is',
+        cart: {
+          items: [
+            { sku: 'SKU-1', qty: 2 },
+            { sku: 'SKU-2', qty: 1 },
+          ],
+          total: 42.5,
+        },
+        flags: ['beta', 'ai-mode'],
+        premium: true,
+        referrer: null,
+      };
       const { widget, renderFn } = createChatWidgetWithContext({
         chat: chatInstance,
-        // Intentionally non-conforming entries: backend (HTTP 422) owns
-        // validation; the client must not silently mutate this payload.
-        context: {
-          'bad key!': 'kept as-is',
-          tooBig: longValue,
-          ok: 'kept',
-        } as Record<string, string>,
+        context,
       });
 
       const helper = algoliasearchHelper(createSearchClient(), '');
@@ -1905,11 +1914,61 @@ data: [DONE]`,
 
       expect(sendMessageSpy).toHaveBeenCalledTimes(1);
       expect((sendMessageSpy.mock.calls[0][0] as any).metadata).toEqual({
-        turnContext: {
-          'bad key!': 'kept as-is',
-          tooBig: longValue,
-          ok: 'kept',
+        turnContext: context,
+      });
+    });
+
+    it('drops entries that push the serialized context past 10 KB and keeps the rest', async () => {
+      const chatInstance = createTestChat();
+      const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
+
+      const oversizeValue = 'x'.repeat(11 * 1024);
+      const { widget, renderFn } = createChatWidgetWithContext({
+        chat: chatInstance,
+        context: {
+          keep: 'small value',
+          oversize: oversizeValue,
+          alsoKeep: { nested: 'still fits' },
         },
+      });
+
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init(createInitOptions({ helper, state: helper.state }));
+
+      const { sendMessage } = renderFn.mock.calls[0][0];
+
+      expect(() => sendMessage({ text: 'hi' })).toWarnDev(
+        '[InstantSearch.js]: The `context` payload exceeds 10240 bytes once serialized as JSON. The following entries were dropped to fit: oversize.'
+      );
+
+      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+      expect((sendMessageSpy.mock.calls[0][0] as any).metadata).toEqual({
+        turnContext: {
+          keep: 'small value',
+          alsoKeep: { nested: 'still fits' },
+        },
+      });
+    });
+
+    it('sends the context untouched when it is exactly at the 10 KB cap', async () => {
+      const chatInstance = createTestChat();
+      const sendMessageSpy = jest.spyOn(chatInstance, 'sendMessage');
+
+      // `{"v":"…"}` adds 8 bytes of JSON overhead around the value.
+      const value = 'x'.repeat(10 * 1024 - 8);
+      const { widget, renderFn } = createChatWidgetWithContext({
+        chat: chatInstance,
+        context: { v: value },
+      });
+
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init(createInitOptions({ helper, state: helper.state }));
+
+      const { sendMessage } = renderFn.mock.calls[0][0];
+      expect(() => sendMessage({ text: 'hi' })).not.toWarnDev();
+
+      expect((sendMessageSpy.mock.calls[0][0] as any).metadata).toEqual({
+        turnContext: { v: value },
       });
     });
 

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -52,6 +52,67 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
+/**
+ * Maximum serialized (UTF-8) size of `metadata.turnContext`. Oversize contexts
+ * are truncated entry-by-entry rather than rejected so a send never fails
+ * because of ambient context.
+ */
+export const TURN_CONTEXT_MAX_BYTES = 10 * 1024;
+
+function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      // Surrogate pair: 4 bytes for the full code point, skip the low half.
+      bytes += 4;
+      i++;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+/**
+ * Caps the serialized turn context at `TURN_CONTEXT_MAX_BYTES`. Entries are
+ * kept in insertion order; any entry that would push the serialized payload
+ * past the cap is dropped (later, smaller entries can still fit). Returns the
+ * input untouched when it already fits.
+ */
+function truncateTurnContext(
+  context: Record<string, unknown>
+): Record<string, unknown> {
+  if (utf8ByteLength(JSON.stringify(context)) <= TURN_CONTEXT_MAX_BYTES) {
+    return context;
+  }
+
+  const truncated: Record<string, unknown> = {};
+  const dropped: string[] = [];
+
+  Object.entries(context).forEach(([key, value]) => {
+    const candidate = JSON.stringify({ ...truncated, [key]: value });
+    if (utf8ByteLength(candidate) <= TURN_CONTEXT_MAX_BYTES) {
+      truncated[key] = value;
+    } else {
+      dropped.push(key);
+    }
+  });
+
+  warning(
+    false,
+    `The \`context\` payload exceeds ${TURN_CONTEXT_MAX_BYTES} bytes once serialized as JSON. The following entries were dropped to fit: ${dropped.join(
+      ', '
+    )}.`
+  );
+
+  return truncated;
+}
+
 export type ChatRenderState<TUiMessage extends UIMessage = UIMessage> = {
   indexUiState: IndexUiState;
   input: string;
@@ -207,12 +268,14 @@ export type ChatConnectorParams<TUiMessage extends UIMessage = UIMessage> = (
    * `messages[last].metadata.turnContext` per the Agent Studio contract — never
    * rendered as a chat bubble and never persisted on assistant turns.
    *
-   * The server validates the payload (flat `Record<string, string>`, key/value
-   * length and shape) and rejects malformed contexts. Pass a function when the
-   * values change per-turn — it is invoked once per send. If the source is
-   * async, resolve it upstream and close over the value.
+   * Values can be any JSON-serializable data (nested objects and arrays
+   * included). The serialized payload is capped at 10 KB (UTF-8): entries that
+   * would push it past the cap are dropped client-side — with a dev-mode
+   * warning — so a send never fails because of oversize context. Pass a
+   * function when the values change per-turn — it is invoked once per send. If
+   * the source is async, resolve it upstream and close over the value.
    */
-  context?: Record<string, string> | (() => Record<string, string>);
+  context?: Record<string, unknown> | (() => Record<string, unknown>);
   /**
    * A message to send automatically when the chat is initialized.
    *
@@ -787,10 +850,12 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
             return _chatInstance.sendMessage(message, ...rest);
           }
 
-          // Resolve once per send; let the server validate the payload and
-          // surface any contract violations.
-          const turnContext =
-            typeof context === 'function' ? context() : context;
+          // Resolve once per send. The client only enforces the 10 KB size
+          // cap (by truncation); the server validates everything else and
+          // surfaces any contract violations.
+          const turnContext = truncateTurnContext(
+            typeof context === 'function' ? context() : context
+          );
 
           return _chatInstance.sendMessage(
             {


### PR DESCRIPTION
Updates the `context` option of the chat connector to the new turn-context contract:

- `context` now accepts any JSON-serializable values (nested objects, arrays, numbers, booleans, null), not just a flat `Record<string, string>`. The payload is still sent as `messages[last].metadata.turnContext`.
- The client now enforces the 10 KB (UTF-8) size cap by truncation instead of relying on server-side rejection: entries are kept in insertion order and any entry that would push the serialized payload past the cap is dropped, with a dev-mode warning listing the dropped keys. A send can no longer fail because of oversize context.
- Contexts at or under the cap are forwarded verbatim; the server still owns all other validation.