### PR TITLE
feat(chat): keep the pre-`context` root props alongside `context`

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatGreeting.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatGreeting.tsx
@@ -55,7 +55,7 @@ export function createChatGreetingComponent({
 }: Pick<Renderer, 'createElement'>) {
   return function ChatGreeting(
     // The deprecated root props are still accepted for back compat.
-    // eslint-disable-next-line typescript-eslint/no-deprecated
+    // eslint-disable-next-line typescript/no-deprecated
     userProps: ChatComponentPropsWithContext<ChatGreetingProps & ChatEmptyProps>
   ) {
     const {

--- a/packages/instantsearch-ui-components/src/components/chat/ChatGreeting.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatGreeting.tsx
@@ -2,7 +2,7 @@
 
 import { cx } from '../../lib';
 
-import type { ChatComponentPropsWithContext } from './types';
+import type { ChatComponentPropsWithContext, ChatEmptyProps } from './types';
 import type { ComponentProps, Renderer } from '../../types';
 
 export type ChatGreetingTranslations = {
@@ -54,13 +54,21 @@ export function createChatGreetingComponent({
   createElement,
 }: Pick<Renderer, 'createElement'>) {
   return function ChatGreeting(
-    userProps: ChatComponentPropsWithContext<ChatGreetingProps>
+    // The deprecated root props are still accepted for back compat.
+    // eslint-disable-next-line typescript-eslint/no-deprecated
+    userProps: ChatComponentPropsWithContext<ChatGreetingProps & ChatEmptyProps>
   ) {
     const {
       translations: userTranslations,
       classNames = {},
       context,
       banner,
+      // Read from `context` instead. Destructured only to keep the deprecated
+      // root-level props out of the DOM spread below; remove in the next major.
+      sendMessage: _sendMessage,
+      status: _status,
+      onClose: _onClose,
+      setInput: _setInput,
       ...props
     } = userProps;
     const translations: Required<ChatGreetingTranslations> = {

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -296,13 +296,13 @@ export function createChatMessageComponent({
       showReasoning = false,
       parseMarkdown = true,
       messages: ownMessages,
-      /* eslint-disable typescript-eslint/no-deprecated -- reading the
+      /* eslint-disable typescript/no-deprecated -- reading the
          deprecated aliases is the point: they are resolved into `context`
          below so callers on the previous API keep working. */
       status: ownStatus,
       tools: ownTools,
       onClose: ownOnClose,
-      /* eslint-enable typescript-eslint/no-deprecated */
+      /* eslint-enable typescript/no-deprecated */
       context: sharedContext,
       ...props
     } = userProps;

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -16,11 +16,14 @@ import { MenuIcon } from './icons';
 import type {
   AddToolResult,
   AddToolResultWithOutput,
+  ChatComponentContext,
   ChatComponentPropsWithContext,
   ChatMessageBase,
   ChatStatus,
   ChatToolMessage,
   ClientSideTool,
+  ClientSideToolContext,
+  ClientSideTools,
   TextUIPart,
 } from './types';
 import type { ChatRecordsStore } from '../../lib/utils/chatRecords';
@@ -30,6 +33,30 @@ import type {
   SendEventForHits,
   VNode,
 } from '../../types';
+
+/**
+ * The root-level props tool layout components received before everything moved
+ * under `context`. Passed alongside `context` so components written against the
+ * previous API keep working. Remove together with
+ * `DeprecatedClientSideToolRootProps` in the next major.
+ */
+function getDeprecatedToolRootProps<TMessage extends ChatMessageBase>(
+  context: ClientSideToolContext<TMessage>
+) {
+  return {
+    message: context.message,
+    messages: context.messages,
+    records: context.records,
+    insightsEventContext: context.insightsEventContext,
+    status: context.status,
+    indexUiState: context.indexUiState,
+    setIndexUiState: context.setIndexUiState,
+    onClose: context.onClose,
+    addToolResult: context.addToolResult,
+    applyFilters: context.applyFilters,
+    sendEvent: context.sendEvent,
+  };
+}
 
 type MessageScopedClientSideTool = ClientSideTool & {
   '~addToolResultForMessage'?: (
@@ -188,6 +215,21 @@ export type ChatMessageProps<
    */
   messages?: TMessage[];
   /**
+   * @deprecated Read `context.status` instead. Overrides `context.status` when
+   * provided, for callers written against the previous API.
+   */
+  status?: ChatStatus;
+  /**
+   * @deprecated Read `context.tools` instead. Overrides `context.tools` when
+   * provided, for callers written against the previous API.
+   */
+  tools?: ClientSideTools;
+  /**
+   * @deprecated Read `context.onClose` instead. Overrides `context.onClose`
+   * when provided, for callers written against the previous API.
+   */
+  onClose?: () => void;
+  /**
    * Optional suggestions element
    */
   suggestionsElement?: VNode;
@@ -254,14 +296,30 @@ export function createChatMessageComponent({
       showReasoning = false,
       parseMarkdown = true,
       messages: ownMessages,
-      context,
+      /* eslint-disable typescript-eslint/no-deprecated -- reading the
+         deprecated aliases is the point: they are resolved into `context`
+         below so callers on the previous API keep working. */
+      status: ownStatus,
+      tools: ownTools,
+      onClose: ownOnClose,
+      /* eslint-enable typescript-eslint/no-deprecated */
+      context: sharedContext,
       ...props
     } = userProps;
 
-    const { status, tools } = context;
-    // The explicit `messages` prop lets a caller override the conversation for
-    // a single message; otherwise the shared `context` is the source of truth.
-    const messages = ownMessages ?? context.messages;
+    // Root-level overrides win over the shared context, so a caller can scope
+    // these to a single message. `messages` is supported going forward; the
+    // other three are deprecated aliases kept for callers written against the
+    // pre-`context` API. Resolving them into one object up front means every
+    // consumer below (tools, actions, text) reads consistent values.
+    const context: ChatComponentContext<TMessage> = {
+      ...sharedContext,
+      messages: ownMessages ?? sharedContext.messages,
+      status: ownStatus ?? sharedContext.status,
+      tools: ownTools ?? sharedContext.tools,
+      onClose: ownOnClose ?? sharedContext.onClose,
+    };
+    const { messages, status, tools } = context;
 
     const translations: Required<ChatMessageTranslations> = {
       messageLabel: 'Message',
@@ -482,26 +540,26 @@ export function createChatMessageComponent({
             });
           }) as SendEventForHits;
 
+          const toolContext: ClientSideToolContext<TMessage> = {
+            ...context,
+            records: tool.records || getFallbackRecords(),
+            message: toolMessage,
+            insightsEventContext: tool.insightsEventContext,
+            indexUiState,
+            setIndexUiState,
+            addToolResult: boundAddToolResult,
+            applyFilters: tool.applyFilters,
+            sendEvent,
+          };
+
           return (
             <div
               key={`${message.id}-${index}`}
               className="ais-ChatMessage-tool"
             >
               <ToolLayoutComponent
-                context={{
-                  ...context,
-                  // `...context` would restore `context.messages`; re-apply the
-                  // resolved `messages` so an explicit override reaches tools too.
-                  messages,
-                  records: tool.records || getFallbackRecords(),
-                  message: toolMessage,
-                  insightsEventContext: tool.insightsEventContext,
-                  indexUiState,
-                  setIndexUiState,
-                  addToolResult: boundAddToolResult,
-                  applyFilters: tool.applyFilters,
-                  sendEvent,
-                }}
+                {...getDeprecatedToolRootProps(toolContext)}
+                context={toolContext}
               />
             </div>
           );

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -35,6 +35,7 @@ import type { ChatMessageLoaderProps } from './ChatMessageLoader';
 import type {
   ChatComponentContext,
   ChatComponentPropsWithContext,
+  ChatEmptyProps,
   ChatLayoutOwnProps,
   ChatMessageBase,
   ChatStatus,
@@ -141,7 +142,9 @@ export type ChatMessagesProps<
    * Custom empty component shown when there are no messages
    */
   emptyComponent?: (
-    props: ChatComponentPropsWithContext<{}, TMessage>
+    // The deprecated root props are still passed alongside `context`.
+    // eslint-disable-next-line typescript-eslint/no-deprecated
+    props: ChatComponentPropsWithContext<ChatEmptyProps, TMessage>
   ) => JSX.Element;
   /**
    * Custom actions component
@@ -651,7 +654,16 @@ export function createChatMessagesComponent({
             }}
           >
             {showEmpty && EmptyComponent && (
-              <EmptyComponent context={context} />
+              <EmptyComponent
+                // Deprecated root-level props, kept alongside `context` for
+                // empty/greeting components written against the previous API.
+                // Remove in the next major.
+                sendMessage={sendMessage}
+                setInput={setInput}
+                status={status}
+                onClose={onClose}
+                context={context}
+              />
             )}
 
             {messages.map((message, index) => (

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -143,7 +143,7 @@ export type ChatMessagesProps<
    */
   emptyComponent?: (
     // The deprecated root props are still passed alongside `context`.
-    // eslint-disable-next-line typescript-eslint/no-deprecated
+    // eslint-disable-next-line typescript/no-deprecated
     props: ChatComponentPropsWithContext<ChatEmptyProps, TMessage>
   ) => JSX.Element;
   /**

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/CarouselTool.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/CarouselTool.test.tsx
@@ -35,6 +35,30 @@ const ItemComponent: ItemComponentProps = ({ item }: ItemArgs) =>
     </div>
   ) as JSX.Element;
 
+/**
+ * The widget hands tool components the shared `context` *and* the deprecated
+ * root-level props kept for back compat, so fixtures mirror both. Drop this
+ * once the deprecated root props are removed.
+ */
+function toolProps(
+  context: ClientSideToolComponentProps['context']
+): ClientSideToolComponentProps {
+  return {
+    context,
+    message: context.message,
+    messages: context.messages,
+    records: context.records,
+    insightsEventContext: context.insightsEventContext,
+    status: context.status,
+    indexUiState: context.indexUiState,
+    setIndexUiState: context.setIndexUiState,
+    onClose: context.onClose,
+    addToolResult: context.addToolResult,
+    applyFilters: context.applyFilters,
+    sendEvent: context.sendEvent,
+  };
+}
+
 function buildMessage(
   input: { query: string; number_of_results?: number },
   output: { hits?: InputHit[]; nbHits?: number; queryID?: string }
@@ -67,26 +91,24 @@ function renderTool(
         getSearchPageURL={overrides.getSearchPageURL}
         headerProps={{ showViewAll: overrides.showViewAll ?? false }}
         itemComponent={ItemComponent}
-        toolProps={{
-          context: {
-            messages: [],
-            status: 'ready',
-            isClearing: false,
-            open: true,
-            maximized: false,
-            tools: {},
-            regenerate: jest.fn(),
-            stop: jest.fn(),
-            onReload: jest.fn(),
-            onClose,
-            message,
-            indexUiState: {},
-            setIndexUiState: jest.fn(),
-            addToolResult: jest.fn(),
-            applyFilters,
-            sendEvent: jest.fn(),
-          },
-        }}
+        toolProps={toolProps({
+          messages: [],
+          status: 'ready',
+          isClearing: false,
+          open: true,
+          maximized: false,
+          tools: {},
+          regenerate: jest.fn(),
+          stop: jest.fn(),
+          onReload: jest.fn(),
+          onClose,
+          message,
+          indexUiState: {},
+          setIndexUiState: jest.fn(),
+          addToolResult: jest.fn(),
+          applyFilters,
+          sendEvent: jest.fn(),
+        })}
       />
     );
   }
@@ -248,29 +270,27 @@ describe('CarouselTool', () => {
         <CarouselTool
           headerProps={{ showViewAll: false }}
           itemComponent={SpyItem}
-          toolProps={{
-            context: {
-              messages: [],
-              status: 'ready',
-              isClearing: false,
-              open: true,
-              maximized: false,
-              tools: {},
-              regenerate: jest.fn(),
-              stop: jest.fn(),
-              onReload: jest.fn(),
-              onClose: jest.fn(),
-              message: buildMessage(
-                { query: 'tv' },
-                { hits: makeHits(2), nbHits: 100, queryID: 'abc' }
-              ),
-              indexUiState: {},
-              setIndexUiState: jest.fn(),
-              addToolResult: jest.fn(),
-              applyFilters: jest.fn(() => ({}) as any) as any,
-              sendEvent: jest.fn(),
-            },
-          }}
+          toolProps={toolProps({
+            messages: [],
+            status: 'ready',
+            isClearing: false,
+            open: true,
+            maximized: false,
+            tools: {},
+            regenerate: jest.fn(),
+            stop: jest.fn(),
+            onReload: jest.fn(),
+            onClose: jest.fn(),
+            message: buildMessage(
+              { query: 'tv' },
+              { hits: makeHits(2), nbHits: 100, queryID: 'abc' }
+            ),
+            indexUiState: {},
+            setIndexUiState: jest.fn(),
+            addToolResult: jest.fn(),
+            applyFilters: jest.fn(() => ({}) as any) as any,
+            sendEvent: jest.fn(),
+          })}
         />
       );
     }
@@ -294,29 +314,27 @@ describe('CarouselTool', () => {
         <CarouselTool
           headerProps={{ showViewAll: false }}
           itemComponent={SpyItem}
-          toolProps={{
-            context: {
-              messages: [],
-              status: 'ready',
-              isClearing: false,
-              open: true,
-              maximized: false,
-              tools: {},
-              regenerate: jest.fn(),
-              stop: jest.fn(),
-              onReload: jest.fn(),
-              onClose: jest.fn(),
-              message: buildMessage(
-                { query: 'tv' },
-                { hits: makeHits(1), nbHits: 1 }
-              ),
-              indexUiState: {},
-              setIndexUiState: jest.fn(),
-              addToolResult: jest.fn(),
-              applyFilters: jest.fn(() => ({}) as any) as any,
-              sendEvent: jest.fn(),
-            },
-          }}
+          toolProps={toolProps({
+            messages: [],
+            status: 'ready',
+            isClearing: false,
+            open: true,
+            maximized: false,
+            tools: {},
+            regenerate: jest.fn(),
+            stop: jest.fn(),
+            onReload: jest.fn(),
+            onClose: jest.fn(),
+            message: buildMessage(
+              { query: 'tv' },
+              { hits: makeHits(1), nbHits: 1 }
+            ),
+            indexUiState: {},
+            setIndexUiState: jest.fn(),
+            addToolResult: jest.fn(),
+            applyFilters: jest.fn(() => ({}) as any) as any,
+            sendEvent: jest.fn(),
+          })}
         />
       );
     }

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -1478,4 +1478,156 @@ describe('ChatMessage', () => {
       output: { owner: 'public' },
     });
   });
+
+  /* eslint-disable typescript-eslint/no-deprecated -- these tests exist to
+     pin the deprecated root-level props until they are removed. */
+  describe('deprecated root-level props', () => {
+    const toolMessage: ChatMessageBase = {
+      role: 'assistant',
+      id: '1',
+      parts: [
+        {
+          type: 'tool-test_tool',
+          toolCallId: '123',
+          input: {},
+          state: 'output-available',
+          output: { data: 'Test data' },
+        },
+      ],
+    };
+
+    test('still passes the pre-`context` root props to tool components', () => {
+      const layoutComponent = jest.fn(() => <div />);
+      const setIndexUiState = jest.fn();
+      const onClose = jest.fn();
+      const applyFilters = jest.fn();
+      const messages = [toolMessage];
+
+      render(
+        <ChatMessage
+          indexUiState={{ query: 'shoes' }}
+          setIndexUiState={setIndexUiState}
+          message={toolMessage}
+          context={createContext({
+            messages,
+            status: 'streaming',
+            onClose,
+            tools: {
+              test_tool: {
+                layoutComponent,
+                addToolResult: jest.fn(),
+                applyFilters,
+              },
+            },
+          })}
+        />
+      );
+
+      // A tool component written against the previous API reads these from the
+      // root; they must stay in lockstep with `context`.
+      expect(layoutComponent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.objectContaining({ toolCallId: '123' }),
+          messages,
+          status: 'streaming',
+          indexUiState: { query: 'shoes' },
+          setIndexUiState,
+          onClose,
+          applyFilters,
+          addToolResult: expect.any(Function),
+          sendEvent: expect.any(Function),
+          records: expect.anything(),
+        }),
+        {}
+      );
+    });
+
+    test('root `status` overrides the shared context', () => {
+      const layoutComponent = jest.fn(() => <div />);
+
+      render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={toolMessage}
+          status="streaming"
+          context={createContext({
+            status: 'ready',
+            tools: {
+              test_tool: {
+                layoutComponent,
+                addToolResult: jest.fn(),
+                applyFilters: jest.fn(),
+              },
+            },
+          })}
+        />
+      );
+
+      expect(layoutComponent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'streaming',
+          context: expect.objectContaining({ status: 'streaming' }),
+        }),
+        {}
+      );
+    });
+
+    test('root `tools` overrides the shared context', () => {
+      const layoutComponent = jest.fn(() => <div />);
+
+      render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={toolMessage}
+          tools={{
+            test_tool: {
+              layoutComponent,
+              addToolResult: jest.fn(),
+              applyFilters: jest.fn(),
+            },
+          }}
+          // The context registers no tools, so the part only renders if the
+          // root-level override wins.
+          context={createContext({ tools: {} })}
+        />
+      );
+
+      expect(layoutComponent).toHaveBeenCalledTimes(1);
+    });
+
+    test('root `onClose` overrides the shared context', () => {
+      const layoutComponent = jest.fn(() => <div />);
+      const onClose = jest.fn();
+
+      render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={toolMessage}
+          onClose={onClose}
+          context={createContext({
+            onClose: jest.fn(),
+            tools: {
+              test_tool: {
+                layoutComponent,
+                addToolResult: jest.fn(),
+                applyFilters: jest.fn(),
+              },
+            },
+          })}
+        />
+      );
+
+      expect(layoutComponent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onClose,
+          context: expect.objectContaining({ onClose }),
+        }),
+        {}
+      );
+    });
+  });
+  /* eslint-enable typescript-eslint/no-deprecated */
 });

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -1479,7 +1479,7 @@ describe('ChatMessage', () => {
     });
   });
 
-  /* eslint-disable typescript-eslint/no-deprecated -- these tests exist to
+  /* eslint-disable typescript/no-deprecated -- these tests exist to
      pin the deprecated root-level props until they are removed. */
   describe('deprecated root-level props', () => {
     const toolMessage: ChatMessageBase = {
@@ -1629,5 +1629,5 @@ describe('ChatMessage', () => {
       );
     });
   });
-  /* eslint-enable typescript-eslint/no-deprecated */
+  /* eslint-enable typescript/no-deprecated */
 });

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -1670,4 +1670,39 @@ describe('ChatMessages', () => {
       {}
     );
   });
+
+  test('still passes the pre-`context` root props to a custom empty component', () => {
+    const Empty = jest.fn(() => <span>Empty</span>);
+    const onClose = jest.fn();
+    const sendMessage = jest.fn();
+    const setInput = jest.fn();
+
+    render(
+      <ChatMessages
+        messages={[]}
+        status="ready"
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        tools={{}}
+        onReload={jest.fn()}
+        onClose={onClose}
+        sendMessage={sendMessage}
+        setInput={setInput}
+        emptyComponent={Empty}
+      />
+    );
+
+    // An empty/greeting component written against the previous API reads these
+    // from the root rather than from `context`.
+    expect(Empty).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sendMessage,
+        setInput,
+        status: 'ready',
+        onClose,
+        context: expect.objectContaining({ status: 'ready' }),
+      }),
+      {}
+    );
+  });
 });

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -596,29 +596,73 @@ export type ChatComponentPropsWithContext<
 };
 
 /**
- * Tool layout components receive a single `context` object: the shared chat
+ * The `context` a tool layout component receives: the shared
  * `ChatComponentContext` merged with the tool's own injected data (the tool
- * `message`, event/filter callbacks, and index UI state). There are no
- * root-level props — everything a tool renders from lives under `context`.
+ * `message`, event/filter callbacks, and index UI state).
+ */
+export type ClientSideToolContext<
+  TMessage extends ChatMessageBase = ChatMessageBase,
+> = ChatComponentContext<TMessage> & {
+  message: ChatToolMessage;
+  /**
+   * The records the chat's tools have fetched. A tool handed plain object IDs
+   * hydrates them with `records.get(objectID)`.
+   */
+  records?: ChatRecordsStore;
+  insightsEventContext?: ChatInsightsEventContext;
+  indexUiState: object;
+  setIndexUiState: (state: object) => void;
+  addToolResult: AddToolResultWithOutput;
+  applyFilters: (params: ApplyFiltersParams) => SearchParameters;
+  sendEvent: SendEventForHits;
+};
+
+/**
+ * The root-level props tool layout components received before everything moved
+ * under `context`. Still passed alongside `context` so components written
+ * against the previous API keep working; they are removed in the next major.
+ *
+ * These are spelled out rather than derived with `Pick` so that `@deprecated`
+ * reaches each property at the point of use in editors.
+ */
+type DeprecatedClientSideToolRootProps<
+  TMessage extends ChatMessageBase = ChatMessageBase,
+> = {
+  /** @deprecated Read `context.message` instead. */
+  message: ChatToolMessage;
+  /** @deprecated Read `context.messages` instead. */
+  messages: TMessage[];
+  /** @deprecated Read `context.records` instead. */
+  records?: ChatRecordsStore;
+  /** @deprecated Read `context.insightsEventContext` instead. */
+  insightsEventContext?: ChatInsightsEventContext;
+  /** @deprecated Read `context.status` instead. */
+  status: ChatStatus;
+  /** @deprecated Read `context.indexUiState` instead. */
+  indexUiState: object;
+  /** @deprecated Read `context.setIndexUiState` instead. */
+  setIndexUiState: (state: object) => void;
+  /** @deprecated Read `context.onClose` instead. */
+  onClose: () => void;
+  /** @deprecated Read `context.addToolResult` instead. */
+  addToolResult: AddToolResultWithOutput;
+  /** @deprecated Read `context.applyFilters` instead. */
+  applyFilters: (params: ApplyFiltersParams) => SearchParameters;
+  /** @deprecated Read `context.sendEvent` instead. */
+  sendEvent: SendEventForHits;
+};
+
+/**
+ * Tool layout components receive a single `context` object holding everything
+ * they render from. The deprecated root-level props are kept required (rather
+ * than optional) so existing components that destructure them keep
+ * type-checking under `strict`; the widget always supplies both.
  */
 export type ClientSideToolComponentProps<
   TMessage extends ChatMessageBase = ChatMessageBase,
 > = {
-  context: ChatComponentContext<TMessage> & {
-    message: ChatToolMessage;
-    /**
-     * The records the chat's tools have fetched. A tool handed plain object IDs
-     * hydrates them with `records.get(objectID)`.
-     */
-    records?: ChatRecordsStore;
-    insightsEventContext?: ChatInsightsEventContext;
-    indexUiState: object;
-    setIndexUiState: (state: object) => void;
-    addToolResult: AddToolResultWithOutput;
-    applyFilters: (params: ApplyFiltersParams) => SearchParameters;
-    sendEvent: SendEventForHits;
-  };
-};
+  context: ClientSideToolContext<TMessage>;
+} & DeprecatedClientSideToolRootProps<TMessage>;
 
 export type ClientSideToolComponent = (
   props: ClientSideToolComponentProps
@@ -666,3 +710,11 @@ export type UserClientSideTool = Omit<
   | 'records'
 >;
 export type UserClientSideTools = Record<string, UserClientSideTool>;
+
+/**
+ * @deprecated Use `ChatComponentPropsWithContext` instead — an empty/greeting
+ * component now reads shared chat state from its `context` prop.
+ */
+export type ChatEmptyProps = Partial<
+  Pick<ChatComponentContext, 'sendMessage' | 'status' | 'onClose' | 'setInput'>
+>;

--- a/packages/instantsearch.js/src/widgets/chat/__tests__/display-results-tool.test.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/__tests__/display-results-tool.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 /** @jsx h */
+import { chatToolProps } from '@instantsearch/testutils';
 import { fireEvent, screen, within } from '@testing-library/dom';
 import { collectChatRecords } from 'instantsearch-ui-components';
 import { h, render } from 'preact';
@@ -55,27 +56,25 @@ const createToolProps = (
     },
   ] as ChatComponentContext['messages'];
 
-  return {
-    context: {
-      messages,
-      status: 'ready',
-      isClearing: false,
-      open: true,
-      maximized: false,
-      tools: {},
-      regenerate: jest.fn(),
-      stop: jest.fn(),
-      onReload: jest.fn(),
-      onClose: jest.fn(),
-      message,
-      records: collectChatRecords(messages),
-      indexUiState: {},
-      setIndexUiState: jest.fn(),
-      addToolResult: jest.fn(),
-      applyFilters: jest.fn(),
-      sendEvent: jest.fn(),
-    },
-  };
+  return chatToolProps({
+    messages,
+    status: 'ready',
+    isClearing: false,
+    open: true,
+    maximized: false,
+    tools: {},
+    regenerate: jest.fn(),
+    stop: jest.fn(),
+    onReload: jest.fn(),
+    onClose: jest.fn(),
+    message,
+    records: collectChatRecords(messages),
+    indexUiState: {},
+    setIndexUiState: jest.fn(),
+    addToolResult: jest.fn(),
+    applyFilters: jest.fn(),
+    sendEvent: jest.fn(),
+  });
 };
 
 describe('createDisplayResultsTool', () => {

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -44,6 +44,7 @@ import type {
 import type {
   ChatClassNames,
   ChatComponentPropsWithContext,
+  ChatEmptyProps,
   ChatHeaderProps,
   ChatHeaderTranslations,
   ChatLayoutOwnProps,
@@ -174,7 +175,7 @@ type ChatWrapperProps = {
         ) => JSX.Element)
       | undefined;
     emptyComponent:
-      | ((props: ChatComponentPropsWithContext<{}>) => JSX.Element)
+      | ((props: ChatComponentPropsWithContext<ChatEmptyProps>) => JSX.Element)
       | undefined;
     actionsComponent:
       | ((
@@ -447,11 +448,9 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
       >(messagesTemplateRef, 'error', 'div')
     : undefined;
   const stableMessagesEmptyComponent = templates.empty
-    ? createStableTemplateComponent<ChatComponentPropsWithContext<{}>>(
-        emptyTemplateRef,
-        'empty',
-        'div'
-      )
+    ? createStableTemplateComponent<
+        ChatComponentPropsWithContext<ChatEmptyProps>
+      >(emptyTemplateRef, 'empty', 'div')
     : undefined;
   const stableAssistantMessageLeadingComponent = templates.assistantMessage
     ?.leading
@@ -1069,7 +1068,7 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
     /**
      * Template to use for the empty screen shown when there are no messages
      */
-    empty?: Template<ChatComponentPropsWithContext<{}>>;
+    empty?: Template<ChatComponentPropsWithContext<ChatEmptyProps>>;
 
     /**
      * Template to use for prompt suggestions.

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -175,6 +175,8 @@ type ChatWrapperProps = {
         ) => JSX.Element)
       | undefined;
     emptyComponent:
+      // The deprecated root props are still passed alongside `context`.
+      // eslint-disable-next-line typescript/no-deprecated
       | ((props: ChatComponentPropsWithContext<ChatEmptyProps>) => JSX.Element)
       | undefined;
     actionsComponent:
@@ -449,6 +451,8 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
     : undefined;
   const stableMessagesEmptyComponent = templates.empty
     ? createStableTemplateComponent<
+        // The deprecated root props are still passed alongside `context`.
+        // eslint-disable-next-line typescript/no-deprecated
         ChatComponentPropsWithContext<ChatEmptyProps>
       >(emptyTemplateRef, 'empty', 'div')
     : undefined;
@@ -1068,6 +1072,8 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
     /**
      * Template to use for the empty screen shown when there are no messages
      */
+    // The deprecated root props are still passed alongside `context`.
+    // eslint-disable-next-line typescript/no-deprecated
     empty?: Template<ChatComponentPropsWithContext<ChatEmptyProps>>;
 
     /**

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.streaming.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.streaming.test.tsx
@@ -7,6 +7,7 @@
  * because it is partial-JSON repair closing an open string literal that lets a
  * mid-delta identifier reach `input` looking complete.
  */
+import { chatToolProps } from '@instantsearch/testutils';
 import { render, screen } from '@testing-library/react';
 import { collectChatRecords } from 'instantsearch-ui-components';
 import { Chat } from 'instantsearch.js/es/lib/chat';
@@ -114,7 +115,7 @@ function renderFrame(part: ClientSideToolComponentProps['context']['message']) {
 
   const { unmount } = render(
     <LayoutComponent
-      context={{
+      {...chatToolProps({
         messages,
         status: 'streaming',
         isClearing: false,
@@ -132,7 +133,7 @@ function renderFrame(part: ClientSideToolComponentProps['context']['message']) {
         addToolResult: jest.fn(),
         setIndexUiState: jest.fn(),
         sendEvent: jest.fn(),
-      }}
+      })}
     />
   );
   const visible = HITS.filter((hit) =>

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/DisplayResultsTool.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 
+import { chatToolProps } from '@instantsearch/testutils';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { collectChatRecords } from 'instantsearch-ui-components';
@@ -110,7 +111,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversation(message, [{ objectID: '1', name: 'Air Runner' }]),
           status: 'streaming',
@@ -120,7 +121,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -149,27 +150,25 @@ describe('createDisplayResultsTool', () => {
         },
       };
 
-      return {
-        context: {
-          ...metadata,
-          ...conversationOf(
-            createMessages(
-              message,
-              objectIDs.map((objectID) => ({
-                objectID,
-                name: `Product ${objectID}`,
-              }))
-            )
-          ),
-          status: 'streaming' as const,
-          message,
-          applyFilters: jest.fn(),
-          indexUiState: {},
-          addToolResult: jest.fn(),
-          setIndexUiState: jest.fn(),
-          sendEvent: jest.fn(),
-        },
-      };
+      return chatToolProps({
+        ...metadata,
+        ...conversationOf(
+          createMessages(
+            message,
+            objectIDs.map((objectID) => ({
+              objectID,
+              name: `Product ${objectID}`,
+            }))
+          )
+        ),
+        status: 'streaming' as const,
+        message,
+        applyFilters: jest.fn(),
+        indexUiState: {},
+        addToolResult: jest.fn(),
+        setIndexUiState: jest.fn(),
+        sendEvent: jest.fn(),
+      });
     };
     const { container, rerender } = render(
       <LayoutComponent {...createToolProps('Original intro', ['1'])} />
@@ -207,7 +206,7 @@ describe('createDisplayResultsTool', () => {
     };
     const { container } = render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(
             createMessages(message, [{ objectID: '1', name: 'Runner' }])
@@ -219,7 +218,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -259,7 +258,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(
             createMessages(message, [
@@ -273,7 +272,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -306,7 +305,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(createMessages(message, [{ objectID: '1' }])),
           message,
@@ -315,7 +314,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent,
-        }}
+        })}
       />
     );
 
@@ -371,7 +370,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(createMessages(message, [{ objectID: '1' }])),
           message,
@@ -380,7 +379,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent,
-        }}
+        })}
       />
     );
 
@@ -425,7 +424,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(messages),
           message,
@@ -434,7 +433,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -468,7 +467,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(messages),
           message,
@@ -477,7 +476,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -519,7 +518,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(
             createMessages(message, [
@@ -533,7 +532,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -573,7 +572,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(
             createMessages(message, [
@@ -587,7 +586,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent,
-        }}
+        })}
       />
     );
 
@@ -637,7 +636,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(
             createMessages(message, [
@@ -651,7 +650,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -669,7 +668,7 @@ describe('createDisplayResultsTool', () => {
 
     const { container } = render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           message: {
             type: 'tool-algolia_display_results',
@@ -687,7 +686,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -715,7 +714,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(
             createMessages(message, [{ objectID: '1', name: 'Air Runner' }])
@@ -726,7 +725,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -741,7 +740,7 @@ describe('createDisplayResultsTool', () => {
 
     const { container } = render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           message: {
             type: 'tool-algolia_display_results',
@@ -755,7 +754,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -782,7 +781,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(
             createMessages(message, [{ objectID: '1', name: 'Air Runner' }])
@@ -793,7 +792,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -815,7 +814,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(createMessages(message, [])),
           status: 'streaming',
@@ -825,7 +824,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -838,7 +837,7 @@ describe('createDisplayResultsTool', () => {
 
     const { container } = render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           message: {
             type: 'tool-algolia_display_results',
@@ -852,7 +851,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -912,7 +911,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(messages),
           message,
@@ -921,7 +920,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -1001,7 +1000,7 @@ describe('createDisplayResultsTool', () => {
 
     const firstRender = render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(messages),
           message: firstDisplayMessage,
@@ -1010,7 +1009,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 
@@ -1022,7 +1021,7 @@ describe('createDisplayResultsTool', () => {
 
     render(
       <LayoutComponent
-        context={{
+        {...chatToolProps({
           ...metadata,
           ...conversationOf(messages),
           message: secondDisplayMessage,
@@ -1031,7 +1030,7 @@ describe('createDisplayResultsTool', () => {
           addToolResult: jest.fn(),
           setIndexUiState: jest.fn(),
           sendEvent: jest.fn(),
-        }}
+        })}
       />
     );
 

--- a/packages/react-instantsearch/src/widgets/chat/tools/__tests__/SearchIndexTool.test.tsx
+++ b/packages/react-instantsearch/src/widgets/chat/tools/__tests__/SearchIndexTool.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 
+import { chatToolProps } from '@instantsearch/testutils';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -58,7 +59,7 @@ describe('createCarouselTool', () => {
 
       render(
         <LayoutComponent
-          context={{
+          {...chatToolProps({
             ...metadata,
             message,
             applyFilters: jest.fn(),
@@ -66,7 +67,7 @@ describe('createCarouselTool', () => {
             addToolResult: jest.fn(),
             setIndexUiState: jest.fn(),
             sendEvent: jest.fn(),
-          }}
+          })}
         />
       );
 
@@ -94,7 +95,7 @@ describe('createCarouselTool', () => {
 
       render(
         <LayoutComponent
-          context={{
+          {...chatToolProps({
             ...metadata,
             message,
             applyFilters: jest.fn(),
@@ -102,7 +103,7 @@ describe('createCarouselTool', () => {
             addToolResult: jest.fn(),
             setIndexUiState: jest.fn(),
             sendEvent: jest.fn(),
-          }}
+          })}
         />
       );
 
@@ -181,7 +182,7 @@ describe('createCarouselTool', () => {
 
         render(
           <LayoutComponent
-            context={{
+            {...chatToolProps({
               ...metadata,
               message,
               applyFilters,
@@ -189,7 +190,7 @@ describe('createCarouselTool', () => {
               addToolResult: jest.fn(),
               setIndexUiState: jest.fn(),
               sendEvent: jest.fn(),
-            }}
+            })}
           />
         );
 

--- a/tests/utils/chatToolProps.ts
+++ b/tests/utils/chatToolProps.ts
@@ -1,0 +1,27 @@
+import type { ClientSideToolComponentProps } from 'instantsearch-ui-components';
+
+/**
+ * Chat tool layout components receive the shared `context` *and* the deprecated
+ * root-level props the widget still passes for back compat. Fixtures only build
+ * the context, so this mirrors it into both shapes.
+ *
+ * Delete alongside the deprecated root props in the next major.
+ */
+export function chatToolProps(
+  context: ClientSideToolComponentProps['context']
+): ClientSideToolComponentProps {
+  return {
+    context,
+    message: context.message,
+    messages: context.messages,
+    records: context.records,
+    insightsEventContext: context.insightsEventContext,
+    status: context.status,
+    indexUiState: context.indexUiState,
+    setIndexUiState: context.setIndexUiState,
+    onClose: context.onClose,
+    addToolResult: context.addToolResult,
+    applyFilters: context.applyFilters,
+    sendEvent: context.sendEvent,
+  };
+}

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './castToJestMock';
+export * from './chatToolProps';
 export * from './createInstantSearchSpy';
 export * from './enzyme';
 export * from './InstantSearchTestWrapper';

--- a/tests/utils/package.json
+++ b/tests/utils/package.json
@@ -7,6 +7,7 @@
     "enzyme": "3.11.0",
     "enzyme-adapter-preact-pure": "2.2.0",
     "enzyme-to-json": "3.6.2",
+    "instantsearch-ui-components": "0.35.1",
     "instantsearch.js": "4.111.1",
     "jest-serializer-html": "7.1.0",
     "preact": "^10.10.0"


### PR DESCRIPTION
Stacked on #7123 — base is `feat/chat-components-metadata`, so the diff here is only the back-compat layer.

## Why

#7123 doesn't add `context` alongside the old props, it **replaces** them. That breaks user-supplied Chat components at **runtime**, not just in types:

| Slot | Break |
| --- | --- |
| Tool layout components | `ClientSideToolComponentProps` drops all 11 root props (`message`, `records`, `addToolResult`, `applyFilters`, `sendEvent`, `indexUiState`, `status`, `onClose`, …) |
| Empty / greeting component + `empty` template | loses `sendMessage`, `setInput`, `status`, `onClose` |
| `ChatMessage` | required `status`, `tools`, `onClose` deleted, required `context` added |
| `ChatEmptyProps` | public exported type removed outright |

`instantsearch-ui-components` is pre-1.0 so a breaking minor is semver-legal there, but the `empty` template payload change lands in `instantsearch.js`, which is on a stable `4.x`.

Worth noting what *isn't* affected: `loader`, `messages.error`, and `actions` kept their root props in #7123 and only gained `context`. Those were already additive.

## How

The merged tool context is a **strict superset** of the props it replaced, and the widget is the caller at every broken slot — so both call styles can coexist and no consumer has to change.

- **Tool components** — `ChatMessage` hoists the merged object and passes it as `context` plus the deprecated root props. The legacy keys are enumerated rather than spread, so the *new* `context`-only fields (`open`, `maximized`, `regenerate`, `stop`, …) don't silently join the deprecated surface. Removal is one block delete.
- **Empty / greeting** — the four root props come back. This covers the `empty` template for free: `createStableTemplateComponent` passes `data={props}` verbatim.
- **`ChatMessage`** — re-accepts `status`/`tools`/`onClose`, resolved into a single `context` object up front (extending the `messages` fallback #7123 already introduced) so tools, actions, and text components all read consistent values.
- **`ChatEmptyProps`** — restored as a deprecated alias. `Partial<>`, because the original had all four optional while `context.status` is required.

Deprecated tool props are kept **required**, not optional. Making them optional would turn `const { message } = props` into `ChatToolMessage | undefined` under `strict` and break exactly the users this is protecting.

Every re-added prop carries `@deprecated` on the property itself (spelled out rather than derived via `Pick`, which doesn't forward the tag), so editors strike them through and `typescript-eslint/no-deprecated` flags them. Intentional internal uses are disabled with a reason.

One non-obvious fix: `ChatGreeting` spreads `...props` onto a `div`. It used to destructure the four shared props away purely to keep them out of the DOM; #7123 dropped that. Restoring the props means restoring the strip, or React warns about unknown DOM attributes.

## Tests

5 new tests pin the contract — all 5 fail against #7123's source and pass here:

- tool components receive all 11 legacy root props, in lockstep with `context`
- root `status` / `tools` / `onClose` each override the shared context
- a custom empty component receives the legacy root props

Verified against #7123 as the baseline: type-check and lint findings are **identical** (174 type errors and 6 lint errors are pre-existing on that branch, from stale `dist/` artifacts — including the 2 pre-existing `types.test.ts` failures). Chat suites: 140 ui-components + 198 cross-flavor common tests pass.

## Follow-up

Removal is a scheduled major with a mechanical codemod, not an unannounced minor. `getDeprecatedToolRootProps` in `ChatMessage.tsx`, `DeprecatedClientSideToolRootProps` in `types.ts`, and the `toolProps` test helper are the three deletion points.

[FX-3927]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FX-3927]: https://algolia.atlassian.net/browse/FX-3927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ