### PR TITLE
feat(insights): send the user token with Recommend requests

### DIFF
--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-integration-test.ts
@@ -383,8 +383,10 @@ describe('network requests', () => {
             "model": "bought-together",
             "objectID": "one",
             "queryParameters": {
+              "clickAnalytics": true,
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
+              "userToken": "cookie-key",
             },
             "threshold": 0,
           },
@@ -434,8 +436,10 @@ describe('network requests', () => {
             "model": "bought-together",
             "objectID": "one",
             "queryParameters": {
+              "clickAnalytics": true,
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
+              "userToken": "cookie-key",
             },
             "threshold": 0,
           },
@@ -534,8 +538,10 @@ describe('network requests', () => {
             "model": "bought-together",
             "objectID": "one",
             "queryParameters": {
+              "clickAnalytics": true,
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
+              "userToken": "cookie-key",
             },
             "threshold": 0,
           },
@@ -585,8 +591,10 @@ describe('network requests', () => {
             "model": "bought-together",
             "objectID": "one",
             "queryParameters": {
+              "clickAnalytics": true,
               "highlightPostTag": "__/ais-highlight__",
               "highlightPreTag": "__ais-highlight__",
+              "userToken": "cookie-key",
             },
             "threshold": 0,
           },

--- a/packages/instantsearch.js/src/lib/utils/__tests__/addInsightsToRecommendParameters.test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/addInsightsToRecommendParameters.test.ts
@@ -7,7 +7,7 @@ describe('addInsightsToRecommendParameters', () => {
     new algoliasearchHelper.RecommendParameters().addRelatedProducts({
       objectID: 'objectID',
       $$id: 1,
-      queryParameters: { hitsPerPage: 3 },
+      queryParameters: { filters: 'brand:Apple' },
     });
 
   it('returns the same parameters when the state has no insights parameters', () => {
@@ -34,7 +34,7 @@ describe('addInsightsToRecommendParameters', () => {
         model: 'related-products',
         $$id: 1,
         queryParameters: {
-          hitsPerPage: 3,
+          filters: 'brand:Apple',
           userToken: 'my-token',
           clickAnalytics: true,
         },
@@ -59,7 +59,7 @@ describe('addInsightsToRecommendParameters', () => {
         objectID: 'objectID',
         model: 'related-products',
         $$id: 1,
-        queryParameters: { hitsPerPage: 3 },
+        queryParameters: { filters: 'brand:Apple' },
       },
     ]);
   });
@@ -77,9 +77,10 @@ describe('addInsightsToRecommendParameters', () => {
       clickAnalytics: true,
     });
 
-    expect(parameters.params[0].queryParameters).toEqual({
-      userToken: 'widget-token',
-      clickAnalytics: false,
-    });
+    expect(parameters.params).toEqual([
+      expect.objectContaining({
+        queryParameters: { userToken: 'widget-token', clickAnalytics: false },
+      }),
+    ]);
   });
 });

--- a/packages/instantsearch.js/src/lib/utils/__tests__/addInsightsToRecommendParameters.test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/addInsightsToRecommendParameters.test.ts
@@ -1,0 +1,85 @@
+import algoliasearchHelper from 'algoliasearch-helper';
+
+import { addInsightsToRecommendParameters } from '../addInsightsToRecommendParameters';
+
+describe('addInsightsToRecommendParameters', () => {
+  const createRecommendParameters = () =>
+    new algoliasearchHelper.RecommendParameters().addRelatedProducts({
+      objectID: 'objectID',
+      $$id: 1,
+      queryParameters: { hitsPerPage: 3 },
+    });
+
+  it('returns the same parameters when the state has no insights parameters', () => {
+    const recommendParameters = createRecommendParameters();
+
+    expect(
+      addInsightsToRecommendParameters(recommendParameters, { query: 'query' })
+    ).toBe(recommendParameters);
+  });
+
+  it('forwards the user token and click analytics to every query', () => {
+    const recommendParameters = createRecommendParameters().addTrendingItems({
+      $$id: 2,
+    });
+
+    const parameters = addInsightsToRecommendParameters(recommendParameters, {
+      userToken: 'my-token',
+      clickAnalytics: true,
+    });
+
+    expect(parameters.params).toEqual([
+      {
+        objectID: 'objectID',
+        model: 'related-products',
+        $$id: 1,
+        queryParameters: {
+          hitsPerPage: 3,
+          userToken: 'my-token',
+          clickAnalytics: true,
+        },
+      },
+      {
+        model: 'trending-items',
+        $$id: 2,
+        queryParameters: { userToken: 'my-token', clickAnalytics: true },
+      },
+    ]);
+  });
+
+  it('does not mutate the given parameters', () => {
+    const recommendParameters = createRecommendParameters();
+
+    addInsightsToRecommendParameters(recommendParameters, {
+      userToken: 'my-token',
+    });
+
+    expect(recommendParameters.params).toEqual([
+      {
+        objectID: 'objectID',
+        model: 'related-products',
+        $$id: 1,
+        queryParameters: { hitsPerPage: 3 },
+      },
+    ]);
+  });
+
+  it('lets the widget parameters take precedence', () => {
+    const recommendParameters =
+      new algoliasearchHelper.RecommendParameters().addRelatedProducts({
+        objectID: 'objectID',
+        $$id: 1,
+        queryParameters: { userToken: 'widget-token', clickAnalytics: false },
+      });
+
+    const parameters = addInsightsToRecommendParameters(recommendParameters, {
+      userToken: 'my-token',
+      clickAnalytics: true,
+    });
+
+    expect(parameters.params[0].queryParameters).toEqual({
+      userToken: 'widget-token',
+      clickAnalytics: false,
+    });
+  });
+});

--- a/packages/instantsearch.js/src/lib/utils/addInsightsToRecommendParameters.ts
+++ b/packages/instantsearch.js/src/lib/utils/addInsightsToRecommendParameters.ts
@@ -26,13 +26,21 @@ export function addInsightsToRecommendParameters(
   }
 
   return new algoliasearchHelper.RecommendParameters({
-    params: recommendParameters.params.map((params) => ({
-      ...params,
-      queryParameters: {
-        ...(clickAnalytics === undefined ? {} : { clickAnalytics }),
-        ...(userToken === undefined ? {} : { userToken }),
-        ...params.queryParameters,
-      },
-    })),
+    params: recommendParameters.params.map((params) => {
+      // v4 `TrendingFacetsQuery` doesn't include `queryParameters`, but the v5
+      // API and the helper support them, like `connectTrendingFacets` does.
+      const { queryParameters } = params as {
+        queryParameters?: PlainSearchParameters;
+      };
+
+      return {
+        ...params,
+        queryParameters: {
+          ...(clickAnalytics === undefined ? {} : { clickAnalytics }),
+          ...(userToken === undefined ? {} : { userToken }),
+          ...queryParameters,
+        },
+      } as RecommendParameters['params'][number];
+    }),
   });
 }

--- a/packages/instantsearch.js/src/lib/utils/addInsightsToRecommendParameters.ts
+++ b/packages/instantsearch.js/src/lib/utils/addInsightsToRecommendParameters.ts
@@ -1,0 +1,38 @@
+import algoliasearchHelper from 'algoliasearch-helper';
+
+import type {
+  PlainSearchParameters,
+  RecommendParameters,
+} from 'algoliasearch-helper';
+
+/**
+ * Forwards the insights-related search parameters to every Recommend query.
+ *
+ * The insights middleware writes `userToken` and `clickAnalytics` on the main
+ * helper's search state, which only feeds search queries: Recommend queries are
+ * built from their own parameters and never read the search state. Without this,
+ * recommendations can't be personalized, and their responses carry no `queryID`
+ * for the connectors to attribute click and conversion events with.
+ *
+ * Parameters set on a widget win, so an explicit `queryParameters.userToken`
+ * keeps overriding the middleware.
+ */
+export function addInsightsToRecommendParameters(
+  recommendParameters: RecommendParameters,
+  { userToken, clickAnalytics }: PlainSearchParameters
+): RecommendParameters {
+  if (userToken === undefined && clickAnalytics === undefined) {
+    return recommendParameters;
+  }
+
+  return new algoliasearchHelper.RecommendParameters({
+    params: recommendParameters.params.map((params) => ({
+      ...params,
+      queryParameters: {
+        ...(clickAnalytics === undefined ? {} : { clickAnalytics }),
+        ...(userToken === undefined ? {} : { userToken }),
+        ...params.queryParameters,
+      },
+    })),
+  });
+}

--- a/packages/instantsearch.js/src/lib/utils/index.ts
+++ b/packages/instantsearch.js/src/lib/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './addInsightsToRecommendParameters';
 export * from './addWidgetId';
 export * from './capitalize';
 export * from './checkIndexUiState';

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -15,7 +15,7 @@ import { fireEvent } from '@testing-library/dom';
 
 import { createInsightsMiddleware } from '..';
 import { createInstantSearch } from '../../../test/createInstantSearch';
-import { connectSearchBox } from '../../connectors';
+import { connectRelatedProducts, connectSearchBox } from '../../connectors';
 import instantsearch from '../../index.es';
 import { history } from '../../lib/routers';
 import { warning } from '../../lib/utils';
@@ -1180,6 +1180,127 @@ describe('insights', () => {
 
         expect(getUserToken()).toEqual('token-from-queue-before-init');
       });
+    });
+  });
+
+  describe('recommend', () => {
+    const getRecommendClient = () =>
+      searchClientWithCredentials as SearchClient & {
+        getRecommendations: jest.Mock;
+      };
+
+    it('sets the userToken and clickAnalytics on recommend queries', async () => {
+      const searchClient = getRecommendClient();
+      const { instantSearchInstance, getUserToken } = createTestEnvironment({
+        insights: true,
+      });
+
+      instantSearchInstance.addWidgets([
+        connectRelatedProducts(() => ({}))({ objectIDs: ['objectID'] }),
+      ]);
+
+      await wait(0);
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(1);
+      expect(searchClient.getRecommendations).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          model: 'related-products',
+          objectID: 'objectID',
+          queryParameters: expect.objectContaining({
+            clickAnalytics: true,
+            userToken: getUserToken(),
+          }),
+        }),
+      ]);
+      expect(getUserToken()).toEqual(expect.stringMatching(/^anonymous-/));
+    });
+
+    it('lets the widget userToken take precedence', async () => {
+      const searchClient = getRecommendClient();
+      const { instantSearchInstance } = createTestEnvironment({
+        insights: true,
+      });
+
+      instantSearchInstance.addWidgets([
+        connectRelatedProducts(() => ({}))({
+          objectIDs: ['objectID'],
+          queryParameters: { userToken: 'widget-token' },
+        }),
+      ]);
+
+      await wait(0);
+
+      expect(searchClient.getRecommendations).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          queryParameters: expect.objectContaining({
+            userToken: 'widget-token',
+          }),
+        }),
+      ]);
+    });
+
+    it('refetches recommendations when the userToken changes', async () => {
+      const searchClient = getRecommendClient();
+      const { insightsClient, instantSearchInstance } = createTestEnvironment({
+        started: false,
+      });
+
+      instantSearchInstance.use(createInsightsMiddleware({ insightsClient }));
+      instantSearchInstance.addWidgets([
+        connectRelatedProducts(() => ({}))({ objectIDs: ['objectID'] }),
+      ]);
+      instantSearchInstance.start();
+
+      await wait(0);
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(1);
+      expect(
+        searchClient.getRecommendations.mock.calls[0][0][0].queryParameters
+          .userToken
+      ).toEqual(expect.stringMatching(/^anonymous-/));
+
+      insightsClient('setUserToken', 'authenticated-token');
+
+      await wait(0);
+
+      // Recommend responses are cached per widget, so this only happens because
+      // the middleware invalidates that cache when the token changes.
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(2);
+      expect(searchClient.getRecommendations).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          queryParameters: expect.objectContaining({
+            userToken: 'authenticated-token',
+          }),
+        }),
+      ]);
+    });
+
+    it('does not refetch recommendations when the userToken is unchanged', async () => {
+      const searchClient = getRecommendClient();
+      const { insightsClient, instantSearchInstance } = createTestEnvironment({
+        started: false,
+      });
+
+      instantSearchInstance.use(
+        createInsightsMiddleware({
+          insightsClient,
+          insightsInitParams: { userToken: 'my-token' },
+        })
+      );
+      instantSearchInstance.addWidgets([
+        connectRelatedProducts(() => ({}))({ objectIDs: ['objectID'] }),
+      ]);
+      instantSearchInstance.start();
+
+      await wait(0);
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(1);
+
+      insightsClient('setUserToken', 'my-token');
+
+      await wait(0);
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -1275,6 +1275,39 @@ describe('insights', () => {
       ]);
     });
 
+    it('does not refetch recommendations when the same numeric userToken is set again', async () => {
+      const searchClient = getRecommendClient();
+      const { insightsClient, instantSearchInstance } = createTestEnvironment({
+        started: false,
+      });
+
+      instantSearchInstance.use(createInsightsMiddleware({ insightsClient }));
+      instantSearchInstance.addWidgets([
+        connectRelatedProducts(() => ({}))({ objectIDs: ['objectID'] }),
+      ]);
+      instantSearchInstance.start();
+
+      await wait(0);
+
+      // The anonymous token is replaced, so this one does refetch.
+      insightsClient('setUserToken', 123);
+
+      await wait(0);
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(2);
+      expect(
+        searchClient.getRecommendations.mock.calls[1][0][0].queryParameters
+          .userToken
+      ).toBe('123');
+
+      // The token normalizes to the same string, so this one must not.
+      insightsClient('setUserToken', 123);
+
+      await wait(0);
+
+      expect(searchClient.getRecommendations).toHaveBeenCalledTimes(2);
+    });
+
     it('does not refetch recommendations when the userToken is unchanged', async () => {
       const searchClient = getRecommendClient();
       const { insightsClient, instantSearchInstance } = createTestEnvironment({

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -262,6 +262,8 @@ export function createInsightsMiddleware<
             });
 
             if (existingToken && existingToken !== userToken) {
+              helper._recommendCache = {};
+
               instantSearchInstance.scheduleSearch();
             }
           }

--- a/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/createInsightsMiddleware.ts
@@ -261,7 +261,7 @@ export function createInsightsMiddleware<
               userToken: normalizedUserToken,
             });
 
-            if (existingToken && existingToken !== userToken) {
+            if (existingToken && existingToken !== normalizedUserToken) {
               helper._recommendCache = {};
 
               instantSearchInstance.scheduleSearch();

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -1,6 +1,7 @@
 import algoliasearchHelper from 'algoliasearch-helper';
 
 import {
+  addInsightsToRecommendParameters,
   checkIndexUiState,
   createDocumentationMessageGenerator,
   resolveSearchParameters,
@@ -823,7 +824,11 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
             mainHelper.state,
             ...resolveSearchParameters(this)
           ),
-        () => this.getHelper()!.recommendState
+        () =>
+          addInsightsToRecommendParameters(
+            this.getHelper()!.recommendState,
+            mainHelper.state
+          )
       );
 
       const indexInitialResults =


### PR DESCRIPTION
### What

Recommend requests now carry the `userToken` and `clickAnalytics` that the insights middleware already sets for search requests.

### Why

The middleware writes both onto the main helper's **search** state. Recommend queries are built from their own `RecommendParameters` and never read that state, so:

- recommendations could not be personalized
- responses carried no `queryID`, leaving `addQueryID()` in the recommend connectors permanently inert

### How

- `addInsightsToRecommendParameters()` folds both params into each recommend query's `queryParameters`, wired into the index widget's `derive()` recommend getter — the same place the search side merges `mainHelper.state`. All flavors and the SSR path inherit it; no per-flavor wiring.
- Widget-level `queryParameters` still win.
- Nothing is added when insights is off.
- The per-widget recommend cache is dropped when the token changes, so an anonymous → logged-in transition refetches instead of serving recommendations personalized for the old token.

### Tests

- 4 unit tests for the util, 4 middleware tests (params on the query, widget override, refetch on change, no refetch when unchanged)
- 4 existing inline snapshots updated; the parallel "no insights" snapshots stay untouched
- `yarn test` 442/442 suites · `type-check`, `type-check:v3`, `type-check:v4` clean · `format:check` clean