### PR TITLE
fix(chat): make closed layouts non-interactive

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatOverlayLayout.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatOverlayLayout.tsx
@@ -28,6 +28,8 @@ export function createChatOverlayLayoutComponent({ createElement }: Renderer) {
       error: _error,
       ...rest
     } = userProps;
+    // React versions before 19 preserve unknown boolean attributes as numbers.
+    const inert = open ? undefined : (1 as unknown as boolean);
 
     return (
       <div
@@ -41,6 +43,7 @@ export function createChatOverlayLayoutComponent({ createElement }: Renderer) {
         )}
       >
         <div
+          inert={inert}
           className={cx(
             'ais-Chat-container',
             open && 'ais-Chat-container--open',

--- a/packages/instantsearch-ui-components/src/components/chat/ChatSidePanelLayout.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatSidePanelLayout.tsx
@@ -37,6 +37,8 @@ export function createChatSidePanelLayoutComponent({
       error: _error,
       ...rest
     } = userProps;
+    // React versions before 19 preserve unknown boolean attributes as numbers.
+    const inert = open ? undefined : (1 as unknown as boolean);
 
     const element =
       typeof document !== 'undefined'
@@ -78,6 +80,7 @@ export function createChatSidePanelLayoutComponent({
         )}
       >
         <div
+          inert={inert}
           className={cx(
             'ais-Chat-container',
             open && 'ais-Chat-container--open',

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatOverlayLayout.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatOverlayLayout.test.tsx
@@ -71,6 +71,41 @@ describe('ChatOverlayLayout', () => {
     );
   });
 
+  test('makes closed content inactive until reopened', () => {
+    const createElementSpy = jest.fn(createElement);
+    const CompatibleChatOverlayLayout = createChatOverlayLayoutComponent({
+      createElement: createElementSpy,
+      Fragment,
+    });
+    const { container, rerender } = render(
+      <CompatibleChatOverlayLayout
+        {...defaultProps}
+        open={false}
+        promptComponent={<button>Send</button>}
+      />
+    );
+    const chatContainer = container.querySelector('.ais-Chat-container')!;
+
+    expect(chatContainer).toHaveAttribute('inert');
+    expect(chatContainer.querySelector('button')).toBeInTheDocument();
+    expect(
+      createElementSpy.mock.calls.some(
+        ([, props]) => (props as { inert?: unknown } | null)?.inert === 1
+      )
+    ).toBe(true);
+
+    rerender(
+      <CompatibleChatOverlayLayout
+        {...defaultProps}
+        open={true}
+        promptComponent={<button>Send</button>}
+      />
+    );
+
+    expect(chatContainer).not.toHaveAttribute('inert');
+    expect(chatContainer.querySelector('button')).toBeInTheDocument();
+  });
+
   test('renders maximized state', () => {
     const { container } = render(
       <ChatOverlayLayout {...defaultProps} maximized={true} />

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatSidePanelLayout.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatSidePanelLayout.test.tsx
@@ -75,6 +75,41 @@ describe('ChatSidePanelLayout', () => {
     );
   });
 
+  test('makes closed content inactive until reopened', () => {
+    const createElementSpy = jest.fn(createElement);
+    const CompatibleChatSidePanelLayout = createChatSidePanelLayoutComponent({
+      createElement: createElementSpy,
+      Fragment,
+    });
+    const { container, rerender } = render(
+      <CompatibleChatSidePanelLayout
+        {...defaultProps}
+        open={false}
+        promptComponent={<button>Send</button>}
+      />
+    );
+    const chatContainer = container.querySelector('.ais-Chat-container')!;
+
+    expect(chatContainer).toHaveAttribute('inert');
+    expect(chatContainer.querySelector('button')).toBeInTheDocument();
+    expect(
+      createElementSpy.mock.calls.some(
+        ([, props]) => (props as { inert?: unknown } | null)?.inert === 1
+      )
+    ).toBe(true);
+
+    rerender(
+      <CompatibleChatSidePanelLayout
+        {...defaultProps}
+        open={true}
+        promptComponent={<button>Send</button>}
+      />
+    );
+
+    expect(chatContainer).not.toHaveAttribute('inert');
+    expect(chatContainer.querySelector('button')).toBeInTheDocument();
+  });
+
   test('renders maximized state', () => {
     const { container } = render(
       <ChatSidePanelLayout {...defaultProps} maximized={true} />


### PR DESCRIPTION
**Summary**

Makes closed Chat overlay and side-panel content non-interactive while keeping it mounted. Adds native `inert` semantics to the shared layouts and regression coverage for closed and reopened states.

[FX-3930](https://algolia.atlassian.net/browse/FX-3930)

**Result**

- Closed overlay and side-panel descendants are inactive.
- Reopening removes `inert` without remounting descendant content.
- Focused tests, declaration build, changed-file lint and format checks and React/Preact renderer compatibility checks pass.
- No visual change.


[FX-3930]: https://algolia.atlassian.net/browse/FX-3930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ