### PR TITLE
fix(chat): skip provider-executed tool calls when auto-continuing

### DIFF
--- a/packages/instantsearch.js/CLAUDE.md
+++ b/packages/instantsearch.js/CLAUDE.md
@@ -8,6 +8,7 @@ The core package. **Every connector lives here and is consumed by all flavors** 
 - `src/widgets/<name>/<name>.tsx` — vanilla JS widget = connector + default template/rendering. Exported from `src/widgets/index.ts`.
 - `src/components/` — the **JS flavor's Preact components** (the widgets' markup). This is the _legacy_ home for widget layout; newer widgets pull their layout from the shared `instantsearch-ui-components` package instead, and some components here are now thin wrappers that import from it. Add **new shared** markup to `instantsearch-ui-components`, not here.
 - `src/lib/` — the InstantSearch runtime: lifecycle orchestration, routing, helper integration.
+- `src/lib/ai-lite/` — hand-written reimplementation of the Vercel AI SDK's UI layer (`UIMessage` parts, the SSE chunk protocol, the `Chat` state machine `connectChat` drives). It replaced `ai@^5.0.18` in #6880 and tracks nothing upstream: AI SDK fixes land on the `ai@6` line and never reach us. **Before changing its semantics, diff the matching file under [`vercel/ai/packages/ai/src/ui`](https://github.com/vercel/ai/tree/main/packages/ai/src/ui)** — the auto-continue predicate silently missed vercel/ai#9944 (don't resend provider-executed tool turns) for months. Deliberate gaps: no tool-approval flow, no metadata/data-part schema validation, no `finishReason`.
 - `src/types/` — public type definitions.
 
 ## Working here

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/utils.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/utils.test.ts
@@ -8,11 +8,10 @@ import {
 
 import type { UIMessage } from '../types';
 
-const assistantMessage = (parts: unknown[]) =>
-  [
-    { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
-    { id: 'a1', role: 'assistant', parts },
-  ] as unknown as UIMessage[];
+const assistantMessage = (parts: UIMessage['parts']): UIMessage[] => [
+  { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+  { id: 'a1', role: 'assistant', parts },
+];
 
 const resolvedToolPart = (
   extra: Record<string, unknown> = {},

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/utils.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/utils.test.ts
@@ -51,7 +51,7 @@ describe('lastAssistantMessageIsCompleteWithToolCalls', () => {
     ).toBe(false);
   });
 
-  it('still continues when the last step holds an unanswered client tool call', () => {
+  it('still continues when the last step includes a non-provider-executed tool call', () => {
     expect(
       lastAssistantMessageIsCompleteWithToolCalls({
         messages: assistantMessage([

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/utils.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/utils.test.ts
@@ -1,7 +1,108 @@
 /**
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
-import { tryParseErrorMessage } from '../utils';
+import {
+  lastAssistantMessageIsCompleteWithToolCalls,
+  tryParseErrorMessage,
+} from '../utils';
+
+import type { UIMessage } from '../types';
+
+const assistantMessage = (parts: unknown[]) =>
+  [
+    { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+    { id: 'a1', role: 'assistant', parts },
+  ] as unknown as UIMessage[];
+
+const resolvedToolPart = (
+  extra: Record<string, unknown> = {},
+  toolCallId = 'call-1'
+) => ({
+  type: 'tool-search',
+  toolCallId,
+  state: 'output-available',
+  input: { query: 'shirt' },
+  output: { hits: [] },
+  ...extra,
+});
+
+const doneTextPart = { type: 'text', text: 'Here you go.', state: 'done' };
+
+describe('lastAssistantMessageIsCompleteWithToolCalls', () => {
+  it('continues a turn whose client tool calls are all resolved', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: assistantMessage([resolvedToolPart()]),
+      })
+    ).toBe(true);
+  });
+
+  // Matches the AI SDK's fix (vercel/ai#9944): a provider-executed call is the
+  // provider's to answer, so the turn is already complete.
+  it('does not continue a turn made of provider-executed tool calls', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: assistantMessage([
+          { type: 'step-start' },
+          resolvedToolPart({ providerExecuted: true }),
+          doneTextPart,
+        ]),
+      })
+    ).toBe(false);
+  });
+
+  it('still continues when the last step holds an unanswered client tool call', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: assistantMessage([
+          { type: 'step-start' },
+          resolvedToolPart({ providerExecuted: true }, 'call-server'),
+          resolvedToolPart({}, 'call-client'),
+        ]),
+      })
+    ).toBe(true);
+  });
+
+  it('only looks at the last step', () => {
+    // The resolved call belongs to a step the model already answered — the
+    // current step has no tool call to continue on.
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: assistantMessage([
+          { type: 'step-start' },
+          resolvedToolPart(),
+          { type: 'step-start' },
+          doneTextPart,
+        ]),
+      })
+    ).toBe(false);
+  });
+
+  it('ignores steps that are not started explicitly', () => {
+    // Streams without `start-step` chunks produce no `step-start` part; the
+    // whole message is then a single step.
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: assistantMessage([resolvedToolPart(), doneTextPart]),
+      })
+    ).toBe(true);
+  });
+
+  it('does not continue while a tool call is still pending', () => {
+    expect(
+      lastAssistantMessageIsCompleteWithToolCalls({
+        messages: assistantMessage([
+          { type: 'step-start' },
+          {
+            ...resolvedToolPart(),
+            state: 'input-available',
+            output: undefined,
+          },
+        ]),
+      })
+    ).toBe(false);
+  });
+});
 
 describe('tryParseErrorMessage', () => {
   it('returns the trimmed `message` from a JSON object', () => {

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/utils.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/utils.test.ts
@@ -8,9 +8,9 @@ import {
 
 import type { UIMessage } from '../types';
 
-const assistantMessage = (parts: UIMessage['parts']): UIMessage[] => [
+const assistantMessage = (parts: unknown[]): UIMessage[] => [
   { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
-  { id: 'a1', role: 'assistant', parts },
+  { id: 'a1', role: 'assistant', parts: parts as UIMessage['parts'] },
 ];
 
 const resolvedToolPart = (

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -122,6 +122,11 @@ export type DynamicToolUIPart = {
   type: 'dynamic-tool';
   toolName: string;
   toolCallId: string;
+  /**
+   * Whether the tool call was executed by the provider. Carried by the
+   * `dynamic: true` tool chunks, like on `ToolUIPart`.
+   */
+  providerExecuted?: boolean;
 } & (
   | {
       state: 'input-streaming';

--- a/packages/instantsearch.js/src/lib/ai-lite/utils.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/utils.ts
@@ -33,7 +33,21 @@ export function lastAssistantMessageIsCompleteWithToolCalls({
 
   if (!lastMessage.parts || lastMessage.parts.length === 0) return false;
 
-  const toolParts = lastMessage.parts.filter(isToolOrDynamicToolUIPart);
+  // Only the last step of the message counts: earlier steps were answered
+  // before the model was called again, so their resolved tool calls must not
+  // continue the turn a second time.
+  const lastStepStartIndex = lastMessage.parts.reduce(
+    (lastIndex, part, index) =>
+      part.type === 'step-start' ? index : lastIndex,
+    -1
+  );
+
+  const toolParts = lastMessage.parts
+    .slice(lastStepStartIndex + 1)
+    .filter(isToolOrDynamicToolUIPart)
+    // A provider-executed tool call is the provider's to answer, so a turn
+    // made of them is already complete — continuing would resend it.
+    .filter((part) => !part.providerExecuted);
 
   if (toolParts.length === 0) return false;
 


### PR DESCRIPTION
## Summary

Closes a drift between `ai-lite`'s `lastAssistantMessageIsCompleteWithToolCalls` and the AI SDK's. #6880 replaced `ai@^5.0.18` with our own lightweight implementation, reimplementing the predicate as it behaved on the v5 line. Upstream's version has since gained two behaviors ours never picked up:

| | upstream | `ai-lite` before this PR |
| --- | --- | --- |
| skip `providerExecuted` tool parts | yes | no |
| scope to the last step via `step-start` | yes | no — every tool part in the message counts |

The `providerExecuted` filter is [vercel/ai#9944](https://github.com/vercel/ai/pull/9944) ([`97b1d77`](https://github.com/vercel/ai/commit/97b1d7794e1b00fa68bc6aa5191e90abbbd860ad), 2025-10-31), *"Don't resend messages for providerExecuted tools"*:

```diff
   const lastStepToolInvocations = message.parts
     .slice(lastStepStartIndex + 1)
-    .filter(isToolOrDynamicToolUIPart);
+    .filter(isToolOrDynamicToolUIPart)
+    .filter(part => !part.providerExecuted);
```

It shipped in `ai@6.0.0-beta.92`, then `ai@6.0.0`, and was never backported to 5.x — so no version of the dependency we forked from carried it.

Both behaviors apply to us: we emit `step-start` parts for `start-step` chunks (`abstract-chat.ts`), and every `ToolUIPart` state already carries an optional `providerExecuted`.

## Why it matters

A provider-executed tool call is the provider's to answer. Once it has an output, the turn is complete — continuing it resends a finished conversation, which shows up as either a duplicated answer or a rejected request rendered through `messagesErrorComponent`. Same class of bug as #7173, one layer up.

The last-step scoping matters for multi-step turns: without it, a resolved tool call from a step the model has already been called back about keeps satisfying the predicate, so a later step that ends in plain text can still trigger a resend.

Messages with no explicit `step-start` are treated as a single step (`lastStepStartIndex` stays `-1`), so streams that never send `start-step` behave exactly as before.

## Relationship to #7173

Independent, and both are worth having:

- **#7173** stops the resend when the server answers its own tool call *without* setting `providerExecuted` — which is what Agent Studio does today, and the reported FX-3900 / FX-3931 bug. It works on ownership bookkeeping, not on the flag.
- **this PR** covers backends that *do* flag their server-executed tools (an Anthropic `web_search` turn through a custom transport, say), and brings the predicate back in line with the SDK it was forked from.

This one alone does not fix FX-3900; it does not depend on #7173 either. No conflicts — #7173 touches `abstract-chat.ts`, this touches `utils.ts`. Both are branched off `master`.

## Testing

`lastAssistantMessageIsCompleteWithToolCalls` had no direct tests; this adds six to `__tests__/utils.test.ts`, including upstream's regression case from #9944 (a `providerExecuted` tool part with `state: 'output-available'` followed by a `text` part with `state: 'done'` → `false`) and the two no-`step-start` compatibility cases.

- `yarn jest packages/instantsearch.js/src/lib/ai-lite packages/instantsearch.js/src/connectors/chat` — 231 passing (the existing `abstract-chat` continuation suite is unchanged and green, which is the compatibility check that matters here).
- `yarn jest common-widgets -t "Chat widget common tests"`, `yarn lint:changed`, oxfmt — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)