### PR TITLE
fix(chat): support caller-owned Chat reuse

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -458,6 +458,54 @@ describe('connectChat', () => {
 
       expect(chat.messages).toEqual(initialMessages);
     });
+
+    it('renders restored initial messages only with the current init options', () => {
+      const chat = new Chat({ persistence: false, transport: {} as any });
+      const initialMessages = [
+        {
+          id: 'initial',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Welcome' }],
+        },
+      ];
+      const renderFn = jest.fn();
+      const widget = connectChat(renderFn)({
+        chat,
+        initialMessages,
+        disableTriggerValidation: true,
+      } as any);
+      const firstInstantSearchInstance = createInstantSearch();
+      const secondInstantSearchInstance = createInstantSearch();
+
+      widget.init(
+        createInitOptions({ instantSearchInstance: firstInstantSearchInstance })
+      );
+      chat.messages = [];
+      renderFn.mockClear();
+
+      widget.init(
+        createInitOptions({
+          instantSearchInstance: secondInstantSearchInstance,
+        })
+      );
+
+      expect(
+        renderFn.mock.calls.map(([renderState, isFirstRendering]) => ({
+          init:
+            renderState.instantSearchInstance === firstInstantSearchInstance
+              ? 'previous'
+              : 'current',
+          isFirstRendering,
+          messages: renderState.messages,
+        }))
+      ).toEqual([
+        {
+          init: 'current',
+          isFirstRendering: true,
+          messages: initialMessages,
+        },
+      ]);
+    });
   });
 
   describe('dispose', () => {

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -461,6 +461,84 @@ describe('connectChat', () => {
   });
 
   describe('dispose', () => {
+    it('unsubscribes each Chat callback once across lifecycle cycles', () => {
+      const chat = new Chat({ persistence: false, transport: {} as any });
+      const unsubscribeErrors = [jest.fn(), jest.fn()];
+      const unsubscribeMessages = [jest.fn(), jest.fn()];
+      const unsubscribeStatuses = [jest.fn(), jest.fn()];
+      jest
+        .spyOn(chat, '~registerErrorCallback')
+        .mockReturnValueOnce(unsubscribeErrors[0])
+        .mockReturnValueOnce(unsubscribeErrors[1]);
+      jest
+        .spyOn(chat, '~registerMessagesCallback')
+        .mockReturnValueOnce(unsubscribeMessages[0])
+        .mockReturnValueOnce(unsubscribeMessages[1]);
+      jest
+        .spyOn(chat, '~registerStatusCallback')
+        .mockReturnValueOnce(unsubscribeStatuses[0])
+        .mockReturnValueOnce(unsubscribeStatuses[1]);
+      const unmountFn = jest.fn();
+      const widget = connectChat(
+        jest.fn(),
+        unmountFn
+      )({
+        chat,
+        disableTriggerValidation: true,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+
+      widget.init(createInitOptions({ helper }));
+      widget.dispose();
+      widget.init(createInitOptions({ helper }));
+      widget.dispose();
+      widget.dispose();
+
+      [
+        ...unsubscribeErrors,
+        ...unsubscribeMessages,
+        ...unsubscribeStatuses,
+      ].forEach((unsubscribe) => expect(unsubscribe).toHaveBeenCalledTimes(1));
+      expect(unmountFn).toHaveBeenCalledTimes(3);
+    });
+
+    it('reuses a caller-owned Chat across connector replacement', () => {
+      const chat = new Chat({ persistence: false, transport: {} as any });
+      const firstRender = jest.fn();
+      const secondRender = jest.fn();
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      const firstWidget = connectChat(firstRender)({
+        chat,
+        disableTriggerValidation: true,
+      });
+      const secondWidget = connectChat(secondRender)({
+        chat,
+        disableTriggerValidation: true,
+      });
+
+      firstWidget.init(createInitOptions({ helper }));
+      firstWidget.dispose();
+      firstRender.mockClear();
+      secondWidget.init(createInitOptions({ helper }));
+      secondRender.mockClear();
+
+      chat.messages = [
+        {
+          id: 'assistant-message',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Hello' }],
+        },
+      ];
+
+      expect(firstRender).not.toHaveBeenCalled();
+      expect(secondRender).toHaveBeenCalledTimes(1);
+
+      secondWidget.dispose();
+      secondRender.mockClear();
+      chat._state.status = 'streaming';
+      expect(secondRender).not.toHaveBeenCalled();
+    });
+
     it('calls the unmount function', () => {
       const unmountFn = jest.fn();
       const makeWidget = connectChat(() => {}, unmountFn);

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -20,7 +20,7 @@ import {
 } from '../../lib/utils';
 import { flat } from '../../lib/utils/flat';
 
-import type { ResponseScopedOnToolCallCallback } from '../../lib/ai-lite/abstract-chat';
+import type { ChatOnToolCallCallback } from '../../lib/ai-lite';
 import type {
   AbstractChat,
   ChatInit as ChatInitAi,
@@ -390,6 +390,13 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
     let feedbackState: ChatRenderState<TUiMessage>['feedbackState'] = {};
     let _sendChatMessageFeedback: ChatRenderState<TUiMessage>['sendChatMessageFeedback'];
     let feedbackAbortController: AbortController | undefined;
+    let chatSubscriptionUnsubscribers: Array<() => void> = [];
+
+    const unsubscribeChatCallbacks = () => {
+      chatSubscriptionUnsubscribers
+        .splice(0)
+        .forEach((unsubscribe) => unsubscribe());
+    };
 
     // Extract suggestions from the last assistant message's data-suggestions part
     const getSuggestionsFromMessages = (messages: TUiMessage[]) => {
@@ -647,7 +654,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           }
 
           return Promise.resolve();
-        }) satisfies ResponseScopedOnToolCallCallback<TUiMessage>,
+        }) satisfies ChatOnToolCallCallback<TUiMessage>,
       } as ChatInitAi<TUiMessage> & { agentId?: string });
     };
 
@@ -739,9 +746,12 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
         });
 
         safelyRunOnBrowser(() => {
-          _chatInstance['~registerErrorCallback'](render);
-          _chatInstance['~registerMessagesCallback'](render);
-          _chatInstance['~registerStatusCallback'](render);
+          unsubscribeChatCallbacks();
+          chatSubscriptionUnsubscribers = [
+            _chatInstance['~registerErrorCallback'](render),
+            _chatInstance['~registerMessagesCallback'](render),
+            _chatInstance['~registerStatusCallback'](render),
+          ];
         });
 
         // Resuming and sending reach the network, which a server render must
@@ -887,6 +897,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
 
       dispose() {
         feedbackAbortController?.abort();
+        unsubscribeChatCallbacks();
         unmountFn();
       },
 

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -736,17 +736,17 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
 
         const hasExistingMessages = _chatInstance.messages.length > 0;
 
-        // Set initialMessages before registering callbacks to avoid
-        // triggering re-renders during init. A server render owns no
-        // conversation, so it leaves the instance empty.
+        // Unsubscribe previous callbacks before setting initialMessages, then
+        // register the current callbacks after to avoid re-renders during init.
+        // A server render owns no conversation, so it leaves the instance empty.
         safelyRunOnBrowser(() => {
+          unsubscribeChatCallbacks();
           if (initialMessages?.length && !resume && !hasExistingMessages) {
             _chatInstance.messages = initialMessages;
           }
         });
 
         safelyRunOnBrowser(() => {
-          unsubscribeChatCallbacks();
           chatSubscriptionUnsubscribers = [
             _chatInstance['~registerErrorCallback'](render),
             _chatInstance['~registerMessagesCallback'](render),

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/public-types.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/public-types.test.ts
@@ -1,0 +1,75 @@
+import type {
+  ChatInit,
+  ChatOnToolCallCallback,
+  ToolResultSubmission,
+  UIMessage,
+} from 'instantsearch.js/es/lib/ai-lite';
+
+type SearchMessage = UIMessage<
+  unknown,
+  {},
+  {
+    search: {
+      input: { query: string };
+      output: { hits: string[] };
+    };
+  }
+>;
+
+describe('ai-lite public types', () => {
+  it('types tool result submission for its response', () => {
+    const submitToolResult: ToolResultSubmission<SearchMessage> = () =>
+      Promise.resolve();
+    const onToolCall: ChatOnToolCallCallback<SearchMessage> = (
+      { toolCall },
+      addToolResult
+    ) => {
+      if (toolCall.dynamic) {
+        return;
+      }
+
+      return addToolResult({
+        tool: toolCall.toolName,
+        toolCallId: toolCall.toolCallId,
+        output: { hits: [] },
+      });
+    };
+    const legacyOnToolCall: ChatOnToolCallCallback<SearchMessage> = ({
+      toolCall,
+    }) => {
+      void toolCall;
+    };
+    const init: Pick<ChatInit<SearchMessage>, 'onToolCall'> = {
+      onToolCall({ toolCall }, addToolResult) {
+        if (toolCall.dynamic) {
+          return;
+        }
+
+        return addToolResult({
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          output: { hits: [] },
+        });
+      },
+    };
+    const legacyInit: Pick<ChatInit<SearchMessage>, 'onToolCall'> = {
+      onToolCall({ toolCall }) {
+        void toolCall;
+      },
+    };
+
+    expect([
+      submitToolResult,
+      onToolCall,
+      legacyOnToolCall,
+      init.onToolCall,
+      legacyInit.onToolCall,
+    ]).toEqual([
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function),
+    ]);
+  });
+});

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -23,6 +23,7 @@ import type {
   InferUIMessageToolCall,
   InferUIMessageTools,
   ProviderMetadata,
+  ToolResultSubmission,
   UIMessage,
   UIMessageChunk,
   ChatOnErrorCallback,
@@ -46,20 +47,6 @@ type ResponseRecord = {
   didEvaluateContinuation: boolean;
 };
 
-type ToolResultSubmission<TUIMessage extends UIMessage> = <
-  TTool extends keyof InferUIMessageTools<TUIMessage>,
->(options: {
-  tool: TTool;
-  toolCallId: string;
-  output: InferUIMessageTools<TUIMessage>[TTool]['output'];
-}) => Promise<void>;
-
-/** @internal */
-export type ResponseScopedOnToolCallCallback<TUIMessage extends UIMessage> = (
-  options: Parameters<ChatOnToolCallCallback<TUIMessage>>[0],
-  addToolResult: ToolResultSubmission<TUIMessage>
-) => ReturnType<ChatOnToolCallCallback<TUIMessage>>;
-
 const defaultGuardrailFallbackResponse =
   'Sorry, we are not able to generate a response at the moment.';
 
@@ -77,7 +64,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
   private readonly transport?: ChatTransport<TUIMessage>;
   private onError?: ChatOnErrorCallback;
-  private onToolCall?: ResponseScopedOnToolCallCallback<TUIMessage>;
+  private onToolCall?: ChatOnToolCallCallback<TUIMessage>;
   private onFinish?: ChatOnFinishCallback<TUIMessage>;
   private onData?: ChatOnDataCallback<TUIMessage>;
   private sendAutomaticallyWhen?: (options: {

--- a/packages/instantsearch.js/src/lib/ai-lite/index.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/index.ts
@@ -74,6 +74,7 @@ export type {
   ChatInit,
   IdGenerator,
   ChatOnErrorCallback,
+  ToolResultSubmission,
   ChatOnToolCallCallback,
   ChatOnFinishCallback,
   ChatOnDataCallback,

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -484,10 +484,20 @@ export type IdGenerator = () => string;
 
 export type ChatOnErrorCallback = (error: Error) => void;
 
-export type ChatOnToolCallCallback<UI_MESSAGE extends UIMessage = UIMessage> =
-  (options: {
+export type ToolResultSubmission<UI_MESSAGE extends UIMessage = UIMessage> = <
+  TOOL extends keyof InferUIMessageTools<UI_MESSAGE>,
+>(options: {
+  tool: TOOL;
+  toolCallId: string;
+  output: InferUIMessageTools<UI_MESSAGE>[TOOL]['output'];
+}) => Promise<void>;
+
+export type ChatOnToolCallCallback<UI_MESSAGE extends UIMessage = UIMessage> = (
+  options: {
     toolCall: InferUIMessageToolCall<UI_MESSAGE>;
-  }) => void | PromiseLike<void>;
+  },
+  addToolResult: ToolResultSubmission<UI_MESSAGE>
+) => void | PromiseLike<void>;
 
 export type ChatOnFinishCallback<UI_MESSAGE extends UIMessage> = (options: {
   message: UI_MESSAGE;


### PR DESCRIPTION
## Summary

Allows a caller-owned Chat instance to be safely reused when its connector widget is replaced.

`connectChat` now unregisters its message, status and error subscriptions during re-initialization and disposal. This prevents stale render callbacks and listener accumulation while preserving the caller-owned Chat transcript.

This also publicly types the response-scoped `addToolResult` function already supplied to `onToolCall`. Client tool results can therefore remain associated with their owning assistant response, including when tool call IDs are reused, without relying on an internal type. Existing one-argument callbacks remain compatible.

This is required by [AlgoliaWeb #29052](https://github.com/algolia/AlgoliaWeb/pull/29052) to update Chat widget inputs without creating a second transcript store.

## Result

- Caller-owned Chat state survives connector replacement.
- Disposed connectors stop receiving Chat updates.
- Client tool callbacks can use a public, typed response-scoped result submitter.
- Connector-owned Chat behavior and existing one-argument callbacks remain unchanged.
- Focused connector, Chat lifecycle and public type suites passed: 162 tests and 1 snapshot.
