### PR TITLE
fix(chat): focus prompt after reveal

### DIFF
--- a/packages/instantsearch.js/src/lib/chat/__tests__/focusAfterReveal.test.ts
+++ b/packages/instantsearch.js/src/lib/chat/__tests__/focusAfterReveal.test.ts
@@ -1,0 +1,333 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import {
+  focusAfterReveal,
+  getActiveContainerAnimations,
+  holdContainerInertUntilReveal,
+  restoreContainerInertUntilReveal,
+} from '../focusAfterReveal';
+
+type ControlledAnimation = {
+  animation: Animation;
+  finish: () => void;
+  cancel: () => void;
+  setPlayState: (playState: AnimationPlayState) => void;
+};
+
+function createControlledAnimation(
+  initialPlayState: AnimationPlayState
+): ControlledAnimation {
+  let resolveFinished!: () => void;
+  let rejectFinished!: () => void;
+  let playState = initialPlayState;
+  const finished = new Promise<void>((resolve, reject) => {
+    resolveFinished = resolve;
+    rejectFinished = reject;
+  });
+  const animation = {
+    effect: {
+      getKeyframes: () => [{ opacity: 0 }, { opacity: 1 }],
+      getTiming: () => ({ iterations: 1 }),
+    },
+    finished,
+    get playState() {
+      return playState;
+    },
+  } as unknown as Animation;
+
+  return {
+    animation,
+    finish: resolveFinished,
+    cancel: rejectFinished,
+    setPlayState(nextPlayState) {
+      playState = nextPlayState;
+    },
+  };
+}
+
+function renderPrompt() {
+  const container = document.createElement('div');
+  container.className = 'ais-Chat-container ais-Chat-container--open';
+  const prompt = document.createElement('textarea');
+  container.appendChild(prompt);
+  document.body.appendChild(container);
+
+  return { container, prompt };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('focusAfterReveal', () => {
+  let opacity: string;
+
+  beforeEach(() => {
+    opacity = '0';
+    jest.spyOn(window, 'getComputedStyle').mockImplementation(
+      () =>
+        ({
+          clipPath: 'none',
+          opacity,
+          rotate: 'none',
+          scale: 'none',
+          transform: 'none',
+          translate: 'none',
+          visibility: 'visible',
+          getPropertyValue: () => 'auto',
+        }) as unknown as CSSStyleDeclaration
+    );
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        callback(0);
+        return 0;
+      });
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    jest.restoreAllMocks();
+  });
+
+  test('waits when an existing reveal animation resumes', async () => {
+    const { container, prompt } = renderPrompt();
+    const reveal = createControlledAnimation('paused');
+    let animations = [reveal.animation];
+    Object.defineProperty(container, 'getAnimations', {
+      configurable: true,
+      value: () => animations,
+    });
+    const focus = jest.spyOn(prompt, 'focus');
+    const animationsBeforeReveal = getActiveContainerAnimations(prompt);
+
+    reveal.setPlayState('running');
+    focusAfterReveal(prompt, animationsBeforeReveal, () => true);
+
+    expect(focus).not.toHaveBeenCalled();
+
+    opacity = '1';
+    animations = [];
+    reveal.finish();
+    await flushPromises();
+
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  test('waits for a replacement reveal after the selected animation is canceled', async () => {
+    const { container, prompt } = renderPrompt();
+    const selectedReveal = createControlledAnimation('running');
+    const replacementReveal = createControlledAnimation('paused');
+    let animations = [selectedReveal.animation];
+    Object.defineProperty(container, 'getAnimations', {
+      configurable: true,
+      value: () => animations,
+    });
+    const focus = jest.spyOn(prompt, 'focus');
+
+    focusAfterReveal(prompt, [], () => true);
+
+    expect(focus).not.toHaveBeenCalled();
+
+    animations = [replacementReveal.animation];
+    selectedReveal.cancel();
+    await flushPromises();
+
+    expect(focus).not.toHaveBeenCalled();
+
+    opacity = '1';
+    animations = [];
+    replacementReveal.finish();
+    await flushPromises();
+
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps a replacement focus request on the reveal already held inert', async () => {
+    const { container, prompt } = renderPrompt();
+    const reveal = createControlledAnimation('running');
+    let animations = [reveal.animation];
+    Object.defineProperty(container, 'getAnimations', {
+      configurable: true,
+      value: () => animations,
+    });
+    const focus = jest.spyOn(prompt, 'focus');
+    let focusRequestId = 1;
+
+    holdContainerInertUntilReveal(prompt);
+    focusAfterReveal(
+      prompt,
+      [],
+      () => focusRequestId === 1,
+      () => focusRequestId === 1
+    );
+
+    const animationsBeforeReplacement = getActiveContainerAnimations(prompt);
+    focusRequestId = 2;
+    holdContainerInertUntilReveal(prompt);
+    focusAfterReveal(
+      prompt,
+      animationsBeforeReplacement,
+      () => focusRequestId === 2,
+      () => focusRequestId === 2
+    );
+
+    expect(container).toHaveAttribute('inert');
+    expect(focus).not.toHaveBeenCalled();
+
+    opacity = '1';
+    animations = [];
+    reveal.finish();
+    await flushPromises();
+
+    expect(container).not.toHaveAttribute('inert');
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  test('carries a replacement reveal observed by a stale request into the newer request', async () => {
+    const { container, prompt } = renderPrompt();
+    const selectedReveal = createControlledAnimation('running');
+    const replacementReveal = createControlledAnimation('running');
+    let animations = [selectedReveal.animation];
+    Object.defineProperty(container, 'getAnimations', {
+      configurable: true,
+      value: () => animations,
+    });
+    const animationFrames: Array<() => void> = [];
+    jest.mocked(window.requestAnimationFrame).mockImplementation((callback) => {
+      animationFrames.push(() => callback(0));
+      return animationFrames.length;
+    });
+    const focus = jest.spyOn(prompt, 'focus');
+    let focusRequestId = 1;
+
+    holdContainerInertUntilReveal(prompt);
+    focusAfterReveal(
+      prompt,
+      [],
+      () => focusRequestId === 1,
+      () => focusRequestId === 1
+    );
+
+    animations = [replacementReveal.animation];
+    selectedReveal.cancel();
+    await flushPromises();
+    expect(animationFrames).toHaveLength(1);
+
+    const animationsBeforeReplacement = getActiveContainerAnimations(prompt);
+    focusRequestId = 2;
+    holdContainerInertUntilReveal(prompt);
+    animationFrames.shift()!();
+    focusAfterReveal(
+      prompt,
+      animationsBeforeReplacement,
+      () => focusRequestId === 2,
+      () => focusRequestId === 2
+    );
+
+    expect(container).toHaveAttribute('inert');
+    expect(focus).not.toHaveBeenCalled();
+
+    opacity = '1';
+    animations = [];
+    replacementReveal.finish();
+    await flushPromises();
+    animationFrames.shift()!();
+
+    expect(container).not.toHaveAttribute('inert');
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps a newer request on a replacement reveal before the canceled reveal settles', async () => {
+    const { container, prompt } = renderPrompt();
+    const selectedReveal = createControlledAnimation('running');
+    const replacementReveal = createControlledAnimation('running');
+    let animations = [selectedReveal.animation];
+    Object.defineProperty(container, 'getAnimations', {
+      configurable: true,
+      value: () => animations,
+    });
+    const focus = jest.spyOn(prompt, 'focus');
+    let focusRequestId = 1;
+
+    holdContainerInertUntilReveal(prompt);
+    focusAfterReveal(
+      prompt,
+      [],
+      () => focusRequestId === 1,
+      () => focusRequestId === 1
+    );
+
+    animations = [replacementReveal.animation];
+    selectedReveal.cancel();
+    const animationsBeforeReplacement = getActiveContainerAnimations(prompt);
+    focusRequestId = 2;
+    holdContainerInertUntilReveal(prompt);
+    focusAfterReveal(
+      prompt,
+      animationsBeforeReplacement,
+      () => focusRequestId === 2,
+      () => focusRequestId === 2
+    );
+
+    expect(container).toHaveAttribute('inert');
+    expect(focus).not.toHaveBeenCalled();
+
+    opacity = '1';
+    animations = [];
+    replacementReveal.finish();
+    await flushPromises();
+
+    expect(container).not.toHaveAttribute('inert');
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  test('releases opening inertness without focusing a replaced prompt', () => {
+    const { container, prompt } = renderPrompt();
+    const focus = jest.spyOn(prompt, 'focus');
+
+    holdContainerInertUntilReveal(prompt);
+    expect(container).toHaveAttribute('inert');
+
+    opacity = '1';
+    focusAfterReveal(
+      prompt,
+      [],
+      () => false,
+      () => true
+    );
+
+    expect(container).not.toHaveAttribute('inert');
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  test('keeps opening inertness when the focus request is no longer current', () => {
+    const { container, prompt } = renderPrompt();
+    const focus = jest.spyOn(prompt, 'focus');
+
+    holdContainerInertUntilReveal(prompt);
+    opacity = '1';
+    focusAfterReveal(
+      prompt,
+      [],
+      () => false,
+      () => false
+    );
+
+    expect(container).toHaveAttribute('inert');
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  test('restores opening inertness after an open layout rerenders', () => {
+    const { container, prompt } = renderPrompt();
+
+    holdContainerInertUntilReveal(prompt);
+    container.removeAttribute('inert');
+    restoreContainerInertUntilReveal(prompt);
+
+    expect(container).toHaveAttribute('inert');
+  });
+});

--- a/packages/instantsearch.js/src/lib/chat/focusAfterReveal.ts
+++ b/packages/instantsearch.js/src/lib/chat/focusAfterReveal.ts
@@ -1,0 +1,135 @@
+export function getActiveContainerAnimations(
+  prompt: HTMLTextAreaElement | null
+): Animation[] {
+  if (!prompt) {
+    return [];
+  }
+
+  const container = prompt.closest<HTMLElement>('.ais-Chat-container');
+  return container && typeof container.getAnimations === 'function'
+    ? container
+        .getAnimations()
+        .filter((animation) => animation.playState !== 'finished')
+    : [];
+}
+
+const revealProperties = [
+  'opacity',
+  'transform',
+  'translate',
+  'scale',
+  'rotate',
+  'visibility',
+  'clip',
+  'clipPath',
+] as const;
+
+type RevealProperty = (typeof revealProperties)[number];
+
+function isRevealed(
+  style: CSSStyleDeclaration,
+  property: RevealProperty
+): boolean {
+  if (property === 'opacity') {
+    return style.opacity === '1';
+  }
+
+  if (property === 'transform') {
+    return [
+      'none',
+      'matrix(1, 0, 0, 1, 0, 0)',
+      'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)',
+    ].includes(style.transform);
+  }
+
+  if (property === 'translate') {
+    return ['none', '0px', '0px 0px', '0px 0px 0px'].includes(style.translate);
+  }
+
+  if (property === 'scale') {
+    return ['none', '1', '1 1'].includes(style.scale);
+  }
+
+  if (property === 'rotate') {
+    return ['none', '0deg'].includes(style.rotate);
+  }
+
+  if (property === 'visibility') {
+    return style.visibility === 'visible';
+  }
+
+  if (property === 'clip') {
+    return ['auto', 'rect(auto, auto, auto, auto)'].includes(
+      style.getPropertyValue('clip')
+    );
+  }
+
+  return style.clipPath === 'none';
+}
+
+function getPendingRevealProperties(
+  prompt: HTMLTextAreaElement | null
+): Set<RevealProperty> {
+  const container = prompt?.closest<HTMLElement>('.ais-Chat-container');
+
+  if (!container || typeof getComputedStyle !== 'function') {
+    return new Set(revealProperties);
+  }
+
+  const style = getComputedStyle(container);
+  return new Set(
+    revealProperties.filter((property) => !isRevealed(style, property))
+  );
+}
+
+function affectsReveal(
+  animation: Animation,
+  pendingRevealProperties: Set<RevealProperty>
+): boolean {
+  if (pendingRevealProperties.size === 0) {
+    return false;
+  }
+
+  const effect = animation.effect as KeyframeEffect | null;
+
+  if (typeof effect?.getKeyframes !== 'function') {
+    return true;
+  }
+
+  return effect
+    .getKeyframes()
+    .some((keyframe) =>
+      Array.from(pendingRevealProperties).some((property) =>
+        Object.prototype.hasOwnProperty.call(keyframe, property)
+      )
+    );
+}
+
+export function focusAfterReveal(
+  prompt: HTMLTextAreaElement | null,
+  animationsBeforeReveal: Animation[],
+  shouldFocus: () => boolean
+): void {
+  const pendingRevealProperties = getPendingRevealProperties(prompt);
+  const revealAnimations = getActiveContainerAnimations(prompt).filter(
+    (animation) =>
+      !animationsBeforeReveal.includes(animation) &&
+      animation.effect?.getTiming().iterations !== Infinity &&
+      affectsReveal(animation, pendingRevealProperties)
+  );
+
+  const focus = () => {
+    if (prompt && shouldFocus()) {
+      prompt.focus();
+    }
+  };
+
+  if (revealAnimations.length === 0) {
+    focus();
+    return;
+  }
+
+  Promise.all(
+    revealAnimations.map((animation) => animation.finished.catch(() => {}))
+  ).then(focus);
+}

--- a/packages/instantsearch.js/src/lib/chat/focusAfterReveal.ts
+++ b/packages/instantsearch.js/src/lib/chat/focusAfterReveal.ts
@@ -1,16 +1,42 @@
+export type ContainerAnimationSnapshot = Array<{
+  animation: Animation;
+  currentTime: CSSNumberish | null;
+  playState: AnimationPlayState;
+  startTime: CSSNumberish | null;
+}>;
+
+const containersHeldInert = new WeakSet<HTMLElement>();
+const revealAnimationsHeldByContainer = new WeakMap<
+  HTMLElement,
+  Set<Animation>
+>();
+
+function getContainer(prompt: HTMLTextAreaElement | null): HTMLElement | null {
+  return prompt?.closest<HTMLElement>('.ais-Chat-container') ?? null;
+}
+
 export function getActiveContainerAnimations(
   prompt: HTMLTextAreaElement | null
-): Animation[] {
-  if (!prompt) {
+): ContainerAnimationSnapshot {
+  return getActiveAnimations(getContainer(prompt));
+}
+
+function getActiveAnimations(
+  container: HTMLElement | null
+): ContainerAnimationSnapshot {
+  if (!container || typeof container.getAnimations !== 'function') {
     return [];
   }
 
-  const container = prompt.closest<HTMLElement>('.ais-Chat-container');
-  return container && typeof container.getAnimations === 'function'
-    ? container
-        .getAnimations()
-        .filter((animation) => animation.playState !== 'finished')
-    : [];
+  return container
+    .getAnimations()
+    .filter((animation) => animation.playState !== 'finished')
+    .map((animation) => ({
+      animation,
+      currentTime: animation.currentTime,
+      playState: animation.playState,
+      startTime: animation.startTime,
+    }));
 }
 
 const revealProperties = [
@@ -68,10 +94,8 @@ function isRevealed(
 }
 
 function getPendingRevealProperties(
-  prompt: HTMLTextAreaElement | null
+  container: HTMLElement | null
 ): Set<RevealProperty> {
-  const container = prompt?.closest<HTMLElement>('.ais-Chat-container');
-
   if (!container || typeof getComputedStyle !== 'function') {
     return new Set(revealProperties);
   }
@@ -105,31 +129,156 @@ function affectsReveal(
     );
 }
 
-export function focusAfterReveal(
-  prompt: HTMLTextAreaElement | null,
-  animationsBeforeReveal: Animation[],
-  shouldFocus: () => boolean
-): void {
-  const pendingRevealProperties = getPendingRevealProperties(prompt);
-  const revealAnimations = getActiveContainerAnimations(prompt).filter(
-    (animation) =>
-      !animationsBeforeReveal.includes(animation) &&
-      animation.effect?.getTiming().iterations !== Infinity &&
-      affectsReveal(animation, pendingRevealProperties)
+function startedDuringReveal(
+  current: ContainerAnimationSnapshot[number],
+  animationsBeforeReveal: ContainerAnimationSnapshot
+): boolean {
+  const previous = animationsBeforeReveal.find(
+    ({ animation }) => animation === current.animation
   );
 
-  const focus = () => {
+  if (!previous) {
+    return true;
+  }
+
+  if (previous.playState !== current.playState) {
+    return true;
+  }
+
+  if (current.startTime !== null && previous.startTime !== current.startTime) {
+    return true;
+  }
+
+  return (
+    typeof previous.currentTime === 'number' &&
+    typeof current.currentTime === 'number' &&
+    current.currentTime < previous.currentTime
+  );
+}
+
+export function holdContainerInertUntilReveal(
+  prompt: HTMLTextAreaElement | null
+): void {
+  const container = getContainer(prompt);
+
+  if (
+    !container?.classList.contains('ais-Chat-container--open') ||
+    container.hasAttribute('inert')
+  ) {
+    return;
+  }
+
+  container.setAttribute('inert', '');
+  containersHeldInert.add(container);
+}
+
+export function restoreContainerInertUntilReveal(
+  prompt: HTMLTextAreaElement | null
+): void {
+  const container = getContainer(prompt);
+
+  if (
+    container &&
+    containersHeldInert.has(container) &&
+    getPendingRevealProperties(container).size > 0
+  ) {
+    container.setAttribute('inert', '');
+  }
+}
+
+function requestAnimationFrameOrRun(callback: () => void): void {
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(callback);
+  } else {
+    callback();
+  }
+}
+
+export function focusAfterReveal(
+  prompt: HTMLTextAreaElement | null,
+  animationsBeforeReveal: ContainerAnimationSnapshot,
+  shouldFocus: () => boolean,
+  shouldRelease: () => boolean = shouldFocus
+): void {
+  const container = getContainer(prompt);
+
+  const settle = () => {
+    if (!shouldRelease()) {
+      return;
+    }
+
+    if (container) {
+      revealAnimationsHeldByContainer.delete(container);
+    }
+
+    if (
+      container &&
+      containersHeldInert.has(container) &&
+      container.classList.contains('ais-Chat-container--open')
+    ) {
+      container.removeAttribute('inert');
+      containersHeldInert.delete(container);
+    }
+
     if (prompt && shouldFocus()) {
       prompt.focus();
     }
   };
 
-  if (revealAnimations.length === 0) {
-    focus();
-    return;
-  }
+  const waitForReveal = () => {
+    const requestIsCurrent = shouldRelease();
+    const pendingRevealProperties = getPendingRevealProperties(container);
+    const heldRevealAnimations = container
+      ? revealAnimationsHeldByContainer.get(container)
+      : undefined;
+    const activeAnimations = getActiveAnimations(container);
+    const heldRevealIsActive = activeAnimations.some(({ animation }) =>
+      heldRevealAnimations?.has(animation)
+    );
+    const replacesInactiveHeldReveal =
+      heldRevealAnimations !== undefined && !heldRevealIsActive;
+    const revealAnimations = activeAnimations.filter(
+      (current) =>
+        (startedDuringReveal(current, animationsBeforeReveal) ||
+          heldRevealAnimations?.has(current.animation) ||
+          replacesInactiveHeldReveal) &&
+        current.animation.effect?.getTiming().iterations !== Infinity &&
+        affectsReveal(current.animation, pendingRevealProperties)
+    );
 
-  Promise.all(
-    revealAnimations.map((animation) => animation.finished.catch(() => {}))
-  ).then(focus);
+    if (
+      container &&
+      revealAnimations.length > 0 &&
+      (!heldRevealAnimations || requestIsCurrent || !heldRevealIsActive)
+    ) {
+      revealAnimationsHeldByContainer.set(
+        container,
+        new Set(revealAnimations.map(({ animation }) => animation))
+      );
+    }
+
+    if (!requestIsCurrent) {
+      if (
+        container &&
+        !container.classList.contains('ais-Chat-container--open')
+      ) {
+        revealAnimationsHeldByContainer.delete(container);
+        containersHeldInert.delete(container);
+      }
+      return;
+    }
+
+    if (revealAnimations.length === 0) {
+      settle();
+      return;
+    }
+
+    Promise.all(
+      revealAnimations.map(({ animation }) =>
+        animation.finished.catch(() => {})
+      )
+    ).then(() => requestAnimationFrameOrRun(waitForReveal));
+  };
+
+  waitForReveal();
 }

--- a/packages/instantsearch.js/src/widgets/chat/__tests__/chat.test.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/__tests__/chat.test.tsx
@@ -550,6 +550,138 @@ describe('chat', () => {
       expect(document.activeElement).toBe(externalButton);
     });
 
+    test('keeps a newer focus request waiting for a replacement reveal', async () => {
+      const container = document.createElement('div');
+      const externalButton = document.createElement('button');
+      document.body.append(container, externalButton);
+
+      const focusSpy = jest.spyOn(HTMLTextAreaElement.prototype, 'focus');
+      const animationFrames: Array<() => void> = [];
+      jest
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback) => {
+          animationFrames.push(() => callback(0));
+          return animationFrames.length;
+        });
+      sessionStorage.setItem('instantsearch-chat-open-state-chat', 'true');
+
+      const search = instantsearch({
+        indexName: 'indexName',
+        searchClient: createSearchClient(),
+      });
+
+      search.addWidgets([
+        chat({
+          container,
+          agentId: 'test-agent-id',
+          disableTriggerValidation: true,
+          persistence: true,
+          requiresSearch: false,
+        }),
+      ]);
+
+      search.start();
+      await wait(0);
+      search.renderState.indexName.chat!.setOpen(false);
+      await wait(0);
+      externalButton.focus();
+
+      let cancelSelectedReveal!: () => void;
+      let selectedRevealPlayState: AnimationPlayState = 'running';
+      let selectedRevealFinishedReads = 0;
+      const selectedRevealFinished = new Promise<void>((_resolve, reject) => {
+        cancelSelectedReveal = () => {
+          selectedRevealPlayState = 'idle';
+          reject();
+        };
+      });
+      let finishReplacementReveal!: () => void;
+      const replacementRevealFinished = new Promise<void>((resolve) => {
+        finishReplacementReveal = resolve;
+      });
+      const selectedReveal = {
+        currentTime: 10,
+        startTime: 0,
+        get playState() {
+          return selectedRevealPlayState;
+        },
+        effect: {
+          getKeyframes: () => [{ opacity: 0 }, { opacity: 1 }],
+          getTiming: () => ({ iterations: 1 }),
+        },
+        get finished() {
+          selectedRevealFinishedReads++;
+          return selectedRevealFinished;
+        },
+      } as unknown as Animation;
+      const replacementReveal = {
+        currentTime: 10,
+        startTime: 0,
+        playState: 'running',
+        effect: selectedReveal.effect,
+        finished: replacementRevealFinished,
+      } as unknown as Animation;
+      const chatContainer = container.querySelector<HTMLElement>(
+        '.ais-Chat-container'
+      )!;
+      let animations = [selectedReveal];
+      Object.defineProperty(chatContainer, 'getAnimations', {
+        configurable: true,
+        value: () =>
+          chatContainer.classList.contains('ais-Chat-container--open')
+            ? animations
+            : [],
+      });
+      jest.spyOn(window, 'getComputedStyle').mockImplementation(
+        () =>
+          ({
+            clipPath: 'none',
+            opacity: '0',
+            rotate: 'none',
+            scale: 'none',
+            transform: 'none',
+            translate: 'none',
+            visibility: 'visible',
+            getPropertyValue: () => 'auto',
+          }) as unknown as CSSStyleDeclaration
+      );
+
+      search.renderState.indexName.chat!.setOpen(true);
+      await wait(0);
+      while (selectedRevealFinishedReads === 0 && animationFrames.length > 0) {
+        animationFrames.shift()!();
+      }
+      expect(selectedRevealFinishedReads).toBeGreaterThan(0);
+      animationFrames.length = 0;
+
+      animations = [replacementReveal];
+      cancelSelectedReveal();
+      search.renderState.indexName.chat!.focusInput();
+      expect(animationFrames).toHaveLength(1);
+      await wait(0);
+      await wait(0);
+      expect(animationFrames).toHaveLength(2);
+      animationFrames.shift()!();
+
+      expect(document.activeElement).toBe(externalButton);
+      expect(chatContainer).toHaveAttribute('inert');
+      expect(focusSpy).not.toHaveBeenCalled();
+
+      animationFrames.shift()!();
+
+      animations = [];
+      finishReplacementReveal();
+      await replacementRevealFinished;
+      await wait(0);
+      animationFrames.shift()!();
+
+      expect(chatContainer).not.toHaveAttribute('inert');
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+      expect(document.activeElement).toBe(
+        container.querySelector('.ais-ChatPrompt-textarea')
+      );
+    });
+
     test('does not move focus when openChat submits to an open panel', async () => {
       const container = document.createElement('div');
       const externalButton = document.createElement('button');
@@ -593,9 +725,16 @@ describe('chat', () => {
       expect(focusSpy).not.toHaveBeenCalled();
     });
 
-    test('keeps prompt autofocus for an inline layout with open persistence', async () => {
+    test('keeps inline prompt focus available with open persistence', async () => {
       const container = document.createElement('div');
-      document.body.appendChild(container);
+      const externalButton = document.createElement('button');
+      document.body.append(container, externalButton);
+      jest
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback) => {
+          callback(0);
+          return 0;
+        });
 
       const search = instantsearch({
         indexName: 'indexName',
@@ -618,6 +757,17 @@ describe('chat', () => {
       expect(
         container.querySelector('.ais-ChatPrompt-textarea')
       ).toHaveAttribute('autofocus');
+
+      externalButton.focus();
+      search.renderState.indexName.chat!.focusInput();
+      await wait(0);
+
+      expect(
+        container.querySelector('.ais-Chat-container')
+      ).not.toHaveAttribute('inert');
+      expect(document.activeElement).toBe(
+        container.querySelector('.ais-ChatPrompt-textarea')
+      );
     });
 
     // A fresh `layoutComponent` per render would remount the chat subtree

--- a/packages/instantsearch.js/src/widgets/chat/__tests__/chat.test.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/__tests__/chat.test.tsx
@@ -489,6 +489,67 @@ describe('chat', () => {
       );
     });
 
+    test('does not focus after a reveal is interrupted by closing', async () => {
+      const container = document.createElement('div');
+      const externalButton = document.createElement('button');
+      document.body.append(container, externalButton);
+
+      const focusSpy = jest.spyOn(HTMLTextAreaElement.prototype, 'focus');
+      jest
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation((callback) => {
+          callback(0);
+          return 0;
+        });
+      sessionStorage.setItem('instantsearch-chat-open-state-chat', 'true');
+
+      const search = instantsearch({
+        indexName: 'indexName',
+        searchClient: createSearchClient(),
+      });
+
+      search.addWidgets([
+        chat({
+          container,
+          agentId: 'test-agent-id',
+          persistence: true,
+          requiresSearch: false,
+        }),
+      ]);
+
+      search.start();
+      await wait(0);
+
+      let finishReveal!: () => void;
+      const finished = new Promise<void>((resolve) => {
+        finishReveal = resolve;
+      });
+      Object.defineProperty(
+        container.querySelector('.ais-Chat-container'),
+        'getAnimations',
+        {
+          configurable: true,
+          value: () => [{ playState: 'running', finished }],
+        }
+      );
+
+      search.renderState.indexName.chat!.setOpen(false);
+      await wait(0);
+      externalButton.focus();
+      search.renderState.indexName.chat!.setOpen(true);
+      await wait(0);
+
+      expect(focusSpy).not.toHaveBeenCalled();
+
+      search.renderState.indexName.chat!.setOpen(false);
+      await wait(0);
+      finishReveal();
+      await finished;
+
+      expect(focusSpy).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(externalButton);
+    });
+
     test('does not move focus when openChat submits to an open panel', async () => {
       const container = document.createElement('div');
       const externalButton = document.createElement('button');

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -14,6 +14,10 @@ import {
   PonderToolType,
   DisplayResultsToolType,
 } from '../../lib/chat';
+import {
+  focusAfterReveal,
+  getActiveContainerAnimations,
+} from '../../lib/chat/focusAfterReveal';
 import { prepareTemplateProps } from '../../lib/templating';
 import { useStickToBottom } from '../../lib/useStickToBottom';
 import {
@@ -363,6 +367,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
 }): Renderer<ChatRenderState, Partial<ChatWidgetParams>> => {
   const state = createLocalState();
   const promptRef = { current: null as HTMLTextAreaElement | null };
+  let focusRequestId = 0;
 
   // Template wrappers are rendered as component types downstream. Recreating
   // them each render would make Preact remount the chat subtree (and drop
@@ -829,12 +834,26 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
     }
 
     const shouldFocusPrompt = consumeInputFocus?.() ?? false;
+    const animationsBeforeReveal = shouldFocusPrompt
+      ? getActiveContainerAnimations(promptRef.current)
+      : [];
 
     rerender();
 
+    if (!open) {
+      focusRequestId++;
+    }
+
     if (shouldFocusPrompt) {
+      const currentFocusRequestId = ++focusRequestId;
       window.requestAnimationFrame(() => {
-        promptRef.current?.focus();
+        const prompt = promptRef.current;
+        focusAfterReveal(prompt, animationsBeforeReveal, () => {
+          return (
+            focusRequestId === currentFocusRequestId &&
+            promptRef.current === prompt
+          );
+        });
       });
     }
   };

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -17,6 +17,8 @@ import {
 import {
   focusAfterReveal,
   getActiveContainerAnimations,
+  holdContainerInertUntilReveal,
+  restoreContainerInertUntilReveal,
 } from '../../lib/chat/focusAfterReveal';
 import { prepareTemplateProps } from '../../lib/templating';
 import { useStickToBottom } from '../../lib/useStickToBottom';
@@ -840,20 +842,32 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
 
     rerender();
 
+    if (open) {
+      restoreContainerInertUntilReveal(promptRef.current);
+    }
+
     if (!open) {
       focusRequestId++;
     }
 
     if (shouldFocusPrompt) {
       const currentFocusRequestId = ++focusRequestId;
+      holdContainerInertUntilReveal(promptRef.current);
       window.requestAnimationFrame(() => {
         const prompt = promptRef.current;
-        focusAfterReveal(prompt, animationsBeforeReveal, () => {
-          return (
-            focusRequestId === currentFocusRequestId &&
-            promptRef.current === prompt
-          );
-        });
+        focusAfterReveal(
+          prompt,
+          animationsBeforeReveal,
+          () => {
+            return (
+              focusRequestId === currentFocusRequestId &&
+              promptRef.current === prompt
+            );
+          },
+          () => {
+            return focusRequestId === currentFocusRequestId;
+          }
+        );
       });
     }
   };

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -10,6 +10,8 @@ import {
 import {
   focusAfterReveal,
   getActiveContainerAnimations,
+  holdContainerInertUntilReveal,
+  restoreContainerInertUntilReveal,
 } from 'instantsearch.js/es/lib/chat/focusAfterReveal';
 import React, {
   createElement,
@@ -48,6 +50,7 @@ import type {
 } from 'instantsearch-ui-components';
 import type { IndexUiState } from 'instantsearch.js';
 import type { UIMessage } from 'instantsearch.js/es/lib/chat';
+import type { ContainerAnimationSnapshot } from 'instantsearch.js/es/lib/chat/focusAfterReveal';
 import type { UseChatProps } from 'react-instantsearch-core';
 
 const ChatUiComponent = createChatComponent({
@@ -209,7 +212,8 @@ export type ChatHandle = {
 
 type AnimationSnapshotProps = {
   promptRef: React.RefObject<HTMLTextAreaElement | null>;
-  animationsBeforeReveal: React.RefObject<Animation[]>;
+  animationsBeforeReveal: React.RefObject<ContainerAnimationSnapshot>;
+  open: boolean;
 };
 
 class AnimationSnapshot extends React.Component<AnimationSnapshotProps> {
@@ -220,9 +224,14 @@ class AnimationSnapshot extends React.Component<AnimationSnapshotProps> {
   componentDidUpdate(
     _previousProps: AnimationSnapshotProps,
     _previousState: unknown,
-    animationsBeforeReveal: Animation[]
+    animationsBeforeReveal: ContainerAnimationSnapshot
   ) {
     this.props.animationsBeforeReveal.current = animationsBeforeReveal;
+    if (!_previousProps.open && this.props.open) {
+      holdContainerInertUntilReveal(this.props.promptRef.current);
+    } else if (this.props.open) {
+      restoreContainerInertUntilReveal(this.props.promptRef.current);
+    }
   }
 
   render() {
@@ -281,7 +290,7 @@ function ChatInner<
 
   const promptRef = useRef<HTMLTextAreaElement>(null);
   const focusRequestId = useRef(0);
-  const animationsBeforeReveal = useRef<Animation[]>([]);
+  const animationsBeforeReveal = useRef<ContainerAnimationSnapshot>([]);
 
   const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
     useStickToBottom({
@@ -348,14 +357,22 @@ function ChatInner<
     if (consumeInputFocus?.()) {
       const currentFocusRequestId = ++focusRequestId.current;
       const previousAnimations = animationsBeforeReveal.current;
+      holdContainerInertUntilReveal(promptRef.current);
       window.requestAnimationFrame(() => {
         const prompt = promptRef.current;
-        focusAfterReveal(prompt, previousAnimations, () => {
-          return (
-            focusRequestId.current === currentFocusRequestId &&
-            promptRef.current === prompt
-          );
-        });
+        focusAfterReveal(
+          prompt,
+          previousAnimations,
+          () => {
+            return (
+              focusRequestId.current === currentFocusRequestId &&
+              promptRef.current === prompt
+            );
+          },
+          () => {
+            return focusRequestId.current === currentFocusRequestId;
+          }
+        );
       });
     }
   });
@@ -485,6 +502,7 @@ function ChatInner<
       <AnimationSnapshot
         promptRef={promptRef}
         animationsBeforeReveal={animationsBeforeReveal}
+        open={open}
       />
       {chat}
     </>

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -7,6 +7,10 @@ import {
   PonderToolType,
   DisplayResultsToolType,
 } from 'instantsearch.js/es/lib/chat';
+import {
+  focusAfterReveal,
+  getActiveContainerAnimations,
+} from 'instantsearch.js/es/lib/chat/focusAfterReveal';
 import React, {
   createElement,
   Fragment,
@@ -203,6 +207,29 @@ export type ChatHandle = {
   setInput: (input: string) => void;
 };
 
+type AnimationSnapshotProps = {
+  promptRef: React.RefObject<HTMLTextAreaElement | null>;
+  animationsBeforeReveal: React.RefObject<Animation[]>;
+};
+
+class AnimationSnapshot extends React.Component<AnimationSnapshotProps> {
+  getSnapshotBeforeUpdate() {
+    return getActiveContainerAnimations(this.props.promptRef.current);
+  }
+
+  componentDidUpdate(
+    _previousProps: AnimationSnapshotProps,
+    _previousState: unknown,
+    animationsBeforeReveal: Animation[]
+  ) {
+    this.props.animationsBeforeReveal.current = animationsBeforeReveal;
+  }
+
+  render() {
+    return null;
+  }
+}
+
 function ChatInner<
   TObject extends RecordWithObjectID,
   TUiMessage extends UIMessage,
@@ -253,6 +280,8 @@ function ChatInner<
   const [maximized, setMaximized] = useState(false);
 
   const promptRef = useRef<HTMLTextAreaElement>(null);
+  const focusRequestId = useRef(0);
+  const animationsBeforeReveal = useRef<Animation[]>([]);
 
   const { scrollRef, contentRef, scrollToBottom, isAtBottom } =
     useStickToBottom({
@@ -311,9 +340,22 @@ function ChatInner<
   }));
 
   useEffect(() => {
+    if (!open) {
+      focusRequestId.current++;
+      return;
+    }
+
     if (consumeInputFocus?.()) {
+      const currentFocusRequestId = ++focusRequestId.current;
+      const previousAnimations = animationsBeforeReveal.current;
       window.requestAnimationFrame(() => {
-        promptRef.current?.focus();
+        const prompt = promptRef.current;
+        focusAfterReveal(prompt, previousAnimations, () => {
+          return (
+            focusRequestId.current === currentFocusRequestId &&
+            promptRef.current === prompt
+          );
+        });
       });
     }
   });
@@ -340,7 +382,7 @@ function ChatInner<
     ...restMessagesProps
   } = messagesProps ?? {};
 
-  return (
+  const chat = (
     <ChatUiComponent
       title={title}
       open={open}
@@ -436,6 +478,16 @@ function ChatInner<
       }}
       classNames={classNames}
     />
+  );
+
+  return (
+    <>
+      <AnimationSnapshot
+        promptRef={promptRef}
+        animationsBeforeReveal={animationsBeforeReveal}
+      />
+      {chat}
+    </>
   );
 }
 

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
@@ -199,6 +199,77 @@ describe('Chat', () => {
     externalButton.remove();
   });
 
+  test('does not focus after a reveal is interrupted by closing', async () => {
+    sessionStorage.setItem('instantsearch-chat-open-state-chat', 'true');
+    const externalButton = document.createElement('button');
+    document.body.appendChild(externalButton);
+
+    const focusSpy = jest.spyOn(HTMLTextAreaElement.prototype, 'focus');
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        callback(0);
+        return 0;
+      });
+    const chatRef = React.createRef<ChatHandle>();
+
+    const { container } = render(
+      <InstantSearch searchClient={searchClient} indexName="indexName">
+        <Chat
+          ref={chatRef}
+          agentId="test-agent-id"
+          disableTriggerValidation={true}
+          persistence={true}
+          requiresSearch={false}
+        />
+        <ChatTrigger floating={false} />
+      </InstantSearch>
+    );
+
+    await act(async () => {
+      await wait(0);
+    });
+
+    let finishReveal!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      finishReveal = resolve;
+    });
+    Object.defineProperty(
+      container.querySelector('.ais-Chat-container'),
+      'getAnimations',
+      {
+        configurable: true,
+        value: () => [{ playState: 'running', finished }],
+      }
+    );
+
+    await act(async () => {
+      chatRef.current!.setOpen(false);
+      await wait(0);
+    });
+    externalButton.focus();
+    await act(async () => {
+      chatRef.current!.setOpen(true);
+      await wait(0);
+    });
+
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      chatRef.current!.setOpen(false);
+      await wait(0);
+    });
+    await act(async () => {
+      finishReveal();
+      await finished;
+    });
+
+    expect(focusSpy).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(externalButton);
+
+    externalButton.remove();
+  });
+
   test('does not move focus when openChat submits to an open panel', async () => {
     sessionStorage.setItem('instantsearch-chat-open-state-chat', 'true');
     const externalButton = document.createElement('button');

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
@@ -270,6 +270,156 @@ describe('Chat', () => {
     externalButton.remove();
   });
 
+  test('keeps a newer focus request waiting for a replacement reveal', async () => {
+    sessionStorage.setItem('instantsearch-chat-open-state-chat', 'true');
+    const externalButton = document.createElement('button');
+    document.body.appendChild(externalButton);
+
+    const focusSpy = jest.spyOn(HTMLTextAreaElement.prototype, 'focus');
+    const animationFrames: Array<() => void> = [];
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        animationFrames.push(() => callback(0));
+        return animationFrames.length;
+      });
+    const chatRef = React.createRef<ChatHandle>();
+    let chatRenderState: Parameters<typeof openChat>[0];
+
+    const { container } = render(
+      <InstantSearch searchClient={searchClient} indexName="indexName">
+        <Chat
+          ref={chatRef}
+          agentId="test-agent-id"
+          disableTriggerValidation={true}
+          persistence={true}
+          requiresSearch={false}
+        />
+        <CaptureChatRenderState
+          capture={(renderState) => {
+            chatRenderState = renderState;
+          }}
+        />
+      </InstantSearch>
+    );
+
+    await act(async () => {
+      await wait(0);
+      chatRef.current!.setOpen(false);
+      await wait(0);
+    });
+    externalButton.focus();
+
+    let cancelSelectedReveal!: () => void;
+    let selectedRevealPlayState: AnimationPlayState = 'running';
+    let selectedRevealFinishedReads = 0;
+    const selectedRevealFinished = new Promise<void>((_resolve, reject) => {
+      cancelSelectedReveal = () => {
+        selectedRevealPlayState = 'idle';
+        reject();
+      };
+    });
+    let finishReplacementReveal!: () => void;
+    const replacementRevealFinished = new Promise<void>((resolve) => {
+      finishReplacementReveal = resolve;
+    });
+    const selectedReveal = {
+      currentTime: 10,
+      startTime: 0,
+      get playState() {
+        return selectedRevealPlayState;
+      },
+      effect: {
+        getKeyframes: () => [{ opacity: 0 }, { opacity: 1 }],
+        getTiming: () => ({ iterations: 1 }),
+      },
+      get finished() {
+        selectedRevealFinishedReads++;
+        return selectedRevealFinished;
+      },
+    } as unknown as Animation;
+    const replacementReveal = {
+      currentTime: 10,
+      startTime: 0,
+      playState: 'running',
+      effect: selectedReveal.effect,
+      finished: replacementRevealFinished,
+    } as unknown as Animation;
+    const chatContainer = container.querySelector<HTMLElement>(
+      '.ais-Chat-container'
+    )!;
+    let animations = [selectedReveal];
+    Object.defineProperty(chatContainer, 'getAnimations', {
+      configurable: true,
+      value: () =>
+        chatContainer.classList.contains('ais-Chat-container--open')
+          ? animations
+          : [],
+    });
+    jest.spyOn(window, 'getComputedStyle').mockImplementation(
+      () =>
+        ({
+          clipPath: 'none',
+          opacity: '0',
+          rotate: 'none',
+          scale: 'none',
+          transform: 'none',
+          translate: 'none',
+          visibility: 'visible',
+          getPropertyValue: () => 'auto',
+        }) as unknown as CSSStyleDeclaration
+    );
+
+    await act(async () => {
+      chatRef.current!.setOpen(true);
+      await wait(0);
+    });
+    while (selectedRevealFinishedReads === 0 && animationFrames.length > 0) {
+      await act(async () => {
+        animationFrames.shift()!();
+      });
+    }
+    expect(selectedRevealFinishedReads).toBeGreaterThan(0);
+    animationFrames.length = 0;
+
+    expect(document.activeElement).toBe(externalButton);
+    expect(chatContainer).toHaveAttribute('inert');
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    animations = [replacementReveal];
+    cancelSelectedReveal();
+    await act(async () => {
+      await wait(0);
+      chatRenderState!.focusInput!();
+      await wait(0);
+    });
+    expect(animationFrames).toHaveLength(2);
+    await act(async () => {
+      animationFrames.shift()!();
+      animationFrames.shift()!();
+    });
+
+    expect(document.activeElement).toBe(externalButton);
+    expect(chatContainer).toHaveAttribute('inert');
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    animations = [];
+    await act(async () => {
+      finishReplacementReveal();
+      await replacementRevealFinished;
+      await wait(0);
+      animationFrames.shift()!();
+    });
+
+    expect(chatContainer).not.toHaveAttribute('inert');
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(
+      container.querySelector('.ais-ChatPrompt-textarea')
+    );
+
+    externalButton.remove();
+  });
+
   test('does not move focus when openChat submits to an open panel', async () => {
     sessionStorage.setItem('instantsearch-chat-open-state-chat', 'true');
     const externalButton = document.createElement('button');
@@ -349,12 +499,19 @@ describe('Chat', () => {
     externalButton.remove();
   });
 
-  test('keeps prompt autofocus for an inline layout with open persistence', async () => {
+  test('keeps inline prompt focus available with open persistence', async () => {
     const externalButton = document.createElement('button');
     document.body.appendChild(externalButton);
     externalButton.focus();
 
     const focusSpy = jest.spyOn(HTMLTextAreaElement.prototype, 'focus');
+    jest
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        callback(0);
+        return 0;
+      });
+    let chatRenderState: Parameters<typeof openChat>[0];
     const { container } = render(
       <InstantSearch searchClient={searchClient} indexName="indexName">
         <Chat
@@ -362,6 +519,11 @@ describe('Chat', () => {
           layoutComponent={ChatInlineLayout}
           persistence={true}
           requiresSearch={false}
+        />
+        <CaptureChatRenderState
+          capture={(renderState) => {
+            chatRenderState = renderState;
+          }}
         />
       </InstantSearch>
     );
@@ -371,6 +533,19 @@ describe('Chat', () => {
     });
 
     expect(focusSpy).toHaveBeenCalled();
+    expect(document.activeElement).toBe(
+      container.querySelector('.ais-ChatPrompt-textarea')
+    );
+
+    externalButton.focus();
+    await act(async () => {
+      chatRenderState!.focusInput!();
+      await wait(0);
+    });
+
+    expect(container.querySelector('.ais-Chat-container')).not.toHaveAttribute(
+      'inert'
+    );
     expect(document.activeElement).toBe(
       container.querySelector('.ais-ChatPrompt-textarea')
     );

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -3084,6 +3084,11 @@ export function createOptionsTests(
         expect(
           document.querySelector('.ais-ChatInlineLayout')
         ).not.toBeInTheDocument();
+        await waitFor(() => {
+          expect(document.activeElement).toBe(
+            document.querySelector('.ais-ChatPrompt-textarea')
+          );
+        });
       });
 
       test('exposes sendMessage to custom layout component', async () => {

--- a/tests/e2e/playwright/specs/chat-focus.spec.ts
+++ b/tests/e2e/playwright/specs/chat-focus.spec.ts
@@ -31,10 +31,6 @@ test.describe('Chat focus', () => {
       )
       .toBe('0');
 
-    const focusAfterReveal = page.waitForEvent('console', {
-      predicate: (message) => message.type() === 'debug',
-    });
-
     await page.evaluate(() => {
       document.addEventListener(
         'focusin',
@@ -50,12 +46,11 @@ test.describe('Chat focus', () => {
           }
 
           const style = getComputedStyle(chatContainer);
-          console.debug(
+          document.documentElement.dataset.chatFocusAfterRevealStyle =
             JSON.stringify({
               opacity: style.opacity,
               transform: style.transform,
-            })
-          );
+            });
         },
         { capture: true }
       );
@@ -63,7 +58,22 @@ test.describe('Chat focus', () => {
 
     await trigger.click();
 
-    const focusStyle = JSON.parse((await focusAfterReveal).text()) as {
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              document.documentElement.dataset.chatFocusAfterRevealStyle ?? null
+          ),
+        { timeout: 2000 }
+      )
+      .not.toBeNull();
+
+    const focusStyle = JSON.parse(
+      (await page.evaluate(
+        () => document.documentElement.dataset.chatFocusAfterRevealStyle
+      ))!
+    ) as {
       opacity: string;
       transform: string;
     };

--- a/tests/e2e/playwright/specs/chat-focus.spec.ts
+++ b/tests/e2e/playwright/specs/chat-focus.spec.ts
@@ -523,4 +523,295 @@ test.describe('Chat focus', () => {
       focusStyle.transform
     );
   });
+
+  test('keeps opening content out of the keyboard order until the reveal finishes', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !['js', 'react'].includes(String(testInfo.project.metadata.flavor)),
+      'Chat is only available in the JavaScript and React examples'
+    );
+
+    await page.goto('../default-theme/');
+
+    const container = page.locator('.ais-Chat-container');
+    const trigger = page.locator('.ais-ChatToggleButton');
+    const prompt = page.locator('.ais-ChatPrompt-textarea');
+
+    await trigger.click();
+    await page.locator('.ais-ChatHeader-close').click();
+    await expect(container).toHaveAttribute('inert', '');
+    await expect(container).toHaveCSS('opacity', '0');
+
+    await page.addStyleTag({
+      content: `
+        @keyframes chat-keyboard-reveal {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+
+        .ais-Chat-container--open {
+          animation: chat-keyboard-reveal 10s linear paused;
+        }
+      `,
+    });
+
+    await trigger.click();
+    await expect(container).toHaveClass(/ais-Chat-container--open/);
+    await expect(container).toHaveCSS('opacity', '0');
+    await expect(trigger).toBeFocused();
+    await expect(container).toHaveAttribute('inert', '');
+
+    await page.keyboard.press('Shift+Tab');
+
+    expect(
+      await container.evaluate((element) =>
+        element.contains(document.activeElement)
+      )
+    ).toBe(false);
+
+    await container.evaluate((element) => {
+      const reveal = element
+        .getAnimations()
+        .find(
+          (animation) =>
+            animation instanceof CSSAnimation &&
+            animation.animationName === 'chat-keyboard-reveal'
+        );
+
+      if (!reveal) {
+        throw new Error('Expected the paused keyboard reveal animation');
+      }
+
+      reveal.finish();
+    });
+
+    await expect(container).toHaveCSS('opacity', '1');
+    await expect(container).not.toHaveAttribute('inert', '');
+    await expect(prompt).toBeFocused();
+  });
+
+  test('waits when an existing reveal animation resumes', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !['js', 'react'].includes(String(testInfo.project.metadata.flavor)),
+      'Chat is only available in the JavaScript and React examples'
+    );
+
+    await page.goto('../default-theme/');
+
+    const container = page.locator('.ais-Chat-container');
+    const trigger = page.locator('.ais-ChatToggleButton');
+    const prompt = page.locator('.ais-ChatPrompt-textarea');
+
+    await trigger.click();
+    await page.locator('.ais-ChatHeader-close').click();
+    await expect(container).toHaveAttribute('inert', '');
+    await expect(container).toHaveCSS('opacity', '0');
+
+    await page.addStyleTag({
+      content: `
+        @keyframes chat-resumed-reveal {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+
+        .ais-Chat-container {
+          animation: chat-resumed-reveal 10s linear both paused;
+        }
+
+        .ais-Chat-container--open {
+          animation-play-state: running;
+        }
+      `,
+    });
+
+    await expect
+      .poll(() =>
+        container.evaluate((element) => {
+          const animation = element
+            .getAnimations()
+            .find(
+              (candidate) =>
+                candidate instanceof CSSAnimation &&
+                candidate.animationName === 'chat-resumed-reveal'
+            );
+
+          if (animation) {
+            (
+              animation as Animation & { observedBeforeOpen?: boolean }
+            ).observedBeforeOpen = true;
+          }
+
+          return animation?.playState;
+        })
+      )
+      .toBe('paused');
+
+    await trigger.click();
+    await expect(container).toHaveClass(/ais-Chat-container--open/);
+    await expect
+      .poll(() =>
+        container.evaluate((element) => {
+          const animation = element
+            .getAnimations()
+            .find(
+              (candidate) =>
+                candidate instanceof CSSAnimation &&
+                candidate.animationName === 'chat-resumed-reveal'
+            ) as (Animation & { observedBeforeOpen?: boolean }) | undefined;
+
+          return {
+            sameAnimation: animation?.observedBeforeOpen === true,
+            playState: animation?.playState,
+          };
+        })
+      )
+      .toEqual({ sameAnimation: true, playState: 'running' });
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).transform)
+      )
+      .toBe('matrix(1, 0, 0, 1, 0, 0)');
+    await expect(container).not.toHaveCSS('opacity', '1');
+    await expect(trigger).toBeFocused();
+
+    await container.evaluate((element) => {
+      const reveal = element
+        .getAnimations()
+        .find(
+          (animation) =>
+            animation instanceof CSSAnimation &&
+            animation.animationName === 'chat-resumed-reveal'
+        );
+
+      if (!reveal) {
+        throw new Error('Expected the resumed reveal animation');
+      }
+
+      reveal.finish();
+    });
+
+    await expect(container).toHaveCSS('opacity', '1');
+    await expect(prompt).toBeFocused();
+  });
+
+  test('waits for a replacement reveal animation', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !['js', 'react'].includes(String(testInfo.project.metadata.flavor)),
+      'Chat is only available in the JavaScript and React examples'
+    );
+
+    await page.goto('../default-theme/');
+
+    const container = page.locator('.ais-Chat-container');
+    const trigger = page.locator('.ais-ChatToggleButton');
+    const prompt = page.locator('.ais-ChatPrompt-textarea');
+
+    await trigger.click();
+    await page.locator('.ais-ChatHeader-close').click();
+    await expect(container).toHaveAttribute('inert', '');
+    await expect(container).toHaveCSS('opacity', '0');
+
+    const initialRevealStyles = await page.addStyleTag({
+      content: `
+        @keyframes chat-initial-reveal {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+
+        .ais-Chat-container--open {
+          animation: chat-initial-reveal 10s linear paused;
+        }
+      `,
+    });
+
+    await trigger.click();
+    await expect(container).toHaveClass(/ais-Chat-container--open/);
+    await expect(container).toHaveCSS('opacity', '0');
+    await expect(trigger).toBeFocused();
+    await expect
+      .poll(() =>
+        container.evaluate((element) =>
+          element
+            .getAnimations()
+            .some(
+              (animation) =>
+                animation instanceof CSSAnimation &&
+                animation.animationName === 'chat-initial-reveal' &&
+                animation.playState === 'paused'
+            )
+        )
+      )
+      .toBe(true);
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).transform)
+      )
+      .toBe('matrix(1, 0, 0, 1, 0, 0)');
+
+    await container.evaluate((element) => {
+      const replacement = element.animate([{ opacity: 0 }, { opacity: 1 }], {
+        duration: 10000,
+        fill: 'both',
+      });
+      replacement.pause();
+      (
+        replacement as Animation & { replacementReveal?: boolean }
+      ).replacementReveal = true;
+    });
+    await initialRevealStyles.evaluate((element) => element.remove());
+
+    await expect
+      .poll(() =>
+        container.evaluate((element) =>
+          element
+            .getAnimations()
+            .every(
+              (animation) =>
+                !(animation instanceof CSSAnimation) ||
+                animation.animationName !== 'chat-initial-reveal'
+            )
+        )
+      )
+      .toBe(true);
+    await expect(container).toHaveCSS('opacity', '0');
+    await expect
+      .poll(() =>
+        container.evaluate((element) =>
+          element
+            .getAnimations()
+            .some(
+              (animation) =>
+                (animation as Animation & { replacementReveal?: boolean })
+                  .replacementReveal === true &&
+                animation.playState === 'paused'
+            )
+        )
+      )
+      .toBe(true);
+    await expect(trigger).toBeFocused();
+
+    await container.evaluate((element) => {
+      const replacement = element
+        .getAnimations()
+        .find(
+          (animation) =>
+            (animation as Animation & { replacementReveal?: boolean })
+              .replacementReveal === true
+        );
+
+      if (!replacement) {
+        throw new Error('Expected the replacement reveal animation');
+      }
+
+      replacement.finish();
+    });
+
+    await expect(container).toHaveCSS('opacity', '1');
+    await expect(prompt).toBeFocused();
+  });
 });

--- a/tests/e2e/playwright/specs/chat-focus.spec.ts
+++ b/tests/e2e/playwright/specs/chat-focus.spec.ts
@@ -1,0 +1,516 @@
+import { test, expect } from '../fixtures';
+
+test.describe('Chat focus', () => {
+  test('focuses the prompt after the layout is revealed', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !['js', 'react'].includes(String(testInfo.project.metadata.flavor)),
+      'Chat is only available in the JavaScript and React examples'
+    );
+
+    await page.goto('../default-theme/');
+
+    const container = page.locator('.ais-Chat-container');
+    const trigger = page.locator('.ais-ChatToggleButton');
+
+    await trigger.click();
+    await expect(container).toHaveClass(/ais-Chat-container--open/);
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).opacity)
+      )
+      .toBe('1');
+
+    await page.locator('.ais-ChatHeader-close').click();
+    await expect(container).not.toHaveClass(/ais-Chat-container--open/);
+    await expect(container).toHaveAttribute('inert', '');
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).opacity)
+      )
+      .toBe('0');
+
+    const focusAfterReveal = page.waitForEvent('console', {
+      predicate: (message) => message.type() === 'debug',
+    });
+
+    await page.evaluate(() => {
+      document.addEventListener(
+        'focusin',
+        (event) => {
+          const prompt = event.target as HTMLElement;
+          if (!prompt.matches('.ais-ChatPrompt-textarea')) {
+            return;
+          }
+
+          const chatContainer = prompt.closest('.ais-Chat-container');
+          if (!chatContainer) {
+            return;
+          }
+
+          const style = getComputedStyle(chatContainer);
+          console.debug(
+            JSON.stringify({
+              opacity: style.opacity,
+              transform: style.transform,
+            })
+          );
+        },
+        { capture: true }
+      );
+    });
+
+    await trigger.click();
+
+    const focusStyle = JSON.parse((await focusAfterReveal).text()) as {
+      opacity: string;
+      transform: string;
+    };
+
+    expect(focusStyle.opacity).toBe('1');
+    expect(['none', 'matrix(1, 0, 0, 1, 0, 0)']).toContain(
+      focusStyle.transform
+    );
+  });
+
+  test('focuses after the reveal when the open state starts an ongoing animation', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !['js', 'react'].includes(String(testInfo.project.metadata.flavor)),
+      'Chat is only available in the JavaScript and React examples'
+    );
+
+    await page.goto('../default-theme/');
+
+    const container = page.locator('.ais-Chat-container');
+    const trigger = page.locator('.ais-ChatToggleButton');
+
+    await trigger.click();
+    await page.locator('.ais-ChatHeader-close').click();
+    await expect(container).toHaveAttribute('inert', '');
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).opacity)
+      )
+      .toBe('0');
+
+    await page.addStyleTag({
+      content: `
+        @keyframes chat-outline-pulse {
+          from { outline-color: transparent; }
+          to { outline-color: currentColor; }
+        }
+
+        .ais-Chat-container--open {
+          animation: chat-outline-pulse 1s linear infinite alternate;
+        }
+      `,
+    });
+
+    await expect
+      .poll(() =>
+        container.evaluate((element) => element.getAnimations().length)
+      )
+      .toBe(0);
+
+    await page.evaluate(() => {
+      document.addEventListener(
+        'focusin',
+        (event) => {
+          const prompt = event.target as HTMLElement;
+          if (!prompt.matches('.ais-ChatPrompt-textarea')) {
+            return;
+          }
+
+          const chatContainer = prompt.closest('.ais-Chat-container');
+          if (!chatContainer) {
+            return;
+          }
+
+          const style = getComputedStyle(chatContainer);
+          document.documentElement.dataset.chatFocusStyle = JSON.stringify({
+            opacity: style.opacity,
+            transform: style.transform,
+          });
+        },
+        { capture: true }
+      );
+    });
+
+    await trigger.click();
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () => document.documentElement.dataset.chatFocusStyle ?? null
+          ),
+        { timeout: 2000 }
+      )
+      .not.toBeNull();
+
+    const focusStyle = JSON.parse(
+      (await page.evaluate(
+        () => document.documentElement.dataset.chatFocusStyle
+      ))!
+    ) as {
+      opacity: string;
+      transform: string;
+    };
+
+    expect(focusStyle.opacity).toBe('1');
+    expect(['none', 'matrix(1, 0, 0, 1, 0, 0)']).toContain(
+      focusStyle.transform
+    );
+    await expect
+      .poll(() =>
+        container.evaluate((element) =>
+          element
+            .getAnimations()
+            .some(
+              (animation) =>
+                animation instanceof CSSAnimation &&
+                animation.animationName === 'chat-outline-pulse' &&
+                animation.playState === 'running'
+            )
+        )
+      )
+      .toBe(true);
+  });
+
+  test('focuses after the reveal while an unrelated animation stays paused', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !['js', 'react'].includes(String(testInfo.project.metadata.flavor)),
+      'Chat is only available in the JavaScript and React examples'
+    );
+
+    await page.goto('../default-theme/');
+
+    const container = page.locator('.ais-Chat-container');
+    const trigger = page.locator('.ais-ChatToggleButton');
+    const prompt = page.locator('.ais-ChatPrompt-textarea');
+
+    await trigger.click();
+    await page.locator('.ais-ChatHeader-close').click();
+    await expect(container).toHaveAttribute('inert', '');
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).opacity)
+      )
+      .toBe('0');
+
+    await page.addStyleTag({
+      content: `
+        @keyframes chat-outline-hold {
+          from { outline-color: transparent; }
+          to { outline-color: currentColor; }
+        }
+
+        .ais-Chat-container--open {
+          animation: chat-outline-hold 10s linear paused;
+        }
+      `,
+    });
+
+    await expect
+      .poll(() =>
+        container.evaluate((element) => element.getAnimations().length)
+      )
+      .toBe(0);
+
+    await trigger.click();
+    await expect(container).toHaveClass(/ais-Chat-container--open/);
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).opacity)
+      )
+      .toBe('1');
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).transform)
+      )
+      .toBe('matrix(1, 0, 0, 1, 0, 0)');
+    await expect
+      .poll(() =>
+        container.evaluate((element) =>
+          element
+            .getAnimations()
+            .some(
+              (animation) =>
+                animation instanceof CSSAnimation &&
+                animation.animationName === 'chat-outline-hold' &&
+                animation.playState === 'paused'
+            )
+        )
+      )
+      .toBe(true);
+    await expect(prompt).toBeFocused();
+  });
+
+  test('focuses when a paused animation leaves the layout visible', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !['js', 'react'].includes(String(testInfo.project.metadata.flavor)),
+      'Chat is only available in the JavaScript and React examples'
+    );
+
+    await page.goto('../default-theme/');
+
+    const container = page.locator('.ais-Chat-container');
+    const trigger = page.locator('.ais-ChatToggleButton');
+    const prompt = page.locator('.ais-ChatPrompt-textarea');
+
+    await trigger.click();
+    await page.locator('.ais-ChatHeader-close').click();
+    await expect(container).toHaveAttribute('inert', '');
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).opacity)
+      )
+      .toBe('0');
+
+    await page.addStyleTag({
+      content: `
+        @keyframes chat-opacity-hold {
+          from { opacity: 1; }
+          to { opacity: 1; }
+        }
+
+        .ais-Chat-container--open {
+          animation: chat-opacity-hold 10s linear paused;
+        }
+      `,
+    });
+
+    await expect
+      .poll(() =>
+        container.evaluate((element) => element.getAnimations().length)
+      )
+      .toBe(0);
+
+    await trigger.click();
+    await expect(container).toHaveClass(/ais-Chat-container--open/);
+    await expect(container).toHaveCSS('opacity', '1');
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).transform)
+      )
+      .toBe('matrix(1, 0, 0, 1, 0, 0)');
+    await expect
+      .poll(() =>
+        container.evaluate((element) =>
+          element
+            .getAnimations()
+            .some(
+              (animation) =>
+                animation instanceof CSSAnimation &&
+                animation.animationName === 'chat-opacity-hold' &&
+                animation.playState === 'paused'
+            )
+        )
+      )
+      .toBe(true);
+    await expect(prompt).toBeFocused();
+  });
+
+  test('waits for a paused reveal animation to finish before focusing', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !['js', 'react'].includes(String(testInfo.project.metadata.flavor)),
+      'Chat is only available in the JavaScript and React examples'
+    );
+
+    await page.goto('../default-theme/');
+
+    const container = page.locator('.ais-Chat-container');
+    const trigger = page.locator('.ais-ChatToggleButton');
+    const prompt = page.locator('.ais-ChatPrompt-textarea');
+
+    await trigger.click();
+    await page.locator('.ais-ChatHeader-close').click();
+    await expect(container).toHaveAttribute('inert', '');
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).opacity)
+      )
+      .toBe('0');
+
+    await page.addStyleTag({
+      content: `
+        @keyframes chat-opacity-reveal {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+
+        .ais-Chat-container--open {
+          animation: chat-opacity-reveal 10s linear paused;
+        }
+      `,
+    });
+
+    await trigger.click();
+    await expect(container).toHaveClass(/ais-Chat-container--open/);
+    await expect
+      .poll(() =>
+        container.evaluate((element) =>
+          element
+            .getAnimations()
+            .some(
+              (animation) =>
+                animation instanceof CSSAnimation &&
+                animation.animationName === 'chat-opacity-reveal' &&
+                animation.playState === 'paused'
+            )
+        )
+      )
+      .toBe(true);
+    await expect(container).toHaveCSS('opacity', '0');
+    await expect(trigger).toBeFocused();
+
+    await container.evaluate((element) => {
+      const reveal = element
+        .getAnimations()
+        .find(
+          (animation) =>
+            animation instanceof CSSAnimation &&
+            animation.animationName === 'chat-opacity-reveal'
+        );
+
+      if (!reveal) {
+        throw new Error('Expected the paused reveal animation');
+      }
+
+      reveal.finish();
+    });
+
+    await expect(container).toHaveCSS('opacity', '1');
+    await expect(prompt).toBeFocused();
+  });
+
+  test('focuses after a reveal animation is canceled while the layout stays open', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      !['js', 'react'].includes(String(testInfo.project.metadata.flavor)),
+      'Chat is only available in the JavaScript and React examples'
+    );
+
+    await page.goto('../default-theme/');
+
+    const container = page.locator('.ais-Chat-container');
+    const trigger = page.locator('.ais-ChatToggleButton');
+
+    await trigger.click();
+    await page.locator('.ais-ChatHeader-close').click();
+    await expect(container).toHaveAttribute('inert', '');
+    await expect
+      .poll(() =>
+        container.evaluate((element) => getComputedStyle(element).opacity)
+      )
+      .toBe('0');
+
+    const revealStyles = await page.addStyleTag({
+      content: `
+        @keyframes chat-opacity-cancel {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+
+        .ais-Chat-container--open {
+          animation: chat-opacity-cancel 10s linear paused;
+        }
+      `,
+    });
+
+    await expect
+      .poll(() =>
+        container.evaluate((element) => element.getAnimations().length)
+      )
+      .toBe(0);
+
+    await page.evaluate(() => {
+      document.addEventListener(
+        'focusin',
+        (event) => {
+          const prompt = event.target as HTMLElement;
+          if (!prompt.matches('.ais-ChatPrompt-textarea')) {
+            return;
+          }
+
+          const chatContainer = prompt.closest('.ais-Chat-container');
+          if (!chatContainer) {
+            return;
+          }
+
+          const style = getComputedStyle(chatContainer);
+          document.documentElement.dataset.chatFocusAfterCancellation =
+            JSON.stringify({
+              opacity: style.opacity,
+              transform: style.transform,
+            });
+        },
+        { capture: true }
+      );
+    });
+
+    await trigger.click();
+    await expect(container).toHaveClass(/ais-Chat-container--open/);
+    await expect(container).toHaveCSS('opacity', '0');
+    await expect(trigger).toBeFocused();
+    await expect
+      .poll(() =>
+        container.evaluate((element) =>
+          element
+            .getAnimations()
+            .some(
+              (animation) =>
+                animation instanceof CSSAnimation &&
+                animation.animationName === 'chat-opacity-cancel' &&
+                animation.playState === 'paused'
+            )
+        )
+      )
+      .toBe(true);
+
+    await revealStyles.evaluate((element) => element.remove());
+
+    await expect
+      .poll(() =>
+        container.evaluate((element) => element.getAnimations().length)
+      )
+      .toBe(0);
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              document.documentElement.dataset.chatFocusAfterCancellation ??
+              null
+          ),
+        { timeout: 2000 }
+      )
+      .not.toBeNull();
+
+    const focusStyle = JSON.parse(
+      (await page.evaluate(
+        () => document.documentElement.dataset.chatFocusAfterCancellation
+      ))!
+    ) as {
+      opacity: string;
+      transform: string;
+    };
+
+    await expect(container).toHaveClass(/ais-Chat-container--open/);
+    await expect(container).not.toHaveAttribute('inert', '');
+    expect(focusStyle.opacity).toBe('1');
+    expect(['none', 'matrix(1, 0, 0, 1, 0, 0)']).toContain(
+      focusStyle.transform
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- wait for the Chat layout to be visibly revealed before focusing its prompt after reopening
- ignore unrelated, infinite and already-visible animations while treating completed or canceled reveal animations as settled
- cancel stale focus after closing, unmounting, replacing the prompt or starting a newer focus request
- keep zero-motion and custom layouts immediate, with the same behavior in JavaScript and React

[FX-3936](https://algolia.atlassian.net/browse/FX-3936)

## Testing

- JavaScript and React wrapper and common Chat tests
- Chromium and Firefox coverage for default, ongoing, unrelated paused, visible paused, finished and canceled reveal animations

Browser checks confirm that focus remains on the trigger while the layout is hidden, then moves to the prompt only after the layout is visible. No visual styling or public API changes.


[FX-3936]: https://algolia.atlassian.net/browse/FX-3936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ