### PR TITLE
feat(vue): PoC — Composition API composables over a shared widget lifecycle controller

### DIFF
--- a/packages/vue-instantsearch/src/composables/__tests__/useConnector.test.js
+++ b/packages/vue-instantsearch/src/composables/__tests__/useConnector.test.js
@@ -1,0 +1,328 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import algoliasearchHelper from 'algoliasearch-helper';
+
+import { mount, nextTick } from '../../../test/utils';
+import { renderCompat, shallowRef } from '../../util/vue-compat';
+import { useConnector } from '../useConnector';
+
+const createFakeIndexWidget = () => ({
+  addWidgets: jest.fn(),
+  removeWidgets: jest.fn(),
+});
+
+const createFakeInstance = () => ({
+  mainIndex: createFakeIndexWidget(),
+  started: true,
+  status: 'idle',
+  renderState: {},
+  templatesConfig: {},
+  error: undefined,
+  client: { search: jest.fn() },
+});
+
+// Composition `inject` reads from the parent chain, so the provided values
+// must come from a real parent component (unlike the mixin tests, which can
+// self-provide through the options API).
+const mountComposable = ({ provide, setup }) => {
+  const Child = {
+    render: () => null,
+    setup,
+  };
+
+  return mount({
+    provide,
+    render: renderCompat((h) => h(Child)),
+  });
+};
+
+describe('useConnector', () => {
+  it('creates the widget with additional properties and adds it to the parent index', () => {
+    const instance = createFakeInstance();
+    const widget = { render: () => {} };
+    const factory = jest.fn(() => widget);
+    const connector = jest.fn(() => factory);
+    const widgetParams = { attribute: 'brand' };
+    let state;
+
+    mountComposable({
+      provide: { $_ais_instantSearchInstance: instance },
+      setup() {
+        state = useConnector(connector, widgetParams, {
+          $$widgetType: 'ais.test',
+        });
+        return {};
+      },
+    });
+
+    expect(connector).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledWith(widgetParams);
+    expect(instance.mainIndex.addWidgets).toHaveBeenCalledTimes(1);
+    expect(instance.mainIndex.addWidgets.mock.calls[0][0]).toEqual([
+      { ...widget, $$widgetType: 'ais.test' },
+    ]);
+    // No `getWidgetRenderState` on the widget: state is `{}`, never null.
+    expect(state.value).toEqual({});
+  });
+
+  it('uses the injected parent index over the main index', () => {
+    const instance = createFakeInstance();
+    const indexWidget = createFakeIndexWidget();
+    const widget = { render: () => {} };
+    const connector = jest.fn(() => () => widget);
+
+    mountComposable({
+      provide: {
+        $_ais_instantSearchInstance: instance,
+        $_ais_getParentIndex: () => indexWidget,
+      },
+      setup() {
+        useConnector(connector);
+        return {};
+      },
+    });
+
+    expect(indexWidget.addWidgets).toHaveBeenCalledWith([widget]);
+    expect(instance.mainIndex.addWidgets).not.toHaveBeenCalled();
+  });
+
+  it('computes the initial render state synchronously before the instance has started', () => {
+    const instance = createFakeInstance();
+    instance.started = false;
+    instance._initialUiState = { indexName: { query: 'iphone' } };
+    const preStartIndex = {
+      addWidgets: jest.fn(),
+      removeWidgets: jest.fn(),
+      getHelper: () => null,
+      getIndexId: () => 'indexName',
+      getIndexName: () => 'indexName',
+    };
+    const widget = {
+      render: () => {},
+      getWidgetSearchParameters: jest.fn((searchParameters, { uiState }) =>
+        searchParameters.setQuery(uiState.query || '')
+      ),
+      getWidgetRenderState: jest.fn(({ state: searchParameters }) => ({
+        query: searchParameters.query,
+        refine: () => {},
+        widgetParams: { ignored: true },
+      })),
+    };
+    const connector = jest.fn(() => () => widget);
+    let state;
+
+    mountComposable({
+      provide: {
+        $_ais_instantSearchInstance: instance,
+        $_ais_getParentIndex: () => preStartIndex,
+      },
+      setup() {
+        state = useConnector(connector);
+        return {};
+      },
+    });
+
+    // The ui state is derived from `_initialUiState`, and `widgetParams` is
+    // stripped from the render state.
+    expect(widget.getWidgetSearchParameters).toHaveBeenCalledWith(
+      expect.anything(),
+      { uiState: { query: 'iphone' } }
+    );
+    expect(state.value).toEqual({ query: 'iphone', refine: expect.any(Function) });
+
+    // Results passed to `getWidgetRenderState` are artificial empty results.
+    const renderStateArgs = widget.getWidgetRenderState.mock.calls[0][0];
+    expect(renderStateArgs.results.__isArtificial).toBe(true);
+    expect(renderStateArgs.results.nbHits).toBe(0);
+  });
+
+  it('computes the initial render state from the index helper once started', () => {
+    const instance = createFakeInstance();
+    const helper = algoliasearchHelper(
+      { search: jest.fn() },
+      'indexName',
+      {}
+    );
+    const startedIndex = {
+      addWidgets: jest.fn(),
+      removeWidgets: jest.fn(),
+      getHelper: () => helper,
+      getIndexId: () => 'indexName',
+      getIndexName: () => 'indexName',
+      getWidgetUiState: () => ({ indexName: { query: 'started' } }),
+      getResults: () => null,
+      getScopedResults: () => [],
+      createURL: () => '#',
+    };
+    const widget = {
+      render: () => {},
+      getWidgetSearchParameters: (searchParameters, { uiState }) =>
+        searchParameters.setQuery(uiState.query || ''),
+      getWidgetRenderState: ({ state: searchParameters }) => ({
+        query: searchParameters.query,
+        widgetParams: {},
+      }),
+    };
+    const connector = jest.fn(() => () => widget);
+    let state;
+
+    mountComposable({
+      provide: {
+        $_ais_instantSearchInstance: instance,
+        $_ais_getParentIndex: () => startedIndex,
+      },
+      setup() {
+        state = useConnector(connector);
+        return {};
+      },
+    });
+
+    expect(state.value).toEqual({ query: 'started' });
+  });
+
+  it('skips the init render and commits subsequent renders', () => {
+    const instance = createFakeInstance();
+    const widget = { render: () => {} };
+    const connector = jest.fn(() => () => widget);
+    let state;
+
+    mountComposable({
+      provide: { $_ais_instantSearchInstance: instance },
+      setup() {
+        state = useConnector(connector);
+        return {};
+      },
+    });
+
+    const renderCallback = connector.mock.calls[0][0];
+    const initialState = state.value;
+
+    renderCallback(
+      { instantSearchInstance: instance, widgetParams: {}, items: ['a'] },
+      true
+    );
+    expect(state.value).toBe(initialState);
+
+    renderCallback(
+      { instantSearchInstance: instance, widgetParams: {}, items: ['a'] },
+      false
+    );
+    expect(state.value).toEqual({ items: ['a'] });
+  });
+
+  it('ignores dequal-equal render states but commits on status change', () => {
+    const instance = createFakeInstance();
+    const widget = { render: () => {} };
+    const connector = jest.fn(() => () => widget);
+    let state;
+
+    mountComposable({
+      provide: { $_ais_instantSearchInstance: instance },
+      setup() {
+        state = useConnector(connector);
+        return {};
+      },
+    });
+
+    const renderCallback = connector.mock.calls[0][0];
+
+    renderCallback(
+      {
+        instantSearchInstance: instance,
+        widgetParams: {},
+        items: ['a'],
+        refine: () => {},
+      },
+      false
+    );
+    const committed = state.value;
+
+    // Same data, new function reference: no commit.
+    renderCallback(
+      {
+        instantSearchInstance: instance,
+        widgetParams: {},
+        items: ['a'],
+        refine: () => {},
+      },
+      false
+    );
+    expect(state.value).toBe(committed);
+
+    // Same data but the search status changed: commit.
+    renderCallback(
+      {
+        instantSearchInstance: { ...instance, status: 'loading' },
+        widgetParams: {},
+        items: ['a'],
+        refine: () => {},
+      },
+      false
+    );
+    expect(state.value).not.toBe(committed);
+    expect(state.value).toEqual({ items: ['a'], refine: expect.any(Function) });
+  });
+
+  it('recreates the widget only when widget params deep-change', async () => {
+    const instance = createFakeInstance();
+    const widget = { render: () => {}, dispose: () => {} };
+    const factory = jest.fn(() => widget);
+    const connector = jest.fn(() => factory);
+    const widgetParams = shallowRef({ attribute: 'brand' });
+    let state;
+
+    mountComposable({
+      provide: { $_ais_instantSearchInstance: instance },
+      setup() {
+        state = useConnector(connector, widgetParams);
+        return {};
+      },
+    });
+
+    // New object, deep-equal values: no recreation (unlike the mixin).
+    widgetParams.value = { attribute: 'brand' };
+    await nextTick();
+    expect(instance.mainIndex.removeWidgets).not.toHaveBeenCalled();
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    // Genuine change: remove-and-recreate, state is not reset.
+    widgetParams.value = { attribute: 'price' };
+    await nextTick();
+    expect(instance.mainIndex.removeWidgets).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(factory).toHaveBeenLastCalledWith({ attribute: 'price' });
+    expect(instance.mainIndex.addWidgets).toHaveBeenCalledTimes(2);
+    expect(state.value).not.toBe(null);
+  });
+
+  it('removes the widget on unmount and ignores late renders', () => {
+    const instance = createFakeInstance();
+    const widget = { render: () => {}, dispose: () => {} };
+    const connector = jest.fn(() => () => widget);
+    let state;
+
+    const wrapper = mountComposable({
+      provide: { $_ais_instantSearchInstance: instance },
+      setup() {
+        state = useConnector(connector);
+        return {};
+      },
+    });
+
+    wrapper.destroy();
+
+    expect(instance.mainIndex.removeWidgets).toHaveBeenCalledWith([widget]);
+
+    // Late connector notification (the <ais-dynamic-widgets> race).
+    const renderCallback = connector.mock.calls[0][0];
+    const before = state.value;
+    renderCallback(
+      { instantSearchInstance: instance, widgetParams: {}, items: ['late'] },
+      false
+    );
+    expect(state.value).toBe(before);
+  });
+});

--- a/packages/vue-instantsearch/src/composables/__tests__/useSearchBox.test.js
+++ b/packages/vue-instantsearch/src/composables/__tests__/useSearchBox.test.js
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+
+// The package-level manual mock replaces `instantsearch.js/es` in unit
+// tests; this suite integrates against the real library.
+jest.unmock('instantsearch.js/es');
+
+import { mount, nextTick } from '../../../test/utils';
+import InstantSearch from '../../components/InstantSearch';
+import { renderCompat } from '../../util/vue-compat';
+import { useSearchBox } from '../useSearchBox';
+
+// Lets InstantSearch start (root mounted + nextTick) and searches resolve.
+const flushSearch = async () => {
+  for (let i = 0; i < 3; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+  }
+};
+
+const mountApp = ({ setup, instantSearchProps = {} }) => {
+  const Child = {
+    render: () => null,
+    setup,
+  };
+
+  return mount({
+    render: renderCompat((h) =>
+      h(
+        InstantSearch,
+        {
+          props: {
+            searchClient: createSearchClient(),
+            indexName: 'indexName',
+            ...instantSearchProps,
+          },
+        },
+        [h(Child)]
+      )
+    ),
+  });
+};
+
+describe('useSearchBox', () => {
+  it('exposes a synchronous initial state before the instance has started', () => {
+    let searchBox;
+
+    mountApp({
+      setup() {
+        searchBox = useSearchBox();
+        return {};
+      },
+    });
+
+    // Asserted synchronously after mount: start() has not run yet.
+    expect(searchBox.query.value).toBe('');
+    expect(searchBox.isSearchStalled.value).toBe(false);
+    expect(typeof searchBox.refine).toBe('function');
+    expect(typeof searchBox.clear).toBe('function');
+  });
+
+  it('derives the initial query from initialUiState', () => {
+    let searchBox;
+
+    mountApp({
+      instantSearchProps: {
+        initialUiState: { indexName: { query: 'iphone' } },
+      },
+      setup() {
+        searchBox = useSearchBox();
+        return {};
+      },
+    });
+
+    expect(searchBox.query.value).toBe('iphone');
+  });
+
+  it('refines and clears the query once started', async () => {
+    let searchBox;
+
+    mountApp({
+      setup() {
+        searchBox = useSearchBox();
+        return {};
+      },
+    });
+
+    await flushSearch();
+
+    searchBox.refine('hello');
+    await flushSearch();
+    expect(searchBox.query.value).toBe('hello');
+
+    searchBox.clear();
+    await flushSearch();
+    expect(searchBox.query.value).toBe('');
+  });
+});

--- a/packages/vue-instantsearch/src/composables/useConnector.js
+++ b/packages/vue-instantsearch/src/composables/useConnector.js
@@ -1,0 +1,139 @@
+import { dequal } from '../util/dequal';
+import { getInitialRenderState } from '../util/getInitialRenderState';
+import {
+  inject,
+  onBeforeUnmount,
+  shallowRef,
+  toValue,
+  watch,
+} from '../util/vue-compat';
+import { createWidgetLifecycleController } from '../util/widgetLifecycleController';
+
+// Deep-snapshot the applied widget params so the deep watch can compare
+// against them: when a reactive object is mutated in place, Vue fires the
+// watcher with `next === prev`, so we must keep our own copy.
+function snapshot(value) {
+  if (Array.isArray(value)) {
+    return value.map(snapshot);
+  }
+  if (value && typeof value === 'object' && value.constructor === Object) {
+    const copy = {};
+    Object.keys(value).forEach((key) => {
+      copy[key] = snapshot(value[key]);
+    });
+    return copy;
+  }
+  return value;
+}
+
+// Function references churn on every connector render; dequal treats any
+// function pair as equal to avoid infinite update loops (same as React).
+const ignoreFunctions = (a, b) =>
+  Boolean(a) &&
+  Boolean(b) &&
+  a.constructor === Function &&
+  b.constructor === Function;
+
+export function useConnector(
+  connector,
+  widgetParams = {},
+  additionalWidgetProperties = {}
+) {
+  const instantSearchInstance = inject(
+    '$_ais_instantSearchInstance',
+    () => {
+      throw new TypeError(
+        'It looks like you forgot to wrap your Algolia search component inside of an "<ais-instant-search>" component.'
+      );
+    },
+    true
+  );
+  const getParentIndex = inject(
+    '$_ais_getParentIndex',
+    () => () => instantSearchInstance.mainIndex,
+    true
+  );
+
+  let shouldSetState = true;
+  let previousRenderState = null;
+  let previousStatus = instantSearchInstance.status;
+
+  const state = shallowRef(null);
+
+  const controller = createWidgetLifecycleController({
+    connector,
+    additionalWidgetProperties,
+    instantSearchInstance,
+    getParentIndex,
+    renderCallback(connectorState, isFirstRender) {
+      // We skip the `init` render: the initial state is computed
+      // synchronously below, and skipping also prevents UI flashes when the
+      // widget params change.
+      if (isFirstRender) {
+        shouldSetState = true;
+        return;
+      }
+
+      // InstantSearch.js may notify after the component unmounted (e.g.
+      // <ais-dynamic-widgets> removals) — ignore those late updates.
+      if (!shouldSetState) {
+        return;
+      }
+
+      const {
+        instantSearchInstance: instance,
+        widgetParams: appliedParams,
+        ...renderState
+      } = connectorState;
+
+      // Only commit when a non-function render param or the search status
+      // changed (status must propagate for loading/stalled/error UIs).
+      if (
+        !dequal(renderState, previousRenderState, ignoreFunctions) ||
+        instance.status !== previousStatus
+      ) {
+        state.value = renderState;
+        previousRenderState = renderState;
+        previousStatus = instance.status;
+      }
+    },
+    unmountCallback() {
+      shouldSetState = false;
+    },
+  });
+
+  const initialWidgetParams = toValue(widgetParams);
+  const widget = controller.mount(initialWidgetParams);
+  let appliedSnapshot = snapshot(initialWidgetParams);
+
+  // Never-null state: computed synchronously before InstantSearch renders,
+  // like React — no `v-if="state"` guard needed in consumers.
+  const noop = () => {};
+  state.value = getInitialRenderState({
+    widget,
+    parentIndex: getParentIndex(),
+    instantSearchInstance,
+    createProbeWidget: () => connector(noop, noop)(initialWidgetParams),
+  });
+
+  watch(
+    () => toValue(widgetParams),
+    (nextWidgetParams) => {
+      // Unlike the mixin, recreation is dequal-guarded: a reactive tick that
+      // yields deep-equal params does not remove/recreate the widget.
+      if (dequal(nextWidgetParams, appliedSnapshot)) {
+        return;
+      }
+      appliedSnapshot = snapshot(nextWidgetParams);
+      controller.update(nextWidgetParams);
+    },
+    { deep: true }
+  );
+
+  onBeforeUnmount(() => {
+    shouldSetState = false;
+    controller.unmount();
+  });
+
+  return state;
+}

--- a/packages/vue-instantsearch/src/composables/useSearchBox.js
+++ b/packages/vue-instantsearch/src/composables/useSearchBox.js
@@ -1,0 +1,21 @@
+import { connectSearchBox } from 'instantsearch.js/es/connectors/index';
+
+import { computed } from '../util/vue-compat';
+
+import { useConnector } from './useConnector';
+
+export function useSearchBox(widgetParams = {}) {
+  const state = useConnector(connectSearchBox, widgetParams, {
+    $$widgetType: 'ais.searchBox',
+  });
+
+  // Public surface per the Vue composables convention: a plain object of
+  // refs (destructurable), with stable function wrappers delegating to the
+  // latest render state so consumers never call `.value`.
+  return {
+    query: computed(() => state.value.query),
+    isSearchStalled: computed(() => state.value.isSearchStalled),
+    refine: (value) => state.value.refine(value),
+    clear: () => state.value.clear(),
+  };
+}

--- a/packages/vue-instantsearch/src/instantsearch.js
+++ b/packages/vue-instantsearch/src/instantsearch.js
@@ -1,5 +1,7 @@
 export { createSuitMixin } from './mixins/suit';
 export { createWidgetMixin } from './mixins/widget';
+export { useConnector } from './composables/useConnector';
+export { useSearchBox } from './composables/useSearchBox';
 export * from './widgets';
 export { plugin as default } from './plugin';
 export { createServerRootMixin } from './util/createServerRootMixin';

--- a/packages/vue-instantsearch/src/mixins/widget.js
+++ b/packages/vue-instantsearch/src/mixins/widget.js
@@ -1,6 +1,6 @@
-import { _objectSpread } from '../util/polyfills';
 import { isVue3 } from '../util/vue-compat';
 import { warn } from '../util/warn';
+import { createWidgetLifecycleController } from '../util/widgetLifecycleController';
 
 export const createWidgetMixin = (
   { connector } = {},
@@ -30,27 +30,19 @@ export const createWidgetMixin = (
   },
   created() {
     if (typeof connector === 'function') {
-      this.factory = connector(this.updateState, () => {});
-      this.widget = _objectSpread(
-        this.factory(this.widgetParams),
-        additionalProperties
-      );
-      this.getParentIndex().addWidgets([this.widget]);
-
-      if (
-        this.instantSearchInstance._initialResults &&
-        !this.instantSearchInstance.started
-      ) {
-        if (typeof this.instantSearchInstance.__forceRender !== 'function') {
-          throw new Error(
-            'You are using server side rendering with <ais-instant-search> instead of <ais-instant-search-ssr>.'
-          );
-        }
-        this.instantSearchInstance.__forceRender(
-          this.widget,
-          this.getParentIndex()
-        );
-      }
+      this.lifecycle = createWidgetLifecycleController({
+        connector,
+        additionalWidgetProperties: additionalProperties,
+        instantSearchInstance: this.instantSearchInstance,
+        getParentIndex: this.getParentIndex,
+        renderCallback: this.updateState,
+        // `this.widget` must be set before `addWidgets`: on a started
+        // instance `init` runs synchronously and `updateState` reads it.
+        onWidgetCreated: (widget) => {
+          this.widget = widget;
+        },
+      });
+      this.lifecycle.mount(this.widgetParams);
     } else if (connector !== true) {
       warn(
         `You are using the InstantSearch widget mixin, but didn't provide a connector.
@@ -64,20 +56,15 @@ Read more on using connectors: https://alg.li/vue-custom`
     }
   },
   [isVue3 ? 'beforeUnmount' : 'beforeDestroy']() {
-    if (this.widget) {
-      this.getParentIndex().removeWidgets([this.widget]);
+    if (this.lifecycle) {
+      this.lifecycle.unmount();
     }
   },
   watch: {
     widgetParams: {
       handler(nextWidgetParams) {
         this.state = null;
-        this.getParentIndex().removeWidgets([this.widget]);
-        this.widget = _objectSpread(
-          this.factory(nextWidgetParams),
-          additionalProperties
-        );
-        this.getParentIndex().addWidgets([this.widget]);
+        this.lifecycle.update(nextWidgetParams);
       },
       deep: true,
     },

--- a/packages/vue-instantsearch/src/util/dequal.js
+++ b/packages/vue-instantsearch/src/util/dequal.js
@@ -1,0 +1,48 @@
+/* eslint-disable complexity */
+
+/*
+ * PoC — copied from `react-instantsearch-core/src/lib/dequal.ts`
+ * (itself dequal/lite v2.0.0 with a 3rd `compare(a, b)` argument used to
+ * skip comparing function references). The sharing-strategy ticket decides
+ * the neutral home for this helper.
+ */
+
+const has = Object.prototype.hasOwnProperty;
+
+export function dequal(foo, bar, compare) {
+  // start of custom implementation
+  if (compare && compare(foo, bar)) {
+    return true;
+  }
+  // end of custom implementation
+
+  let ctor;
+  let len;
+  if (foo === bar) return true;
+
+  if (foo && bar && (ctor = foo.constructor) === bar.constructor) {
+    if (ctor === Date) return foo.getTime() === bar.getTime();
+    if (ctor === RegExp) return foo.toString() === bar.toString();
+
+    if (ctor === Array) {
+      if ((len = foo.length) === bar.length) {
+        while (len-- && dequal(foo[len], bar[len], compare));
+      }
+      return len === -1;
+    }
+
+    if (!ctor || typeof foo === 'object') {
+      len = 0;
+      // eslint-disable-next-line guard-for-in, instantsearch/no-for-in
+      for (ctor in foo) {
+        if (has.call(foo, ctor) && ++len && !has.call(bar, ctor)) return false;
+        if (!(ctor in bar) || !dequal(foo[ctor], bar[ctor], compare))
+          return false;
+      }
+      return Object.keys(bar).length === len;
+    }
+  }
+
+  // eslint-disable-next-line no-self-compare
+  return foo !== foo && bar !== bar;
+}

--- a/packages/vue-instantsearch/src/util/getInitialRenderState.js
+++ b/packages/vue-instantsearch/src/util/getInitialRenderState.js
@@ -1,0 +1,141 @@
+import algoliasearchHelper from 'algoliasearch-helper';
+
+/*
+ * PoC — synchronous initial render state, ported from
+ * `react-instantsearch-core` (`useConnector`'s `useState` initializer +
+ * `getIndexSearchResults` + `createSearchResults`).
+ *
+ * One Vue-specific addition: Vue mounts widgets in `created()`/`setup()`,
+ * *before* `instantsearch.start()` runs (root `mounted` + `$nextTick`), so
+ * unlike React there is no helper yet on first mount. The pre-start branch
+ * derives an equivalent helper from the initial ui state.
+ *
+ * NOTE (packaging): `algoliasearch-helper` is only a devDependency of
+ * vue-instantsearch today; shipping this requires promoting it (or hosting
+ * these helpers in a neutral home) — an RFC point.
+ */
+
+export function createSearchResults(state) {
+  return new algoliasearchHelper.SearchResults(
+    state,
+    [
+      {
+        query: state.query || '',
+        page: state.page || 0,
+        hitsPerPage: state.hitsPerPage || 20,
+        hits: [],
+        nbHits: 0,
+        nbPages: 0,
+        params: '',
+        exhaustiveNbHits: true,
+        exhaustiveFacetsCount: true,
+        processingTimeMS: 0,
+        index: state.index,
+      },
+    ],
+    {
+      // used by connectors to prevent persisting these results
+      __isArtificial: true,
+    }
+  );
+}
+
+function getIndexSearchResults(indexWidget) {
+  const helper = indexWidget.getHelper();
+  const results =
+    // On SSR, we get the results injected on the Index.
+    indexWidget.getResults() ||
+    // On the browser, we create fallback results based on the helper state.
+    createSearchResults(helper.state);
+  const scopedResults = indexWidget.getScopedResults().map((scopedResult) => {
+    const fallbackResults =
+      scopedResult.indexId === indexWidget.getIndexId()
+        ? results
+        : createSearchResults(scopedResult.helper.state);
+
+    return {
+      ...scopedResult,
+      // We keep `results` from being `null`.
+      results: scopedResult.results || fallbackResults,
+    };
+  });
+
+  return { results, scopedResults };
+}
+
+export function getInitialRenderState({
+  widget: realWidget,
+  parentIndex,
+  instantSearchInstance,
+  createProbeWidget,
+}) {
+  if (!realWidget.getWidgetRenderState) {
+    return {};
+  }
+
+  const startedHelper = parentIndex.getHelper();
+  // Connectors cache function refs (refine, clear…) on the widget, closing
+  // over the first helper `getWidgetRenderState` sees. Pre-start that helper
+  // is a detached one, so the state is computed on a throwaway probe widget
+  // to avoid poisoning the real widget's cache.
+  const widget = startedHelper ? realWidget : createProbeWidget();
+  let helper;
+  let results;
+  let scopedResults;
+
+  if (startedHelper) {
+    // Same path as React: the instance has started, reuse the index helper.
+    const uiState = parentIndex.getWidgetUiState({})[parentIndex.getIndexId()];
+    startedHelper.state =
+      (widget.getWidgetSearchParameters &&
+        widget.getWidgetSearchParameters(startedHelper.state, { uiState })) ||
+      startedHelper.state;
+    helper = startedHelper;
+    const indexResults = getIndexSearchResults(parentIndex);
+    results = indexResults.results;
+    scopedResults = indexResults.scopedResults;
+  } else {
+    // Pre-start branch (Vue-only): derive a detached helper from the widget's
+    // search parameters and the instance's initial ui state.
+    const uiState =
+      (instantSearchInstance._initialUiState || {})[
+        parentIndex.getIndexId()
+      ] || {};
+    const initialParameters = new algoliasearchHelper.SearchParameters({
+      index: parentIndex.getIndexName(),
+    });
+    const searchParameters =
+      (widget.getWidgetSearchParameters &&
+        widget.getWidgetSearchParameters(initialParameters, { uiState })) ||
+      initialParameters;
+    helper = algoliasearchHelper(
+      instantSearchInstance.client,
+      parentIndex.getIndexName(),
+      searchParameters
+    );
+    results = createSearchResults(helper.state);
+    scopedResults = [];
+  }
+
+  // We get the widget render state by providing the same parameters as
+  // InstantSearch provides to the widget's `render` method.
+  const { widgetParams, ...renderState } = widget.getWidgetRenderState({
+    helper,
+    parent: parentIndex,
+    instantSearchInstance,
+    results,
+    scopedResults,
+    state: helper.state,
+    renderState: instantSearchInstance.renderState,
+    templatesConfig: instantSearchInstance.templatesConfig,
+    // `parentIndex.createURL` throws before the instance has started.
+    createURL: startedHelper ? parentIndex.createURL : () => '#',
+    searchMetadata: {
+      isSearchStalled: instantSearchInstance.status === 'stalled',
+    },
+    status: instantSearchInstance.status,
+    error: instantSearchInstance.error,
+  });
+
+  return renderState;
+}

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue2.js
@@ -1,4 +1,4 @@
-import Vue from 'vue';
+import Vue, { unref } from 'vue';
 
 const isVue2 = true;
 const isVue3 = false;
@@ -59,8 +59,23 @@ export function getScopedSlot(component, name) {
   return (component.$scopedSlots || {})[name];
 }
 
+// Composition APIs available in both Vue 2.7 and Vue 3 with compatible
+// signatures (PoC: consumed by the composables).
+export {
+  computed,
+  inject,
+  onBeforeUnmount,
+  shallowRef,
+  unref,
+  watch,
+} from 'vue';
+
+// `toValue` is Vue 3.3+ only; local shim works in 2.7 and 3.
+export function toValue(source) {
+  return typeof source === 'function' ? source() : unref(source);
+}
+
 // Vue3-only APIs
-export const computed = undefined;
 export const createApp = undefined;
 export const createSSRApp = undefined;
 export const createRef = undefined;
@@ -70,7 +85,6 @@ export const defineComponent = undefined;
 export const del = undefined;
 export const getCurrentInstance = undefined;
 export const h = undefined;
-export const inject = undefined;
 export const isRaw = undefined;
 export const isReactive = undefined;
 export const isReadonly = undefined;
@@ -79,7 +93,6 @@ export const markRaw = undefined;
 export const nextTick = undefined;
 export const onActivated = undefined;
 export const onBeforeMount = undefined;
-export const onBeforeUnmount = undefined;
 export const onBeforeUpdate = undefined;
 export const onDeactivated = undefined;
 export const onErrorCaptured = undefined;
@@ -95,14 +108,11 @@ export const ref = undefined;
 export const set = undefined;
 export const shallowReactive = undefined;
 export const shallowReadonly = undefined;
-export const shallowRef = undefined;
 export const toRaw = undefined;
 export const toRef = undefined;
 export const toRefs = undefined;
 export const triggerRef = undefined;
-export const unref = undefined;
 export const useCSSModule = undefined;
 export const useCssModule = undefined;
 export const warn = undefined;
-export const watch = undefined;
 export const watchEffect = undefined;

--- a/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
+++ b/packages/vue-instantsearch/src/util/vue-compat/index-vue3.js
@@ -5,7 +5,22 @@ const isVue3 = true;
 const Vue2 = undefined;
 
 export { createApp, createSSRApp, h, version, nextTick } from 'vue';
+// Composition APIs available in both Vue 2.7 and Vue 3 with compatible
+// signatures (PoC: consumed by the composables).
+export {
+  computed,
+  inject,
+  onBeforeUnmount,
+  shallowRef,
+  unref,
+  watch,
+} from 'vue';
 export { Vue, Vue2, isVue2, isVue3 };
+
+// `toValue` is Vue 3.3+ only; local shim keeps 2.7/3.0-3.2 parity.
+export function toValue(source) {
+  return typeof source === 'function' ? source() : Vue.unref(source);
+}
 
 export function renderCompat(fn) {
   function h(tag, props, ...childrenArray) {

--- a/packages/vue-instantsearch/src/util/widgetLifecycleController.js
+++ b/packages/vue-instantsearch/src/util/widgetLifecycleController.js
@@ -1,0 +1,68 @@
+import { _objectSpread } from './polyfills';
+
+/**
+ * PoC — framework-agnostic widget lifecycle controller.
+ *
+ * Owns the connector -> factory -> widget wiring shared by the Options-API
+ * mixin (`createWidgetMixin`) and the composables (`useConnector`):
+ * widget creation with additional properties, add/remove on the parent index,
+ * remove-and-recreate on widget params change, and the SSR force-render.
+ *
+ * State-update policy stays with each consumer (they differ: the mixin keeps
+ * its historical null-start semantics, the composable adopts React's).
+ */
+export function createWidgetLifecycleController({
+  connector,
+  additionalWidgetProperties = {},
+  instantSearchInstance,
+  getParentIndex,
+  renderCallback,
+  unmountCallback = () => {},
+  // Called between widget creation and `addWidgets`: on a started instance,
+  // `addWidgets` runs the widget's `init` synchronously, and the render
+  // callback may need to see the widget already (e.g. the mixin reads
+  // `this.widget.dependsOn`).
+  onWidgetCreated = () => {},
+}) {
+  const factory = connector(renderCallback, unmountCallback);
+  let widget = null;
+
+  const createWidget = (widgetParams) => {
+    widget = _objectSpread(factory(widgetParams), additionalWidgetProperties);
+    onWidgetCreated(widget);
+    return widget;
+  };
+
+  return {
+    mount(widgetParams) {
+      widget = createWidget(widgetParams);
+      getParentIndex().addWidgets([widget]);
+
+      if (
+        instantSearchInstance._initialResults &&
+        !instantSearchInstance.started
+      ) {
+        if (typeof instantSearchInstance.__forceRender !== 'function') {
+          throw new Error(
+            'You are using server side rendering with <ais-instant-search> instead of <ais-instant-search-ssr>.'
+          );
+        }
+        instantSearchInstance.__forceRender(widget, getParentIndex());
+      }
+
+      return widget;
+    },
+    update(nextWidgetParams) {
+      getParentIndex().removeWidgets([widget]);
+      widget = createWidget(nextWidgetParams);
+      getParentIndex().addWidgets([widget]);
+      return widget;
+    },
+    unmount() {
+      if (widget) {
+        getParentIndex().removeWidgets([widget]);
+        widget = null;
+      }
+    },
+  };
+}


### PR DESCRIPTION
**Summary**

Throwaway PoC supporting [RFC: Composition API composables for Vue InstantSearch](https://algolia.atlassian.net/wiki/spaces/FX/pages/7414186032/RFC+Composition+API+composables+for+Vue+InstantSearch). **Not intended to merge** — it exists so RFC reviewers can read the diff and comment inline.

It proves the RFC's central claim: `createWidgetMixin` and a new `useConnector` composable can share a plain-JS widget lifecycle controller without breaking the mixin's public contract.

- `src/util/widgetLifecycleController.js` — shared core: connector → factory → widget, add/remove on the parent index, remove-and-recreate on params change, SSR `__forceRender`; state-update policy stays per consumer.
- `src/mixins/widget.js` rewired over the controller — public contract unchanged (options, `this.state`, `this.widget`, timing, warnings, SSR error).
- `src/composables/useConnector.js` + `useSearchBox.js` — sync initial render state (never null), `shallowRef` out, `MaybeRefOrGetter` in, dequal-guarded commits and recreation.
- `vue-compat` shim: real re-exports of composition APIs on both Vue 2.7 and Vue 3 sides + a `toValue` shim; build/Jest infra picked them up with zero config changes.

**Result**

The existing `vue-instantsearch` suite passes **untouched** in both modes:

- Vue 2.7: 54 suites, 568 passed / 0 failed
- Vue 3 (`prepare-vue3`): 54 suites, 562 passed / 0 failed

Plus 11 new PoC tests (8 `useConnector` unit, 3 `useSearchBox` integration), passing in both modes.