### PR TITLE
feat(tasks): add transport option

### DIFF
--- a/packages/instantsearch.js/scripts/typescript/extract.js
+++ b/packages/instantsearch.js/scripts/typescript/extract.js
@@ -16,7 +16,7 @@ shell.exec(
 );
 
 const taskEndpointDeclaration = fs.readFileSync(
-  path.join(__dirname, '../../es/lib/tasks/endpoint.d.ts'),
+  'es/lib/tasks/endpoint.d.ts',
   'utf8'
 );
 assert.doesNotMatch(

--- a/packages/instantsearch.js/scripts/typescript/extract.js
+++ b/packages/instantsearch.js/scripts/typescript/extract.js
@@ -2,6 +2,8 @@
 
 /* eslint-disable import/no-commonjs, no-console */
 
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const path = require('path');
 
 const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
@@ -11,6 +13,16 @@ console.log(`Compiling definitions...`);
 
 shell.exec(
   `tsc -p ${path.join(__dirname, 'tsconfig.declaration.json')} --outDir es/`
+);
+
+const taskEndpointDeclaration = fs.readFileSync(
+  path.join(__dirname, '../../es/lib/tasks/endpoint.d.ts'),
+  'utf8'
+);
+assert.doesNotMatch(
+  taskEndpointDeclaration,
+  /export declare function createTaskTransport/,
+  '`createTaskTransport` must not be published from the Tasks endpoint declarations.'
 );
 
 // replace block ts-ignore comments with line ones to support TS < 3.9

--- a/packages/instantsearch.js/scripts/typescript/extract.js
+++ b/packages/instantsearch.js/scripts/typescript/extract.js
@@ -2,8 +2,6 @@
 
 /* eslint-disable import/no-commonjs, no-console */
 
-const assert = require('node:assert/strict');
-const fs = require('node:fs');
 const path = require('path');
 
 const { Extractor, ExtractorConfig } = require('@microsoft/api-extractor');
@@ -13,16 +11,6 @@ console.log(`Compiling definitions...`);
 
 shell.exec(
   `tsc -p ${path.join(__dirname, 'tsconfig.declaration.json')} --outDir es/`
-);
-
-const taskEndpointDeclaration = fs.readFileSync(
-  'es/lib/tasks/endpoint.d.ts',
-  'utf8'
-);
-assert.doesNotMatch(
-  taskEndpointDeclaration,
-  /export declare function createTaskTransport/,
-  '`createTaskTransport` must not be published from the Tasks endpoint declarations.'
 );
 
 // replace block ts-ignore comments with line ones to support TS < 3.9

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -809,7 +809,16 @@ describe('connectPromptSuggestions', () => {
       await flush(DEBOUNCE_WAIT);
 
       expect(prepare).toHaveBeenCalledTimes(1);
-      expect(prepare).toHaveBeenCalledWith({
+      const preparedRequest = prepare.mock.calls[0][0];
+      expect({
+        task: preparedRequest.task,
+        input: preparedRequest.input,
+        stream: preparedRequest.stream,
+        body: preparedRequest.body,
+        credentials: preparedRequest.credentials,
+        headers: preparedRequest.headers,
+        api: preparedRequest.api,
+      }).toEqual({
         task: 'prompt-suggestions',
         input: expect.any(Object),
         stream: true,

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -777,9 +777,24 @@ describe('connectPromptSuggestions', () => {
     });
 
     it('lets transport.prepareSendMessagesRequest mutate the body', async () => {
-      const prepare = jest.fn((body: Record<string, unknown>) => ({
-        body: { ...body, injected: true },
-      }));
+      const prepare = jest.fn(
+        (request: {
+          task: string;
+          input: Record<string, unknown>;
+          stream: boolean;
+          body: Record<string, unknown> | undefined;
+          credentials: RequestCredentials | undefined;
+          headers: HeadersInit | undefined;
+          api: string;
+        }) => ({
+          body: {
+            task: request.task,
+            input: request.input,
+            ...request.body,
+            injected: true,
+          },
+        })
+      );
       const widget = connectPromptSuggestions(jest.fn())({
         transport: {
           api: 'https://example.test/agents',
@@ -794,11 +809,55 @@ describe('connectPromptSuggestions', () => {
       await flush(DEBOUNCE_WAIT);
 
       expect(prepare).toHaveBeenCalledTimes(1);
+      expect(prepare).toHaveBeenCalledWith({
+        task: 'prompt-suggestions',
+        input: expect.any(Object),
+        stream: true,
+        body: undefined,
+        credentials: undefined,
+        headers: { 'x-foo': 'bar' },
+        api: 'https://example.test/agents',
+      });
       const [[url, init]] = (global.fetch as jest.Mock).mock.calls;
       expect(url).toBe('https://example.test/agents?stream=true');
       const parsed = JSON.parse((init as RequestInit).body as string);
       expect(parsed.injected).toBe(true);
       expect((init as RequestInit).headers).toMatchObject({ 'x-foo': 'bar' });
+    });
+
+    it('forwards combined agent and transport options to one task request', async () => {
+      const customFetch = jest.fn(() =>
+        Promise.resolve(jsonResponse({ output: { suggestions: ['combined'] } }))
+      ) as unknown as typeof fetch;
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'agent',
+        transport: {
+          api: 'https://custom.test/tasks',
+          credentials: 'include',
+          headers: { 'x-custom': '1' },
+          fetch: customFetch,
+        },
+        configurationId: 'prompt-suggestions',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      expect(customFetch).toHaveBeenCalledWith(
+        'https://custom.test/tasks?stream=true',
+        expect.objectContaining({
+          credentials: 'include',
+          headers: {
+            'x-custom': '1',
+            'x-algolia-application-id': 'appId',
+            'x-algolia-api-key': 'apiKey',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -8,7 +8,7 @@ import {
 } from '../../lib/utils';
 import connectTasks from '../tasks/connectTasks';
 
-import type { TaskTransport } from '../../lib/tasks';
+import type { TaskTransportOptions } from '../../lib/tasks';
 import type {
   Connector,
   DisposeOptions,
@@ -49,8 +49,8 @@ function buildSuggestionMessage(suggestion: string): string {
   return `The user clicked this on-page suggestion. Use the current page context first, then search only if needed.\n\nSuggestion: ${suggestion}`;
 }
 
-/** Custom transport for the task request. Alias of the generic `TaskTransport`, kept for API stability. */
-export type PromptSuggestionsTransport = TaskTransport;
+/** Custom transport for the task request. Alias of the generic `TaskTransportOptions`, kept for API stability. */
+export type PromptSuggestionsTransport = TaskTransportOptions;
 
 /** Metadata passed to `transformItems`. */
 export type PromptSuggestionsTransformItemsMetadata = {

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -90,10 +90,10 @@ export type PromptSuggestionsSource =
   | {
       /** ID of the agent configured in the Algolia dashboard. */
       agentId: string;
-      transport?: never;
+      transport?: PromptSuggestionsTransport;
     }
   | {
-      /** Custom transport. When set, `agentId` and client credentials are ignored. */
+      /** Custom task transport options. */
       transport: PromptSuggestionsTransport;
       agentId?: never;
     };
@@ -412,14 +412,29 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         renderOutward(latestRenderOptions);
       };
 
-      const tasksWidget = connectTasks(
-        handleInnerRender,
-        noop
-      )({
-        ...(transport ? { transport } : { agentId }),
-        task: configurationId,
-        stream: true,
-      } as TasksConnectorParams);
+      let tasksParams: TasksConnectorParams;
+      if (agentId) {
+        tasksParams = {
+          agentId,
+          transport,
+          task: configurationId,
+          stream: true,
+        };
+      } else if (transport) {
+        tasksParams = {
+          transport,
+          task: configurationId,
+          stream: true,
+        };
+      } else {
+        throw new Error(
+          withUsage(
+            'The `agentId` option is required unless a custom `transport` is provided.'
+          )
+        );
+      }
+
+      const tasksWidget = connectTasks(handleInnerRender, noop)(tasksParams);
 
       return {
         $$type: 'ais.promptSuggestions',

--- a/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
@@ -9,6 +9,7 @@ import { createInitOptions } from '../../../../test/createWidget';
 import { connectTasks } from '../../index';
 
 import type { TasksConnectorParams } from '../connectTasks';
+import type { TaskTransport } from 'instantsearch.js/es/lib/tasks';
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -247,6 +248,81 @@ describe('connectTasks', () => {
       expect(request.headers).toMatchObject({ 'x-custom': '1' });
     });
 
+    it('preserves body-only request preparation when spreading its argument', async () => {
+      const customFetch = jest.fn<
+        ReturnType<typeof fetch>,
+        Parameters<typeof fetch>
+      >(() => Promise.resolve(jsonResponse({ output: { ok: true } })));
+      const transport: TaskTransport = {
+        api: 'https://custom.test/tasks',
+        fetch: customFetch,
+        prepareSendMessagesRequest: (body) => ({
+          body: { ...body, locale: 'en' },
+        }),
+      };
+      const { lastState } = init({
+        transport,
+        task: 'generate',
+        stream: false,
+      });
+
+      await expect(lastState().submit({ query: 'shoes' })).resolves.toEqual({
+        ok: true,
+      });
+
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      expect(customFetch).toHaveBeenCalledWith('https://custom.test/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          task: 'generate',
+          input: { query: 'shoes' },
+          locale: 'en',
+        }),
+      });
+    });
+
+    it('serializes in-place body preparation assignments to reserved field names', async () => {
+      const customFetch = jest.fn<
+        ReturnType<typeof fetch>,
+        Parameters<typeof fetch>
+      >(() => Promise.resolve(jsonResponse({ output: { ok: true } })));
+      const transport: TaskTransport = {
+        api: 'https://custom.test/tasks',
+        fetch: customFetch,
+        prepareSendMessagesRequest: (body) => {
+          body.locale = 'en';
+          body.stream = 'payload-stream';
+          body.headers = { audience: 'internal' };
+          body.body = { source: 'suggestions' };
+          return { body };
+        },
+      };
+      const { lastState } = init({
+        transport,
+        task: 'generate',
+        stream: false,
+      });
+
+      await expect(lastState().submit({ query: 'shoes' })).resolves.toEqual({
+        ok: true,
+      });
+
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      expect(customFetch).toHaveBeenCalledWith('https://custom.test/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          task: 'generate',
+          input: { query: 'shoes' },
+          locale: 'en',
+          stream: 'payload-stream',
+          headers: { audience: 'internal' },
+          body: { source: 'suggestions' },
+        }),
+      });
+    });
+
     it('composes agent defaults with explicit transport options', async () => {
       const customFetch = jest.fn(() =>
         Promise.resolve(jsonResponse({ output: { ok: true } }))
@@ -404,7 +480,16 @@ describe('connectTasks', () => {
         code: 'TASK_BLOCKED',
         details: { category: 'restricted_content' },
       });
-      expect(prepareSendMessagesRequest).toHaveBeenCalledWith({
+      const preparedRequest = prepareSendMessagesRequest.mock.calls[0][0];
+      expect({
+        task: preparedRequest.task,
+        input: preparedRequest.input,
+        stream: preparedRequest.stream,
+        body: preparedRequest.body,
+        credentials: preparedRequest.credentials,
+        headers: preparedRequest.headers,
+        api: preparedRequest.api,
+      }).toEqual({
         task: 'generate_suggestions',
         input: { query: 'shoes' },
         stream: true,

--- a/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
@@ -6,7 +6,7 @@ import { createSearchClient } from '@instantsearch/mocks';
 import algoliasearchHelper from 'algoliasearch-helper';
 
 import { createInitOptions } from '../../../../test/createWidget';
-import connectTasks from '../connectTasks';
+import { connectTasks } from '../../index';
 
 import type { TasksConnectorParams } from '../connectTasks';
 
@@ -245,6 +245,99 @@ describe('connectTasks', () => {
       const [[url, request]] = (global.fetch as jest.Mock).mock.calls;
       expect(url).toContain('https://custom.test/tasks');
       expect(request.headers).toMatchObject({ 'x-custom': '1' });
+    });
+
+    it('preserves an error thrown by a custom fetch', async () => {
+      class TaskRequestError extends Error {
+        constructor(
+          message: string,
+          readonly code: string,
+          readonly details: { category: string }
+        ) {
+          super(message);
+        }
+      }
+
+      const networkFetch = jest.fn<
+        ReturnType<typeof fetch>,
+        Parameters<typeof fetch>
+      >(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              message: 'Task request blocked',
+              code: 'TASK_BLOCKED',
+              details: { category: 'restricted_content' },
+            }),
+            { status: 422, headers: { 'Content-Type': 'application/json' } }
+          )
+        )
+      );
+      let requestError: TaskRequestError | undefined;
+      const customFetch = jest.fn<
+        ReturnType<typeof fetch>,
+        Parameters<typeof fetch>
+      >(async (...args) => {
+        const response = await networkFetch(...args);
+        const body: {
+          message: string;
+          code: string;
+          details: { category: string };
+        } = await response.json();
+        requestError = new TaskRequestError(
+          body.message,
+          body.code,
+          body.details
+        );
+        throw requestError;
+      });
+      const prepareSendMessagesRequest = jest.fn(
+        (body: Record<string, unknown>) => ({
+          body: { ...body, configuration: { name: 'preview' } },
+        })
+      );
+      const { lastState } = init({
+        transport: {
+          api: 'https://custom.test/tasks',
+          headers: { 'x-custom': '1' },
+          fetch: customFetch,
+          prepareSendMessagesRequest,
+        },
+        task: 'generate_suggestions',
+      });
+
+      await expect(lastState().submit({ query: 'shoes' })).resolves.toBe(
+        undefined
+      );
+
+      expect(lastState().error).toBe(requestError);
+      expect(lastState().error).toMatchObject({
+        message: 'Task request blocked',
+        code: 'TASK_BLOCKED',
+        details: { category: 'restricted_content' },
+      });
+      expect(prepareSendMessagesRequest).toHaveBeenCalledWith({
+        task: 'generate_suggestions',
+        input: { query: 'shoes' },
+      });
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      expect(networkFetch).toHaveBeenCalledTimes(1);
+      expect(customFetch).toHaveBeenCalledWith(
+        'https://custom.test/tasks?stream=true',
+        {
+          method: 'POST',
+          headers: {
+            'x-custom': '1',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            task: 'generate_suggestions',
+            input: { query: 'shoes' },
+            configuration: { name: 'preview' },
+          }),
+        }
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
@@ -247,6 +247,81 @@ describe('connectTasks', () => {
       expect(request.headers).toMatchObject({ 'x-custom': '1' });
     });
 
+    it('composes agent defaults with explicit transport options', async () => {
+      const customFetch = jest.fn(() =>
+        Promise.resolve(jsonResponse({ output: { ok: true } }))
+      ) as unknown as typeof fetch;
+      const prepareSendMessagesRequest = jest.fn(
+        (request: {
+          task: string;
+          input: Record<string, unknown>;
+          stream: boolean;
+          body: Record<string, unknown> | undefined;
+          credentials: RequestCredentials | undefined;
+          headers: HeadersInit | undefined;
+          api: string;
+        }) => ({
+          body: {
+            task: request.task,
+            input: request.input,
+            ...request.body,
+            prepared: true,
+          },
+          headers: {
+            'x-prepared': 'yes',
+            'x-algolia-application-id': 'spoofed-app',
+          },
+        })
+      );
+      const { lastState } = init({
+        agentId: 'my-agent',
+        transport: {
+          api: 'https://custom.test/tasks',
+          credentials: 'include',
+          headers: { 'x-custom': '1' },
+          body: { locale: 'en' },
+          fetch: customFetch,
+          prepareSendMessagesRequest,
+        },
+        task: 'generate',
+        stream: false,
+      });
+
+      await expect(lastState().submit({ query: 'shoes' })).resolves.toEqual({
+        ok: true,
+      });
+
+      expect(prepareSendMessagesRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: 'generate',
+          input: { query: 'shoes' },
+          stream: false,
+          body: { locale: 'en' },
+          credentials: 'include',
+          api: 'https://custom.test/tasks',
+          headers: expect.objectContaining({
+            'x-custom': '1',
+            'x-algolia-application-id': 'appId',
+            'x-algolia-api-key': 'apiKey',
+          }),
+        })
+      );
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      expect(customFetch).toHaveBeenCalledWith(
+        'https://custom.test/tasks',
+        expect.objectContaining({
+          credentials: 'include',
+          headers: {
+            'x-prepared': 'yes',
+            'x-algolia-application-id': 'appId',
+            'x-algolia-api-key': 'apiKey',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     it('preserves an error thrown by a custom fetch', async () => {
       class TaskRequestError extends Error {
         constructor(
@@ -292,8 +367,21 @@ describe('connectTasks', () => {
         throw requestError;
       });
       const prepareSendMessagesRequest = jest.fn(
-        (body: Record<string, unknown>) => ({
-          body: { ...body, configuration: { name: 'preview' } },
+        (request: {
+          task: string;
+          input: Record<string, unknown>;
+          stream: boolean;
+          body: Record<string, unknown> | undefined;
+          credentials: RequestCredentials | undefined;
+          headers: HeadersInit | undefined;
+          api: string;
+        }) => ({
+          body: {
+            task: request.task,
+            input: request.input,
+            ...request.body,
+            configuration: { name: 'preview' },
+          },
         })
       );
       const { lastState } = init({
@@ -319,6 +407,11 @@ describe('connectTasks', () => {
       expect(prepareSendMessagesRequest).toHaveBeenCalledWith({
         task: 'generate_suggestions',
         input: { query: 'shoes' },
+        stream: true,
+        body: undefined,
+        credentials: undefined,
+        headers: { 'x-custom': '1' },
+        api: 'https://custom.test/tasks',
       });
       expect(customFetch).toHaveBeenCalledTimes(1);
       expect(networkFetch).toHaveBeenCalledTimes(1);
@@ -326,6 +419,7 @@ describe('connectTasks', () => {
         'https://custom.test/tasks?stream=true',
         {
           method: 'POST',
+          credentials: undefined,
           headers: {
             'x-custom': '1',
             'Content-Type': 'application/json',

--- a/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
@@ -1,4 +1,5 @@
-import { createTaskRunner, resolveEndpoint } from '../../lib/tasks';
+import { createTaskRunner } from '../../lib/tasks';
+import { createTaskTransport } from '../../lib/tasks/endpoint';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
@@ -51,7 +52,7 @@ export type TasksRenderState<TOutput = unknown> = {
 export type TasksSource =
   | {
       agentId: string;
-      transport?: never;
+      transport?: TaskTransport;
     }
   | {
       transport: TaskTransport;
@@ -178,17 +179,7 @@ const connectTasks: TasksConnector = function connectTasks<TOutput = unknown>(
       init(initOptions) {
         const { instantSearchInstance } = initOptions;
 
-        if (transport) {
-          const resolved = resolveEndpoint({ transport });
-          runner = createTaskRunner({
-            endpoint: resolved.endpoint,
-            headers: resolved.headers,
-            task,
-            fetch: resolved.fetch,
-            stream,
-            prepareRequest: resolved.prepareSendMessagesRequest,
-          });
-        } else {
+        if (agentId) {
           const [appId, apiKey] = getAppIdAndApiKey(
             instantSearchInstance.client
           );
@@ -201,15 +192,21 @@ const connectTasks: TasksConnector = function connectTasks<TOutput = unknown>(
             );
           }
 
-          const resolved = resolveEndpoint({
+          const taskTransport = createTaskTransport({
+            transport,
             appId,
             apiKey,
             agentId,
             algoliaAgent: getAlgoliaAgent(instantSearchInstance.client),
           });
           runner = createTaskRunner({
-            endpoint: resolved.endpoint,
-            headers: resolved.headers,
+            transport: taskTransport,
+            task,
+            stream,
+          });
+        } else {
+          runner = createTaskRunner({
+            transport: createTaskTransport({ transport }),
             task,
             stream,
           });

--- a/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
@@ -184,6 +184,7 @@ const connectTasks: TasksConnector = function connectTasks<TOutput = unknown>(
             endpoint: resolved.endpoint,
             headers: resolved.headers,
             task,
+            fetch: resolved.fetch,
             stream,
             prepareRequest: resolved.prepareSendMessagesRequest,
           });

--- a/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
@@ -8,7 +8,7 @@ import {
   noop,
 } from '../../lib/utils';
 
-import type { TaskRunner, TaskTransport } from '../../lib/tasks';
+import type { TaskRunner, TaskTransportOptions } from '../../lib/tasks';
 import type { Renderer, Unmounter, Widget } from '../../types';
 
 const withUsage = createDocumentationMessageGenerator({
@@ -52,10 +52,10 @@ export type TasksRenderState<TOutput = unknown> = {
 export type TasksSource =
   | {
       agentId: string;
-      transport?: TaskTransport;
+      transport?: TaskTransportOptions;
     }
   | {
-      transport: TaskTransport;
+      transport: TaskTransportOptions;
       agentId?: never;
     };
 

--- a/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
@@ -1,4 +1,5 @@
 import { createTaskRunner } from '../../lib/tasks';
+// This connector-only helper is intentionally excluded from public declarations.
 import { createTaskTransport } from '../../lib/tasks/endpoint';
 import {
   checkRendering,

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/endpoint-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/endpoint-test.ts
@@ -1,68 +1,194 @@
-import { resolveEndpoint } from '../endpoint';
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
 
-describe('resolveEndpoint', () => {
+import { createTaskTransport } from '../endpoint';
+
+function createFetch() {
+  return jest.fn<ReturnType<typeof fetch>, Parameters<typeof fetch>>(() =>
+    Promise.resolve(
+      new Response(JSON.stringify({ output: { ok: true } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+  );
+}
+
+function send(transport: ReturnType<typeof createTaskTransport>) {
+  return transport.sendTask({ task: 'task', input: {}, stream: false });
+}
+
+describe('createTaskTransport', () => {
   describe('credentials', () => {
-    it('builds the tasks endpoint and sets the Algolia auth headers', () => {
-      const resolved = resolveEndpoint({
+    it('builds the tasks endpoint and sets the Algolia auth headers', async () => {
+      const customFetch = createFetch();
+      const transport = createTaskTransport({
         appId: 'APP',
         apiKey: 'KEY',
         agentId: 'my-agent',
+        transport: { fetch: customFetch },
       });
 
-      expect(resolved.endpoint).toBe(
+      await send(transport);
+
+      const [[url, request]] = customFetch.mock.calls;
+      expect(url).toBe(
         'https://APP.algolia.net/agent-studio/1/agents/my-agent/tasks'
       );
-      expect(resolved.headers).toMatchObject({
+      expect(request?.headers).toMatchObject({
         'x-algolia-application-id': 'APP',
         'x-algolia-api-key': 'KEY',
       });
     });
 
-    it('appends the `; tasks` marker to the x-algolia-agent header', () => {
-      const resolved = resolveEndpoint({
+    it('appends the `; tasks` marker to the x-algolia-agent header', async () => {
+      const customFetch = createFetch();
+      const transport = createTaskTransport({
         appId: 'APP',
         apiKey: 'KEY',
         agentId: 'my-agent',
         algoliaAgent: 'instantsearch.js (4.95.0)',
+        transport: { fetch: customFetch },
       });
 
-      expect(resolved.headers['x-algolia-agent']).toBe(
-        'instantsearch.js (4.95.0); tasks'
-      );
+      await send(transport);
+
+      const [[, request]] = customFetch.mock.calls;
+      expect(request?.headers).toMatchObject({
+        'x-algolia-agent': 'instantsearch.js (4.95.0); tasks',
+      });
     });
 
-    it('omits the x-algolia-agent header when no algoliaAgent is provided', () => {
-      const resolved = resolveEndpoint({
+    it('omits the x-algolia-agent header when no algoliaAgent is provided', async () => {
+      const customFetch = createFetch();
+      const transport = createTaskTransport({
         appId: 'APP',
         apiKey: 'KEY',
         agentId: 'my-agent',
+        transport: { fetch: customFetch },
       });
 
-      expect(resolved.headers).not.toHaveProperty('x-algolia-agent');
+      await send(transport);
+
+      const [[, request]] = customFetch.mock.calls;
+      expect(request?.headers).not.toHaveProperty('x-algolia-agent');
     });
 
     it('throws when credentials are incomplete', () => {
       expect(() =>
-        resolveEndpoint({ appId: 'APP', agentId: 'my-agent' })
-      ).toThrowError(/transport.*appId, apiKey, agentId/);
+        createTaskTransport({ appId: 'APP', agentId: 'my-agent' })
+      ).toThrowError(/appId.*apiKey.*agentId/);
     });
   });
 
   describe('transport', () => {
-    it('uses the transport endpoint and headers verbatim', () => {
-      const prepareSendMessagesRequest = jest.fn();
-      const resolved = resolveEndpoint({
+    it('uses the transport endpoint and headers verbatim', async () => {
+      const customFetch = createFetch();
+      const transport = createTaskTransport({
         transport: {
           api: 'https://custom.test/tasks',
           headers: { 'x-custom': '1' },
+          fetch: customFetch,
+        },
+      });
+
+      await send(transport);
+
+      expect(customFetch).toHaveBeenCalledWith(
+        'https://custom.test/tasks',
+        expect.objectContaining({
+          headers: {
+            'x-custom': '1',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+    });
+
+    it('composes explicit transport options with protected agent headers', async () => {
+      const customFetch = createFetch();
+      const prepareSendMessagesRequest = jest.fn(
+        (request: {
+          task: string;
+          input: Record<string, unknown>;
+          stream: boolean;
+          body: Record<string, unknown> | undefined;
+          credentials: RequestCredentials | undefined;
+          headers: HeadersInit | undefined;
+          api: string;
+        }) => ({
+          body: {
+            task: request.task,
+            input: request.input,
+            ...request.body,
+          },
+          headers: {
+            'x-prepared': 'yes',
+            'x-algolia-application-id': 'spoofed-app',
+            'X-Algolia-API-Key': 'spoofed-key',
+            'x-algolia-agent': 'spoofed-agent',
+          },
+        })
+      );
+      const taskTransport = createTaskTransport({
+        appId: 'APP',
+        apiKey: 'KEY',
+        agentId: 'agent',
+        algoliaAgent: 'instantsearch.js (4.95.0)',
+        transport: {
+          api: 'https://custom.test/tasks',
+          credentials: 'include',
+          headers: {
+            'x-custom': '1',
+            'X-Algolia-Application-ID': 'spoofed-app',
+          },
+          body: { locale: 'en' },
+          fetch: customFetch,
           prepareSendMessagesRequest,
         },
       });
 
-      expect(resolved.endpoint).toBe('https://custom.test/tasks');
-      expect(resolved.headers).toEqual({ 'x-custom': '1' });
-      expect(resolved.prepareSendMessagesRequest).toBe(
-        prepareSendMessagesRequest
+      await expect(
+        taskTransport.sendTask({
+          task: 'generate',
+          input: { query: 'shoes' },
+          stream: false,
+        })
+      ).resolves.toEqual({ ok: true });
+
+      expect(prepareSendMessagesRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: 'generate',
+          input: { query: 'shoes' },
+          stream: false,
+          body: { locale: 'en' },
+          credentials: 'include',
+          api: 'https://custom.test/tasks',
+          headers: expect.objectContaining({
+            'x-custom': '1',
+            'x-algolia-application-id': 'APP',
+            'x-algolia-api-key': 'KEY',
+            'x-algolia-agent': 'instantsearch.js (4.95.0); tasks',
+          }),
+        })
+      );
+      expect(
+        prepareSendMessagesRequest.mock.calls[0][0].headers
+      ).not.toHaveProperty('X-Algolia-Application-ID');
+      expect(customFetch).toHaveBeenCalledTimes(1);
+      expect(customFetch).toHaveBeenCalledWith(
+        'https://custom.test/tasks',
+        expect.objectContaining({
+          credentials: 'include',
+          headers: {
+            'x-prepared': 'yes',
+            'x-algolia-application-id': 'APP',
+            'x-algolia-api-key': 'KEY',
+            'x-algolia-agent': 'instantsearch.js (4.95.0); tasks',
+            'Content-Type': 'application/json',
+          },
+        })
       );
     });
   });

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/fetchTask-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/fetchTask-test.ts
@@ -2,212 +2,50 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 
-import { fetchTask } from '../fetchTask';
+import { fetchTask } from '..';
 
-function jsonResponse(body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  });
-}
-
-// Builds a fake `text/event-stream` response whose body replays `events` as
-// SSE `data:` lines. Kept as a plain object (not a real `Response`) so the test
-// doesn't depend on `Response.body` support in the jsdom environment.
-function sseResponse(events: string[]): Response {
-  const encoder = new TextEncoder();
-  const body = new ReadableStream<Uint8Array>({
-    start(controller) {
-      events.forEach((event) => {
-        controller.enqueue(encoder.encode(`data: ${event}\n\n`));
-      });
-      controller.close();
-    },
-  });
-  return {
-    ok: true,
-    status: 200,
-    headers: {
-      get: (name: string) =>
-        name.toLowerCase() === 'content-type' ? 'text/event-stream' : null,
-    },
-    body,
-  } as unknown as Response;
-}
-
-function outputEvent(output: unknown): string {
-  return JSON.stringify({ type: 'data-task-output', data: { output } });
-}
-
-const OPTIONS = {
-  endpoint: 'https://example.test/agents/xyz/tasks',
-  headers: { 'x-algolia-application-id': 'app' },
-  payload: { task: 'some_task', input: { foo: 'bar' } },
-};
-
-describe('fetchTask', () => {
+describe('fetchTask compatibility', () => {
   const originalFetch = global.fetch;
+
   afterEach(() => {
     global.fetch = originalFetch;
   });
 
-  it('requests the endpoint with `stream=true`, POSTing the payload as JSON', async () => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve(jsonResponse({ output: { ok: true } }))
-    ) as unknown as typeof fetch;
-
-    await fetchTask(OPTIONS);
-
-    const [[url, init]] = (global.fetch as jest.Mock).mock.calls;
-    expect(url).toBe('https://example.test/agents/xyz/tasks?stream=true');
-    expect(init.method).toBe('POST');
-    expect(init.headers).toMatchObject({
-      'x-algolia-application-id': 'app',
-      'Content-Type': 'application/json',
-    });
-    expect(JSON.parse(init.body)).toEqual(OPTIONS.payload);
-  });
-
-  it('appends `stream=true` to an endpoint that already has a query string', async () => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve(jsonResponse({ output: {} }))
-    ) as unknown as typeof fetch;
-
-    await fetchTask({ ...OPTIONS, endpoint: `${OPTIONS.endpoint}?v=1` });
-
-    const [[url]] = (global.fetch as jest.Mock).mock.calls;
-    expect(url).toBe('https://example.test/agents/xyz/tasks?v=1&stream=true');
-  });
-
-  it('resolves with the buffered JSON body when the response is not a stream', async () => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve(jsonResponse({ output: { suggestions: ['a', 'b'] } }))
-    ) as unknown as typeof fetch;
-
-    const onData = jest.fn();
-    const result = await fetchTask({ ...OPTIONS, onData });
-
-    expect(result).toEqual({ output: { suggestions: ['a', 'b'] } });
-    // A buffered response never streams, so `onData` is not called.
-    expect(onData).not.toHaveBeenCalled();
-  });
-
-  it('streams each accumulated snapshot and resolves with the final payload', async () => {
-    global.fetch = jest.fn(() =>
+  it('performs one request and returns the response envelope', async () => {
+    const envelope = { output: { suggestions: ['one'] } };
+    const fetchMock = jest.fn(() =>
       Promise.resolve(
-        sseResponse([
-          JSON.stringify({ type: 'start' }),
-          outputEvent({ suggestions: [''] }),
-          outputEvent({ suggestions: ['What'] }),
-          outputEvent({ suggestions: ['What', 'Any deals?'] }),
-          JSON.stringify({ type: 'finish' }),
-          '[DONE]',
-        ])
+        new Response(JSON.stringify(envelope), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
       )
-    ) as unknown as typeof fetch;
+    );
+    global.fetch = jest.fn();
 
-    const seen: unknown[] = [];
-    const result = await fetchTask({
-      ...OPTIONS,
-      onData: (data) => seen.push(data),
-    });
-
-    expect(seen).toEqual([
-      { output: { suggestions: [''] } },
-      { output: { suggestions: ['What'] } },
-      { output: { suggestions: ['What', 'Any deals?'] } },
-    ]);
-    expect(result).toEqual({ output: { suggestions: ['What', 'Any deals?'] } });
-  });
-
-  it('repairs a raw partial-JSON output payload while streaming', async () => {
-    // `data` is the raw (still-incomplete) JSON text the model emits, not a
-    // pre-parsed object — exercising the shared partial-JSON repair.
-    global.fetch = jest.fn(() =>
-      Promise.resolve(
-        sseResponse([
-          JSON.stringify({
-            type: 'data-task-output',
-            data: '{"output":{"suggestions":["Wh',
-          }),
-          JSON.stringify({
-            type: 'data-task-output',
-            data: '{"output":{"suggestions":["What?"]}}',
-          }),
-          '[DONE]',
-        ])
-      )
-    ) as unknown as typeof fetch;
-
-    const seen: unknown[] = [];
-    const result = await fetchTask({
-      ...OPTIONS,
-      onData: (data) => seen.push(data),
-    });
-
-    // The unterminated first payload is repaired into a usable partial.
-    expect(seen[0]).toEqual({ output: { suggestions: ['Wh'] } });
-    expect(result).toEqual({ output: { suggestions: ['What?'] } });
-  });
-
-  it('rejects when the stream emits a terminal `error` event', async () => {
-    // The backend can stream partial output and then fail; the terminal
-    // `error` event must reject rather than resolve the last partial snapshot
-    // as a success.
-    global.fetch = jest.fn(() =>
-      Promise.resolve(
-        sseResponse([
-          outputEvent({ suggestions: ['What'] }),
-          JSON.stringify({ type: 'error', errorText: 'stream failed' }),
-          '[DONE]',
-        ])
-      )
-    ) as unknown as typeof fetch;
-
-    const seen: unknown[] = [];
     await expect(
-      fetchTask({ ...OPTIONS, onData: (data) => seen.push(data) })
-    ).rejects.toThrow('stream failed');
+      fetchTask({
+        endpoint: 'https://example.test/tasks',
+        headers: { 'x-custom': 'yes' },
+        payload: { task: 'recommend', input: { query: 'shoes' } },
+        fetch: fetchMock,
+        stream: false,
+      })
+    ).resolves.toEqual(envelope);
 
-    // Any partial received before the error is not surfaced as a result.
-    expect(seen).toEqual([{ output: { suggestions: ['What'] } }]);
-  });
-
-  it('omits `stream=true` and reads JSON when `stream` is false', async () => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve(jsonResponse({ output: { suggestions: ['a'] } }))
-    ) as unknown as typeof fetch;
-
-    const onData = jest.fn();
-    const result = await fetchTask({ ...OPTIONS, stream: false, onData });
-
-    const [[url]] = (global.fetch as jest.Mock).mock.calls;
-    expect(url).toBe('https://example.test/agents/xyz/tasks');
-    expect(result).toEqual({ output: { suggestions: ['a'] } });
-    expect(onData).not.toHaveBeenCalled();
-  });
-
-  it('reads JSON even from an event-stream body when `stream` is false', async () => {
-    // A caller that opted out of streaming should never consume the SSE body,
-    // even if the server responds with one.
-    global.fetch = jest.fn(() =>
-      Promise.resolve(sseResponse([outputEvent({ suggestions: ['x'] })]))
-    ) as unknown as typeof fetch;
-
-    const onData = jest.fn();
-    // `sseResponse` has no `.json()`, so reaching the JSON branch would throw —
-    // asserting the rejection is enough to prove we didn't take the stream path.
-    await expect(
-      fetchTask({ ...OPTIONS, stream: false, onData })
-    ).rejects.toThrow();
-    expect(onData).not.toHaveBeenCalled();
-  });
-
-  it('rejects on a non-ok response', async () => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve(new Response('nope', { status: 500 }))
-    ) as unknown as typeof fetch;
-
-    await expect(fetchTask(OPTIONS)).rejects.toThrow('HTTP error 500');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('https://example.test/tasks', {
+      method: 'POST',
+      credentials: undefined,
+      headers: {
+        'x-custom': 'yes',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        task: 'recommend',
+        input: { query: 'shoes' },
+      }),
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/public-types.test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/public-types.test.ts
@@ -8,14 +8,16 @@ import {
   type ResolvedEndpoint,
   type TaskEndpoint,
   type TaskPrepareRequest,
+  type TaskRunnerOptions,
   type TaskTransport,
+  type TaskTransportOptions,
 } from 'instantsearch.js/es/lib/tasks';
 
 import type { TasksConnectorParams } from 'instantsearch.js/es/connectors/tasks/connectTasks';
 
 describe('tasks public types', () => {
   it('supports default, custom, prepared, and combined agent configuration', () => {
-    const transport: TaskTransport = {
+    const transport: TaskTransportOptions = {
       api: '/custom/tasks',
       credentials: () => Promise.resolve<RequestCredentials>('include'),
       headers: async () => new Headers({ 'x-custom': '1' }),
@@ -40,15 +42,45 @@ describe('tasks public types', () => {
       transport,
       task: 'generate',
     };
+    const releasedTransport: TaskTransport = {
+      api: '/custom/tasks',
+      prepareSendMessagesRequest: (body) => ({ body: { ...body } }),
+    };
+    const releasedPreparation: TasksConnectorParams = {
+      transport: releasedTransport,
+      task: 'generate',
+    };
+    // @ts-expect-error Rich options are resolved asynchronously by DefaultTaskTransport.
+    const endpointWithRichTransport: TaskEndpoint = { transport };
+    type ResolveEndpointOptions = Parameters<typeof resolveEndpoint>[0];
+    // @ts-expect-error Rich options are not accepted by the synchronous endpoint helper.
+    const resolvedRichTransport: ResolveEndpointOptions = { transport };
+    void endpointWithRichTransport;
+    void resolvedRichTransport;
 
-    expect([defaultTransport, customTransport, combined.transport]).toEqual([
+    expect([
+      defaultTransport,
+      customTransport,
+      combined.transport,
+      releasedPreparation.transport,
+    ]).toEqual([
       expect.any(DefaultTaskTransport),
       expect.any(DefaultTaskTransport),
       transport,
+      releasedTransport,
     ]);
   });
 
   it('preserves the published task helper surface', () => {
+    const endpointTransport: TaskTransport = {
+      api: 'https://example.test/tasks',
+    };
+    const transportEndpoint: TaskEndpoint = {
+      transport: endpointTransport,
+    };
+    const resolvedTransport = resolveEndpoint({
+      transport: endpointTransport,
+    });
     const prepareRequest: TaskPrepareRequest = (body) => ({
       body: { ...body, locale: 'en' },
     });
@@ -73,12 +105,21 @@ describe('tasks public types', () => {
       payload: buildTaskPayload(payloadOptions),
       stream: false,
     };
+    const runnerOptions: TaskRunnerOptions = {
+      endpoint: resolved.endpoint,
+      headers: resolved.headers,
+      task: 'recommend',
+      transport: undefined,
+    };
 
     expect(fetchOptions.payload).toEqual({
       task: 'recommend',
       input: { query: 'shoes' },
       locale: 'en',
     });
+    expect(transportEndpoint.transport).toBe(endpointTransport);
+    expect(resolvedTransport.endpoint).toBe('https://example.test/tasks');
+    void runnerOptions;
     expect(fetchTask).toEqual(expect.any(Function));
   });
 });

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/public-types.test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/public-types.test.ts
@@ -1,0 +1,84 @@
+import {
+  buildTaskPayload,
+  DefaultTaskTransport,
+  fetchTask,
+  resolveEndpoint,
+  type BuildTaskPayloadOptions,
+  type FetchTaskOptions,
+  type ResolvedEndpoint,
+  type TaskEndpoint,
+  type TaskPrepareRequest,
+  type TaskTransport,
+} from 'instantsearch.js/es/lib/tasks';
+
+import type { TasksConnectorParams } from 'instantsearch.js/es/connectors/tasks/connectTasks';
+
+describe('tasks public types', () => {
+  it('supports default, custom, prepared, and combined agent configuration', () => {
+    const transport: TaskTransport = {
+      api: '/custom/tasks',
+      credentials: () => Promise.resolve<RequestCredentials>('include'),
+      headers: async () => new Headers({ 'x-custom': '1' }),
+      body: async () => ({ locale: 'en' }),
+      fetch: (...args) => fetch(...args),
+      prepareSendMessagesRequest: (request) =>
+        Promise.resolve({
+          api: request.api,
+          credentials: request.credentials,
+          headers: request.headers,
+          body: {
+            task: request.task,
+            input: request.input,
+            ...request.body,
+          },
+        }),
+    };
+    const defaultTransport = new DefaultTaskTransport();
+    const customTransport = new DefaultTaskTransport(transport);
+    const combined: TasksConnectorParams = {
+      agentId: 'agent',
+      transport,
+      task: 'generate',
+    };
+
+    expect([defaultTransport, customTransport, combined.transport]).toEqual([
+      expect.any(DefaultTaskTransport),
+      expect.any(DefaultTaskTransport),
+      transport,
+    ]);
+  });
+
+  it('preserves the published task helper surface', () => {
+    const prepareRequest: TaskPrepareRequest = (body) => ({
+      body: { ...body, locale: 'en' },
+    });
+    const payloadOptions: BuildTaskPayloadOptions = {
+      task: 'recommend',
+      input: { query: 'shoes' },
+      prepareRequest,
+    };
+    const endpointOptions: TaskEndpoint = {
+      credentials: {
+        appId: 'app',
+        apiKey: 'key',
+        agentId: 'agent',
+      },
+    };
+    const resolved: ResolvedEndpoint = resolveEndpoint({
+      ...endpointOptions.credentials,
+    });
+    const fetchOptions: FetchTaskOptions = {
+      endpoint: resolved.endpoint,
+      headers: resolved.headers,
+      payload: buildTaskPayload(payloadOptions),
+      stream: false,
+    };
+
+    expect(fetchOptions.payload).toEqual({
+      task: 'recommend',
+      input: { query: 'shoes' },
+      locale: 'en',
+    });
+    expect(fetchTask).toEqual(expect.any(Function));
+  });
+});

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/public-types.test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/public-types.test.ts
@@ -125,7 +125,9 @@ describe('tasks public types', () => {
   });
 
   it('keeps published task runner option fields readable', () => {
-    function readOptions(options: TaskRunnerOptions) {
+    type ReflectedTaskRunnerOptions = Parameters<typeof createTaskRunner>[0];
+
+    function readOptions(options: ReflectedTaskRunnerOptions) {
       const endpoint: string = options.endpoint;
       const headers: Record<string, string> = options.headers;
       const prepareRequest: TaskPrepareRequest | undefined =
@@ -135,7 +137,7 @@ describe('tasks public types', () => {
     }
 
     const prepareRequest: TaskPrepareRequest = (body) => ({ body });
-    const options: TaskRunnerOptions = {
+    const options: ReflectedTaskRunnerOptions = {
       endpoint: 'https://example.test/tasks',
       headers: { 'x-custom': '1' },
       task: 'recommend',

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/public-types.test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/public-types.test.ts
@@ -1,5 +1,6 @@
 import {
   buildTaskPayload,
+  createTaskRunner,
   DefaultTaskTransport,
   fetchTask,
   resolveEndpoint,
@@ -121,5 +122,35 @@ describe('tasks public types', () => {
     expect(resolvedTransport.endpoint).toBe('https://example.test/tasks');
     void runnerOptions;
     expect(fetchTask).toEqual(expect.any(Function));
+  });
+
+  it('keeps published task runner option fields readable', () => {
+    function readOptions(options: TaskRunnerOptions) {
+      const endpoint: string = options.endpoint;
+      const headers: Record<string, string> = options.headers;
+      const prepareRequest: TaskPrepareRequest | undefined =
+        options.prepareRequest;
+
+      return { endpoint, headers, prepareRequest };
+    }
+
+    const prepareRequest: TaskPrepareRequest = (body) => ({ body });
+    const options: TaskRunnerOptions = {
+      endpoint: 'https://example.test/tasks',
+      headers: { 'x-custom': '1' },
+      task: 'recommend',
+      prepareRequest,
+    };
+    const transportRunner = createTaskRunner({
+      transport: new DefaultTaskTransport(),
+      task: 'recommend',
+    });
+
+    expect(readOptions(options)).toEqual({
+      endpoint: 'https://example.test/tasks',
+      headers: { 'x-custom': '1' },
+      prepareRequest,
+    });
+    void transportRunner;
   });
 });

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/taskRunner-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/taskRunner-test.ts
@@ -5,6 +5,7 @@
 import {
   createTaskRunner,
   DefaultTaskTransport,
+  resolveEndpoint,
   type TaskRunnerOptions,
 } from 'instantsearch.js/es/lib/tasks';
 
@@ -86,6 +87,47 @@ describe('createTaskRunner', () => {
     });
 
     expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards resolved custom fetch with the endpoint options shape', async () => {
+    const customFetch = jest.fn<
+      ReturnType<typeof fetch>,
+      Parameters<typeof fetch>
+    >(() => Promise.resolve(jsonResponse({ output: { ok: true } })));
+    const globalFetch = jest.fn<
+      ReturnType<typeof fetch>,
+      Parameters<typeof fetch>
+    >(() => Promise.resolve(jsonResponse({ output: { ok: false } })));
+    global.fetch = globalFetch;
+    const runner = createTaskRunner({
+      ...resolveEndpoint({
+        transport: {
+          api: 'https://example.test/tasks',
+          headers: { 'x-custom': '1' },
+          fetch: customFetch,
+        },
+      }),
+      task: 'recommend',
+      stream: false,
+    });
+
+    await expect(runner.submit({ query: 'shoes' })).resolves.toEqual({
+      ok: true,
+    });
+
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    expect(customFetch).toHaveBeenCalledWith('https://example.test/tasks', {
+      method: 'POST',
+      headers: {
+        'x-custom': '1',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        task: 'recommend',
+        input: { query: 'shoes' },
+      }),
+    });
+    expect(globalFetch).not.toHaveBeenCalled();
   });
 
   it('accepts the current transport options shape', async () => {

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/taskRunner-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/taskRunner-test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import {
+  createTaskRunner,
+  DefaultTaskTransport,
+  type TaskRunnerOptions,
+} from 'instantsearch.js/es/lib/tasks';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('createTaskRunner', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('accepts the endpoint options shape', async () => {
+    const customFetch = jest.fn<
+      ReturnType<typeof fetch>,
+      Parameters<typeof fetch>
+    >(() =>
+      Promise.resolve(
+        jsonResponse({ output: { suggestions: ['recommended'] } })
+      )
+    );
+    const prepareRequest = jest.fn((body: Record<string, unknown>) => ({
+      body: { ...body, locale: 'en' },
+    }));
+    global.fetch = customFetch;
+    const runner = createTaskRunner({
+      endpoint: 'https://example.test/tasks',
+      headers: { 'x-custom': '1' },
+      task: 'recommend',
+      stream: false,
+      prepareRequest,
+    });
+
+    await expect(
+      Promise.resolve().then(() => runner.submit({ query: 'shoes' }))
+    ).resolves.toEqual({ suggestions: ['recommended'] });
+
+    expect(prepareRequest).toHaveBeenCalledWith({
+      task: 'recommend',
+      input: { query: 'shoes' },
+    });
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    expect(customFetch).toHaveBeenCalledWith('https://example.test/tasks', {
+      method: 'POST',
+      headers: {
+        'x-custom': '1',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        task: 'recommend',
+        input: { query: 'shoes' },
+        locale: 'en',
+      }),
+    });
+  });
+
+  it('accepts endpoint options with an undefined transport property', async () => {
+    const customFetch = jest.fn<
+      ReturnType<typeof fetch>,
+      Parameters<typeof fetch>
+    >(() => Promise.resolve(jsonResponse({ output: { ok: true } })));
+    global.fetch = customFetch;
+    const options: TaskRunnerOptions = {
+      endpoint: 'https://example.test/tasks',
+      headers: { 'x-custom': '1' },
+      task: 'recommend',
+      stream: false,
+      transport: undefined,
+    };
+    const runner = createTaskRunner(options);
+
+    await expect(runner.submit({ query: 'shoes' })).resolves.toEqual({
+      ok: true,
+    });
+
+    expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the current transport options shape', async () => {
+    const customFetch = jest.fn<
+      ReturnType<typeof fetch>,
+      Parameters<typeof fetch>
+    >(() => Promise.resolve(jsonResponse({ output: { ok: true } })));
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+    const runner = createTaskRunner({
+      transport,
+      task: 'recommend',
+      stream: false,
+    });
+
+    await expect(runner.submit({ query: 'shoes' })).resolves.toEqual({
+      ok: true,
+    });
+    expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
@@ -1,0 +1,281 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { DefaultTaskTransport } from '..';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function sseResponse(events: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      events.forEach((event) => {
+        controller.enqueue(encoder.encode(`data: ${event}\n\n`));
+      });
+      controller.close();
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type' ? 'text/event-stream' : null,
+    },
+    body,
+  } as unknown as Response;
+}
+
+function outputEvent(output: unknown): string {
+  return JSON.stringify({ type: 'data-task-output', data: { output } });
+}
+
+describe('DefaultTaskTransport', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('owns async request preparation and performs exactly one request', async () => {
+    const customFetch = jest.fn(
+      (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+        Promise.resolve(jsonResponse({ output: { suggestions: ['a'] } }))
+    );
+    const prepareSendMessagesRequest = jest.fn(
+      async (request: {
+        task: string;
+        input: Record<string, unknown>;
+        stream: boolean;
+        body: Record<string, unknown> | undefined;
+        credentials: RequestCredentials | undefined;
+        headers: HeadersInit | undefined;
+        api: string;
+      }) => ({
+        api: 'https://prepared.test/tasks',
+        credentials: 'same-origin' as const,
+        headers: { 'x-prepared': 'yes' },
+        body: {
+          task: request.task,
+          input: request.input,
+          ...request.body,
+          prepared: true,
+        },
+      })
+    );
+    const transport = new DefaultTaskTransport({
+      api: 'https://initial.test/tasks',
+      credentials: () => Promise.resolve<RequestCredentials>('include'),
+      headers: async () => new Headers({ 'x-initial': 'yes' }),
+      body: async () => ({ locale: 'en' }),
+      fetch: customFetch,
+      prepareSendMessagesRequest,
+    });
+
+    await expect(
+      transport.sendTask({
+        task: 'generate_suggestions',
+        input: { query: 'shoes' },
+        stream: true,
+      })
+    ).resolves.toEqual({ suggestions: ['a'] });
+
+    expect(prepareSendMessagesRequest).toHaveBeenCalledWith({
+      task: 'generate_suggestions',
+      input: { query: 'shoes' },
+      stream: true,
+      body: { locale: 'en' },
+      credentials: 'include',
+      headers: expect.any(Headers),
+      api: 'https://initial.test/tasks',
+    });
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    expect(customFetch).toHaveBeenCalledWith(
+      'https://prepared.test/tasks?stream=true',
+      {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'x-prepared': 'yes',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          task: 'generate_suggestions',
+          input: { query: 'shoes' },
+          locale: 'en',
+          prepared: true,
+        }),
+      }
+    );
+  });
+
+  it('preserves the exact error thrown by a custom fetch', async () => {
+    class StructuredTaskError extends Error {
+      constructor(
+        message: string,
+        readonly code: string,
+        readonly details: { category: string }
+      ) {
+        super(message);
+      }
+    }
+    const requestError = new StructuredTaskError('blocked', 'TASK_BLOCKED', {
+      category: 'off_topic',
+    });
+    const customFetch = jest.fn(
+      (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+        Promise.reject(requestError)
+    );
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+
+    await expect(
+      transport.sendTask({ task: 't', input: {}, stream: false })
+    ).rejects.toBe(requestError);
+    expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the default API and merges configured body fields', async () => {
+    const customFetch = jest.fn(
+      (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+        Promise.resolve(jsonResponse({ output: { ok: true } }))
+    );
+    const transport = new DefaultTaskTransport({
+      body: { locale: 'en' },
+      fetch: customFetch,
+    });
+
+    await transport.sendTask({
+      task: 'generate',
+      input: { query: 'shoes' },
+      stream: false,
+    });
+
+    expect(customFetch).toHaveBeenCalledWith('/api/tasks', {
+      method: 'POST',
+      credentials: undefined,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        task: 'generate',
+        input: { query: 'shoes' },
+        locale: 'en',
+      }),
+    });
+  });
+
+  it('appends streaming to an API that already has query parameters', async () => {
+    const customFetch = jest.fn(
+      (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+        Promise.resolve(jsonResponse({ output: { ok: true } }))
+    );
+    const transport = new DefaultTaskTransport({
+      api: 'https://example.test/tasks?version=1',
+      fetch: customFetch,
+    });
+
+    await transport.sendTask({ task: 't', input: {}, stream: true });
+
+    expect(customFetch).toHaveBeenCalledWith(
+      'https://example.test/tasks?version=1&stream=true',
+      expect.any(Object)
+    );
+  });
+
+  it('streams unwrapped snapshots and resolves the final output', async () => {
+    const customFetch = jest.fn(() =>
+      Promise.resolve(
+        sseResponse([
+          JSON.stringify({ type: 'start' }),
+          outputEvent({ value: 'a' }),
+          outputEvent({ value: 'ab' }),
+          JSON.stringify({ type: 'finish' }),
+          '[DONE]',
+        ])
+      )
+    ) as unknown as typeof fetch;
+    const onData = jest.fn();
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+
+    await expect(
+      transport.sendTask({ task: 't', input: {}, stream: true, onData })
+    ).resolves.toEqual({ value: 'ab' });
+    expect(onData.mock.calls).toEqual([[{ value: 'a' }], [{ value: 'ab' }]]);
+  });
+
+  it('repairs partial JSON while streaming', async () => {
+    const customFetch = jest.fn(() =>
+      Promise.resolve(
+        sseResponse([
+          JSON.stringify({
+            type: 'data-task-output',
+            data: '{"output":{"suggestions":["Wh',
+          }),
+          JSON.stringify({
+            type: 'data-task-output',
+            data: '{"output":{"suggestions":["What?"]}}',
+          }),
+          '[DONE]',
+        ])
+      )
+    ) as unknown as typeof fetch;
+    const onData = jest.fn();
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+
+    await expect(
+      transport.sendTask({ task: 't', input: {}, stream: true, onData })
+    ).resolves.toEqual({ suggestions: ['What?'] });
+    expect(onData.mock.calls[0][0]).toEqual({ suggestions: ['Wh'] });
+  });
+
+  it('uses buffered JSON and does not emit partial data when streaming is disabled', async () => {
+    const customFetch = jest.fn(
+      (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+        Promise.resolve(jsonResponse({ output: { done: true } }))
+    );
+    const onData = jest.fn();
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+
+    await expect(
+      transport.sendTask({ task: 't', input: {}, stream: false, onData })
+    ).resolves.toEqual({ done: true });
+    expect(onData).not.toHaveBeenCalled();
+  });
+
+  it('keeps the generic default error for a non-success response', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve(new Response('nope', { status: 503 }))
+    ) as unknown as typeof fetch;
+    const transport = new DefaultTaskTransport();
+
+    await expect(
+      transport.sendTask({ task: 't', input: {}, stream: false })
+    ).rejects.toThrow('HTTP error 503');
+  });
+
+  it('streams unwrapped partial outputs and rejects terminal errors', async () => {
+    const onData = jest.fn();
+    const customFetch = jest.fn(() =>
+      Promise.resolve(
+        sseResponse([
+          JSON.stringify({
+            type: 'data-task-output',
+            data: { output: { value: 'partial' } },
+          }),
+          JSON.stringify({ type: 'error', errorText: 'stream failed' }),
+          '[DONE]',
+        ])
+      )
+    ) as unknown as typeof fetch;
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+
+    await expect(
+      transport.sendTask({ task: 't', input: {}, stream: true, onData })
+    ).rejects.toThrow('stream failed');
+    expect(onData).toHaveBeenCalledWith({ value: 'partial' });
+  });
+});

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
@@ -86,7 +86,16 @@ describe('DefaultTaskTransport', () => {
       })
     ).resolves.toEqual({ suggestions: ['a'] });
 
-    expect(prepareSendMessagesRequest).toHaveBeenCalledWith({
+    const preparedRequest = prepareSendMessagesRequest.mock.calls[0][0];
+    expect({
+      task: preparedRequest.task,
+      input: preparedRequest.input,
+      stream: preparedRequest.stream,
+      body: preparedRequest.body,
+      credentials: preparedRequest.credentials,
+      headers: preparedRequest.headers,
+      api: preparedRequest.api,
+    }).toEqual({
       task: 'generate_suggestions',
       input: { query: 'shoes' },
       stream: true,

--- a/packages/instantsearch.js/src/lib/tasks/endpoint.ts
+++ b/packages/instantsearch.js/src/lib/tasks/endpoint.ts
@@ -5,6 +5,8 @@ export type TaskPrepareRequest = (body: Record<string, unknown>) => {
 export type TaskTransport = {
   api: string;
   headers?: Record<string, string>;
+  /** Custom fetch implementation. Defaults to the global `fetch`. */
+  fetch?: typeof fetch;
   prepareSendMessagesRequest?: TaskPrepareRequest;
 };
 
@@ -21,6 +23,7 @@ export type TaskEndpoint =
 export type ResolvedEndpoint = {
   endpoint: string;
   headers: Record<string, string>;
+  fetch?: TaskTransport['fetch'];
   prepareSendMessagesRequest?: TaskTransport['prepareSendMessagesRequest'];
 };
 
@@ -45,6 +48,7 @@ export function resolveEndpoint(params: {
     return {
       endpoint: params.transport.api,
       headers: params.transport.headers || {},
+      fetch: params.transport.fetch,
       prepareSendMessagesRequest: params.transport.prepareSendMessagesRequest,
     };
   }

--- a/packages/instantsearch.js/src/lib/tasks/endpoint.ts
+++ b/packages/instantsearch.js/src/lib/tasks/endpoint.ts
@@ -1,14 +1,11 @@
-export type TaskPrepareRequest = (body: Record<string, unknown>) => {
-  body: Record<string, unknown>;
-};
+import { resolveValue } from '../ai-lite/utils';
 
-export type TaskTransport = {
-  api: string;
-  headers?: Record<string, string>;
-  /** Custom fetch implementation. Defaults to the global `fetch`. */
-  fetch?: typeof fetch;
-  prepareSendMessagesRequest?: TaskPrepareRequest;
-};
+import { DefaultTaskTransport } from './transport';
+
+import type {
+  TaskPrepareSendMessagesRequest,
+  TaskTransport,
+} from './transport';
 
 export type TaskCredentials = {
   appId: string;
@@ -16,15 +13,26 @@ export type TaskCredentials = {
   agentId: string;
 };
 
+export type TaskPrepareRequest = (body: Record<string, unknown>) => {
+  body: Record<string, unknown>;
+};
+
+type TaskEndpointTransport = {
+  api: string;
+  headers?: Record<string, string>;
+  fetch?: typeof fetch;
+  prepareSendMessagesRequest?: TaskPrepareRequest;
+};
+
 export type TaskEndpoint =
-  | { transport: TaskTransport; credentials?: never }
+  | { transport: TaskEndpointTransport; credentials?: never }
   | { transport?: never; credentials: TaskCredentials };
 
 export type ResolvedEndpoint = {
   endpoint: string;
   headers: Record<string, string>;
-  fetch?: TaskTransport['fetch'];
-  prepareSendMessagesRequest?: TaskTransport['prepareSendMessagesRequest'];
+  fetch?: typeof fetch;
+  prepareSendMessagesRequest?: TaskPrepareRequest;
 };
 
 function buildEndpoint({
@@ -38,7 +46,7 @@ function buildEndpoint({
 }
 
 export function resolveEndpoint(params: {
-  transport?: TaskTransport;
+  transport?: TaskEndpointTransport;
   appId?: string;
   apiKey?: string;
   agentId?: string;
@@ -71,4 +79,95 @@ export function resolveEndpoint(params: {
     endpoint: buildEndpoint({ appId: params.appId, agentId: params.agentId }),
     headers,
   };
+}
+
+function isHeaders(headers: HeadersInit): headers is Headers {
+  return (
+    !Array.isArray(headers) &&
+    'entries' in headers &&
+    typeof headers.entries === 'function'
+  );
+}
+
+function headersToRecord(headers: HeadersInit | undefined) {
+  if (!headers) {
+    return {};
+  }
+  if (isHeaders(headers)) {
+    return Object.fromEntries(headers.entries());
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+  return { ...headers };
+}
+
+function mergeProtectedHeaders(
+  headers: HeadersInit | undefined,
+  protectedHeaders: Record<string, string>
+): Record<string, string> {
+  const merged = headersToRecord(headers);
+  Object.entries(protectedHeaders).forEach(([protectedName, value]) => {
+    Object.keys(merged).forEach((name) => {
+      if (name.toLowerCase() === protectedName.toLowerCase()) {
+        delete merged[name];
+      }
+    });
+    merged[protectedName] = value;
+  });
+  return merged;
+}
+
+/** @internal */
+export function createTaskTransport({
+  transport = {},
+  appId,
+  apiKey,
+  agentId,
+  algoliaAgent,
+}: {
+  transport?: TaskTransport;
+  appId?: string;
+  apiKey?: string;
+  agentId?: string;
+  algoliaAgent?: string;
+}): DefaultTaskTransport {
+  if (!agentId) {
+    return new DefaultTaskTransport(transport);
+  }
+  if (!appId || !apiKey) {
+    throw new Error(
+      '[tasks] `appId` and `apiKey` are required when `agentId` is provided.'
+    );
+  }
+
+  const protectedHeaders: Record<string, string> = {
+    'x-algolia-application-id': appId,
+    'x-algolia-api-key': apiKey,
+  };
+  if (algoliaAgent) {
+    protectedHeaders['x-algolia-agent'] = `${algoliaAgent}; tasks`;
+  }
+
+  const originalPrepare = transport.prepareSendMessagesRequest;
+  const prepareSendMessagesRequest: TaskPrepareSendMessagesRequest | undefined =
+    originalPrepare
+      ? (request) =>
+          Promise.resolve(originalPrepare(request)).then((prepared) => ({
+            ...prepared,
+            headers: prepared.headers
+              ? mergeProtectedHeaders(prepared.headers, protectedHeaders)
+              : undefined,
+          }))
+      : undefined;
+
+  return new DefaultTaskTransport({
+    ...transport,
+    api: transport.api ?? buildEndpoint({ appId, agentId }),
+    headers: () =>
+      Promise.resolve(resolveValue(transport.headers)).then((headers) =>
+        mergeProtectedHeaders(headers, protectedHeaders)
+      ),
+    prepareSendMessagesRequest,
+  });
 }

--- a/packages/instantsearch.js/src/lib/tasks/endpoint.ts
+++ b/packages/instantsearch.js/src/lib/tasks/endpoint.ts
@@ -4,7 +4,7 @@ import { DefaultTaskTransport } from './transport';
 
 import type {
   TaskPrepareSendMessagesRequest,
-  TaskTransport,
+  TaskTransportOptions,
 } from './transport';
 
 export type TaskCredentials = {
@@ -17,7 +17,7 @@ export type TaskPrepareRequest = (body: Record<string, unknown>) => {
   body: Record<string, unknown>;
 };
 
-type TaskEndpointTransport = {
+export type TaskTransport = {
   api: string;
   headers?: Record<string, string>;
   fetch?: typeof fetch;
@@ -25,7 +25,7 @@ type TaskEndpointTransport = {
 };
 
 export type TaskEndpoint =
-  | { transport: TaskEndpointTransport; credentials?: never }
+  | { transport: TaskTransport; credentials?: never }
   | { transport?: never; credentials: TaskCredentials };
 
 export type ResolvedEndpoint = {
@@ -46,7 +46,7 @@ function buildEndpoint({
 }
 
 export function resolveEndpoint(params: {
-  transport?: TaskEndpointTransport;
+  transport?: TaskTransport;
   appId?: string;
   apiKey?: string;
   agentId?: string;
@@ -126,7 +126,7 @@ export function createTaskTransport({
   agentId,
   algoliaAgent,
 }: {
-  transport?: TaskTransport;
+  transport?: TaskTransportOptions;
   appId?: string;
   apiKey?: string;
   agentId?: string;

--- a/packages/instantsearch.js/src/lib/tasks/fetchTask.ts
+++ b/packages/instantsearch.js/src/lib/tasks/fetchTask.ts
@@ -1,8 +1,4 @@
-import {
-  parseJsonEventStream,
-  parsePartialJson,
-  processStream,
-} from '../ai-lite';
+import { DefaultTaskTransport } from './transport';
 
 import type { TaskPrepareRequest } from './endpoint';
 
@@ -22,56 +18,6 @@ export function buildTaskPayload({
   return prepareRequest ? prepareRequest(payload).body : payload;
 }
 
-type TaskStreamChunk = {
-  type?: string;
-  data?: unknown;
-  errorText?: string;
-};
-
-function withStreamParam(url: string): string {
-  return url.includes('?') ? `${url}&stream=true` : `${url}?stream=true`;
-}
-
-function resolveStreamedOutput(data: unknown, previous: unknown): unknown {
-  return typeof data === 'string' ? parsePartialJson(data, previous) : data;
-}
-
-function consumeTaskStream(
-  body: ReadableStream<Uint8Array>,
-  onData?: (data: unknown) => void
-): Promise<unknown> {
-  return new Promise<unknown>((resolve, reject) => {
-    const chunkStream = parseJsonEventStream(
-      body
-    ) as unknown as ReadableStream<TaskStreamChunk>;
-    let latest: unknown;
-    processStream(
-      chunkStream,
-      (chunk) => {
-        if (!chunk) {
-          return;
-        }
-        // A terminal `error` event aborts the task: reject rather than let the
-        // stream close and resolve the last partial snapshot as a success.
-        // Throwing here lets `processStream` release the reader and stop
-        // consuming; the rejection propagates to the caller's `.catch`.
-        if (chunk.type === 'error') {
-          throw new Error(chunk.errorText || 'Task stream error');
-        }
-        if (chunk.type !== 'data-task-output') {
-          return;
-        }
-        latest = resolveStreamedOutput(chunk.data, latest);
-        if (onData) {
-          onData(latest);
-        }
-      },
-      () => resolve(latest),
-      reject
-    );
-  });
-}
-
 export type FetchTaskOptions = {
   endpoint: string;
   headers: Record<string, string>;
@@ -89,71 +35,17 @@ export function fetchTask({
   onData,
   stream = true,
 }: FetchTaskOptions): Promise<unknown> {
-  const fetchFn = customFetch ?? fetch;
-
-  return fetchFn(stream ? withStreamParam(endpoint) : endpoint, {
-    method: 'POST',
-    headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  }).then((response) => {
-    if (!response.ok) {
-      throw new Error(`HTTP error ${response.status}`);
-    }
-    const contentType = response.headers?.get?.('content-type') || '';
-    if (stream && response.body && contentType.includes('text/event-stream')) {
-      return consumeTaskStream(response.body, onData);
-    }
-    return response.json();
+  const transport = new DefaultTaskTransport({
+    api: endpoint,
+    headers,
+    fetch: customFetch,
+    prepareSendMessagesRequest: () => ({ body: payload }),
   });
-}
 
-function unwrap(envelope: unknown): unknown {
-  return (envelope as { output?: unknown } | null | undefined)?.output;
-}
-
-export type TaskRunnerOptions = {
-  endpoint: string;
-  headers: Record<string, string>;
-  task: string;
-  fetch?: typeof fetch;
-  stream?: boolean;
-  prepareRequest?: TaskPrepareRequest;
-};
-
-export type TaskSubmitOptions = {
-  onData?: (output: unknown) => void;
-};
-
-export type TaskRunner = {
-  submit: (
-    variables: Record<string, unknown>,
-    options?: TaskSubmitOptions
-  ) => Promise<unknown>;
-};
-
-export function createTaskRunner({
-  endpoint,
-  headers,
-  task,
-  fetch: customFetch,
-  stream = true,
-  prepareRequest,
-}: TaskRunnerOptions): TaskRunner {
-  return {
-    submit(variables, { onData } = {}) {
-      const payload = buildTaskPayload({
-        task,
-        input: variables,
-        prepareRequest,
-      });
-      return fetchTask({
-        endpoint,
-        headers,
-        payload,
-        fetch: customFetch,
-        stream,
-        onData: onData ? (partial) => onData(unwrap(partial)) : undefined,
-      }).then(unwrap);
-    },
-  };
+  return transport.sendTaskRequest({
+    task: '',
+    input: {},
+    stream,
+    onData,
+  });
 }

--- a/packages/instantsearch.js/src/lib/tasks/fetchTask.ts
+++ b/packages/instantsearch.js/src/lib/tasks/fetchTask.ts
@@ -76,6 +76,7 @@ export type FetchTaskOptions = {
   endpoint: string;
   headers: Record<string, string>;
   payload: Record<string, unknown>;
+  fetch?: typeof fetch;
   onData?: (data: unknown) => void;
   stream?: boolean;
 };
@@ -84,10 +85,13 @@ export function fetchTask({
   endpoint,
   headers,
   payload,
+  fetch: customFetch,
   onData,
   stream = true,
 }: FetchTaskOptions): Promise<unknown> {
-  return fetch(stream ? withStreamParam(endpoint) : endpoint, {
+  const fetchFn = customFetch ?? fetch;
+
+  return fetchFn(stream ? withStreamParam(endpoint) : endpoint, {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -111,6 +115,7 @@ export type TaskRunnerOptions = {
   endpoint: string;
   headers: Record<string, string>;
   task: string;
+  fetch?: typeof fetch;
   stream?: boolean;
   prepareRequest?: TaskPrepareRequest;
 };
@@ -130,6 +135,7 @@ export function createTaskRunner({
   endpoint,
   headers,
   task,
+  fetch: customFetch,
   stream = true,
   prepareRequest,
 }: TaskRunnerOptions): TaskRunner {
@@ -144,6 +150,7 @@ export function createTaskRunner({
         endpoint,
         headers,
         payload,
+        fetch: customFetch,
         stream,
         onData: onData ? (partial) => onData(unwrap(partial)) : undefined,
       }).then(unwrap);

--- a/packages/instantsearch.js/src/lib/tasks/index.ts
+++ b/packages/instantsearch.js/src/lib/tasks/index.ts
@@ -8,12 +8,13 @@ export type {
   TaskCredentials,
   TaskEndpoint,
   TaskPrepareRequest,
+  TaskTransport,
 } from './endpoint';
 export type { BuildTaskPayloadOptions, FetchTaskOptions } from './fetchTask';
 export type {
   TaskPrepareSendMessagesRequest,
   TaskSendOptions,
-  TaskTransport,
+  TaskTransportOptions,
 } from './transport';
 export type {
   TaskRunner,

--- a/packages/instantsearch.js/src/lib/tasks/index.ts
+++ b/packages/instantsearch.js/src/lib/tasks/index.ts
@@ -1,17 +1,22 @@
+export { DefaultTaskTransport } from './transport';
 export { resolveEndpoint } from './endpoint';
-export { buildTaskPayload, createTaskRunner, fetchTask } from './fetchTask';
+export { buildTaskPayload, fetchTask } from './fetchTask';
+export { createTaskRunner } from './taskRunner';
 
 export type {
   ResolvedEndpoint,
-  TaskPrepareRequest,
-  TaskTransport,
   TaskCredentials,
   TaskEndpoint,
+  TaskPrepareRequest,
 } from './endpoint';
+export type { BuildTaskPayloadOptions, FetchTaskOptions } from './fetchTask';
 export type {
-  BuildTaskPayloadOptions,
-  FetchTaskOptions,
+  TaskPrepareSendMessagesRequest,
+  TaskSendOptions,
+  TaskTransport,
+} from './transport';
+export type {
   TaskRunner,
   TaskRunnerOptions,
   TaskSubmitOptions,
-} from './fetchTask';
+} from './taskRunner';

--- a/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
+++ b/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
@@ -1,10 +1,21 @@
-import type { DefaultTaskTransport } from './transport';
+import { DefaultTaskTransport } from './transport';
 
-export type TaskRunnerOptions = {
-  transport: DefaultTaskTransport;
-  task: string;
-  stream?: boolean;
-};
+import type { TaskPrepareRequest } from './endpoint';
+
+export type TaskRunnerOptions =
+  | {
+      transport: DefaultTaskTransport;
+      task: string;
+      stream?: boolean;
+    }
+  | {
+      transport?: undefined;
+      endpoint: string;
+      headers: Record<string, string>;
+      task: string;
+      stream?: boolean;
+      prepareRequest?: TaskPrepareRequest;
+    };
 
 export type TaskSubmitOptions = {
   onData?: (output: unknown) => void;
@@ -17,11 +28,24 @@ export type TaskRunner = {
   ) => Promise<unknown>;
 };
 
-export function createTaskRunner({
-  transport,
-  task,
-  stream = true,
-}: TaskRunnerOptions): TaskRunner {
+export function createTaskRunner(options: TaskRunnerOptions): TaskRunner {
+  const { task, stream = true } = options;
+  let transport: DefaultTaskTransport;
+
+  if (options.transport !== undefined) {
+    transport = options.transport;
+  } else {
+    const { prepareRequest } = options;
+    transport = new DefaultTaskTransport({
+      api: options.endpoint,
+      headers: options.headers,
+      prepareSendMessagesRequest: prepareRequest
+        ? ({ task: requestTask, input }) =>
+            prepareRequest({ task: requestTask, input })
+        : undefined,
+    });
+  }
+
   return {
     submit(input, { onData } = {}) {
       return transport.sendTask({ task, input, stream, onData });

--- a/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
+++ b/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
@@ -23,6 +23,12 @@ export type TaskRunner = {
   ) => Promise<unknown>;
 };
 
+export function createTaskRunner(options: {
+  transport: DefaultTaskTransport;
+  task: string;
+  stream?: boolean;
+}): TaskRunner;
+export function createTaskRunner(options: TaskRunnerOptions): TaskRunner;
 export function createTaskRunner(
   options:
     | TaskRunnerOptions

--- a/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
+++ b/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
@@ -2,20 +2,15 @@ import { DefaultTaskTransport } from './transport';
 
 import type { TaskPrepareRequest } from './endpoint';
 
-export type TaskRunnerOptions =
-  | {
-      transport: DefaultTaskTransport;
-      task: string;
-      stream?: boolean;
-    }
-  | {
-      transport?: undefined;
-      endpoint: string;
-      headers: Record<string, string>;
-      task: string;
-      stream?: boolean;
-      prepareRequest?: TaskPrepareRequest;
-    };
+export type TaskRunnerOptions = {
+  transport?: undefined;
+  endpoint: string;
+  headers: Record<string, string>;
+  fetch?: typeof fetch;
+  task: string;
+  stream?: boolean;
+  prepareRequest?: TaskPrepareRequest;
+};
 
 export type TaskSubmitOptions = {
   onData?: (output: unknown) => void;
@@ -28,7 +23,15 @@ export type TaskRunner = {
   ) => Promise<unknown>;
 };
 
-export function createTaskRunner(options: TaskRunnerOptions): TaskRunner {
+export function createTaskRunner(
+  options:
+    | TaskRunnerOptions
+    | {
+        transport: DefaultTaskTransport;
+        task: string;
+        stream?: boolean;
+      }
+): TaskRunner {
   const { task, stream = true } = options;
   let transport: DefaultTaskTransport;
 
@@ -39,6 +42,7 @@ export function createTaskRunner(options: TaskRunnerOptions): TaskRunner {
     transport = new DefaultTaskTransport({
       api: options.endpoint,
       headers: options.headers,
+      fetch: options.fetch,
       prepareSendMessagesRequest: prepareRequest
         ? ({ task: requestTask, input }) =>
             prepareRequest({ task: requestTask, input })

--- a/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
+++ b/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
@@ -1,0 +1,30 @@
+import type { DefaultTaskTransport } from './transport';
+
+export type TaskRunnerOptions = {
+  transport: DefaultTaskTransport;
+  task: string;
+  stream?: boolean;
+};
+
+export type TaskSubmitOptions = {
+  onData?: (output: unknown) => void;
+};
+
+export type TaskRunner = {
+  submit: (
+    variables: Record<string, unknown>,
+    options?: TaskSubmitOptions
+  ) => Promise<unknown>;
+};
+
+export function createTaskRunner({
+  transport,
+  task,
+  stream = true,
+}: TaskRunnerOptions): TaskRunner {
+  return {
+    submit(input, { onData } = {}) {
+      return transport.sendTask({ task, input, stream, onData });
+    },
+  };
+}

--- a/packages/instantsearch.js/src/lib/tasks/transport.ts
+++ b/packages/instantsearch.js/src/lib/tasks/transport.ts
@@ -1,0 +1,244 @@
+import {
+  parseJsonEventStream,
+  parsePartialJson,
+  processStream,
+} from '../ai-lite';
+import { resolveValue } from '../ai-lite/utils';
+
+import type { Resolvable } from '../ai-lite';
+
+export type TaskPrepareSendMessagesRequest = (options: {
+  task: string;
+  input: Record<string, unknown>;
+  stream: boolean;
+  body: Record<string, unknown> | undefined;
+  credentials: RequestCredentials | undefined;
+  headers: HeadersInit | undefined;
+  api: string;
+}) =>
+  | {
+      body: object;
+      headers?: HeadersInit;
+      credentials?: RequestCredentials;
+      api?: string;
+    }
+  | PromiseLike<{
+      body: object;
+      headers?: HeadersInit;
+      credentials?: RequestCredentials;
+      api?: string;
+    }>;
+
+export type TaskTransport = {
+  api?: string;
+  credentials?: Resolvable<RequestCredentials>;
+  headers?: Resolvable<Record<string, string> | Headers>;
+  body?: Resolvable<object>;
+  fetch?: typeof fetch;
+  prepareSendMessagesRequest?: TaskPrepareSendMessagesRequest;
+};
+
+export type TaskSendOptions = {
+  task: string;
+  input: Record<string, unknown>;
+  stream: boolean;
+  onData?: (output: unknown) => void;
+};
+
+function isHeaders(headers: HeadersInit): headers is Headers {
+  return (
+    !Array.isArray(headers) &&
+    'entries' in headers &&
+    typeof headers.entries === 'function'
+  );
+}
+
+function headersToRecord(headers: HeadersInit | undefined) {
+  if (!headers) {
+    return {};
+  }
+  if (isHeaders(headers)) {
+    return Object.fromEntries(headers.entries());
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+  return headers;
+}
+
+function withJsonContentType(headers: HeadersInit | undefined) {
+  const merged = { ...headersToRecord(headers) };
+  Object.keys(merged).forEach((name) => {
+    if (name.toLowerCase() === 'content-type') {
+      delete merged[name];
+    }
+  });
+  merged['Content-Type'] = 'application/json';
+  return merged;
+}
+
+function withStreamParam(url: string): string {
+  return url.includes('?') ? `${url}&stream=true` : `${url}?stream=true`;
+}
+
+function resolveStreamedOutput(data: unknown, previous: unknown): unknown {
+  return typeof data === 'string' ? parsePartialJson(data, previous) : data;
+}
+
+function unwrap(envelope: unknown): unknown {
+  if (
+    typeof envelope === 'object' &&
+    envelope !== null &&
+    'output' in envelope
+  ) {
+    return envelope.output;
+  }
+  return undefined;
+}
+
+function consumeTaskStream(
+  body: ReadableStream<Uint8Array>,
+  onData?: (data: unknown) => void
+): Promise<unknown> {
+  return new Promise<unknown>((resolve, reject) => {
+    const chunkStream = parseJsonEventStream(body);
+    let latest: unknown;
+    processStream(
+      chunkStream,
+      (chunk) => {
+        if (!chunk) {
+          return;
+        }
+        if (chunk.type === 'error') {
+          throw new Error(chunk.errorText || 'Task stream error');
+        }
+        if (chunk.type !== 'data-task-output') {
+          return;
+        }
+        latest = resolveStreamedOutput(chunk.data, latest);
+        if (onData) {
+          onData(latest);
+        }
+      },
+      () => resolve(latest),
+      reject
+    );
+  });
+}
+
+/** Default HTTP transport for named Tasks requests and task-output streams. */
+export class DefaultTaskTransport {
+  protected api: string;
+  protected credentials: Resolvable<RequestCredentials> | undefined;
+  protected headers: Resolvable<Record<string, string> | Headers> | undefined;
+  protected body: Resolvable<object> | undefined;
+  protected fetch: typeof fetch | undefined;
+  protected prepareSendMessagesRequest:
+    | TaskPrepareSendMessagesRequest
+    | undefined;
+
+  constructor({
+    api = '/api/tasks',
+    credentials,
+    headers,
+    body,
+    fetch: customFetch,
+    prepareSendMessagesRequest,
+  }: TaskTransport = {}) {
+    this.api = api;
+    this.credentials = credentials;
+    this.headers = headers;
+    this.body = body;
+    this.fetch = customFetch;
+    this.prepareSendMessagesRequest = prepareSendMessagesRequest;
+  }
+
+  sendTask({ task, input, stream, onData }: TaskSendOptions): Promise<unknown> {
+    return this.sendTaskRequest({
+      task,
+      input,
+      stream,
+      onData: onData ? (data) => onData(unwrap(data)) : undefined,
+    }).then(unwrap);
+  }
+
+  /** @internal */
+  sendTaskRequest({
+    task,
+    input,
+    stream,
+    onData,
+  }: TaskSendOptions): Promise<unknown> {
+    const fetchFn = this.fetch ?? fetch;
+
+    return Promise.all([
+      resolveValue(this.credentials),
+      resolveValue(this.headers),
+      resolveValue(this.body),
+    ]).then(([resolvedCredentials, resolvedHeaders, resolvedBody]) => {
+      let api = this.api;
+      let credentials = resolvedCredentials;
+      let headers: HeadersInit = withJsonContentType(resolvedHeaders);
+      let body: object = {
+        task,
+        input,
+        ...resolvedBody,
+      };
+      const preparedBody = resolvedBody ? { ...resolvedBody } : undefined;
+      const preparePromise = this.prepareSendMessagesRequest
+        ? Promise.resolve(
+            this.prepareSendMessagesRequest({
+              task,
+              input,
+              stream,
+              body: preparedBody,
+              credentials: resolvedCredentials,
+              headers: resolvedHeaders,
+              api: this.api,
+            })
+          )
+        : Promise.resolve(null);
+
+      return preparePromise.then((prepared) => {
+        if (prepared) {
+          body = prepared.body;
+          if (prepared.api) {
+            api = prepared.api;
+          }
+          if (prepared.credentials) {
+            credentials = prepared.credentials;
+          }
+          if (prepared.headers) {
+            headers = withJsonContentType(prepared.headers);
+          }
+        }
+
+        const request: RequestInit = {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+        };
+        if (credentials !== undefined) {
+          request.credentials = credentials;
+        }
+
+        return fetchFn(stream ? withStreamParam(api) : api, request).then(
+          (response) => {
+            if (!response.ok) {
+              throw new Error(`HTTP error ${response.status}`);
+            }
+            const contentType = response.headers?.get?.('content-type') || '';
+            if (
+              stream &&
+              response.body &&
+              contentType.includes('text/event-stream')
+            ) {
+              return consumeTaskStream(response.body, onData);
+            }
+            return response.json();
+          }
+        );
+      });
+    });
+  }
+}

--- a/packages/instantsearch.js/src/lib/tasks/transport.ts
+++ b/packages/instantsearch.js/src/lib/tasks/transport.ts
@@ -29,7 +29,7 @@ export type TaskPrepareSendMessagesRequest = (options: {
       api?: string;
     }>;
 
-export type TaskTransport = {
+export type TaskTransportOptions = {
   api?: string;
   credentials?: Resolvable<RequestCredentials>;
   headers?: Resolvable<Record<string, string> | Headers>;
@@ -83,6 +83,38 @@ function withStreamParam(url: string): string {
 
 function resolveStreamedOutput(data: unknown, previous: unknown): unknown {
   return typeof data === 'string' ? parsePartialJson(data, previous) : data;
+}
+
+function createTaskPreparationContext(
+  context: Parameters<TaskPrepareSendMessagesRequest>[0]
+): Parameters<TaskPrepareSendMessagesRequest>[0] {
+  type Context = Parameters<TaskPrepareSendMessagesRequest>[0];
+
+  function hideProperty<TKey extends keyof Context>(key: TKey) {
+    const value = context[key];
+    Object.defineProperty(context, key, {
+      configurable: true,
+      enumerable: false,
+      get: () => value,
+      set(nextValue: Context[TKey]) {
+        Reflect.deleteProperty(context, key);
+        Object.defineProperty(context, key, {
+          configurable: true,
+          enumerable: true,
+          value: nextValue,
+          writable: true,
+        });
+      },
+    });
+  }
+
+  // Rich metadata stays out of legacy body spreads until assigned as payload.
+  hideProperty('stream');
+  hideProperty('body');
+  hideProperty('credentials');
+  hideProperty('headers');
+  hideProperty('api');
+  return context;
 }
 
 function unwrap(envelope: unknown): unknown {
@@ -144,7 +176,7 @@ export class DefaultTaskTransport {
     body,
     fetch: customFetch,
     prepareSendMessagesRequest,
-  }: TaskTransport = {}) {
+  }: TaskTransportOptions = {}) {
     this.api = api;
     this.credentials = credentials;
     this.headers = headers;
@@ -187,15 +219,17 @@ export class DefaultTaskTransport {
       const preparedBody = resolvedBody ? { ...resolvedBody } : undefined;
       const preparePromise = this.prepareSendMessagesRequest
         ? Promise.resolve(
-            this.prepareSendMessagesRequest({
-              task,
-              input,
-              stream,
-              body: preparedBody,
-              credentials: resolvedCredentials,
-              headers: resolvedHeaders,
-              api: this.api,
-            })
+            this.prepareSendMessagesRequest(
+              createTaskPreparationContext({
+                task,
+                input,
+                stream,
+                body: preparedBody,
+                credentials: resolvedCredentials,
+                headers: resolvedHeaders,
+                api: this.api,
+              })
+            )
           )
         : Promise.resolve(null);
 

--- a/packages/react-instantsearch/src/widgets/PromptSuggestions.tsx
+++ b/packages/react-instantsearch/src/widgets/PromptSuggestions.tsx
@@ -60,16 +60,16 @@ export function PromptSuggestions({
   transformItems,
   ...props
 }: PromptSuggestionsProps) {
+  const source = agentId !== undefined ? { agentId, transport } : { transport };
   const { suggestions, isLoading, onSuggestionClick, isChatBusy, sendToChat } =
     usePromptSuggestions(
       {
-        agentId,
-        transport,
+        ...source,
         configurationId,
         transformHits,
         context,
         transformItems,
-      } as UsePromptSuggestionsProps,
+      },
       {
         $$widgetType: 'ais.promptSuggestions',
       }

--- a/tests/common/widgets/prompt-suggestions/options.ts
+++ b/tests/common/widgets/prompt-suggestions/options.ts
@@ -285,6 +285,70 @@ export function createOptionsTests(
       );
     });
 
+    test('composes agent identity with a custom fetch transport', async () => {
+      const searchClient = Object.assign(
+        createResultsClient([{ objectID: '1', name: 'Product 1' }]),
+        { _ua: 'instantsearch.js (test)' }
+      );
+      const fetchMock = jest.fn(
+        (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+          Promise.resolve(
+            new Response(
+              JSON.stringify({ output: { suggestions: SUGGESTIONS } }),
+              {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              }
+            )
+          )
+      );
+      const transport = {
+        fetch: fetchMock,
+        headers: {
+          'x-custom-header': 'custom-value',
+          'X-Algolia-Application-ID': 'custom-app',
+          'X-Algolia-API-Key': 'custom-key',
+          'X-Algolia-Agent': 'custom-agent',
+        },
+      };
+
+      await setup({
+        instantSearchOptions: { indexName: 'indexName', searchClient },
+        widgetParams: {
+          javascript: {
+            agentId: 'test-agent-id',
+            transport,
+            configurationId: 'prompt-suggestions',
+          },
+          react: {
+            agentId: 'test-agent-id',
+            transport,
+            configurationId: 'prompt-suggestions',
+          },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(DEBOUNCE_MS + 50);
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://appId.algolia.net/agent-studio/1/agents/test-agent-id/tasks?stream=true',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'x-custom-header': 'custom-value',
+            'x-algolia-application-id': 'appId',
+            'x-algolia-api-key': 'apiKey',
+            'x-algolia-agent': 'instantsearch.js (test); tasks',
+            'Content-Type': 'application/json',
+          },
+        })
+      );
+    });
+
     test('sends only the provided context and skips auto-extraction', async () => {
       const searchClient = createResultsClient([
         { objectID: '1', name: 'Product 1' },


### PR DESCRIPTION
**Summary**

Aligns Tasks and Prompt Suggestions with the Chat request-ownership model. `DefaultTaskTransport` now owns request preparation, execution and response parsing, while app-specific error decoding stays with consumers.

**Result**

- Supports `api`, `credentials`, `headers`, `body`, custom `fetch` and async request preparation.
- Preserves structured consumer errors, default HTTP errors, streaming, sequencing, invalidation and existing public Tasks exports.
- Keeps `agentId` and transport options composable across InstantSearch and React InstantSearch.
- Adds transport, connector, public type and shared Prompt Suggestions coverage.

[FX-3989]

[FX-3989]: https://algolia.atlassian.net/browse/FX-3989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ