### PR TITLE
test(chat): cover custom image attributes in display results

### DIFF
--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -1860,9 +1860,13 @@ export function createOptionsTests(
           {
             state = 'output-available',
             output = { status: 'success' },
+            hits = ['1', '2', '3', '4', '5'].map((objectID) => ({
+              objectID,
+            })),
           }: {
             state?: 'input-streaming' | 'input-available' | 'output-available';
             output?: unknown;
+            hits?: Array<Record<string, unknown> & { objectID: string }>;
           } = {}
         ) =>
           ({
@@ -1875,9 +1879,7 @@ export function createOptionsTests(
                 input: { query: 'test' },
                 state: 'output-available',
                 output: {
-                  hits: ['1', '2', '3', '4', '5'].map((objectID) => ({
-                    objectID,
-                  })),
+                  hits,
                 },
               },
               {
@@ -1981,6 +1983,65 @@ export function createOptionsTests(
               )
             ).toHaveLength(2);
           });
+        });
+
+        test('renders a non-default image attribute in display results', async () => {
+          const searchClient = createSearchClient();
+          const thumbnailUrl = 'https://example.com/shoe.jpg';
+
+          const chat = new Chat({
+            messages: [
+              displayResultsMessage(
+                {
+                  groups: [{ results: [{ objectID: '1' }] }],
+                },
+                {
+                  hits: [{ objectID: '1', thumbnail_url: thumbnailUrl }],
+                }
+              ),
+            ],
+            id: 'chat-id',
+          });
+
+          await setup({
+            instantSearchOptions: {
+              indexName: 'indexName',
+              searchClient,
+            },
+            widgetParams: {
+              javascript: {
+                ...createDefaultWidgetParams(chat),
+                templates: {
+                  item: (hit) =>
+                    `<img src="${
+                      (hit as typeof hit & { thumbnail_url: string })
+                        .thumbnail_url
+                    }" alt="" />`,
+                },
+              },
+              react: {
+                ...createDefaultWidgetParams(chat),
+                itemComponent: ({ item }) => (
+                  <img
+                    src={
+                      (item as typeof item & { thumbnail_url: string })
+                        .thumbnail_url
+                    }
+                    alt=""
+                  />
+                ),
+              },
+              vue: {},
+            },
+          });
+
+          await openChat(act);
+
+          expect(
+            document.querySelector(
+              '.ais-ChatToolDisplayResults .ais-Carousel-item img'
+            )
+          ).toHaveAttribute('src', thumbnailUrl);
         });
 
         test('shows the streaming caption only for the active response', async () => {

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -15,6 +15,7 @@ import {
   chatInlineLayout,
   chatSidePanelLayout,
 } from 'instantsearch.js/es/templates';
+import { createElement as createPreactElement } from 'preact';
 import React from 'react';
 import { ChatInlineLayout, ChatSidePanelLayout } from 'react-instantsearch';
 
@@ -2013,10 +2014,11 @@ export function createOptionsTests(
                 ...createDefaultWidgetParams(chat),
                 templates: {
                   item: (hit) =>
-                    `<img src="${
-                      (hit as typeof hit & { thumbnail_url: string })
-                        .thumbnail_url
-                    }" alt="" />`,
+                    createPreactElement('img', {
+                      src: (hit as typeof hit & { thumbnail_url: string })
+                        .thumbnail_url,
+                      alt: '',
+                    }),
                 },
               },
               react: {


### PR DESCRIPTION
## Summary

- cover a non-default `thumbnail_url` from Search tool hits in Display Results
- verify image rendering through public JavaScript and React Chat
- keep runtime behavior unchanged because full-record hydration already preserves custom attributes

Related: [FX-3932](https://algolia.atlassian.net/browse/FX-3932)


[FX-3932]: https://algolia.atlassian.net/browse/FX-3932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ