### PR TITLE
feat(chat): support custom text rendering

### DIFF
--- a/packages/instantsearch-ui-components/__tests__/types.test.ts
+++ b/packages/instantsearch-ui-components/__tests__/types.test.ts
@@ -251,3 +251,56 @@ describe('Exposes correct types', () => {
     });
   });
 });
+
+test('exposes Chat text component types from the public entry point', () => {
+  const fileName = path.join(__dirname, 'chat-message-text-component.ts');
+  const source = `
+    import type {
+      ChatMessageBase,
+      ChatMessageProps,
+      ChatMessageTextComponentProps,
+      ChatStatus,
+      TextUIPart,
+    } from '../dist/es';
+
+    const textComponent: ChatMessageProps['textComponent'] = (props) => {
+      const part: TextUIPart = props.part;
+      const message: ChatMessageBase = props.message;
+      const messages: ChatMessageBase[] | undefined = props.messages;
+      const status: ChatStatus = props.status;
+      const partIndex: number = props.partIndex;
+      const context: ChatMessageTextComponentProps = props;
+      void part;
+      void message;
+      void messages;
+      void status;
+      void partIndex;
+      void context;
+      return null as never;
+    };
+    void textComponent;
+  `;
+  const compilerOptions: ts.CompilerOptions = {
+    module: ts.ModuleKind.CommonJS,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2020,
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (sourceName, languageVersion, onError) =>
+    sourceName === fileName
+      ? ts.createSourceFile(fileName, source, languageVersion, true)
+      : getSourceFile(sourceName, languageVersion, onError);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  const errors = ts
+    .getPreEmitDiagnostics(program)
+    .map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+    );
+
+  expect(errors).toEqual([]);
+});

--- a/packages/instantsearch-ui-components/__tests__/types.test.ts
+++ b/packages/instantsearch-ui-components/__tests__/types.test.ts
@@ -304,3 +304,59 @@ test('exposes Chat text component types from the public entry point', () => {
 
   expect(errors).toEqual([]);
 });
+
+test('preserves custom message types in Chat text component props', () => {
+  const fileName = path.join(
+    __dirname,
+    'chat-message-text-component-generic.ts'
+  );
+  const source = `
+    import type {
+      ChatMessagesProps,
+      UIMessage,
+    } from '../dist/es';
+
+    type AppMetadata = { sourceIds: string[] };
+    type AppMessage = UIMessage<AppMetadata>;
+
+    const assistantMessageProps: NonNullable<
+      ChatMessagesProps<AppMessage>['assistantMessageProps']
+    > = {
+      textComponent({ message, messages }) {
+        if (message.metadata) {
+          const metadata: AppMetadata = message.metadata;
+          void metadata.sourceIds;
+        }
+        if (messages) {
+          const conversation: AppMessage[] = messages;
+          void conversation;
+        }
+        return null;
+      },
+    };
+    void assistantMessageProps;
+  `;
+  const compilerOptions: ts.CompilerOptions = {
+    module: ts.ModuleKind.CommonJS,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2020,
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (sourceName, languageVersion, onError) =>
+    sourceName === fileName
+      ? ts.createSourceFile(fileName, source, languageVersion, true)
+      : getSourceFile(sourceName, languageVersion, onError);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  const errors = ts
+    .getPreEmitDiagnostics(program)
+    .map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+    );
+
+  expect(errors).toEqual([]);
+});

--- a/packages/instantsearch-ui-components/__tests__/types.test.ts
+++ b/packages/instantsearch-ui-components/__tests__/types.test.ts
@@ -276,7 +276,7 @@ test('exposes Chat text component types from the public entry point', () => {
       void status;
       void partIndex;
       void context;
-      return null as never;
+      return null;
     };
     void textComponent;
   `;

--- a/packages/instantsearch-ui-components/__tests__/types.test.ts
+++ b/packages/instantsearch-ui-components/__tests__/types.test.ts
@@ -312,12 +312,34 @@ test('preserves custom message types in Chat text component props', () => {
   );
   const source = `
     import type {
+      ChatMessageProps,
       ChatMessagesProps,
       UIMessage,
     } from '../dist/es';
 
     type AppMetadata = { sourceIds: string[] };
     type AppMessage = UIMessage<AppMetadata>;
+    type BaseRoleMessageProps = NonNullable<
+      ChatMessagesProps['assistantMessageProps']
+    >;
+
+    const reusableRoleMessageProps: BaseRoleMessageProps = {
+      parseMarkdown: false,
+    };
+    const baseMessage = {
+      role: 'assistant' as const,
+      id: 'base',
+      parts: [],
+    };
+    const legacyRoleMessageProps: BaseRoleMessageProps = {
+      message: baseMessage,
+      messages: [baseMessage],
+    };
+    const reusableMessageProps: Partial<
+      Omit<ChatMessageProps, 'ref' | 'key'>
+    > = {
+      parseMarkdown: false,
+    };
 
     const assistantMessageProps: NonNullable<
       ChatMessagesProps<AppMessage>['assistantMessageProps']
@@ -335,6 +357,24 @@ test('preserves custom message types in Chat text component props', () => {
       },
     };
     void assistantMessageProps;
+
+    const messagesProps: ChatMessagesProps<AppMessage> = {
+      messages: [],
+      indexUiState: {},
+      setIndexUiState() {},
+      tools: {},
+      onReload() {},
+      onClose() {},
+      assistantMessageProps: reusableMessageProps,
+      userMessageProps: reusableRoleMessageProps,
+    };
+    void messagesProps;
+
+    const legacyMessagesProps: ChatMessagesProps<AppMessage> = {
+      ...messagesProps,
+      assistantMessageProps: legacyRoleMessageProps,
+    };
+    void legacyMessagesProps;
   `;
   const compilerOptions: ts.CompilerOptions = {
     module: ts.ModuleKind.CommonJS,

--- a/packages/instantsearch-ui-components/src/components/chat/Chat.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/Chat.tsx
@@ -11,7 +11,7 @@ import type { ChatHeaderProps, ChatHeaderOwnProps } from './ChatHeader';
 import type { ChatMessagesProps } from './ChatMessages';
 import type { ChatPromptProps, ChatPromptOwnProps } from './ChatPrompt';
 import type { ChatPromptSuggestionsOwnProps } from './ChatPromptSuggestions';
-import type { ChatLayoutOwnProps } from './types';
+import type { ChatLayoutOwnProps, ChatMessageBase } from './types';
 import type { Renderer, ComponentProps, Hooks } from '../../types';
 
 export type ChatClassNames = {
@@ -24,7 +24,10 @@ export type ChatClassNames = {
   suggestions?: ChatPromptSuggestionsOwnProps['classNames'];
 };
 
-export type ChatProps = Omit<ComponentProps<'div'>, 'onError' | 'title'> & {
+export type ChatProps<TMessage extends ChatMessageBase = ChatMessageBase> =
+  Omit<ComponentProps<'div'>, 'onError' | 'title'> & ChatOwnProps<TMessage>;
+
+type ChatOwnProps<TMessage extends ChatMessageBase> = {
   /*
    * Whether the chat is open or closed.
    */
@@ -40,7 +43,7 @@ export type ChatProps = Omit<ComponentProps<'div'>, 'onError' | 'title'> & {
   /*
    * Props for the ChatMessages component.
    */
-  messagesProps: ChatMessagesProps;
+  messagesProps: ChatMessagesProps<TMessage>;
   /*
    * Props for the ChatPrompt component.
    */
@@ -122,7 +125,9 @@ export function createChatComponent({
     Fragment,
   });
 
-  return function Chat(userProps: ChatProps) {
+  return function Chat<TMessage extends ChatMessageBase = ChatMessageBase>(
+    userProps: ChatProps<TMessage>
+  ) {
     const {
       open,
       maximized = false,

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -120,7 +120,7 @@ export type ChatMessageTextComponentProps<
    */
   status: ChatStatus;
   /**
-   * The text part's index within the message
+   * The text part's index in the full `message.parts` array
    */
   partIndex: number;
 };

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -20,6 +20,7 @@ import type {
   ChatToolMessage,
   ClientSideTool,
   ClientSideTools,
+  TextUIPart,
 } from './types';
 import type {
   ComponentProps,
@@ -99,6 +100,29 @@ export type ChatMessageActionProps = {
   onClick?: (message: ChatMessageBase) => void;
 };
 
+export type ChatMessageTextComponentProps = {
+  /**
+   * The text part to render
+   */
+  part: TextUIPart;
+  /**
+   * The message containing the text part
+   */
+  message: ChatMessageBase;
+  /**
+   * The full conversation, when available
+   */
+  messages?: ChatMessageBase[];
+  /**
+   * The current chat status
+   */
+  status: ChatStatus;
+  /**
+   * The text part's index within the message
+   */
+  partIndex: number;
+};
+
 export type ChatMessageProps = ComponentProps<'article'> & {
   /**
    * The message object associated with this chat message
@@ -139,6 +163,10 @@ export type ChatMessageProps = ComponentProps<'article'> & {
    * Footer content
    */
   footerComponent?: () => JSX.Element;
+  /**
+   * Custom text part renderer
+   */
+  textComponent?: (props: ChatMessageTextComponentProps) => JSX.Element;
   /**
    * The index UI state
    */
@@ -193,7 +221,10 @@ export type ChatMessageProps = ComponentProps<'article'> & {
 // Keep in sync with packages/instantsearch.js/src/lib/chat/index.ts
 const SearchIndexToolType = 'algolia_search_index';
 
-export function createChatMessageComponent({ createElement }: Renderer) {
+export function createChatMessageComponent({
+  createElement,
+  Fragment,
+}: Renderer) {
   const Button = createButtonComponent({ createElement });
   const ChatMessageReasoning = createChatMessageReasoningComponent({
     createElement,
@@ -211,6 +242,7 @@ export function createChatMessageComponent({ createElement }: Renderer) {
       leadingComponent: LeadingComponent,
       actionsComponent: ActionsComponent,
       footerComponent: FooterComponent,
+      textComponent: TextComponent,
       tools = {},
       indexUiState,
       setIndexUiState,
@@ -329,6 +361,19 @@ export function createChatMessageComponent({ createElement }: Renderer) {
           part.text.endsWith('</context>')
         ) {
           return null;
+        }
+        if (TextComponent) {
+          return (
+            <Fragment key={`${message.id}-${index}`}>
+              <TextComponent
+                part={part}
+                message={message}
+                messages={messages}
+                status={status}
+                partIndex={index}
+              />
+            </Fragment>
+          );
         }
         if (!parseMarkdown) {
           // Render the literal text. The `ais-ChatMessage-text` class applies

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -166,7 +166,7 @@ export type ChatMessageProps = ComponentProps<'article'> & {
   /**
    * Custom text part renderer
    */
-  textComponent?: (props: ChatMessageTextComponentProps) => JSX.Element;
+  textComponent?: (props: ChatMessageTextComponentProps) => JSX.Element | null;
   /**
    * The index UI state
    */

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -100,7 +100,9 @@ export type ChatMessageActionProps = {
   onClick?: (message: ChatMessageBase) => void;
 };
 
-export type ChatMessageTextComponentProps = {
+export type ChatMessageTextComponentProps<
+  TMessage extends ChatMessageBase = ChatMessageBase,
+> = {
   /**
    * The text part to render
    */
@@ -108,11 +110,11 @@ export type ChatMessageTextComponentProps = {
   /**
    * The message containing the text part
    */
-  message: ChatMessageBase;
+  message: TMessage;
   /**
    * The full conversation, when available
    */
-  messages?: ChatMessageBase[];
+  messages?: TMessage[];
   /**
    * The current chat status
    */
@@ -123,11 +125,13 @@ export type ChatMessageTextComponentProps = {
   partIndex: number;
 };
 
-export type ChatMessageProps = ComponentProps<'article'> & {
+export type ChatMessageProps<
+  TMessage extends ChatMessageBase = ChatMessageBase,
+> = ComponentProps<'article'> & {
   /**
    * The message object associated with this chat message
    */
-  message: ChatMessageBase;
+  message: TMessage;
   /**
    * The status of the message (e.g. whether it's still streaming)
    */
@@ -166,7 +170,9 @@ export type ChatMessageProps = ComponentProps<'article'> & {
   /**
    * Custom text part renderer
    */
-  textComponent?: (props: ChatMessageTextComponentProps) => JSX.Element | null;
+  textComponent?: (
+    props: ChatMessageTextComponentProps<TMessage>
+  ) => JSX.Element | null;
   /**
    * The index UI state
    */
@@ -180,7 +186,7 @@ export type ChatMessageProps = ComponentProps<'article'> & {
    * receive object IDs (e.g. display results) can hydrate records from a
    * preceding search tool's hits.
    */
-  messages?: ChatMessageBase[];
+  messages?: TMessage[];
   /**
    * Close the chat
    */
@@ -230,7 +236,9 @@ export function createChatMessageComponent({
     createElement,
   });
 
-  return function ChatMessage(userProps: ChatMessageProps) {
+  return function ChatMessage<
+    TMessage extends ChatMessageBase = ChatMessageBase,
+  >(userProps: ChatMessageProps<TMessage>) {
     const {
       classNames = {},
       message,

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -201,11 +201,13 @@ export type ChatMessagesProps<
   /**
    * Optional user message props
    */
-  userMessageProps?: Partial<Omit<ChatMessageProps, 'ref' | 'key'>>;
+  userMessageProps?: Partial<Omit<ChatMessageProps<TMessage>, 'ref' | 'key'>>;
   /**
    * Optional assistant message props
    */
-  assistantMessageProps?: Partial<Omit<ChatMessageProps, 'ref' | 'key'>>;
+  assistantMessageProps?: Partial<
+    Omit<ChatMessageProps<TMessage>, 'ref' | 'key'>
+  >;
   /**
    * Whether the scroll is at the bottom (controlled state)
    */
@@ -257,12 +259,12 @@ function getInstantSearchStatus(tools: ClientSideTools) {
 const hasOwnKey = (target: object | undefined, key: string) =>
   target !== undefined && Object.prototype.hasOwnProperty.call(target, key);
 
-function createDefaultMessageComponent<
-  TMessage extends ChatMessageBase = ChatMessageBase,
->({ createElement, Fragment }: Renderer) {
+function createDefaultMessageComponent({ createElement, Fragment }: Renderer) {
   const ChatMessage = createChatMessageComponent({ createElement, Fragment });
 
-  return function DefaultMessage({
+  return function DefaultMessage<
+    TMessage extends ChatMessageBase = ChatMessageBase,
+  >({
     message,
     status,
     userMessageProps,
@@ -285,11 +287,11 @@ function createDefaultMessageComponent<
     message: TMessage;
     isCurrentMessage: boolean;
     status: ChatStatus;
-    userMessageProps?: Partial<ChatMessageProps>;
-    assistantMessageProps?: Partial<ChatMessageProps>;
+    userMessageProps?: Partial<ChatMessageProps<TMessage>>;
+    assistantMessageProps?: Partial<ChatMessageProps<TMessage>>;
     indexUiState: object;
     setIndexUiState: (state: object) => void;
-    messages?: ChatMessageBase[];
+    messages?: TMessage[];
     tools: ClientSideTools;
     onReload: (messageId?: string) => void;
     onClose: () => void;
@@ -396,17 +398,19 @@ export function createChatMessagesComponent({
   useMemo,
 }: Renderer & Pick<Hooks, 'useMemo'>) {
   const Button = createButtonComponent({ createElement });
-  const DefaultMessageComponent =
-    createDefaultMessageComponent<ChatMessageBase>({ createElement, Fragment });
+  const DefaultMessageComponent = createDefaultMessageComponent({
+    createElement,
+    Fragment,
+  });
   // Skip re-rendering (and re-compiling the markdown of) completed messages on
   // every streaming delta. The deps tuple matches the row's render inputs;
   // callbacks/`indexUiState` are intentionally excluded because `getUiState()`
   // returns a fresh object every render and would defeat the memo — completed
   // rows keep the callbacks/`indexUiState` they last rendered with until their
   // next genuine update.
-  function MemoizedDefaultMessage(
-    props: Parameters<typeof DefaultMessageComponent>[0]
-  ) {
+  function MemoizedDefaultMessage<
+    TMessage extends ChatMessageBase = ChatMessageBase,
+  >(props: Parameters<typeof DefaultMessageComponent<TMessage>>[0]) {
     const messageFeedback = props.feedbackState?.[props.message.id];
     const instantSearchStatus = getInstantSearchStatus(props.tools);
     // Read the row's own side, mirroring `DefaultMessage`, so one role's change

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -105,6 +105,12 @@ export type ChatMessagesClassNames = {
   scrollToBottomHidden: string | string[];
 };
 
+type ChatMessageRoleProps<TMessage extends ChatMessageBase = ChatMessageBase> =
+  Partial<
+    Omit<ChatMessageProps<TMessage>, 'ref' | 'key' | 'message' | 'messages'>
+  > &
+    Partial<Pick<ChatMessageProps, 'message' | 'messages'>>;
+
 export type ChatMessagesProps<
   TMessage extends ChatMessageBase = ChatMessageBase,
 > = ComponentProps<'div'> & {
@@ -201,13 +207,11 @@ export type ChatMessagesProps<
   /**
    * Optional user message props
    */
-  userMessageProps?: Partial<Omit<ChatMessageProps<TMessage>, 'ref' | 'key'>>;
+  userMessageProps?: ChatMessageRoleProps<TMessage>;
   /**
    * Optional assistant message props
    */
-  assistantMessageProps?: Partial<
-    Omit<ChatMessageProps<TMessage>, 'ref' | 'key'>
-  >;
+  assistantMessageProps?: ChatMessageRoleProps<TMessage>;
   /**
    * Whether the scroll is at the bottom (controlled state)
    */
@@ -287,8 +291,8 @@ function createDefaultMessageComponent({ createElement, Fragment }: Renderer) {
     message: TMessage;
     isCurrentMessage: boolean;
     status: ChatStatus;
-    userMessageProps?: Partial<ChatMessageProps<TMessage>>;
-    assistantMessageProps?: Partial<ChatMessageProps<TMessage>>;
+    userMessageProps?: ChatMessageRoleProps<TMessage>;
+    assistantMessageProps?: ChatMessageRoleProps<TMessage>;
     indexUiState: object;
     setIndexUiState: (state: object) => void;
     messages?: TMessage[];
@@ -373,12 +377,10 @@ function createDefaultMessageComponent({ createElement, Fragment }: Renderer) {
       <ChatMessage
         side={message.role === 'user' ? 'right' : 'left'}
         variant={message.role === 'user' ? 'neutral' : 'subtle'}
-        message={message}
         status={status}
         tools={tools}
         indexUiState={indexUiState}
         setIndexUiState={setIndexUiState}
-        messages={messages}
         onClose={onClose}
         actions={defaultActions}
         actionsComponent={actionsComponent}
@@ -387,6 +389,8 @@ function createDefaultMessageComponent({ createElement, Fragment }: Renderer) {
         translations={messageTranslations}
         suggestionsElement={suggestionsElement}
         {...messageProps}
+        message={message}
+        messages={messages}
       />
     );
   };

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -417,6 +417,10 @@ export function createChatMessagesComponent({
         : props.assistantMessageProps;
     const showReasoning = messageProps?.showReasoning;
     const parseMarkdown = messageProps?.parseMarkdown;
+    const textComponent = messageProps?.textComponent;
+    // Custom text components receive the conversation, so their completed rows
+    // must update with it. Keep the default renderer's streaming optimization.
+    const textComponentMessages = textComponent ? props.messages : undefined;
     // Object-level fallback, matching the render: the spread replaces
     // `translations` wholesale, and it copies a key holding `undefined` too. Both
     // are why this resolves by own-key presence rather than key by key.
@@ -448,6 +452,8 @@ export function createChatMessagesComponent({
         messageFeedback,
         showReasoning,
         parseMarkdown,
+        textComponent,
+        textComponentMessages,
         reasoningLabel,
         reasoningClassName,
         reasoningHeaderClassName,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -9,11 +9,11 @@ import { Fragment, createElement } from 'preact';
 import {
   createChatMessageComponent,
   type ChatMessageClassNames,
+  type ChatMessageTextComponentProps,
   type ChatMessageTranslations,
 } from '../ChatMessage';
 
 import type { AddToolResult, ChatMessageBase, ClientSideTool } from '../types';
-import type { ChatMessageTextComponentProps } from 'instantsearch-ui-components';
 
 const ChatMessage = createChatMessageComponent({
   createElement,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '../ChatMessage';
 
 import type { AddToolResult, ChatMessageBase, ClientSideTool } from '../types';
+import type { ChatMessageTextComponentProps } from 'instantsearch-ui-components';
 
 const ChatMessage = createChatMessageComponent({
   createElement,
@@ -383,7 +384,10 @@ describe('ChatMessage', () => {
     );
   });
 
-  test('keeps reasoning disclosures in message part order', () => {
+  test('keeps reasoning and tool renderers in message part order with a custom text component', () => {
+    const textComponent = jest.fn(({ part }: ChatMessageTextComponentProps) => (
+      <span data-testid="custom-text">{part.text}</span>
+    ));
     const { container, getAllByRole, getByText, queryAllByRole } = render(
       <ChatMessage
         indexUiState={{}}
@@ -414,6 +418,7 @@ describe('ChatMessage', () => {
         }}
         onClose={jest.fn()}
         showReasoning={true}
+        textComponent={textComponent}
       />
     );
 
@@ -426,6 +431,10 @@ describe('ChatMessage', () => {
     expect(children[1]).toContainElement(getByText('Tool result'));
     expect(children[2]).toBe(disclosures[1]);
     expect(children[3]).toContainElement(getByText('Final answer'));
+    expect(children[3]).toContainElement(
+      container.querySelector('[data-testid="custom-text"]')
+    );
+    expect(textComponent).toHaveBeenCalledTimes(1);
     expect(queryAllByRole('region')).toHaveLength(0);
   });
 
@@ -911,6 +920,65 @@ describe('ChatMessage', () => {
     expect(container.querySelector('em')).not.toBeNull();
     expect(container.querySelector('em')!.textContent).toBe('b');
     expect(container.querySelector('.ais-ChatMessage-text')).toBeNull();
+  });
+
+  test('renders each text part with a custom component and its message context', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        { type: 'text' as const, text: 'First answer' },
+        { type: 'step-start' as const },
+        { type: 'text' as const, text: 'Second answer' },
+      ],
+    };
+    const textComponent = jest.fn(
+      ({ part, partIndex }: ChatMessageTextComponentProps) => (
+        <p data-part-index={partIndex}>{part.text}</p>
+      )
+    );
+
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={message}
+        status="streaming"
+        tools={{}}
+        onClose={jest.fn()}
+        textComponent={textComponent}
+      />
+    );
+
+    expect(
+      textComponent.mock.calls.map(([props]) => ({
+        part: props.part,
+        message: props.message,
+        messages: props.messages,
+        status: props.status,
+        partIndex: props.partIndex,
+      }))
+    ).toEqual([
+      {
+        part: message.parts[0],
+        message,
+        messages: undefined,
+        status: 'streaming',
+        partIndex: 0,
+      },
+      {
+        part: message.parts[2],
+        message,
+        messages: undefined,
+        status: 'streaming',
+        partIndex: 2,
+      },
+    ]);
+    expect(
+      Array.from(container.querySelectorAll('[data-part-index]')).map(
+        (element) => element.textContent
+      )
+    ).toEqual(['First answer', 'Second answer']);
   });
 
   test('renders text parts as plain text when parseMarkdown is false', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -1001,6 +1001,50 @@ describe('ChatMessages', () => {
         screen.getByTestId('conversation-length-assistant-3')
       ).toHaveTextContent('3');
     });
+
+    test('keeps the conversation owned by ChatMessages', () => {
+      const message = {
+        role: 'assistant' as const,
+        id: 'assistant-1',
+        parts: [{ type: 'text' as const, text: 'Answer' }],
+      };
+      const messages = [message];
+      const textComponent = ({
+        messages: currentMessages,
+      }: ChatMessageTextComponentProps) => (
+        <span data-testid="conversation-id">{currentMessages?.[0].id}</span>
+      );
+      const createProps = (conversationId: string) => ({
+        messages,
+        indexUiState: {},
+        setIndexUiState: jest.fn(),
+        assistantMessageProps: {
+          textComponent,
+          messages: [
+            {
+              ...message,
+              id: conversationId,
+            },
+          ],
+        },
+        tools: {},
+        onReload: jest.fn(),
+        onClose: jest.fn(),
+      });
+
+      const { rerender } = render(
+        <MemoizedChatMessages {...createProps('override-a')} />
+      );
+      expect(screen.getByTestId('conversation-id')).toHaveTextContent(
+        'assistant-1'
+      );
+
+      rerender(<MemoizedChatMessages {...createProps('override-b')} />);
+
+      expect(screen.getByTestId('conversation-id')).toHaveTextContent(
+        'assistant-1'
+      );
+    });
   });
 
   describe('parseMarkdown', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -10,6 +10,7 @@ import * as chatUtils from '../../../lib/utils/chat';
 import { createChatMessageErrorComponent } from '../ChatMessageError';
 import { createChatMessagesComponent } from '../ChatMessages';
 
+import type { ChatMessageTextComponentProps } from '../ChatMessage';
 import type { ChatMessageErrorProps } from '../ChatMessageError';
 
 const ChatMessages = createChatMessagesComponent({
@@ -842,6 +843,164 @@ describe('ChatMessages', () => {
     rerender(<MemoizedChatMessages {...createProps(true)} />);
 
     expect(container.querySelector('details')).not.toBeNull();
+  });
+
+  describe('textComponent', () => {
+    test('routes the ordered conversation through both message prop paths', () => {
+      const messages = [
+        {
+          role: 'user' as const,
+          id: 'user-1',
+          parts: [{ type: 'text' as const, text: 'Question' }],
+        },
+        {
+          role: 'assistant' as const,
+          id: 'assistant-1',
+          parts: [{ type: 'text' as const, text: 'Answer' }],
+        },
+      ];
+      const userTextComponent = jest.fn(
+        ({ part }: ChatMessageTextComponentProps) => (
+          <span data-testid="user-text">{part.text}</span>
+        )
+      );
+      const assistantTextComponent = jest.fn(
+        ({ part }: ChatMessageTextComponentProps) => (
+          <span data-testid="assistant-text">{part.text}</span>
+        )
+      );
+
+      render(
+        <ChatMessages
+          messages={messages}
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          status="ready"
+          userMessageProps={{ textComponent: userTextComponent }}
+          assistantMessageProps={{ textComponent: assistantTextComponent }}
+          tools={{}}
+          onReload={jest.fn()}
+          onClose={jest.fn()}
+        />
+      );
+
+      expect(userTextComponent.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          part: messages[0].parts[0],
+          message: messages[0],
+          messages,
+          status: 'ready',
+          partIndex: 0,
+        })
+      );
+      expect(assistantTextComponent.mock.calls[0][0]).toEqual(
+        expect.objectContaining({
+          part: messages[1].parts[0],
+          message: messages[1],
+          messages,
+          status: 'ready',
+          partIndex: 0,
+        })
+      );
+      expect(screen.getByTestId('user-text')).toHaveTextContent('Question');
+      expect(screen.getByTestId('assistant-text')).toHaveTextContent('Answer');
+    });
+
+    test('updates completed messages when the text component changes', () => {
+      const message = {
+        role: 'assistant' as const,
+        id: 'assistant-1',
+        parts: [{ type: 'text' as const, text: 'Answer' }],
+      };
+      const messages = [message];
+      const FirstTextComponent = ({ part }: ChatMessageTextComponentProps) => (
+        <span data-testid="first-text">{part.text}</span>
+      );
+      const SecondTextComponent = ({ part }: ChatMessageTextComponentProps) => (
+        <span data-testid="second-text">{part.text}</span>
+      );
+      const createProps = (
+        textComponent: (props: ChatMessageTextComponentProps) => JSX.Element
+      ) => ({
+        messages,
+        indexUiState: {},
+        setIndexUiState: jest.fn(),
+        assistantMessageProps: { textComponent },
+        tools: {},
+        onReload: jest.fn(),
+        onClose: jest.fn(),
+      });
+
+      const { rerender } = render(
+        <MemoizedChatMessages {...createProps(FirstTextComponent)} />
+      );
+      expect(screen.getByTestId('first-text')).toHaveTextContent('Answer');
+
+      rerender(<MemoizedChatMessages {...createProps(SecondTextComponent)} />);
+
+      expect(screen.queryByTestId('first-text')).not.toBeInTheDocument();
+      expect(screen.getByTestId('second-text')).toHaveTextContent('Answer');
+    });
+
+    test('keeps the ordered conversation current for completed messages', () => {
+      const firstMessage = {
+        role: 'assistant' as const,
+        id: 'assistant-1',
+        parts: [{ type: 'text' as const, text: 'First answer' }],
+      };
+      const secondMessage = {
+        role: 'assistant' as const,
+        id: 'assistant-2',
+        parts: [{ type: 'text' as const, text: 'Second answer' }],
+      };
+      const thirdMessage = {
+        role: 'assistant' as const,
+        id: 'assistant-3',
+        parts: [{ type: 'text' as const, text: 'Third answer' }],
+      };
+      const textComponent = ({
+        message,
+        messages,
+      }: ChatMessageTextComponentProps) => (
+        <span data-testid={`conversation-length-${message.id}`}>
+          {messages?.length}
+        </span>
+      );
+      const createProps = (
+        messages: Array<typeof firstMessage | typeof secondMessage>
+      ) => ({
+        messages,
+        indexUiState: {},
+        setIndexUiState: jest.fn(),
+        assistantMessageProps: { textComponent },
+        tools: {},
+        onReload: jest.fn(),
+        onClose: jest.fn(),
+      });
+
+      const { rerender } = render(
+        <MemoizedChatMessages {...createProps([firstMessage, secondMessage])} />
+      );
+      expect(
+        screen.getByTestId('conversation-length-assistant-1')
+      ).toHaveTextContent('2');
+
+      rerender(
+        <MemoizedChatMessages
+          {...createProps([firstMessage, secondMessage, thirdMessage])}
+        />
+      );
+
+      expect(
+        screen.getByTestId('conversation-length-assistant-1')
+      ).toHaveTextContent('3');
+      expect(
+        screen.getByTestId('conversation-length-assistant-2')
+      ).toHaveTextContent('3');
+      expect(
+        screen.getByTestId('conversation-length-assistant-3')
+      ).toHaveTextContent('3');
+    });
   });
 
   describe('parseMarkdown', () => {

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -52,6 +52,7 @@ import type {
   ChatEmptyProps,
   ChatMessageLoaderProps,
   ChatMessageProps,
+  ChatMessageTextComponentProps,
   ChatMessagesTranslations,
   ChatPromptProps,
   ChatPromptTranslations,
@@ -172,11 +173,13 @@ type ChatWrapperProps = {
       | undefined;
     assistantMessageProps: {
       leadingComponent: ChatMessageProps['leadingComponent'];
+      textComponent: ChatMessageProps['textComponent'];
       footerComponent: ChatMessageProps['footerComponent'];
       showReasoning: ChatMessageProps['showReasoning'];
     };
     userMessageProps: {
       leadingComponent: ChatMessageProps['leadingComponent'];
+      textComponent: ChatMessageProps['textComponent'];
       footerComponent: ChatMessageProps['footerComponent'];
     };
     translations: Partial<ChatMessagesTranslations>;
@@ -448,6 +451,13 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
         'fragment'
       )
     : undefined;
+  const stableAssistantMessageTextComponent = templates.assistantMessage?.text
+    ? createStableTemplateComponent<ChatMessageTextComponentProps>(
+        assistantMessageTemplateRef,
+        'text',
+        'fragment'
+      )
+    : undefined;
   const stableAssistantMessageFooterComponent = templates.assistantMessage
     ?.footer
     ? createStableTemplateComponent<Record<string, never>>(
@@ -460,6 +470,13 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
     ? createStableTemplateComponent<Record<string, never>>(
         userMessageTemplateRef,
         'leading',
+        'fragment'
+      )
+    : undefined;
+  const stableUserMessageTextComponent = templates.userMessage?.text
+    ? createStableTemplateComponent<ChatMessageTextComponentProps>(
+        userMessageTemplateRef,
+        'text',
         'fragment'
       )
     : undefined;
@@ -761,11 +778,13 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
             actionsComponent: stableActionsComponent,
             assistantMessageProps: {
               leadingComponent: stableAssistantMessageLeadingComponent,
+              textComponent: stableAssistantMessageTextComponent,
               footerComponent: stableAssistantMessageFooterComponent,
               showReasoning,
             },
             userMessageProps: {
               leadingComponent: stableUserMessageLeadingComponent,
+              textComponent: stableUserMessageTextComponent,
               footerComponent: stableUserMessageFooterComponent,
             },
             translations: messagesTranslations,
@@ -956,6 +975,10 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
        */
       leading: Template;
       /**
+       * Template to use for assistant message text parts.
+       */
+      text: Template<ChatMessageTextComponentProps>;
+      /**
        * Template to use for the assistant message footer content.
        */
       footer: Template;
@@ -969,6 +992,10 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
        * Template to use for the user message leading content.
        */
       leading: Template;
+      /**
+       * Template to use for user message text parts.
+       */
+      text: Template<ChatMessageTextComponentProps>;
       /**
        * Template to use for the user message footer content.
        */

--- a/packages/react-instantsearch/__tests__/types.test.ts
+++ b/packages/react-instantsearch/__tests__/types.test.ts
@@ -6,6 +6,7 @@ test('preserves custom message types in Chat text component props', () => {
   const fileName = path.join(__dirname, 'chat-text-component-generic.ts');
   const source = `
     import type { ChatProps } from '../dist/es';
+    import type { ChatMessageProps } from 'instantsearch-ui-components';
     import type { UIMessage } from 'instantsearch.js/es/lib/chat';
 
     type AppMetadata = { sourceIds: string[] };
@@ -13,6 +14,30 @@ test('preserves custom message types in Chat text component props', () => {
     type MessagesProps = NonNullable<
       ChatProps<unknown, AppMessage>['messagesProps']
     >;
+    type BaseMessagesProps = NonNullable<
+      ChatProps<unknown>['messagesProps']
+    >;
+    type BaseRoleMessageProps = NonNullable<
+      BaseMessagesProps['assistantMessageProps']
+    >;
+
+    const reusableRoleMessageProps: BaseRoleMessageProps = {
+      parseMarkdown: false,
+    };
+    const baseMessage = {
+      role: 'assistant' as const,
+      id: 'base',
+      parts: [],
+    };
+    const legacyRoleMessageProps: BaseRoleMessageProps = {
+      message: baseMessage,
+      messages: [baseMessage],
+    };
+    const reusableMessageProps: Partial<
+      Omit<ChatMessageProps, 'ref' | 'key'>
+    > = {
+      parseMarkdown: false,
+    };
 
     const textComponent: NonNullable<
       NonNullable<MessagesProps['assistantMessageProps']>['textComponent']
@@ -35,6 +60,21 @@ test('preserves custom message types in Chat text component props', () => {
       userMessageProps: { textComponent },
     };
     void messagesProps;
+
+    const compatibleMessagesProps: MessagesProps = {
+      onClose() {},
+      onReload() {},
+      assistantMessageProps: reusableMessageProps,
+      userMessageProps: reusableRoleMessageProps,
+    };
+    void compatibleMessagesProps;
+
+    const legacyMessagesProps: MessagesProps = {
+      onClose() {},
+      onReload() {},
+      assistantMessageProps: legacyRoleMessageProps,
+    };
+    void legacyMessagesProps;
 
     const baseMessagesProps: NonNullable<
       ChatProps<unknown>['messagesProps']

--- a/packages/react-instantsearch/__tests__/types.test.ts
+++ b/packages/react-instantsearch/__tests__/types.test.ts
@@ -1,0 +1,76 @@
+import path from 'path';
+
+import ts from 'typescript';
+
+test('preserves custom message types in Chat text component props', () => {
+  const fileName = path.join(__dirname, 'chat-text-component-generic.ts');
+  const source = `
+    import type { ChatProps } from '../dist/es';
+    import type { UIMessage } from 'instantsearch.js/es/lib/chat';
+
+    type AppMetadata = { sourceIds: string[] };
+    type AppMessage = UIMessage<AppMetadata>;
+    type MessagesProps = NonNullable<
+      ChatProps<unknown, AppMessage>['messagesProps']
+    >;
+
+    const textComponent: NonNullable<
+      NonNullable<MessagesProps['assistantMessageProps']>['textComponent']
+    > = ({ message, messages }) => {
+      if (message.metadata) {
+        const metadata: AppMetadata = message.metadata;
+        void metadata.sourceIds;
+      }
+      if (messages) {
+        const conversation: AppMessage[] = messages;
+        void conversation;
+      }
+      return null;
+    };
+
+    const messagesProps: MessagesProps = {
+      onClose() {},
+      onReload() {},
+      assistantMessageProps: { textComponent },
+      userMessageProps: { textComponent },
+    };
+    void messagesProps;
+
+    const baseMessagesProps: NonNullable<
+      ChatProps<unknown>['messagesProps']
+    > = {
+      onClose() {},
+      onReload() {},
+      assistantMessageProps: {
+        textComponent({ message }) {
+          void message;
+          return null;
+        },
+      },
+    };
+    void baseMessagesProps;
+  `;
+  const compilerOptions: ts.CompilerOptions = {
+    module: ts.ModuleKind.CommonJS,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2020,
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (sourceName, languageVersion, onError) =>
+    sourceName === fileName
+      ? ts.createSourceFile(fileName, source, languageVersion, true)
+      : getSourceFile(sourceName, languageVersion, onError);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  const errors = ts
+    .getPreEmitDiagnostics(program)
+    .map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+    );
+
+  expect(errors).toEqual([]);
+});

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -130,8 +130,8 @@ type UiProps = Pick<
 
 type UserHeaderProps = Omit<ChatUiProps['headerProps'], 'onClose'>;
 
-type UserMessagesProps = Omit<
-  ChatUiProps['messagesProps'],
+type UserMessagesProps<TUiMessage extends UIMessage = UIMessage> = Omit<
+  ChatUiProps<TUiMessage>['messagesProps'],
   | 'messages'
   | 'tools'
   | 'indexUiState'
@@ -163,7 +163,7 @@ export type ChatProps<TObject, TUiMessage extends UIMessage = UIMessage> = Omit<
     tools?: UserClientSideTools;
     getSearchPageURL?: (nextUiState: IndexUiState) => string;
     headerProps?: UserHeaderProps;
-    messagesProps?: UserMessagesProps;
+    messagesProps?: UserMessagesProps<TUiMessage>;
     promptProps?: UserPromptProps;
     layoutComponent?: (props: ChatLayoutOwnProps) => JSX.Element;
     headerComponent?: ChatUiProps['headerComponent'];

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
@@ -13,7 +13,7 @@ import { ChatInlineLayout } from '../../components/ChatInlineLayout';
 import { Chat } from '../Chat';
 import { ChatTrigger } from '../ChatTrigger';
 
-import type { ChatHandle } from '../Chat';
+import type { ChatHandle, ChatProps } from '../Chat';
 import type { UIMessage } from 'instantsearch.js/es/lib/chat';
 
 const searchClient = createSearchClient();
@@ -464,6 +464,72 @@ describe('Chat', () => {
     expect(
       screen.getByRole('group', { name: 'Reasoning' }).textContent
     ).toContain('Check the **catalog**.');
+  });
+
+  test('routes an assistant text component through messagesProps', async () => {
+    const chat = new ChatInstance<UIMessage>({
+      persistence: false,
+      messages: [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'Custom answer' }],
+        },
+      ],
+    });
+    const calls: Array<{
+      partText: string;
+      messageId: string;
+      messageCount: number | undefined;
+      status: string;
+      partIndex: number;
+    }> = [];
+    const messagesProps = {
+      onClose: () => {},
+      onReload: () => {},
+      assistantMessageProps: {
+        textComponent: ({ part, message, messages, status, partIndex }) => {
+          calls.push({
+            partText: part.text,
+            messageId: message.id,
+            messageCount: messages?.length,
+            status,
+            partIndex,
+          });
+          return <span data-testid="assistant-text">{part.text}</span>;
+        },
+      },
+    } satisfies NonNullable<ChatProps<unknown>['messagesProps']>;
+
+    render(
+      <InstantSearch
+        searchClient={searchClient}
+        indexName="indexName"
+        future={{ preserveSharedStateOnUnmount: true }}
+      >
+        <Chat
+          chat={chat}
+          transport={{ api: 'http://unused' }}
+          layoutComponent={ChatInlineLayout}
+          requiresSearch={false}
+          messagesProps={messagesProps}
+        />
+      </InstantSearch>
+    );
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(screen.getByTestId('assistant-text')).toHaveTextContent(
+      'Custom answer'
+    );
+    expect(calls[calls.length - 1]).toEqual({
+      partText: 'Custom answer',
+      messageId: 'assistant-1',
+      messageCount: 1,
+      status: 'ready',
+      partIndex: 0,
+    });
   });
 
   test('updates reasoning on completed messages when parseMarkdown changes', async () => {

--- a/tests/common/widgets/chat/templates.tsx
+++ b/tests/common/widgets/chat/templates.tsx
@@ -465,6 +465,172 @@ export function createTemplatesTests(
         expect(footerElements[0]).toHaveClass('MESSAGE-FOOTER');
         expect(footerElements[1]).toHaveClass('MESSAGE-FOOTER');
       });
+
+      test('renders text parts with their message context', async () => {
+        const searchClient = createSearchClient();
+        const chat = new Chat({
+          messages: [
+            {
+              id: 'user-1',
+              role: 'user',
+              parts: [
+                { type: 'text', text: 'User first' },
+                { type: 'step-start' },
+                { type: 'text', text: 'User second' },
+              ],
+            },
+            {
+              id: 'assistant-1',
+              role: 'assistant',
+              parts: [
+                { type: 'text', text: 'Assistant first' },
+                { type: 'step-start' },
+                { type: 'text', text: 'Assistant second' },
+              ],
+            },
+          ],
+        });
+        Object.defineProperty(chat, 'status', {
+          get: () => 'streaming',
+        });
+
+        await setup({
+          instantSearchOptions: {
+            indexName: 'indexName',
+            searchClient,
+          },
+          widgetParams: {
+            javascript: {
+              ...createDefaultWidgetParams(chat),
+              templates: {
+                assistantMessage: {
+                  text: (
+                    { part, message, messages, status, partIndex },
+                    { html }
+                  ) => html`<span
+                    class="custom-text-part"
+                    data-message-id="${message.id}"
+                    data-conversation="${messages
+                      ?.map(({ id }) => id)
+                      .join(',')}"
+                    data-status="${status}"
+                    data-part-index="${partIndex}"
+                    >${part.text}</span
+                  >`,
+                },
+                userMessage: {
+                  text: (
+                    { part, message, messages, status, partIndex },
+                    { html }
+                  ) => html`<span
+                    class="custom-text-part"
+                    data-message-id="${message.id}"
+                    data-conversation="${messages
+                      ?.map(({ id }) => id)
+                      .join(',')}"
+                    data-status="${status}"
+                    data-part-index="${partIndex}"
+                    >${part.text}</span
+                  >`,
+                },
+              },
+            },
+            react: {
+              ...createDefaultWidgetParams(chat),
+              messagesProps: {
+                onClose: () => {},
+                onReload: () => {},
+                assistantMessageProps: {
+                  textComponent: ({
+                    part,
+                    message,
+                    messages,
+                    status,
+                    partIndex,
+                  }) => (
+                    <span
+                      className="custom-text-part"
+                      data-message-id={message.id}
+                      data-conversation={messages
+                        ?.map(({ id }) => id)
+                        .join(',')}
+                      data-status={status}
+                      data-part-index={partIndex}
+                    >
+                      {part.text}
+                    </span>
+                  ),
+                },
+                userMessageProps: {
+                  textComponent: ({
+                    part,
+                    message,
+                    messages,
+                    status,
+                    partIndex,
+                  }) => (
+                    <span
+                      className="custom-text-part"
+                      data-message-id={message.id}
+                      data-conversation={messages
+                        ?.map(({ id }) => id)
+                        .join(',')}
+                      data-status={status}
+                      data-part-index={partIndex}
+                    >
+                      {part.text}
+                    </span>
+                  ),
+                },
+              },
+            },
+            vue: {},
+          },
+        });
+
+        await openChat(act);
+
+        expect(
+          Array.from(document.querySelectorAll('.custom-text-part')).map(
+            (element) => ({
+              text: element.textContent,
+              messageId: element.getAttribute('data-message-id'),
+              conversation: element.getAttribute('data-conversation'),
+              status: element.getAttribute('data-status'),
+              partIndex: Number(element.getAttribute('data-part-index')),
+            })
+          )
+        ).toEqual([
+          {
+            text: 'User first',
+            messageId: 'user-1',
+            conversation: 'user-1,assistant-1',
+            status: 'streaming',
+            partIndex: 0,
+          },
+          {
+            text: 'User second',
+            messageId: 'user-1',
+            conversation: 'user-1,assistant-1',
+            status: 'streaming',
+            partIndex: 2,
+          },
+          {
+            text: 'Assistant first',
+            messageId: 'assistant-1',
+            conversation: 'user-1,assistant-1',
+            status: 'streaming',
+            partIndex: 0,
+          },
+          {
+            text: 'Assistant second',
+            messageId: 'assistant-1',
+            conversation: 'user-1,assistant-1',
+            status: 'streaming',
+            partIndex: 2,
+          },
+        ]);
+      });
     });
 
     test('renders with custom actions', async () => {


### PR DESCRIPTION
## Summary

Allows Chat consumers to customize individual text parts without replacing the complete message row.

`ChatMessageProps` now accepts an optional `textComponent` with the text part, its owning message, the current conversation when available, the Chat status and the part index. The existing `assistantMessageProps` and `userMessageProps` paths expose it without a new framework-level prop.

InstantSearch continues to own reasoning, tools, actions, feedback, suggestions, loaders and message accessibility. Completed messages using a custom renderer update when the conversation changes, while the default renderer keeps its existing memoization behavior.

This is required by [AlgoliaWeb #29052](https://github.com/algolia/AlgoliaWeb/pull/29052) to preserve its existing inline citation rendering after migrating to the InstantSearch Chat widget.

[FX-3953]

## Result

- Consumers can customize text parts through the shared Chat message API.
- Direct Chat messages and both React message-role paths are supported.
- Default Markdown and plain-text rendering remain unchanged.
- Focused Chat UI, React, JavaScript and public type suites passed.


[FX-3953]: https://algolia.atlassian.net/browse/FX-3953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ