### PR TITLE
fix(chat): omit widget-owned message callbacks

### DIFF
--- a/packages/react-instantsearch/__tests__/types.test.ts
+++ b/packages/react-instantsearch/__tests__/types.test.ts
@@ -54,24 +54,18 @@ test('preserves custom message types in Chat text component props', () => {
     };
 
     const messagesProps: MessagesProps = {
-      onClose() {},
-      onReload() {},
       assistantMessageProps: { textComponent },
       userMessageProps: { textComponent },
     };
     void messagesProps;
 
     const compatibleMessagesProps: MessagesProps = {
-      onClose() {},
-      onReload() {},
       assistantMessageProps: reusableMessageProps,
       userMessageProps: reusableRoleMessageProps,
     };
     void compatibleMessagesProps;
 
     const legacyMessagesProps: MessagesProps = {
-      onClose() {},
-      onReload() {},
       assistantMessageProps: legacyRoleMessageProps,
     };
     void legacyMessagesProps;
@@ -79,8 +73,6 @@ test('preserves custom message types in Chat text component props', () => {
     const baseMessagesProps: NonNullable<
       ChatProps<unknown>['messagesProps']
     > = {
-      onClose() {},
-      onReload() {},
       assistantMessageProps: {
         textComponent({ message }) {
           void message;
@@ -91,6 +83,69 @@ test('preserves custom message types in Chat text component props', () => {
     void baseMessagesProps;
   `;
   const compilerOptions: ts.CompilerOptions = {
+    module: ts.ModuleKind.CommonJS,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2020,
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (sourceName, languageVersion, onError) =>
+    sourceName === fileName
+      ? ts.createSourceFile(fileName, source, languageVersion, true)
+      : getSourceFile(sourceName, languageVersion, onError);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  const errors = ts
+    .getPreEmitDiagnostics(program)
+    .map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+    );
+
+  expect(errors).toEqual([]);
+});
+
+test('accepts Chat text components without widget-owned callbacks', () => {
+  const fileName = path.join(__dirname, 'chat-text-components.tsx');
+  const source = `
+    import { Chat } from '../dist/es';
+    import type { UIMessage } from 'instantsearch.js/es/lib/chat';
+
+    type AppMetadata = { sourceIds: string[] };
+    type AppMessage = UIMessage<AppMetadata>;
+    type AppHit = { objectID: string; __position: number };
+
+    const chat = (
+      <Chat<AppHit, AppMessage>
+        agentId="agent"
+        messagesProps={{
+          assistantMessageProps: {
+            textComponent({ part, message, messages }) {
+              const metadata: AppMetadata | undefined = message.metadata;
+              const conversation: AppMessage[] | undefined = messages;
+              void metadata;
+              void conversation;
+              return <span>{part.text}</span>;
+            },
+          },
+          userMessageProps: {
+            textComponent({ part, message, messages }) {
+              const metadata: AppMetadata | undefined = message.metadata;
+              const conversation: AppMessage[] | undefined = messages;
+              void metadata;
+              void conversation;
+              return <span>{part.text}</span>;
+            },
+          },
+        }}
+      />
+    );
+    void chat;
+  `;
+  const compilerOptions: ts.CompilerOptions = {
+    jsx: ts.JsxEmit.ReactJSX,
     module: ts.ModuleKind.CommonJS,
     moduleResolution: ts.ModuleResolutionKind.Node10,
     noEmit: true,

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -138,6 +138,8 @@ type UserMessagesProps<TUiMessage extends UIMessage = UIMessage> = Omit<
   | 'setIndexUiState'
   | 'scrollRef'
   | 'contentRef'
+  | 'onClose'
+  | 'onReload'
   | 'messageComponent'
   | 'leadingComponent'
   | 'footerComponent'

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
@@ -398,8 +398,6 @@ describe('Chat', () => {
             <span data-testid="assistant-leading" />
           )}
           messagesProps={{
-            onClose: () => {},
-            onReload: () => {},
             assistantMessageProps: { autoHideActions: true },
           }}
         />
@@ -449,8 +447,6 @@ describe('Chat', () => {
           requiresSearch={false}
           showReasoning={true}
           messagesProps={{
-            onClose: () => {},
-            onReload: () => {},
             assistantMessageProps: { parseMarkdown: false },
           }}
         />
@@ -485,8 +481,6 @@ describe('Chat', () => {
       partIndex: number;
     }> = [];
     const messagesProps = {
-      onClose: () => {},
-      onReload: () => {},
       assistantMessageProps: {
         textComponent: ({ part, message, messages, status, partIndex }) => {
           calls.push({
@@ -577,8 +571,6 @@ describe('Chat', () => {
             requiresSearch={false}
             showReasoning={true}
             messagesProps={{
-              onClose: () => {},
-              onReload: () => {},
               assistantMessageProps: { parseMarkdown },
             }}
           />

--- a/tests/common/widgets/chat/reasoning.tsx
+++ b/tests/common/widgets/chat/reasoning.tsx
@@ -149,8 +149,6 @@ export function createReasoningTests(
             ...createDefaultWidgetParams(createChatWithReasoning()),
             showReasoning: true,
             messagesProps: {
-              onClose: () => {},
-              onReload: () => {},
               assistantMessageProps: {
                 autoHideActions: true,
               },

--- a/tests/common/widgets/chat/templates.tsx
+++ b/tests/common/widgets/chat/templates.tsx
@@ -538,8 +538,6 @@ export function createTemplatesTests(
             react: {
               ...createDefaultWidgetParams(chat),
               messagesProps: {
-                onClose: () => {},
-                onReload: () => {},
                 assistantMessageProps: {
                   textComponent: ({
                     part,


### PR DESCRIPTION
## Summary

- omit React-owned callbacks from the public Chat `messagesProps` type
- cover the documented assistant and user text-renderer usage
- remove callback workarounds from Chat tests

## Context

The custom text-renderer docs exposed that `messagesProps` required `onClose` and `onReload` even though React Chat supplies both callbacks.

This fixes the public TypeScript contract without changing runtime behavior.

## Testing

- public React type tests
- React Chat and common Chat tests
- React declaration build and repository typecheck
