### PR TITLE
feat(chat): allow client side tool calls to cancel automatically if output not given before a new message

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -546,6 +546,18 @@ export type ClientSideTool = {
       addToolResult: AddToolResultWithOutput;
     }
   ) => void;
+  /**
+   * Output reported for this tool call while it is still waiting for a result —
+   * for example when the user sends another message instead of interacting with
+   * the tool. Every tool call has to be answered for a request to be valid, so
+   * unanswered calls are reported as cancelled automatically; implement this to
+   * control what the model sees, for example `{ confirmed: false }` for a
+   * confirmation prompt. Without it, the call is reported as failed.
+   *
+   * This only affects what is sent: the tool keeps waiting locally, so a result
+   * submitted later still lands and is sent from then on.
+   */
+  cancelOutput?: (params: { toolCallId: string; input: unknown }) => unknown;
   applyFilters: (params: ApplyFiltersParams) => SearchParameters;
 };
 export type ClientSideTools = Record<string, ClientSideTool>;

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -547,15 +547,12 @@ export type ClientSideTool = {
     }
   ) => void;
   /**
-   * Output reported for this tool call while it is still waiting for a result —
-   * for example when the user sends another message instead of interacting with
-   * the tool. Every tool call has to be answered for a request to be valid, so
-   * unanswered calls are reported as cancelled automatically; implement this to
-   * control what the model sees, for example `{ confirmed: false }` for a
-   * confirmation prompt. Without it, the call is reported as failed.
+   * Output reported for this tool call when a request is sent while it is still
+   * waiting for a result, for example `{ confirmed: false }` for a confirmation
+   * prompt. Without it, the call is reported as failed.
    *
    * This only affects what is sent: the tool keeps waiting locally, so a result
-   * submitted later still lands and is sent from then on.
+   * submitted later still lands.
    */
   cancelOutput?: (params: { toolCallId: string; input: unknown }) => unknown;
   applyFilters: (params: ApplyFiltersParams) => SearchParameters;

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1289,6 +1289,116 @@ describe('connectChat', () => {
       expect(widget.chatInstance.status).toBe('ready');
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
+
+    describe('cancelling a tool call the user never answered', () => {
+      const pendingToolCallResponse = () =>
+        chatStream([
+          { type: 'start', messageId: 'assistant-1' },
+          {
+            type: 'tool-input-available',
+            toolName: 'confirm',
+            toolCallId: 'call-1',
+            input: { sku: 'A1' },
+          },
+          { type: 'finish' },
+        ]);
+      const emptyResponse = () =>
+        chatStream([
+          { type: 'start', messageId: 'assistant-2' },
+          { type: 'finish' },
+        ]);
+
+      // The tool renders a card and waits for the user, so `onToolCall`
+      // returns without submitting an output.
+      const awaitUser = jest.fn();
+
+      const toolPartsSentOn = (fetchMock: jest.Mock, callIndex: number) =>
+        JSON.parse(fetchMock.mock.calls[callIndex][1].body)
+          .messages.flatMap((message: { parts: unknown[] }) => message.parts)
+          .filter((part: object) => 'toolCallId' in part);
+
+      it('reports the call as failed when the tool has no cancelOutput', async () => {
+        const fetchMock = jest
+          .fn()
+          .mockResolvedValueOnce(pendingToolCallResponse())
+          .mockResolvedValueOnce(emptyResponse());
+        const { widget } = getInitializedWidget({
+          agentId: undefined,
+          persistence: false,
+          transport: { fetch: fetchMock },
+          tools: { confirm: { onToolCall: awaitUser } },
+        });
+
+        await widget.chatInstance.sendMessage({ text: 'buy the first one' });
+        await widget.chatInstance.sendMessage({ text: 'never mind' });
+
+        expect(toolPartsSentOn(fetchMock, 1)).toEqual([
+          expect.objectContaining({
+            toolCallId: 'call-1',
+            state: 'output-error',
+          }),
+        ]);
+        expect(widget.chatInstance.status).toBe('ready');
+      });
+
+      it('commits the output returned by the tool `cancelOutput`', async () => {
+        const fetchMock = jest
+          .fn()
+          .mockResolvedValueOnce(pendingToolCallResponse())
+          .mockResolvedValueOnce(emptyResponse());
+        const cancelOutput = jest.fn(() => ({ confirmed: false }));
+        const { widget } = getInitializedWidget({
+          agentId: undefined,
+          persistence: false,
+          transport: { fetch: fetchMock },
+          tools: { confirm: { onToolCall: awaitUser, cancelOutput } },
+        });
+
+        await widget.chatInstance.sendMessage({ text: 'buy the first one' });
+        await widget.chatInstance.sendMessage({ text: 'never mind' });
+
+        expect(cancelOutput).toHaveBeenCalledWith({
+          toolCallId: 'call-1',
+          input: { sku: 'A1' },
+        });
+        expect(toolPartsSentOn(fetchMock, 1)).toEqual([
+          expect.objectContaining({
+            toolCallId: 'call-1',
+            state: 'output-available',
+            output: { confirmed: false },
+          }),
+        ]);
+      });
+
+      it('falls back to a failed call when `cancelOutput` throws', async () => {
+        const fetchMock = jest
+          .fn()
+          .mockResolvedValueOnce(pendingToolCallResponse())
+          .mockResolvedValueOnce(emptyResponse());
+        const cancelOutput = jest.fn(() => {
+          throw new Error('boom');
+        });
+        const { widget } = getInitializedWidget({
+          agentId: undefined,
+          persistence: false,
+          transport: { fetch: fetchMock },
+          tools: { confirm: { onToolCall: awaitUser, cancelOutput } },
+        });
+
+        await widget.chatInstance.sendMessage({ text: 'buy the first one' });
+        await widget.chatInstance.sendMessage({ text: 'never mind' });
+
+        expect(toolPartsSentOn(fetchMock, 1)).toEqual([
+          expect.objectContaining({
+            toolCallId: 'call-1',
+            state: 'output-error',
+          }),
+        ]);
+        // The send that triggered the cancellation still went out.
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(widget.chatInstance.status).toBe('ready');
+      });
+    });
   });
 
   describe('default chat instance', () => {

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1369,6 +1369,31 @@ describe('connectChat', () => {
         ]);
       });
 
+      it('reports the call as failed when `cancelOutput` returns nothing', async () => {
+        const fetchMock = jest
+          .fn()
+          .mockResolvedValueOnce(pendingToolCallResponse())
+          .mockResolvedValueOnce(emptyResponse());
+        const cancelOutput = jest.fn(() => undefined);
+        const { widget } = getInitializedWidget({
+          agentId: undefined,
+          persistence: false,
+          transport: { fetch: fetchMock },
+          tools: { confirm: { onToolCall: awaitUser, cancelOutput } },
+        });
+
+        await widget.chatInstance.sendMessage({ text: 'buy the first one' });
+        await widget.chatInstance.sendMessage({ text: 'never mind' });
+
+        expect(toolPartsSentOn(fetchMock, 1)).toEqual([
+          expect.objectContaining({
+            toolCallId: 'call-1',
+            state: 'output-error',
+          }),
+        ]);
+        expect(widget.chatInstance.status).toBe('ready');
+      });
+
       it('falls back to a failed call when `cancelOutput` throws', async () => {
         const fetchMock = jest
           .fn()

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1308,8 +1308,7 @@ describe('connectChat', () => {
           { type: 'finish' },
         ]);
 
-      // The tool renders a card and waits for the user, so `onToolCall`
-      // returns without submitting an output.
+      // `onToolCall` returns without submitting an output.
       const awaitUser = jest.fn();
 
       const toolPartsSentOn = (fetchMock: jest.Mock, callIndex: number) =>
@@ -1394,7 +1393,6 @@ describe('connectChat', () => {
             state: 'output-error',
           }),
         ]);
-        // The send that triggered the cancellation still went out.
         expect(fetchMock).toHaveBeenCalledTimes(2);
         expect(widget.chatInstance.status).toBe('ready');
       });

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -469,8 +469,8 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       'chat' in options
     );
 
-    // The Algolia MCP Server suffixes its search tool with the index name
-    // (`searchIndex_products`), so those names fall back to the base tool.
+    // Compatibility shim with Algolia MCP Server search tool, which suffixes
+    // the tool name with the index name (`searchIndex_products`).
     const resolveTool = (toolName: string) =>
       tools[toolName] ||
       (toolName.startsWith(`${SearchIndexToolType}_`)
@@ -721,8 +721,6 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           try {
             return { output: cancelOutput({ toolCallId, input }) };
           } catch {
-            // A throwing `cancelOutput` must not block the request that
-            // triggered the cancellation; report the call as failed instead.
             warning(
               false,
               `The \`cancelOutput\` of the "${toolName}" tool threw an error. The tool call is reported as failed instead.`

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -719,7 +719,9 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           if (!cancelOutput) return undefined;
 
           try {
-            return { output: cancelOutput({ toolCallId, input }) };
+            const output = cancelOutput({ toolCallId, input });
+            // `undefined` means the tool declined to provide an output.
+            return output === undefined ? undefined : { output };
           } catch {
             warning(
               false,

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -469,6 +469,14 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       'chat' in options
     );
 
+    // The Algolia MCP Server suffixes its search tool with the index name
+    // (`searchIndex_products`), so those names fall back to the base tool.
+    const resolveTool = (toolName: string) =>
+      tools[toolName] ||
+      (toolName.startsWith(`${SearchIndexToolType}_`)
+        ? tools[SearchIndexToolType]
+        : undefined);
+
     let _chatInstance: Chat<TUiMessage>;
     let input = '';
     let open = false;
@@ -702,23 +710,28 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
         sendAutomaticallyWhen,
         transport,
         shouldRepairToolInput(toolName) {
-          let tool = tools[toolName];
-          if (!tool && toolName.startsWith(`${SearchIndexToolType}_`)) {
-            tool = tools[SearchIndexToolType];
-          }
+          const tool = resolveTool(toolName);
           if (!tool) return true;
           return Boolean(tool.streamInput);
         },
-        onToolCall: (({ toolCall }, submitToolResult) => {
-          let tool = tools[toolCall.toolName];
+        resolveCancelledToolOutput({ toolName, toolCallId, input }) {
+          const cancelOutput = resolveTool(toolName)?.cancelOutput;
+          if (!cancelOutput) return undefined;
 
-          // Compatibility shim with Algolia MCP Server search tool
-          if (
-            !tool &&
-            toolCall.toolName.startsWith(`${SearchIndexToolType}_`)
-          ) {
-            tool = tools[SearchIndexToolType];
+          try {
+            return { output: cancelOutput({ toolCallId, input }) };
+          } catch {
+            // A throwing `cancelOutput` must not block the request that
+            // triggered the cancellation; report the call as failed instead.
+            warning(
+              false,
+              `The \`cancelOutput\` of the "${toolName}" tool threw an error. The tool call is reported as failed instead.`
+            );
+            return undefined;
           }
+        },
+        onToolCall: (({ toolCall }, submitToolResult) => {
+          const tool = resolveTool(toolCall.toolName);
 
           if (!tool) {
             if (__DEV__) {

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -4670,8 +4670,7 @@ describe('AbstractChat unanswered tool calls in outbound requests', () => {
     finishChunk(),
   ];
 
-  // A client-side tool that renders a card and waits for the user: the call is
-  // announced, the callback returns, and no output is submitted.
+  // A client-side tool that waits for the user instead of submitting an output.
   const awaitUser = () => undefined;
 
   function toolPartsSentOn(
@@ -4697,8 +4696,6 @@ describe('AbstractChat unanswered tool calls in outbound requests', () => {
 
     await chat.sendMessage({ text: 'actually, show me something else' });
 
-    // The turn the provider receives holds no tool call without a result, so
-    // the request is valid and the chat does not lock into an error state.
     expect(toolPartsSentOn(sendMessages, 1)).toEqual([
       expect.objectContaining({
         toolCallId: 'call-1',
@@ -4724,8 +4721,6 @@ describe('AbstractChat unanswered tool calls in outbound requests', () => {
     await chat.sendMessage({ text: 'buy the first one' });
     await chat.sendMessage({ text: 'actually, show me something else' });
 
-    // The card is still mounted: reporting the call as cancelled on the wire
-    // must not disable the button the user is about to press.
     expect(assistantToolPart(state, 'call-1')).toMatchObject({
       state: 'input-available',
     });
@@ -4741,7 +4736,6 @@ describe('AbstractChat unanswered tool calls in outbound requests', () => {
       output: { confirmed: true },
     });
 
-    // Once answered, later requests carry the real output, not a cancellation.
     await chat.sendMessage({ text: 'anything else?' });
     expect(toolPartsSentOn(sendMessages, 2)).toEqual([
       expect.objectContaining({
@@ -4787,8 +4781,6 @@ describe('AbstractChat unanswered tool calls in outbound requests', () => {
         emptyChunks('msg-3'),
       ],
       onToolCall: awaitUser,
-      // The predicate must not see the cancellation as a completed turn and
-      // fire a continuation alongside the send that reported it.
       sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
     });
 
@@ -4820,8 +4812,7 @@ describe('AbstractChat unanswered tool calls in outbound requests', () => {
     });
 
     await chat.sendMessage({ text: 'buy the first one' });
-    // A second turn keeps the unanswered call in history instead of slicing it
-    // off when regenerating.
+    // The second turn keeps the unanswered call in history when regenerating.
     await chat.sendMessage({ text: 'and what about shipping?' });
     await chat.regenerate();
 

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -4773,6 +4773,30 @@ describe('AbstractChat unanswered tool calls in outbound requests', () => {
     expect(toolPart.errorText).toBeUndefined();
   });
 
+  it('reports the call as failed when the cancellation hook throws', async () => {
+    const resolveCancelledToolOutput = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const { chat, state, sendMessages } = createTestSetup({
+      chunksByRequest: [pendingToolChunks(), emptyChunks('msg-2')],
+      onToolCall: awaitUser,
+      resolveCancelledToolOutput,
+    });
+
+    await chat.sendMessage({ text: 'buy the first one' });
+    await chat.sendMessage({ text: 'actually, show me something else' });
+
+    expect(toolPartsSentOn(sendMessages, 1)).toEqual([
+      expect.objectContaining({
+        toolCallId: 'call-1',
+        state: 'output-error',
+        errorText: expect.any(String),
+      }),
+    ]);
+    expect(state.status).toBe('ready');
+    expect(state.error).toBeUndefined();
+  });
+
   it('does not send a duplicate request for the cancelled turn', async () => {
     const { chat, sendMessages } = createTestSetup({
       chunksByRequest: [

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -4,8 +4,10 @@
 import { ChatState as RuntimeChatState } from '../../chat/chat';
 import { AbstractChat } from '../abstract-chat';
 import { parseJsonEventStream } from '../stream-parser';
+import { lastAssistantMessageIsCompleteWithToolCalls } from '../utils';
 
 import type {
+  ChatInit,
   ChatOnErrorCallback,
   ChatOnFinishCallback,
   ChatState,
@@ -109,6 +111,7 @@ function createTestSetup(
     onFinish,
     onError,
     sendAutomaticallyWhen,
+    resolveCancelledToolOutput,
     state = new InMemoryChatState(),
   }: {
     chunks?: UIMessageChunk[];
@@ -128,6 +131,7 @@ function createTestSetup(
     sendAutomaticallyWhen?: (options: {
       messages: UIMessage[];
     }) => boolean | PromiseLike<boolean>;
+    resolveCancelledToolOutput?: ChatInit<UIMessage>['resolveCancelledToolOutput'];
     state?: ChatState<UIMessage>;
   } = { chunks: [] }
 ) {
@@ -165,6 +169,7 @@ function createTestSetup(
     onFinish,
     onToolCall,
     sendAutomaticallyWhen,
+    resolveCancelledToolOutput,
   });
 
   return { chat, state, transport, sendMessages };
@@ -4639,5 +4644,243 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         text: 'Sorry, search is unavailable right now.',
       });
     });
+  });
+});
+
+describe('AbstractChat unanswered tool calls in outbound requests', () => {
+  const pendingToolChunks = (
+    { providerExecuted }: { providerExecuted?: boolean } = {},
+    messageId = 'msg-1'
+  ): UIMessageChunk[] => [
+    startChunk(messageId),
+    {
+      type: 'tool-input-available',
+      toolName: 'confirm',
+      toolCallId: 'call-1',
+      input: { sku: 'A1' },
+      providerExecuted,
+    },
+    finishChunk(),
+  ];
+
+  const emptyChunks = (messageId: string): UIMessageChunk[] => [
+    startChunk(messageId),
+    { type: 'text-start', id: 'text-1' },
+    { type: 'text-delta', id: 'text-1', delta: 'Sure.' },
+    finishChunk(),
+  ];
+
+  // A client-side tool that renders a card and waits for the user: the call is
+  // announced, the callback returns, and no output is submitted.
+  const awaitUser = () => undefined;
+
+  function toolPartsSentOn(
+    sendMessages: ReturnType<typeof createTestSetup>['sendMessages'],
+    callIndex: number
+  ): any[] {
+    return sendMessages.mock.calls[callIndex][0].messages
+      .flatMap((message: UIMessage) => message.parts)
+      .filter((part: any) => 'toolCallId' in part);
+  }
+
+  it('reports an unanswered tool call as failed in the next request', async () => {
+    const { chat, state, sendMessages } = createTestSetup({
+      chunksByRequest: [pendingToolChunks(), emptyChunks('msg-2')],
+      onToolCall: awaitUser,
+    });
+
+    await chat.sendMessage({ text: 'buy the first one' });
+
+    expect(assistantToolPart(state, 'call-1')).toMatchObject({
+      state: 'input-available',
+    });
+
+    await chat.sendMessage({ text: 'actually, show me something else' });
+
+    // The turn the provider receives holds no tool call without a result, so
+    // the request is valid and the chat does not lock into an error state.
+    expect(toolPartsSentOn(sendMessages, 1)).toEqual([
+      expect.objectContaining({
+        toolCallId: 'call-1',
+        input: { sku: 'A1' },
+        state: 'output-error',
+        errorText: expect.any(String),
+      }),
+    ]);
+    expect(state.status).toBe('ready');
+    expect(state.error).toBeUndefined();
+  });
+
+  it('keeps the call open locally so a late answer still lands', async () => {
+    const { chat, state, sendMessages } = createTestSetup({
+      chunksByRequest: [
+        pendingToolChunks(),
+        emptyChunks('msg-2'),
+        emptyChunks('msg-3'),
+      ],
+      onToolCall: awaitUser,
+    });
+
+    await chat.sendMessage({ text: 'buy the first one' });
+    await chat.sendMessage({ text: 'actually, show me something else' });
+
+    // The card is still mounted: reporting the call as cancelled on the wire
+    // must not disable the button the user is about to press.
+    expect(assistantToolPart(state, 'call-1')).toMatchObject({
+      state: 'input-available',
+    });
+
+    await chat.addToolResult({
+      tool: 'confirm',
+      toolCallId: 'call-1',
+      output: { confirmed: true },
+    });
+
+    expect(assistantToolPart(state, 'call-1')).toMatchObject({
+      state: 'output-available',
+      output: { confirmed: true },
+    });
+
+    // Once answered, later requests carry the real output, not a cancellation.
+    await chat.sendMessage({ text: 'anything else?' });
+    expect(toolPartsSentOn(sendMessages, 2)).toEqual([
+      expect.objectContaining({
+        toolCallId: 'call-1',
+        state: 'output-available',
+        output: { confirmed: true },
+      }),
+    ]);
+  });
+
+  it('reports the resolved cancellation output when one is provided', async () => {
+    const resolveCancelledToolOutput = jest.fn(() => ({
+      output: { confirmed: false },
+    }));
+    const { chat, sendMessages } = createTestSetup({
+      chunksByRequest: [pendingToolChunks(), emptyChunks('msg-2')],
+      onToolCall: awaitUser,
+      resolveCancelledToolOutput,
+    });
+
+    await chat.sendMessage({ text: 'buy the first one' });
+    await chat.sendMessage({ text: 'actually, show me something else' });
+
+    expect(resolveCancelledToolOutput).toHaveBeenCalledWith({
+      toolName: 'confirm',
+      toolCallId: 'call-1',
+      input: { sku: 'A1' },
+    });
+
+    const [toolPart] = toolPartsSentOn(sendMessages, 1);
+    expect(toolPart).toMatchObject({
+      state: 'output-available',
+      output: { confirmed: false },
+    });
+    expect(toolPart.errorText).toBeUndefined();
+  });
+
+  it('does not send a duplicate request for the cancelled turn', async () => {
+    const { chat, sendMessages } = createTestSetup({
+      chunksByRequest: [
+        pendingToolChunks(),
+        emptyChunks('msg-2'),
+        emptyChunks('msg-3'),
+      ],
+      onToolCall: awaitUser,
+      // The predicate must not see the cancellation as a completed turn and
+      // fire a continuation alongside the send that reported it.
+      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    });
+
+    await chat.sendMessage({ text: 'buy the first one' });
+    await chat.sendMessage({ text: 'actually, show me something else' });
+
+    expect(sendMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it('repairs unanswered tool calls on regenerate', async () => {
+    const { chat, sendMessages } = createTestSetup({
+      chunksByRequest: [
+        [
+          startChunk('msg-1'),
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Confirm?' },
+          {
+            type: 'tool-input-available',
+            toolName: 'confirm',
+            toolCallId: 'call-1',
+            input: { sku: 'A1' },
+          },
+          finishChunk(),
+        ],
+        emptyChunks('msg-2'),
+        emptyChunks('msg-3'),
+      ],
+      onToolCall: awaitUser,
+    });
+
+    await chat.sendMessage({ text: 'buy the first one' });
+    // A second turn keeps the unanswered call in history instead of slicing it
+    // off when regenerating.
+    await chat.sendMessage({ text: 'and what about shipping?' });
+    await chat.regenerate();
+
+    expect(toolPartsSentOn(sendMessages, 2)).toEqual([
+      expect.objectContaining({ toolCallId: 'call-1', state: 'output-error' }),
+    ]);
+  });
+
+  it('leaves provider-executed tool calls to the provider', async () => {
+    const { chat, sendMessages } = createTestSetup({
+      chunksByRequest: [
+        pendingToolChunks({ providerExecuted: true }),
+        emptyChunks('msg-2'),
+      ],
+      onToolCall: awaitUser,
+    });
+
+    await chat.sendMessage({ text: 'buy the first one' });
+    await chat.sendMessage({ text: 'actually, show me something else' });
+
+    expect(toolPartsSentOn(sendMessages, 1)).toEqual([
+      expect.objectContaining({
+        toolCallId: 'call-1',
+        state: 'input-available',
+      }),
+    ]);
+  });
+
+  it('sends answered tool calls unchanged', async () => {
+    const { chat, sendMessages } = createTestSetup({
+      chunksByRequest: [
+        [
+          startChunk('msg-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: { q: 'hello' },
+          },
+          {
+            type: 'tool-output-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            output: { hits: ['hello'] },
+          },
+          finishChunk(),
+        ],
+        emptyChunks('msg-2'),
+      ],
+    });
+
+    await chat.sendMessage({ text: 'search for hello' });
+    await chat.sendMessage({ text: 'thanks' });
+
+    expect(toolPartsSentOn(sendMessages, 1)).toEqual([
+      expect.objectContaining({
+        state: 'output-available',
+        output: { hits: ['hello'] },
+      }),
+    ]);
   });
 });

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -64,12 +64,8 @@ function getToolName(part: { type: string; toolName?: string }): string {
   return part.type.slice('tool-'.length);
 }
 
-/**
- * A tool call that has been announced but has no output yet, and whose output
- * the client owns. Provider-executed calls are resolved server-side, so
- * authoring a result for them here would contradict the provider's own
- * transcript.
- */
+// A tool call awaiting an output that the client owns. Provider-executed calls
+// are resolved server-side, so they are left alone.
 function isPendingToolPart<TPart>(
   part: TPart
 ): part is TPart & { toolCallId: string } {
@@ -89,11 +85,8 @@ function isPendingToolPart<TPart>(
   );
 }
 
-/**
- * Moves a tool part to a terminal state, dropping the fields that only belong
- * to the state being left behind (`output-error` forbids `output`, and a
- * committed output is no longer `preliminary`).
- */
+// Drops the fields that only belong to the state being left behind:
+// `output-error` forbids `output`, and a committed output is not `preliminary`.
 function withTerminalToolState<TPart>(
   part: TPart,
   terminalState: TerminalToolState
@@ -545,18 +538,13 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   }
 
   /**
-   * The transcript to send, with every tool call that is still awaiting an
-   * output reported as cancelled. A provider rejects a turn holding a tool call
-   * with no matching result, so a client-side tool the user walked away from —
-   * by sending another message instead of interacting with its card — would
-   * otherwise fail this request and every one after it, leaving clearing the
-   * conversation as the only way out of the error state.
+   * The transcript to send, with every tool call still awaiting an output
+   * reported as cancelled — a provider rejects a turn holding a tool call with
+   * no matching result.
    *
-   * The repair deliberately stays on this copy instead of being committed to
-   * `messages`: the card is still mounted, so the user can answer it after the
-   * send, and that late `addToolResult` must still land. Local state therefore
-   * keeps the call open, and every request reports it cancelled until it is
-   * answered.
+   * The repair stays on this copy rather than being committed to `messages`:
+   * the card is still mounted, so a result submitted after the send must still
+   * land, and is sent as the real output from then on.
    */
   private getOutboundMessages(): TUIMessage[] {
     let outboundMessages: TUIMessage[] | undefined;
@@ -841,7 +829,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     }
 
     // Resolved as late as possible, so a tool that submits its output in the
-    // meantime is sent as answered rather than cancelled.
+    // meantime is sent as answered.
     const messages = this.getOutboundMessages();
 
     return this.consume((abortSignal) =>

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -577,11 +577,18 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   private resolveToolCallCancellation(
     part: TUIMessage['parts'][number] & { toolCallId: string }
   ): TerminalToolState {
-    const cancellation = this.resolveCancelledToolOutput?.({
-      toolName: getToolName(part),
-      toolCallId: part.toolCallId,
-      input: 'input' in part ? part.input : undefined,
-    });
+    let cancellation;
+
+    // Repairing the outbound transcript must never fail the request build.
+    try {
+      cancellation = this.resolveCancelledToolOutput?.({
+        toolName: getToolName(part),
+        toolCallId: part.toolCallId,
+        input: 'input' in part ? part.input : undefined,
+      });
+    } catch {
+      cancellation = undefined;
+    }
 
     return cancellation
       ? { state: 'output-available', output: cancellation.output }

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -50,6 +50,69 @@ type ResponseRecord = {
 const defaultGuardrailFallbackResponse =
   'Sorry, we are not able to generate a response at the moment.';
 
+const TOOL_CALL_CANCELLED_ERROR_TEXT =
+  'The tool call was cancelled: the conversation moved on before a result was provided.';
+
+type TerminalToolState =
+  | { state: 'output-available'; output: unknown }
+  | { state: 'output-error'; errorText: string };
+
+function getToolName(part: { type: string; toolName?: string }): string {
+  if (part.type === 'dynamic-tool') {
+    return part.toolName ?? part.type;
+  }
+  return part.type.slice('tool-'.length);
+}
+
+/**
+ * A tool call that has been announced but has no output yet, and whose output
+ * the client owns. Provider-executed calls are resolved server-side, so
+ * authoring a result for them here would contradict the provider's own
+ * transcript.
+ */
+function isPendingToolPart<TPart>(
+  part: TPart
+): part is TPart & { toolCallId: string } {
+  const candidate = part as {
+    type?: unknown;
+    toolCallId?: unknown;
+    state?: unknown;
+    providerExecuted?: unknown;
+  };
+
+  return (
+    typeof candidate.type === 'string' &&
+    typeof candidate.toolCallId === 'string' &&
+    (candidate.state === 'input-streaming' ||
+      candidate.state === 'input-available') &&
+    candidate.providerExecuted !== true
+  );
+}
+
+/**
+ * Moves a tool part to a terminal state, dropping the fields that only belong
+ * to the state being left behind (`output-error` forbids `output`, and a
+ * committed output is no longer `preliminary`).
+ */
+function withTerminalToolState<TPart>(
+  part: TPart,
+  terminalState: TerminalToolState
+): TPart {
+  const {
+    // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+    preliminary: _ignoredPreliminary,
+    // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+    rawOutput: _ignoredRawOutput,
+    // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+    output: _ignoredOutput,
+    // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+    errorText: _ignoredErrorText,
+    ...retainedPart
+  } = part as any;
+
+  return { ...retainedPart, ...terminalState } as TPart;
+}
+
 /**
  * Abstract base class for chat implementations.
  */
@@ -71,6 +134,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     messages: TUIMessage[];
   }) => boolean | PromiseLike<boolean>;
   private shouldRepairToolInput?: (toolName: string) => boolean;
+  private resolveCancelledToolOutput?: ChatInit<TUIMessage>['resolveCancelledToolOutput'];
 
   private activeResponse: ResponseRecord | null = null;
   private latestResponse: ResponseRecord | null = null;
@@ -92,6 +156,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     onData,
     sendAutomaticallyWhen,
     shouldRepairToolInput,
+    resolveCancelledToolOutput,
   }: Omit<ChatInit<TUIMessage>, 'messages'> & {
     state: ChatState<TUIMessage>;
   }) {
@@ -105,6 +170,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     this.onData = onData;
     this.sendAutomaticallyWhen = sendAutomaticallyWhen;
     this.shouldRepairToolInput = shouldRepairToolInput;
+    this.resolveCancelledToolOutput = resolveCancelledToolOutput;
   }
 
   /**
@@ -464,19 +530,11 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     ) {
       return false;
     }
-    const {
-      // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-      preliminary: _ignoredPreliminary,
-      // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-      rawOutput: _ignoredRawOutput,
-      ...committedPart
-    } = part as any;
     const updatedParts = [...message.parts];
-    updatedParts[partIndex] = {
-      ...committedPart,
-      state: 'output-available' as const,
+    updatedParts[partIndex] = withTerminalToolState(part, {
+      state: 'output-available',
       output,
-    };
+    });
 
     const updatedMessage = {
       ...message,
@@ -484,6 +542,62 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     } as TUIMessage;
     this.replaceMessage(messageIndex, updatedMessage, response);
     return true;
+  }
+
+  /**
+   * The transcript to send, with every tool call that is still awaiting an
+   * output reported as cancelled. A provider rejects a turn holding a tool call
+   * with no matching result, so a client-side tool the user walked away from —
+   * by sending another message instead of interacting with its card — would
+   * otherwise fail this request and every one after it, leaving clearing the
+   * conversation as the only way out of the error state.
+   *
+   * The repair deliberately stays on this copy instead of being committed to
+   * `messages`: the card is still mounted, so the user can answer it after the
+   * send, and that late `addToolResult` must still land. Local state therefore
+   * keeps the call open, and every request reports it cancelled until it is
+   * answered.
+   */
+  private getOutboundMessages(): TUIMessage[] {
+    let outboundMessages: TUIMessage[] | undefined;
+
+    this.messages.forEach((message, messageIndex) => {
+      let repairedParts: TUIMessage['parts'] | undefined;
+
+      message.parts.forEach((part, partIndex) => {
+        if (!isPendingToolPart(part)) return;
+
+        repairedParts = repairedParts || [...message.parts];
+        repairedParts[partIndex] = withTerminalToolState(
+          part,
+          this.resolveToolCallCancellation(part)
+        );
+      });
+
+      if (repairedParts) {
+        outboundMessages = outboundMessages || [...this.messages];
+        outboundMessages[messageIndex] = {
+          ...message,
+          parts: repairedParts,
+        } as TUIMessage;
+      }
+    });
+
+    return outboundMessages || this.messages;
+  }
+
+  private resolveToolCallCancellation(
+    part: TUIMessage['parts'][number] & { toolCallId: string }
+  ): TerminalToolState {
+    const cancellation = this.resolveCancelledToolOutput?.({
+      toolName: getToolName(part),
+      toolCallId: part.toolCallId,
+      input: 'input' in part ? part.input : undefined,
+    });
+
+    return cancellation
+      ? { state: 'output-available', output: cancellation.output }
+      : { state: 'output-error', errorText: TOOL_CALL_CANCELLED_ERROR_TEXT };
   }
 
   private continueResponse(response?: ResponseRecord): Promise<void> {
@@ -726,10 +840,14 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       );
     }
 
+    // Resolved as late as possible, so a tool that submits its output in the
+    // meantime is sent as answered rather than cancelled.
+    const messages = this.getOutboundMessages();
+
     return this.consume((abortSignal) =>
       this.transport!.sendMessages({
         chatId: this.id,
-        messages: this.messages,
+        messages,
         abortSignal,
         trigger: options.trigger,
         messageId: options.messageId,

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -524,6 +524,16 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
     messages: UI_MESSAGE[];
   }) => boolean | PromiseLike<boolean>;
   shouldRepairToolInput?: (toolName: string) => boolean;
+  /**
+   * Resolves the output to report for a tool call that a request carries while
+   * it is still awaiting its result. Return `undefined` to report the call as
+   * failed instead, which is the default.
+   */
+  resolveCancelledToolOutput?: (params: {
+    toolName: string;
+    toolCallId: string;
+    input: unknown;
+  }) => { output: unknown } | undefined;
 }
 
 export type CreateUIMessage<UI_MESSAGE extends UIMessage> = Omit<

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -525,9 +525,8 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
   }) => boolean | PromiseLike<boolean>;
   shouldRepairToolInput?: (toolName: string) => boolean;
   /**
-   * Resolves the output to report for a tool call that a request carries while
-   * it is still awaiting its result. Return `undefined` to report the call as
-   * failed instead, which is the default.
+   * Output to report for a tool call a request carries while it is still
+   * awaiting its result. Return `undefined` to report the call as failed.
    */
   resolveCancelledToolOutput?: (params: {
     toolName: string;

--- a/tests/common/widgets/chat/index.ts
+++ b/tests/common/widgets/chat/index.ts
@@ -6,6 +6,7 @@ import { createPersistenceTests } from './persistence';
 import { createReasoningTests } from './reasoning';
 import { createStreamingTests } from './streaming';
 import { createTemplatesTests } from './templates';
+import { createToolCancellationTests } from './tool-cancellation';
 import { createTranslationsTests } from './translations';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -60,6 +61,7 @@ export function createChatWidgetTests(
     createReasoningTests(setup, { act, skippedTests, flavor });
     createStreamingTests(setup, { act, skippedTests, flavor });
     createTemplatesTests(setup, { act, skippedTests, flavor });
+    createToolCancellationTests(setup, { act, skippedTests, flavor });
     createTranslationsTests(setup, { act, skippedTests, flavor });
   });
 }

--- a/tests/common/widgets/chat/tool-cancellation.tsx
+++ b/tests/common/widgets/chat/tool-cancellation.tsx
@@ -20,8 +20,7 @@ function chunksToStream(
   });
 }
 
-// A turn that hands a client-side tool call to the frontend and stops there:
-// the output is the user's to provide, by interacting with the rendered card.
+// A turn that hands a client-side tool call to the frontend and stops there.
 const pendingToolCallChunks: UIMessageChunk[] = [
   { type: 'start', messageId: 'assistant-1' },
   { type: 'text-start', id: 'text-1' },
@@ -91,7 +90,6 @@ export function createToolCancellationTests(
 
       await submitPrompt('buy the first one', act);
 
-      // The tool call was handed over and is waiting for an output.
       expect(chat.messages[1].parts).toContainEqual(
         expect.objectContaining({
           toolCallId: 'tool-call-1',
@@ -111,16 +109,13 @@ export function createToolCancellationTests(
         .flatMap((message) => message.parts)
         .filter((part) => 'toolCallId' in part);
 
-      // Every tool call in the payload is answered, so the request is valid and
-      // the conversation stays usable instead of erroring out for good.
       expect(sentToolParts).toEqual([
         expect.objectContaining({
           toolCallId: 'tool-call-1',
           state: 'output-error',
         }),
       ]);
-      // The repair stays on the wire: the card is still mounted, so answering
-      // it after the send must still work.
+      // The repair stays on the wire; the local call is still answerable.
       expect(chat.messages[1].parts).toContainEqual(
         expect.objectContaining({
           toolCallId: 'tool-call-1',

--- a/tests/common/widgets/chat/tool-cancellation.tsx
+++ b/tests/common/widgets/chat/tool-cancellation.tsx
@@ -1,0 +1,139 @@
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import userEvent from '@testing-library/user-event';
+import { Chat } from 'instantsearch.js/es/lib/chat';
+
+import { createDefaultWidgetParams, openChat } from './utils';
+
+import type { ChatWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+import type { UIMessageChunk } from 'instantsearch.js/es/lib/ai-lite';
+
+function chunksToStream(
+  chunks: UIMessageChunk[]
+): ReadableStream<UIMessageChunk> {
+  return new ReadableStream({
+    start(controller) {
+      chunks.forEach((chunk) => controller.enqueue(chunk));
+      controller.close();
+    },
+  });
+}
+
+// A turn that hands a client-side tool call to the frontend and stops there:
+// the output is the user's to provide, by interacting with the rendered card.
+const pendingToolCallChunks: UIMessageChunk[] = [
+  { type: 'start', messageId: 'assistant-1' },
+  { type: 'text-start', id: 'text-1' },
+  { type: 'text-delta', id: 'text-1', delta: 'Confirm the purchase?' },
+  {
+    type: 'tool-input-available',
+    toolName: 'confirm',
+    toolCallId: 'tool-call-1',
+    input: { sku: 'A1' },
+  },
+  { type: 'finish' },
+];
+
+const answeredChunks: UIMessageChunk[] = [
+  { type: 'start', messageId: 'assistant-2' },
+  { type: 'text-start', id: 'text-2' },
+  { type: 'text-delta', id: 'text-2', delta: 'Here are other options.' },
+  { type: 'finish' },
+];
+
+async function submitPrompt(
+  text: string,
+  act: Required<TestOptions>['act']
+): Promise<void> {
+  userEvent.type(document.querySelector('.ais-ChatPrompt-textarea')!, text);
+  userEvent.click(document.querySelector('.ais-ChatPrompt-submit')!);
+
+  await act(async () => {
+    await wait(0);
+    await wait(0);
+  });
+}
+
+export function createToolCancellationTests(
+  setup: ChatWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('pending tool call cancellation', () => {
+    test('keeps sending after the user ignores a client-side tool call', async () => {
+      const searchClient = createSearchClient();
+      let requestIndex = 0;
+      const sendMessages = jest.fn((_options: unknown) => {
+        const chunks =
+          requestIndex === 0 ? pendingToolCallChunks : answeredChunks;
+        requestIndex++;
+        return Promise.resolve(chunksToStream(chunks));
+      });
+
+      const chat = new Chat({
+        persistence: false,
+        transport: {
+          sendMessages,
+          reconnectToStream: jest.fn(() => Promise.resolve(null)),
+        },
+      });
+
+      await setup({
+        instantSearchOptions: { indexName: 'indexName', searchClient },
+        widgetParams: {
+          javascript: createDefaultWidgetParams(chat),
+          react: createDefaultWidgetParams(chat),
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      await submitPrompt('buy the first one', act);
+
+      // The tool call was handed over and is waiting for an output.
+      expect(chat.messages[1].parts).toContainEqual(
+        expect.objectContaining({
+          toolCallId: 'tool-call-1',
+          state: 'input-available',
+        })
+      );
+
+      // Instead of interacting with the card, the user asks something else.
+      await submitPrompt('actually, show me something else', act);
+
+      const sentMessages = (
+        sendMessages.mock.calls[1][0] as {
+          messages: Array<{ parts: Array<Record<string, unknown>> }>;
+        }
+      ).messages;
+      const sentToolParts = sentMessages
+        .flatMap((message) => message.parts)
+        .filter((part) => 'toolCallId' in part);
+
+      // Every tool call in the payload is answered, so the request is valid and
+      // the conversation stays usable instead of erroring out for good.
+      expect(sentToolParts).toEqual([
+        expect.objectContaining({
+          toolCallId: 'tool-call-1',
+          state: 'output-error',
+        }),
+      ]);
+      // The repair stays on the wire: the card is still mounted, so answering
+      // it after the send must still work.
+      expect(chat.messages[1].parts).toContainEqual(
+        expect.objectContaining({
+          toolCallId: 'tool-call-1',
+          state: 'input-available',
+        })
+      );
+      expect(chat.status).toBe('ready');
+      expect(
+        document.querySelector('.ais-ChatMessageError')
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('.ais-ChatMessages')!.textContent
+      ).toContain('Here are other options.');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

When the agent hands a client-side tool call to the frontend and the user never answers the card (no `addToolResult`), the next message would put the chat into a sticky error state whose only escape is "Start a new conversation". Providers reject a turn that carries a `tool_use` with no matching `tool_result`, so the request failed before it reached the model.

Sending now repairs those calls on the outbound transcript: every tool call still awaiting a result is reported as terminal, so the request is valid and the conversation keeps going.

## What changed

- **`AbstractChat.getOutboundMessages()`** (`ai-lite/abstract-chat.ts`) — builds the transcript to send, rewriting each pending client-side tool part to a terminal state. Resolved as late as possible in `makeRequest`, and returns the same array by structural sharing when nothing is pending.
- **The repair is outbound-only.** Local `messages` keep the call at `input-available`, so the card stays mounted and a result submitted after the send still lands and is sent as the real output from then on.
- **`provider-executed` calls are left alone** — they're resolved server-side.
- **New `cancelOutput` hook on client-side tools** (public, `instantsearch-ui-components`) — lets a tool say what the model should see, e.g. `cancelOutput: () => ({ confirmed: false })`. Without it, the call is reported as `output-error` with a "the conversation moved on" message. `connectChat` wires it through and falls back to the error result if it throws (with a `warning`).

## Behavior

| Case | Sent to the provider |
| --- | --- |
| No `cancelOutput` (default) | `output-error` + cancellation `errorText` |
| `cancelOutput` returns a value | `output-available` with that output |
| `cancelOutput` throws | `output-error` (dev warning) |
| `providerExecuted` tool | untouched |

In all cases: local state stays `input-available`, `status` returns to `ready`, no `.ais-ChatMessageError`.

[FX-3929]


[FX-3929]: https://algolia.atlassian.net/browse/FX-3929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ