### PR TITLE
fix(chat): warn on unmatched tool results

### DIFF
--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 import { ChatState as RuntimeChatState } from '../../chat/chat';
+import { warning } from '../../utils/logger';
 import { AbstractChat } from '../abstract-chat';
 import { parseJsonEventStream } from '../stream-parser';
 import { lastAssistantMessageIsCompleteWithToolCalls } from '../utils';
@@ -2863,6 +2864,74 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       ]);
     });
 
+    it('warns when queued global routing becomes unsafe before commit', async () => {
+      warning.cache = {};
+      const warn = jest.spyOn(global.console, 'warn');
+      warn.mockImplementation(() => {});
+      const responseStarted = deferred<undefined>();
+      const releaseResponse = deferred<undefined>();
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        streamFactory: () =>
+          new ReadableStream<UIMessageChunk>({
+            start(controller) {
+              controller.enqueue(startChunk('assistant-active'));
+              responseStarted.resolve(undefined);
+              releaseResponse.promise.then(() => {
+                controller.enqueue(finishChunk());
+                controller.close();
+              });
+            },
+          }),
+        sendAutomaticallyWhen,
+      });
+      setup.chat.messages = [
+        {
+          id: 'assistant-restored',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
+
+      try {
+        const send = setup.chat.sendMessage({ text: 'keep working' });
+        await responseStarted.promise;
+        const result = setup.chat.addToolResult({
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { ok: true },
+        });
+        setup.chat.messages = setup.chat.messages.filter(
+          (message) => message.id !== 'assistant-restored'
+        );
+
+        releaseResponse.resolve(undefined);
+        await send;
+        await result;
+
+        expect(warn).toHaveBeenCalledWith(
+          '[InstantSearch.js]: addToolResult ignored because toolCallId "call-1" does not identify one pending tool call. Use the scoped addToolResult callback when call IDs may be reused.'
+        );
+        expect(
+          setup.state.messages.some((message) =>
+            message.parts.some((part) => 'output' in part)
+          )
+        ).toBe(false);
+        expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+        expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      } finally {
+        warn.mockRestore();
+        warning.cache = {};
+      }
+    });
+
     it('ignores a public result when restored messages share a call id', async () => {
       const setup = createTestSetup({
         sendAutomaticallyWhen: () => false,
@@ -4052,19 +4121,245 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(setup.state.status).toBe('ready');
     });
 
-    it('quietly ignores an unknown toolCallId', async () => {
+    it('warns when an unknown global toolCallId is ignored', async () => {
+      warning.cache = {};
+      const warn = jest.spyOn(global.console, 'warn');
+      warn.mockImplementation(() => {});
       const sendAutomaticallyWhen = jest.fn(() => true);
       const setup = createTestSetup({ sendAutomaticallyWhen });
+      setup.chat.messages = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'expected',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
 
-      await setup.chat.addToolResult({
-        tool: 'search',
-        toolCallId: 'missing',
-        output: { ok: true },
+      try {
+        await setup.chat.addToolResult({
+          tool: 'search',
+          toolCallId: 'missing',
+          output: { privateValue: 'do not log' },
+        });
+
+        expect(warn).toHaveBeenCalledWith(
+          '[InstantSearch.js]: addToolResult ignored because toolCallId "missing" does not identify one pending tool call. Use the scoped addToolResult callback when call IDs may be reused.'
+        );
+        expect(warn.mock.calls.join(' ')).not.toContain('do not log');
+        expect(setup.state.messages[0].parts[0]).toMatchObject({
+          toolCallId: 'expected',
+          state: 'input-available',
+        });
+        expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+        expect(setup.sendMessages).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+        warning.cache = {};
+      }
+    });
+
+    it('warns when global identifier-only routing is disabled', async () => {
+      warning.cache = {};
+      const warn = jest.spyOn(global.console, 'warn');
+      warn.mockImplementation(() => {});
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({ sendAutomaticallyWhen });
+      setup.chat.messages = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
+      setup.chat.resetConversationId();
+
+      try {
+        await setup.chat.addToolResult({
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { ok: true },
+        });
+
+        expect(warn).toHaveBeenCalledWith(
+          '[InstantSearch.js]: addToolResult ignored because toolCallId "call-1" does not identify one pending tool call. Use the scoped addToolResult callback when call IDs may be reused.'
+        );
+        expect(setup.state.messages[0].parts[0]).toMatchObject({
+          state: 'input-available',
+        });
+        expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+        expect(setup.sendMessages).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+        warning.cache = {};
+      }
+    });
+
+    it('warns once when a global toolCallId has ambiguous owners', async () => {
+      warning.cache = {};
+      const warn = jest.spyOn(global.console, 'warn');
+      warn.mockImplementation(() => {});
+      const sendAutomaticallyWhen = jest.fn(() => false);
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk('assistant-1'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'shared-call',
+              input: { owner: 'first' },
+            },
+            finishChunk(),
+          ],
+          [
+            startChunk('assistant-2'),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'shared-call',
+              input: { owner: 'second' },
+            },
+            finishChunk(),
+          ],
+        ],
+        onToolCall: () => undefined,
+        sendAutomaticallyWhen,
       });
 
-      expect(setup.state.messages).toEqual([]);
-      expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
-      expect(setup.sendMessages).not.toHaveBeenCalled();
+      try {
+        await setup.chat.sendMessage({ text: 'first search' });
+        await setup.chat.sendMessage({ text: 'second search' });
+        const messagesBeforeResults = setup.chat.messages;
+
+        await setup.chat.addToolResult({
+          tool: 'search',
+          toolCallId: 'shared-call',
+          output: { privateValue: 'first ignored output' },
+        });
+        await setup.chat.addToolResult({
+          tool: 'search',
+          toolCallId: 'shared-call',
+          output: { privateValue: 'second ignored output' },
+        });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalledWith(
+          '[InstantSearch.js]: addToolResult ignored because toolCallId "shared-call" does not identify one pending tool call. Use the scoped addToolResult callback when call IDs may be reused.'
+        );
+        expect(warn.mock.calls.join(' ')).not.toContain('ignored output');
+        expect(setup.chat.messages).toBe(messagesBeforeResults);
+        expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+        expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+      } finally {
+        warn.mockRestore();
+        warning.cache = {};
+      }
+    });
+
+    it('silently ignores an already-settled global duplicate', async () => {
+      warning.cache = {};
+      const warn = jest.spyOn(global.console, 'warn');
+      warn.mockImplementation(() => {});
+      const sendAutomaticallyWhen = jest.fn(() => false);
+      const setup = createTestSetup({ sendAutomaticallyWhen });
+      setup.chat.messages = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
+
+      try {
+        await setup.chat.addToolResult({
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { accepted: true },
+        });
+        await setup.chat.addToolResult({
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { accepted: false },
+        });
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(setup.state.messages[0].parts[0]).toMatchObject({
+          state: 'output-available',
+          output: { accepted: true },
+        });
+        expect(sendAutomaticallyWhen).toHaveBeenCalledTimes(1);
+        expect(setup.sendMessages).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+        warning.cache = {};
+      }
+    });
+
+    it('silently ignores a response-scoped result after retirement', async () => {
+      warning.cache = {};
+      const warn = jest.spyOn(global.console, 'warn');
+      warn.mockImplementation(() => {});
+      let submitResult!: TestChat['addToolResult'];
+      const sendAutomaticallyWhen = jest.fn(() => true);
+      const setup = createTestSetup({
+        chunks: [
+          startChunk('assistant-1'),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: (_options, addToolResult) => {
+          submitResult = addToolResult!;
+        },
+        sendAutomaticallyWhen,
+      });
+
+      try {
+        await setup.chat.sendMessage({ text: 'search' });
+        setup.chat.messages = setup.chat.messages.filter(
+          (message) => message.id !== 'assistant-1'
+        );
+        await submitResult({
+          tool: 'search',
+          toolCallId: 'call-1',
+          output: { privateValue: 'retired output' },
+        });
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(
+          setup.chat.messages.some((message) => message.id === 'assistant-1')
+        ).toBe(false);
+        expect(sendAutomaticallyWhen).not.toHaveBeenCalled();
+        expect(setup.sendMessages).toHaveBeenCalledTimes(1);
+      } finally {
+        warn.mockRestore();
+        warning.cache = {};
+      }
     });
 
     it('settles an unknown public result returned from onToolCall', async () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { isEqual } from '../utils/isEqual';
+import { warning } from '../utils/logger';
 
 import { parsePartialJson } from './parse-partial-json';
 import { processStream } from './stream-parser';
@@ -62,6 +63,13 @@ function getToolName(part: { type: string; toolName?: string }): string {
     return part.toolName ?? part.type;
   }
   return part.type.slice('tool-'.length);
+}
+
+function warnInvalidGlobalToolResult(toolCallId: string): void {
+  warning(
+    false,
+    `addToolResult ignored because toolCallId "${toolCallId}" does not identify one pending tool call. Use the scoped addToolResult callback when call IDs may be reused.`
+  );
 }
 
 // A tool call awaiting an output that the client owns. Provider-executed calls
@@ -728,6 +736,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
    */
   addToolResult: ToolResultSubmission<TUIMessage> = (options) => {
     if (!this.acceptsIdentifierOnlyToolResults) {
+      warnInvalidGlobalToolResult(options.toolCallId);
       return Promise.resolve();
     }
 
@@ -745,14 +754,23 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       );
       return matchingMessages.length === 1 ? matchingMessages[0] : undefined;
     };
-    if (!findMatchingMessage()) return Promise.resolve();
+    if (!findMatchingMessage()) {
+      warnInvalidGlobalToolResult(options.toolCallId);
+      return Promise.resolve();
+    }
 
     return this.jobExecutor.run(() => {
-      if (!this.acceptsIdentifierOnlyToolResults) return Promise.resolve();
+      if (!this.acceptsIdentifierOnlyToolResults) {
+        warnInvalidGlobalToolResult(options.toolCallId);
+        return Promise.resolve();
+      }
 
       const message = findMatchingMessage();
+      if (!message) {
+        warnInvalidGlobalToolResult(options.toolCallId);
+        return Promise.resolve();
+      }
       if (
-        !message ||
         !this.commit(
           options.toolCallId,
           options.output,

--- a/tests/common/widgets/chat/index.ts
+++ b/tests/common/widgets/chat/index.ts
@@ -7,6 +7,7 @@ import { createReasoningTests } from './reasoning';
 import { createStreamingTests } from './streaming';
 import { createTemplatesTests } from './templates';
 import { createToolCancellationTests } from './tool-cancellation';
+import { createToolResultTests } from './tool-results';
 import { createTranslationsTests } from './translations';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -62,6 +63,7 @@ export function createChatWidgetTests(
     createStreamingTests(setup, { act, skippedTests, flavor });
     createTemplatesTests(setup, { act, skippedTests, flavor });
     createToolCancellationTests(setup, { act, skippedTests, flavor });
+    createToolResultTests(setup, { act, skippedTests, flavor });
     createTranslationsTests(setup, { act, skippedTests, flavor });
   });
 }

--- a/tests/common/widgets/chat/tool-results.tsx
+++ b/tests/common/widgets/chat/tool-results.tsx
@@ -65,7 +65,7 @@ export function createToolResultTests(
                 templates: {
                   layout(data) {
                     captureSubmission(data);
-                    return `<span data-tool-call-id="${data.message.toolCallId}"></span>`;
+                    return '<span></span>';
                   },
                 },
               },

--- a/tests/common/widgets/chat/tool-results.tsx
+++ b/tests/common/widgets/chat/tool-results.tsx
@@ -1,0 +1,130 @@
+/** @jsx React.createElement */
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import { Chat } from 'instantsearch.js/es/lib/chat';
+import React from 'react';
+
+import { createDefaultWidgetParams, openChat } from './utils';
+
+import type { ChatWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+import type { ClientSideToolTemplateData } from 'instantsearch.js/es/widgets/chat/chat';
+
+export function createToolResultTests(
+  setup: ChatWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('tool results', () => {
+    test('settles repeated tool calls by id when results arrive in reverse order', async () => {
+      const searchClient = createSearchClient();
+      const submissions = new Map<
+        string,
+        ClientSideToolTemplateData['addToolResult']
+      >();
+      const captureSubmission = ({
+        message,
+        addToolResult,
+      }: ClientSideToolTemplateData) => {
+        submissions.set(message.toolCallId, addToolResult);
+      };
+      const chat = new Chat({
+        id: 'chat-id',
+        persistence: false,
+        messages: [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [
+              {
+                type: 'tool-review',
+                toolCallId: 'review-1',
+                state: 'input-available',
+                input: { item: 'first' },
+              },
+              {
+                type: 'tool-review',
+                toolCallId: 'review-2',
+                state: 'input-available',
+                input: { item: 'second' },
+              },
+            ],
+          },
+        ],
+      });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            tools: {
+              review: {
+                templates: {
+                  layout(data) {
+                    captureSubmission(data);
+                    return `<span data-tool-call-id="${data.message.toolCallId}"></span>`;
+                  },
+                },
+              },
+            },
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            tools: {
+              review: {
+                layoutComponent(data) {
+                  captureSubmission(data);
+                  return (
+                    <span data-tool-call-id={data.message.toolCallId}></span>
+                  );
+                },
+              },
+            },
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      await act(async () => {
+        await submissions.get('review-2')!({
+          output: { settled: 'second' },
+        });
+        await wait(0);
+      });
+
+      expect(chat.messages[0].parts).toMatchObject([
+        { toolCallId: 'review-1', state: 'input-available' },
+        {
+          toolCallId: 'review-2',
+          state: 'output-available',
+          output: { settled: 'second' },
+        },
+      ]);
+
+      await act(async () => {
+        await submissions.get('review-1')!({
+          output: { settled: 'first' },
+        });
+        await wait(0);
+      });
+
+      expect(chat.messages[0].parts).toMatchObject([
+        {
+          toolCallId: 'review-1',
+          state: 'output-available',
+          output: { settled: 'first' },
+        },
+        {
+          toolCallId: 'review-2',
+          state: 'output-available',
+          output: { settled: 'second' },
+        },
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- warn in development when the global `addToolResult` API cannot identify one pending tool call
- preserve exact-ID routing, production no-op behavior and duplicate or stale-callback idempotency
- cover repeated same-named tool calls settled in reverse order through JavaScript and React Chat


Related: [FX-3951](https://algolia.atlassian.net/browse/FX-3951)


[FX-3951]: https://algolia.atlassian.net/browse/FX-3951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ