### PR TITLE
fix(chat): keep the maximized overlay panel inside the viewport

### DIFF
--- a/packages/instantsearch.css/src/components/chat/_chat-overlay-layout.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-overlay-layout.scss
@@ -1,16 +1,21 @@
 @use '../../shared/_variables';
 
 .ais-ChatOverlayLayout {
+  /* stylelint-disable-next-line length-zero-no-unit */
+  --ais-chat-trigger-offset: 0px;
+
   position: fixed;
   justify-content: flex-end;
   gap: var(--ais-spacing);
   align-items: flex-end;
   right: var(--ais-chat-margin);
-  bottom: var(--ais-chat-margin);
+  bottom: calc(var(--ais-chat-margin) + var(--ais-chat-trigger-offset));
   width: var(--ais-chat-width);
   height: var(--ais-chat-height);
   max-width: calc(100% - var(--ais-chat-margin) * 2);
-  max-height: calc(100% - var(--ais-chat-margin) * 2);
+  max-height: calc(
+    100% - var(--ais-chat-margin) * 2 - var(--ais-chat-trigger-offset)
+  );
   z-index: var(--ais-z-index-chat);
   pointer-events: none;
 
@@ -44,7 +49,7 @@
 }
 
 body:has(.ais-ChatToggleButton--floating) .ais-ChatOverlayLayout {
-  bottom: calc(var(--ais-chat-margin) + var(--ais-spacing) * 4);
+  --ais-chat-trigger-offset: calc(var(--ais-spacing) * 4);
 }
 
 @media (max-width: variables.$ais-chat-breakpoint) {


### PR DESCRIPTION
**Summary**

This PR fixes the chat overlay panel being clipped above the top of the window when it is maximized on a page that also mounts a floating `chatTrigger`. The header row holding the maximize/restore and close buttons was pushed off screen, so the panel could not be un-maximized or closed from these buttons.

| Before | After |
|:------:|:-----:|
| <img width="2864" height="1836" alt="screenshot-20260819-114704@2x" src="https://github.com/user-attachments/assets/1f9a320c-48b5-410f-93ca-d95506e487b1" /> | <img width="2864" height="1836" alt="screenshot-20260819-114721@2x" src="https://github.com/user-attachments/assets/8b1f7cfc-ff16-4ad3-aa59-b7c1e442603c" /> |