### PR TITLE
fix(chat): update query extraction in search index tool

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
@@ -1,6 +1,6 @@
 /** @jsx createElement */
 
-import { getFacetFiltersFromToolInput } from '../../../lib/utils/chat';
+import { getApplyFiltersParamsFromToolInput } from '../../../lib/utils/chat';
 import { addAbsolutePosition, addQueryID } from '../../../lib/utils/hits';
 import { createButtonComponent } from '../../Button';
 import { createCarouselComponent, generateCarouselId } from '../../Carousel';
@@ -72,10 +72,9 @@ function createHeaderComponent({ createElement }: Renderer) {
               onClick={() => {
                 if (!input || !applyFilters) return;
 
-                const params = applyFilters({
-                  query: input.query,
-                  facetFilters: getFacetFiltersFromToolInput(input),
-                });
+                const params = applyFilters(
+                  getApplyFiltersParamsFromToolInput(input)
+                );
 
                 if (getSearchPageURL) {
                   const searchPageURL = getSearchPageURL(params);

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -455,21 +455,40 @@ export type AddToolResultWithOutput = (
   params: Pick<Parameters<AddToolResult>[0], 'output'>
 ) => ReturnType<AddToolResult>;
 
-type SearchToolInputBase = {
+type SearchToolQueryBase = {
   query: string;
   number_of_results?: number;
 };
 
-type DefaultSearchToolInput = SearchToolInputBase & {
+type DefaultSearchToolQuery = SearchToolQueryBase & {
   facet_filters?: string[][];
 };
 
-type McpSearchToolInput = SearchToolInputBase & {
+type McpSearchToolQuery = SearchToolQueryBase & {
   facet_filters?: undefined;
   [facetKey: `facet_${string}`]: string[] | undefined;
 };
 
-export type SearchToolInput = DefaultSearchToolInput | McpSearchToolInput;
+/**
+ * A single query of a search tool input: the query string along with its
+ * refinements, either as a ready-to-use `facet_filters` array or as individual
+ * `facet_<attribute>` keys.
+ */
+export type SearchToolQuery = DefaultSearchToolQuery | McpSearchToolQuery;
+
+/** Search tool input holding the query and its refinements at the root. */
+type SingleQuerySearchToolInput = SearchToolQuery & { queries?: undefined };
+
+/** Search tool input nesting one or more queries in a `queries` array. */
+type MultiQuerySearchToolInput = {
+  query?: undefined;
+  facet_filters?: undefined;
+  queries: SearchToolQuery[];
+};
+
+export type SearchToolInput =
+  | SingleQuerySearchToolInput
+  | MultiQuerySearchToolInput;
 
 export type ApplyFiltersParams = {
   query?: string;

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -455,16 +455,20 @@ export type AddToolResultWithOutput = (
   params: Pick<Parameters<AddToolResult>[0], 'output'>
 ) => ReturnType<AddToolResult>;
 
-type SearchToolQueryBase = {
+type SearchToolExtraFields = {
+  [key: string]: unknown;
+};
+
+type SearchToolQueryBase = SearchToolExtraFields & {
   query: string;
   number_of_results?: number;
 };
 
-type DefaultSearchToolQuery = SearchToolQueryBase & {
+type FacetFiltersSearchToolQuery = SearchToolQueryBase & {
   facet_filters?: string[][];
 };
 
-type McpSearchToolQuery = SearchToolQueryBase & {
+type FacetKeysSearchToolQuery = SearchToolQueryBase & {
   facet_filters?: undefined;
   [facetKey: `facet_${string}`]: string[] | undefined;
 };
@@ -474,13 +478,15 @@ type McpSearchToolQuery = SearchToolQueryBase & {
  * refinements, either as a ready-to-use `facet_filters` array or as individual
  * `facet_<attribute>` keys.
  */
-export type SearchToolQuery = DefaultSearchToolQuery | McpSearchToolQuery;
+export type SearchToolQuery =
+  | FacetFiltersSearchToolQuery
+  | FacetKeysSearchToolQuery;
 
 /** Search tool input holding the query and its refinements at the root. */
 type SingleQuerySearchToolInput = SearchToolQuery & { queries?: undefined };
 
 /** Search tool input nesting one or more queries in a `queries` array. */
-type MultiQuerySearchToolInput = {
+type MultiQuerySearchToolInput = SearchToolExtraFields & {
   query?: undefined;
   facet_filters?: undefined;
   queries: SearchToolQuery[];

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -1,27 +1,32 @@
-import { getFacetFiltersFromToolInput, getHitsByObjectID } from '../chat';
+import { getApplyFiltersParamsFromToolInput, getHitsByObjectID } from '../chat';
 
 import type { ChatMessageBase, ChatToolMessage } from '../../../components';
 
-describe('getFacetFiltersFromToolInput', () => {
-  test('returns undefined when input is undefined', () => {
-    expect(getFacetFiltersFromToolInput(undefined)).toBeUndefined();
+type ToolInput = Parameters<typeof getApplyFiltersParamsFromToolInput>[0];
+
+describe('getApplyFiltersParamsFromToolInput', () => {
+  test('returns nothing to refine when input is undefined', () => {
+    expect(getApplyFiltersParamsFromToolInput(undefined)).toEqual({
+      query: undefined,
+      facetFilters: undefined,
+    });
   });
 
-  test('returns the standard `facet_filters` array when present', () => {
+  test('returns the query and the standard `facet_filters` array', () => {
     const facetFilters = [['brand:Apple'], ['type:book']];
 
     expect(
-      getFacetFiltersFromToolInput({
+      getApplyFiltersParamsFromToolInput({
         query: 'phone',
         facet_filters: facetFilters,
       })
-    ).toBe(facetFilters);
+    ).toEqual({ query: 'phone', facetFilters });
   });
 
   test('builds facet filters from MCP `facet_<attribute>` keys', () => {
     expect(
-      getFacetFiltersFromToolInput({
-        query: '',
+      getApplyFiltersParamsFromToolInput({
+        query: 'book',
         clickAnalytics: true,
         facet_type: ['book'],
         facet_brand: [],
@@ -35,43 +40,84 @@ describe('getFacetFiltersFromToolInput', () => {
         facet__collections: [],
         facet_price: [],
         userIntent: 'irrelevant',
-      } as Parameters<typeof getFacetFiltersFromToolInput>[0])
-    ).toEqual([
-      ['type:book'],
-      [
-        'categories:Literature & Fiction',
-        'categories:Mystery, Thriller & Suspense',
-        'categories:Teen & Young Adult',
+      } as ToolInput)
+    ).toEqual({
+      query: 'book',
+      facetFilters: [
+        ['type:book'],
+        [
+          'categories:Literature & Fiction',
+          'categories:Mystery, Thriller & Suspense',
+          'categories:Teen & Young Adult',
+        ],
       ],
-    ]);
+    });
+  });
+
+  test('reads the query and the facets of the first entry of a `queries` input', () => {
+    expect(
+      getApplyFiltersParamsFromToolInput({
+        queries: [
+          {
+            query: 'laptop',
+            facet_free_shipping: null,
+            facet_brand: null,
+            facet_categories: ['Laptops'],
+            'facet_hierarchicalCategories.lvl0': ['Computers & Tablets'],
+            'facet_hierarchicalCategories.lvl1': [
+              'Computers & Tablets > Laptops',
+            ],
+            'facet_hierarchicalCategories.lvl2': null,
+            facet_price: null,
+          },
+          { query: 'ignored', facet_brand: ['Apple'] },
+        ],
+        clickAnalytics: true,
+        originalQuery: 'give me some laptops',
+      } as unknown as ToolInput)
+    ).toEqual({
+      query: 'laptop',
+      facetFilters: [
+        ['categories:Laptops'],
+        ['hierarchicalCategories.lvl0:Computers & Tablets'],
+        ['hierarchicalCategories.lvl1:Computers & Tablets > Laptops'],
+      ],
+    });
+  });
+
+  test('returns nothing to refine when `queries` is empty', () => {
+    expect(getApplyFiltersParamsFromToolInput({ queries: [] })).toEqual({
+      query: undefined,
+      facetFilters: undefined,
+    });
   });
 
   test('preserves the attribute name including leading underscores', () => {
     expect(
-      getFacetFiltersFromToolInput({
+      getApplyFiltersParamsFromToolInput({
         query: '',
         facet__collections: ['summer'],
-      } as Parameters<typeof getFacetFiltersFromToolInput>[0])
+      } as ToolInput).facetFilters
     ).toEqual([['_collections:summer']]);
   });
 
   test('ignores non-string and empty facet values', () => {
     expect(
-      getFacetFiltersFromToolInput({
+      getApplyFiltersParamsFromToolInput({
         query: '',
         facet_brand: [],
         facet_type: [42, 'book', null] as unknown as string[],
-      } as Parameters<typeof getFacetFiltersFromToolInput>[0])
+      } as ToolInput).facetFilters
     ).toEqual([['type:book']]);
   });
 
-  test('returns undefined when there are no facet refinements', () => {
+  test('returns no facet filters when there are no refinements', () => {
     expect(
-      getFacetFiltersFromToolInput({
+      getApplyFiltersParamsFromToolInput({
         query: 'phone',
         facet_brand: [],
         facet_type: [],
-      } as Parameters<typeof getFacetFiltersFromToolInput>[0])
+      } as ToolInput).facetFilters
     ).toBeUndefined();
   });
 });

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -2,8 +2,6 @@ import { getApplyFiltersParamsFromToolInput, getHitsByObjectID } from '../chat';
 
 import type { ChatMessageBase, ChatToolMessage } from '../../../components';
 
-type ToolInput = Parameters<typeof getApplyFiltersParamsFromToolInput>[0];
-
 describe('getApplyFiltersParamsFromToolInput', () => {
   test('returns nothing to refine when input is undefined', () => {
     expect(getApplyFiltersParamsFromToolInput(undefined)).toEqual({
@@ -40,7 +38,7 @@ describe('getApplyFiltersParamsFromToolInput', () => {
         facet__collections: [],
         facet_price: [],
         userIntent: 'irrelevant',
-      } as ToolInput)
+      })
     ).toEqual({
       query: 'book',
       facetFilters: [
@@ -74,7 +72,7 @@ describe('getApplyFiltersParamsFromToolInput', () => {
         ],
         clickAnalytics: true,
         originalQuery: 'give me some laptops',
-      } as unknown as ToolInput)
+      })
     ).toEqual({
       query: 'laptop',
       facetFilters: [
@@ -97,7 +95,7 @@ describe('getApplyFiltersParamsFromToolInput', () => {
       getApplyFiltersParamsFromToolInput({
         query: '',
         facet__collections: ['summer'],
-      } as ToolInput).facetFilters
+      }).facetFilters
     ).toEqual([['_collections:summer']]);
   });
 
@@ -106,8 +104,8 @@ describe('getApplyFiltersParamsFromToolInput', () => {
       getApplyFiltersParamsFromToolInput({
         query: '',
         facet_brand: [],
-        facet_type: [42, 'book', null] as unknown as string[],
-      } as ToolInput).facetFilters
+        facet_type: [42, 'book', null],
+      }).facetFilters
     ).toEqual([['type:book']]);
   });
 
@@ -117,7 +115,7 @@ describe('getApplyFiltersParamsFromToolInput', () => {
         query: 'phone',
         facet_brand: [],
         facet_type: [],
-      } as ToolInput).facetFilters
+      }).facetFilters
     ).toBeUndefined();
   });
 });

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -2,10 +2,12 @@ import { startsWith } from './startsWith';
 
 import type { ChatMessageBase } from '../../components';
 import type {
+  ApplyFiltersParams,
   ChatToolMessage,
   ClientSideTool,
   ClientSideTools,
   SearchToolInput,
+  SearchToolQuery,
 } from '../../components/chat/types';
 import type { RecordWithObjectID } from '../../types';
 
@@ -68,27 +70,32 @@ export const findTool = (
 
 const FACET_KEY_PREFIX = 'facet_';
 
-/**
- * Extracts the `facetFilters` from a search tool input.
- *
- * The default search tool provides a ready-to-use `facet_filters` array. The
- * Algolia MCP Server search tool instead expresses refinements as individual
- * `facet_<attribute>` keys (e.g. `facet_categories: ['Books', 'Toys']`), which
- * are converted here into the `[['attribute:value']]` shape `applyFilters`
- * expects.
- */
-export const getFacetFiltersFromToolInput = (
+const hasQueries = (
+  input: SearchToolInput
+): input is { queries: SearchToolQuery[] } => Array.isArray(input.queries);
+
+const getSearchToolQuery = (
   input: SearchToolInput | undefined
-): string[][] | undefined => {
+): SearchToolQuery | undefined => {
   if (!input) {
     return undefined;
   }
 
-  if (Array.isArray(input.facet_filters)) {
-    return input.facet_filters;
+  return hasQueries(input) ? input.queries[0] : input;
+};
+
+const getFacetFilters = (
+  query: SearchToolQuery | undefined
+): string[][] | undefined => {
+  if (!query) {
+    return undefined;
   }
 
-  const facetFilters = Object.entries(input).reduce<string[][]>(
+  if (Array.isArray(query.facet_filters)) {
+    return query.facet_filters;
+  }
+
+  const facetFilters = Object.entries(query).reduce<string[][]>(
     (acc, [key, value]) => {
       if (!startsWith(key, FACET_KEY_PREFIX) || !Array.isArray(value)) {
         return acc;
@@ -109,6 +116,26 @@ export const getFacetFiltersFromToolInput = (
   );
 
   return facetFilters.length > 0 ? facetFilters : undefined;
+};
+
+/**
+ * Extracts the refinements a search tool searched with, in the shape
+ * `applyFilters` expects.
+ *
+ * The default search tool provides a ready-to-use `facet_filters` array. The
+ * Algolia MCP Server search tool instead expresses refinements as individual
+ * `facet_<attribute>` keys (e.g. `facet_categories: ['Books', 'Toys']`), which
+ * are converted here into `[['attribute:value']]`.
+ */
+export const getApplyFiltersParamsFromToolInput = (
+  input: SearchToolInput | undefined
+): ApplyFiltersParams => {
+  const query = getSearchToolQuery(input);
+
+  return {
+    query: query?.query,
+    facetFilters: getFacetFilters(query),
+  };
 };
 
 const isSearchToolPart = (part: ChatToolMessage) =>

--- a/packages/instantsearch-ui-components/src/lib/utils/index.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/index.ts
@@ -1,4 +1,4 @@
-export { getFacetFiltersFromToolInput } from './chat';
+export { getApplyFiltersParamsFromToolInput } from './chat';
 export * from './find';
 export * from './hits';
 export * from './promptSuggestions';

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -2,9 +2,12 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 
-import { createSearchClient } from '@instantsearch/mocks';
+import {
+  createSearchClient,
+  createSingleSearchResponse,
+} from '@instantsearch/mocks';
 import { waitFor } from '@testing-library/dom';
-import algoliasearchHelper from 'algoliasearch-helper';
+import algoliasearchHelper, { SearchResults } from 'algoliasearch-helper';
 
 import { createInstantSearch } from '../../../../test/createInstantSearch';
 import {
@@ -27,7 +30,10 @@ jest.mock('../../../lib/utils/sendChatMessageFeedback', () => ({
 }));
 
 describe('connectChat', () => {
-  const getInitializedWidget = (widgetParams: ChatConnectorParams = {}) => {
+  const getInitializedWidget = (
+    widgetParams: ChatConnectorParams = {},
+    helper = algoliasearchHelper(createSearchClient(), '')
+  ) => {
     const renderFn = jest.fn();
     const makeWidget = connectChat(renderFn);
     const widget = makeWidget({
@@ -35,8 +41,6 @@ describe('connectChat', () => {
       disableTriggerValidation: true,
       ...widgetParams,
     } as ChatConnectorParams);
-
-    const helper = algoliasearchHelper(createSearchClient(), '');
 
     widget.init(createInitOptions({ helper }));
 
@@ -592,6 +596,92 @@ describe('connectChat', () => {
       renderState.sendChatMessageFeedback!('msg-1', 0);
 
       expect(mockedFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('applyFilters', () => {
+    const getApplyFilters = () => {
+      const helper = algoliasearchHelper(createSearchClient(), 'index', {
+        hierarchicalFacets: [
+          {
+            name: 'hierarchicalCategories.lvl0',
+            attributes: [
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+            ],
+            separator: ' > ',
+          },
+        ],
+      });
+      helper.lastResults = new SearchResults(helper.state, [
+        createSingleSearchResponse(),
+      ]);
+
+      const { getRenderState } = getInitializedWidget(
+        { tools: { testTool: {} } },
+        helper
+      );
+
+      return {
+        helper,
+        applyFilters: getRenderState().tools.testTool.applyFilters,
+      };
+    };
+
+    it('refines the query and the facets of the search tool', () => {
+      const { helper, applyFilters } = getApplyFilters();
+
+      applyFilters({
+        query: 'laptop',
+        facetFilters: [['categories:Laptops'], ['brand:Apple']],
+      });
+
+      expect(helper.state.query).toBe('laptop');
+      expect(helper.state.disjunctiveFacetsRefinements).toEqual({
+        categories: ['Laptops'],
+        brand: ['Apple'],
+      });
+    });
+
+    it('keeps the value after the first colon in a facet filter', () => {
+      const { helper, applyFilters } = getApplyFilters();
+
+      applyFilters({ facetFilters: [['brand:Bang & Olufsen: Beoplay']] });
+
+      expect(helper.state.disjunctiveFacetsRefinements).toEqual({
+        brand: ['Bang & Olufsen: Beoplay'],
+      });
+    });
+
+    it('refines a hierarchical facet from its deepest level', () => {
+      const { helper, applyFilters } = getApplyFilters();
+
+      applyFilters({
+        facetFilters: [
+          ['hierarchicalCategories.lvl0:Computers & Tablets'],
+          ['hierarchicalCategories.lvl1:Computers & Tablets > Laptops'],
+        ],
+      });
+
+      expect(helper.state.hierarchicalFacetsRefinements).toEqual({
+        'hierarchicalCategories.lvl0': ['Computers & Tablets > Laptops'],
+      });
+      expect(helper.state.disjunctiveFacetsRefinements).toEqual({});
+    });
+
+    it('refines a hierarchical facet regardless of the level order', () => {
+      const { helper, applyFilters } = getApplyFilters();
+
+      applyFilters({
+        facetFilters: [
+          ['hierarchicalCategories.lvl1:Computers & Tablets > Laptops'],
+          ['hierarchicalCategories.lvl0:Computers & Tablets'],
+        ],
+      });
+
+      expect(helper.state.hierarchicalFacetsRefinements).toEqual({
+        'hierarchicalCategories.lvl0': ['Computers & Tablets > Laptops'],
+      });
     });
   });
 

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -289,29 +289,53 @@ function updateStateFromSearchToolInput(
   );
 
   if (params.facetFilters) {
-    const attributes = flat(params.facetFilters).map((filter) => {
-      const [attribute, value] = filter.split(':');
+    const refinements = flat(params.facetFilters).reduce<
+      Array<{ attribute: string; value: string }>
+    >((acc, filter) => {
+      const separatorIndex = filter.indexOf(':');
 
-      return { attribute, value };
-    });
+      if (separatorIndex > 0) {
+        acc.push({
+          attribute: filter.slice(0, separatorIndex),
+          value: filter.slice(separatorIndex + 1),
+        });
+      }
 
-    attributes.forEach(({ attribute, value }) => {
+      return acc;
+    }, []);
+
+    const hierarchicalRefinements = new Map<string, string>();
+
+    refinements.forEach(({ attribute, value }) => {
+      const hierarchicalFacet = helper.state.hierarchicalFacets.find(
+        (facet) =>
+          facet.name === attribute || facet.attributes.includes(attribute)
+      );
+
+      if (hierarchicalFacet) {
+        const currentValue = hierarchicalRefinements.get(
+          hierarchicalFacet.name
+        );
+
+        if (currentValue === undefined || value.length > currentValue.length) {
+          hierarchicalRefinements.set(hierarchicalFacet.name, value);
+        }
+
+        return;
+      }
+
       if (
         !helper.state.isConjunctiveFacet(attribute) &&
-        !helper.state.isHierarchicalFacet(attribute) &&
         !helper.state.isDisjunctiveFacet(attribute)
       ) {
-        const s = helper.state.addDisjunctiveFacet(attribute);
-        helper.setState(s);
-        helper.toggleFacetRefinement(attribute, value);
-      } else {
-        const attr =
-          helper.state.hierarchicalFacets.find(
-            (facet) => facet.name === attribute
-          )?.name || attribute;
-
-        helper.toggleFacetRefinement(attr, value);
+        helper.setState(helper.state.addDisjunctiveFacet(attribute));
       }
+
+      helper.toggleFacetRefinement(attribute, value);
+    });
+
+    hierarchicalRefinements.forEach((value, name) => {
+      helper.toggleFacetRefinement(name, value);
     });
   }
 

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/SearchIndexTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/SearchIndexTool.test.tsx
@@ -90,15 +90,9 @@ describe('createCarouselTool', () => {
       expect(screen.getByText('MCP Product 2')).toBeInTheDocument();
     });
 
-    test('converts MCP `facet_<name>` input into `facetFilters` on "View all"', async () => {
-      const applyFilters = jest.fn().mockReturnValue({});
-      const tool = createCarouselTool<TestHit>(true, mockItemComponent);
-      const LayoutComponent = tool.layoutComponent!;
-
-      const message: ClientSideToolComponentProps['message'] = {
-        type: 'tool-algolia_search_index_products',
-        state: 'output-available',
-        toolCallId: 'test-call-id',
+    test.each([
+      {
+        shape: 'MCP `facet_<name>`',
         input: {
           query: '',
           facet_type: ['book'],
@@ -106,33 +100,81 @@ describe('createCarouselTool', () => {
           facet_categories: ['Literature & Fiction', 'Teen & Young Adult'],
           facet__collections: [],
         },
-        output: {
-          hits: [{ objectID: '1', name: 'MCP Product 1', __position: 1 }],
-          nbHits: 50,
+        expected: {
+          query: '',
+          facetFilters: [
+            ['type:book'],
+            [
+              'categories:Literature & Fiction',
+              'categories:Teen & Young Adult',
+            ],
+          ],
         },
-      };
+      },
+      {
+        shape: 'multi-query `queries`',
+        input: {
+          queries: [
+            {
+              query: 'laptop',
+              facet_free_shipping: null,
+              facet_type: null,
+              facet_brand: null,
+              facet_categories: ['Laptops'],
+              'facet_hierarchicalCategories.lvl0': ['Computers & Tablets'],
+              'facet_hierarchicalCategories.lvl1': [
+                'Computers & Tablets > Laptops',
+              ],
+              'facet_hierarchicalCategories.lvl2': null,
+              facet_price: null,
+            },
+          ],
+          clickAnalytics: true,
+          originalQuery: 'give me some laptops',
+        },
+        expected: {
+          query: 'laptop',
+          facetFilters: [
+            ['categories:Laptops'],
+            ['hierarchicalCategories.lvl0:Computers & Tablets'],
+            ['hierarchicalCategories.lvl1:Computers & Tablets > Laptops'],
+          ],
+        },
+      },
+    ])(
+      'refines the page from a $shape input on "View all"',
+      async ({ input, expected }) => {
+        const applyFilters = jest.fn().mockReturnValue({});
+        const tool = createCarouselTool<TestHit>(true, mockItemComponent);
+        const LayoutComponent = tool.layoutComponent!;
 
-      render(
-        <LayoutComponent
-          message={message}
-          applyFilters={applyFilters}
-          onClose={jest.fn()}
-          indexUiState={{}}
-          addToolResult={jest.fn()}
-          setIndexUiState={jest.fn()}
-          sendEvent={jest.fn()}
-        />
-      );
+        const message: ClientSideToolComponentProps['message'] = {
+          type: 'tool-algolia_search_index_products',
+          state: 'output-available',
+          toolCallId: 'test-call-id',
+          input,
+          output: {
+            hits: [{ objectID: '1', name: 'Product 1', __position: 1 }],
+            nbHits: 50,
+          },
+        };
 
-      await userEvent.click(screen.getByText('View all'));
+        render(
+          <LayoutComponent
+            message={message}
+            applyFilters={applyFilters}
+            onClose={jest.fn()}
+            indexUiState={{}}
+            addToolResult={jest.fn()}
+            setIndexUiState={jest.fn()}
+            sendEvent={jest.fn()}
+          />
+        );
 
-      expect(applyFilters).toHaveBeenCalledWith({
-        query: '',
-        facetFilters: [
-          ['type:book'],
-          ['categories:Literature & Fiction', 'categories:Teen & Young Adult'],
-        ],
-      });
-    });
+        await userEvent.click(screen.getByText('View all'));
+
+        expect(applyFilters).toHaveBeenCalledWith(expected);
+      }
+    );
   });
 });


### PR DESCRIPTION
The search index tool now sends the `input-available` step's data as `{ "queries": [ { "query": "...", ... } ] }`. This PR updates the utils and connector to handle this.