### PR TITLE
feat(insights): send the user token with Recommend fallback queries

### DIFF
--- a/packages/instantsearch.js/src/lib/utils/__tests__/addInsightsToRecommendParameters.test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/addInsightsToRecommendParameters.test.ts
@@ -116,6 +116,35 @@ describe('addInsightsToRecommendParameters', () => {
     ]);
   });
 
+  it('merges into the fallback parameters without overriding either value', () => {
+    const parameters = addInsightsToRecommendParameters(
+      new algoliasearchHelper.RecommendParameters()
+        .addRelatedProducts({
+          objectID: 'only-token',
+          $$id: 1,
+          fallbackParameters: { userToken: 'widget-token' },
+        })
+        .addRelatedProducts({
+          objectID: 'only-click-analytics',
+          $$id: 2,
+          fallbackParameters: { clickAnalytics: false },
+        }),
+      { userToken: 'my-token', clickAnalytics: true }
+    );
+
+    expect(parameters.params).toEqual([
+      expect.objectContaining({
+        objectID: 'only-token',
+        // The widget kept its token and still got the missing parameter.
+        fallbackParameters: { userToken: 'widget-token', clickAnalytics: true },
+      }),
+      expect.objectContaining({
+        objectID: 'only-click-analytics',
+        fallbackParameters: { clickAnalytics: false, userToken: 'my-token' },
+      }),
+    ]);
+  });
+
   it('does not mutate the given parameters', () => {
     const recommendParameters = createRecommendParameters();
 
@@ -149,6 +178,35 @@ describe('addInsightsToRecommendParameters', () => {
     expect(parameters.params).toEqual([
       expect.objectContaining({
         queryParameters: { userToken: 'widget-token', clickAnalytics: false },
+      }),
+    ]);
+  });
+
+  it('merges into the query parameters without overriding either value', () => {
+    const parameters = addInsightsToRecommendParameters(
+      new algoliasearchHelper.RecommendParameters()
+        .addRelatedProducts({
+          objectID: 'only-token',
+          $$id: 1,
+          queryParameters: { userToken: 'widget-token' },
+        })
+        .addRelatedProducts({
+          objectID: 'only-click-analytics',
+          $$id: 2,
+          queryParameters: { clickAnalytics: false },
+        }),
+      { userToken: 'my-token', clickAnalytics: true }
+    );
+
+    expect(parameters.params).toEqual([
+      expect.objectContaining({
+        objectID: 'only-token',
+        // The widget kept its token and still got the missing parameter.
+        queryParameters: { userToken: 'widget-token', clickAnalytics: true },
+      }),
+      expect.objectContaining({
+        objectID: 'only-click-analytics',
+        queryParameters: { clickAnalytics: false, userToken: 'my-token' },
       }),
     ]);
   });

--- a/packages/instantsearch.js/src/lib/utils/__tests__/addInsightsToRecommendParameters.test.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/addInsightsToRecommendParameters.test.ts
@@ -47,6 +47,75 @@ describe('addInsightsToRecommendParameters', () => {
     ]);
   });
 
+  it('forwards them to the fallback parameters when the widget has some', () => {
+    const recommendParameters =
+      new algoliasearchHelper.RecommendParameters().addRelatedProducts({
+        objectID: 'objectID',
+        $$id: 1,
+        fallbackParameters: { filters: 'brand:Apple' },
+      });
+
+    const parameters = addInsightsToRecommendParameters(recommendParameters, {
+      userToken: 'my-token',
+      clickAnalytics: true,
+    });
+
+    expect(parameters.params).toEqual([
+      expect.objectContaining({
+        fallbackParameters: {
+          filters: 'brand:Apple',
+          userToken: 'my-token',
+          clickAnalytics: true,
+        },
+      }),
+    ]);
+  });
+
+  it('does not introduce fallback parameters when the widget has none', () => {
+    const parameters = addInsightsToRecommendParameters(
+      new algoliasearchHelper.RecommendParameters().addRelatedProducts({
+        objectID: 'objectID',
+        $$id: 1,
+        // What the connectors send when the widget declares no fallback.
+        fallbackParameters: undefined,
+      }),
+      { userToken: 'my-token', clickAnalytics: true }
+    );
+
+    expect(parameters.params).toEqual([
+      {
+        objectID: 'objectID',
+        model: 'related-products',
+        $$id: 1,
+        fallbackParameters: undefined,
+        queryParameters: { userToken: 'my-token', clickAnalytics: true },
+      },
+    ]);
+  });
+
+  it('lets the widget fallback parameters take precedence', () => {
+    const parameters = addInsightsToRecommendParameters(
+      new algoliasearchHelper.RecommendParameters().addRelatedProducts({
+        objectID: 'objectID',
+        $$id: 1,
+        fallbackParameters: {
+          userToken: 'widget-token',
+          clickAnalytics: false,
+        },
+      }),
+      { userToken: 'my-token', clickAnalytics: true }
+    );
+
+    expect(parameters.params).toEqual([
+      expect.objectContaining({
+        fallbackParameters: {
+          userToken: 'widget-token',
+          clickAnalytics: false,
+        },
+      }),
+    ]);
+  });
+
   it('does not mutate the given parameters', () => {
     const recommendParameters = createRecommendParameters();
 

--- a/packages/instantsearch.js/src/lib/utils/addInsightsToRecommendParameters.ts
+++ b/packages/instantsearch.js/src/lib/utils/addInsightsToRecommendParameters.ts
@@ -16,6 +16,9 @@ import type {
  *
  * Parameters set on a widget win, so an explicit `queryParameters.userToken`
  * keeps overriding the middleware.
+ *
+ * The fallback query is a regular search, so it gets the same treatment — but
+ * only merged into a `fallbackParameters` the widget already set. See below.
  */
 export function addInsightsToRecommendParameters(
   recommendParameters: RecommendParameters,
@@ -25,21 +28,36 @@ export function addInsightsToRecommendParameters(
     return recommendParameters;
   }
 
+  const insightsParameters = {
+    ...(clickAnalytics === undefined ? {} : { clickAnalytics }),
+    ...(userToken === undefined ? {} : { userToken }),
+  };
+
   return new algoliasearchHelper.RecommendParameters({
     params: recommendParameters.params.map((params) => {
-      // v4 `TrendingFacetsQuery` doesn't include `queryParameters`, but the v5
-      // API and the helper support them, like `connectTrendingFacets` does.
-      const { queryParameters } = params as {
+      // v4 `TrendingFacetsQuery` doesn't include `queryParameters` or
+      // `fallbackParameters`, but the v5 API and the helper support them, like
+      // `connectTrendingFacets` does.
+      const { queryParameters, fallbackParameters } = params as {
         queryParameters?: PlainSearchParameters;
+        fallbackParameters?: PlainSearchParameters;
       };
 
       return {
         ...params,
         queryParameters: {
-          ...(clickAnalytics === undefined ? {} : { clickAnalytics }),
-          ...(userToken === undefined ? {} : { userToken }),
+          ...insightsParameters,
           ...queryParameters,
         },
+        // Merged into a fallback the widget configured, never introduced: a
+        // widget without `fallbackParameters` sends none today, and adding the
+        // parameter would change the request for every one of them.
+        ...(fallbackParameters && {
+          fallbackParameters: {
+            ...insightsParameters,
+            ...fallbackParameters,
+          },
+        }),
       } as RecommendParameters['params'][number];
     }),
   });

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -1239,6 +1239,49 @@ describe('insights', () => {
       ]);
     });
 
+    it('sets them on the fallback parameters of a widget that has some', async () => {
+      const searchClient = getRecommendClient();
+      const { instantSearchInstance, getUserToken } = createTestEnvironment({
+        insights: true,
+      });
+
+      instantSearchInstance.addWidgets([
+        connectRelatedProducts(() => ({}))({
+          objectIDs: ['objectID'],
+          fallbackParameters: { filters: 'brand:Apple' },
+        }),
+      ]);
+
+      await wait(0);
+
+      expect(searchClient.getRecommendations).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          fallbackParameters: expect.objectContaining({
+            filters: 'brand:Apple',
+            clickAnalytics: true,
+            userToken: getUserToken(),
+          }),
+        }),
+      ]);
+    });
+
+    it('leaves the fallback parameters alone when a widget has none', async () => {
+      const searchClient = getRecommendClient();
+      const { instantSearchInstance } = createTestEnvironment({
+        insights: true,
+      });
+
+      instantSearchInstance.addWidgets([
+        connectRelatedProducts(() => ({}))({ objectIDs: ['objectID'] }),
+      ]);
+
+      await wait(0);
+
+      expect(
+        searchClient.getRecommendations.mock.calls[0][0][0].fallbackParameters
+      ).toBeUndefined();
+    });
+
     it('refetches recommendations when the userToken changes', async () => {
       const searchClient = getRecommendClient();
       const { insightsClient, instantSearchInstance } = createTestEnvironment({

--- a/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
+++ b/packages/instantsearch.js/src/middlewares/__tests__/createInsightsMiddleware.ts
@@ -1265,6 +1265,34 @@ describe('insights', () => {
       ]);
     });
 
+    it('lets the fallback parameters of a widget take precedence', async () => {
+      const searchClient = getRecommendClient();
+      const { instantSearchInstance } = createTestEnvironment({
+        insights: true,
+      });
+
+      instantSearchInstance.addWidgets([
+        connectRelatedProducts(() => ({}))({
+          objectIDs: ['objectID'],
+          fallbackParameters: {
+            userToken: 'widget-token',
+            clickAnalytics: false,
+          },
+        }),
+      ]);
+
+      await wait(0);
+
+      expect(searchClient.getRecommendations).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          fallbackParameters: expect.objectContaining({
+            userToken: 'widget-token',
+            clickAnalytics: false,
+          }),
+        }),
+      ]);
+    });
+
     it('leaves the fallback parameters alone when a widget has none', async () => {
       const searchClient = getRecommendClient();
       const { instantSearchInstance } = createTestEnvironment({


### PR DESCRIPTION
Follow-up to #7153, which set `userToken` and `clickAnalytics` on Recommend queries but not on their fallback.

A fallback query is a regular search against the index, so it should be personalized and attributed too.

- merged into `fallbackParameters` only when the widget set one — never introduced where there is none, since that would change the request for every widget without a fallback
- merge, not override: values the widget set always win, and the middleware only fills the gaps