### PR TITLE
feat(chat): let tools claim the names a server derives from them

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -730,19 +730,14 @@ export type ClientSideTool = {
   layoutComponent?: ClientSideToolComponent;
   streamInput?: boolean;
   /**
-   * Whether this tool also handles a tool call sent under `toolName`.
+   * Whether this tool also handles a call sent under `toolName`.
    *
-   * Only consulted when no tool is registered under that exact name, so it can
-   * never shadow another registration. Declare it when the server derives the
-   * name it sends from the registered one: the Algolia MCP Server exposes the
-   * search tool once per index and appends the index name, so
-   * `algolia_search_index` has to answer to `algolia_search_index_products`
-   * too.
+   * Consulted only when no tool is registered under that exact name, so it
+   * can't shadow another registration. Needed when the server names a call
+   * after the registered tool: the Algolia MCP Server appends the index name,
+   * so `algolia_search_index` has to answer to `algolia_search_index_products`.
    *
-   * Omitted means the tool only handles its own name. That is deliberate —
-   * `a_b` is ambiguous between the tool `a_b` and the tool `a` addressing `b`,
-   * so which of two overlapping names wins is the registration site's call, not
-   * something the resolver can infer.
+   * Omitted means the tool only handles its own name.
    */
   matchesToolName?: (toolName: string) => boolean;
   /**

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -730,6 +730,22 @@ export type ClientSideTool = {
   layoutComponent?: ClientSideToolComponent;
   streamInput?: boolean;
   /**
+   * Whether this tool also handles a tool call sent under `toolName`.
+   *
+   * Only consulted when no tool is registered under that exact name, so it can
+   * never shadow another registration. Declare it when the server derives the
+   * name it sends from the registered one: the Algolia MCP Server exposes the
+   * search tool once per index and appends the index name, so
+   * `algolia_search_index` has to answer to `algolia_search_index_products`
+   * too.
+   *
+   * Omitted means the tool only handles its own name. That is deliberate —
+   * `a_b` is ambiguous between the tool `a_b` and the tool `a` addressing `b`,
+   * so which of two overlapping names wins is the registration site's call, not
+   * something the resolver can infer.
+   */
+  matchesToolName?: (toolName: string) => boolean;
+  /**
    * Whether this tool call should render.
    *
    * Returning `false` skips the part entirely and keeps the loader visible, so

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -216,7 +216,16 @@ describe('findTool', () => {
   test('points at `matchesToolName` when a registered name is a prefix', () => {
     expect(findTool('tool-foo_products', { foo })).toBeUndefined();
     expect(global.console.warn).toHaveBeenCalledWith(
-      '[instantsearch-ui-components] No tool is registered for "foo_products". The registered "foo" is a prefix of it, but a prefix alone doesn\'t resolve: declare `matchesToolName` on it to also handle "foo_products".'
+      '[instantsearch-ui-components] No tool is registered for "foo_products". The registered tool "foo" is a prefix of it, but a prefix alone doesn\'t resolve: declare `matchesToolName` on the tool that should handle "foo_products".'
+    );
+  });
+
+  test('lists every registered prefix of an unresolved name', () => {
+    expect(
+      findTool('tool-foo_bar_products', { foo_bar: fooBar, foo })
+    ).toBeUndefined();
+    expect(global.console.warn).toHaveBeenCalledWith(
+      '[instantsearch-ui-components] No tool is registered for "foo_bar_products". The registered tools "foo", "foo_bar" are prefixes of it, but a prefix alone doesn\'t resolve: declare `matchesToolName` on the tool that should handle "foo_bar_products".'
     );
   });
 });

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -1,4 +1,6 @@
+import { warnCache } from '../../../warn';
 import { findTool, getApplyFiltersParamsFromToolInput } from '../chat';
+import { startsWith } from '../startsWith';
 
 describe('getApplyFiltersParamsFromToolInput', () => {
   test('returns nothing to refine when input is undefined', () => {
@@ -121,27 +123,21 @@ describe('getApplyFiltersParamsFromToolInput', () => {
 describe('findTool', () => {
   const foo = { name: 'foo' };
   const fooBar = { name: 'foo_bar' };
+  // Opts in to the names a server derives from `foo`, the way the MCP Server
+  // suffixes the search tool with the index name.
+  const suffixedFoo = {
+    name: 'foo',
+    matchesToolName: (toolName: string) => startsWith(toolName, 'foo_'),
+  };
+
+  beforeEach(() => {
+    warnCache.current = {};
+    (global.console.warn as jest.Mock).mockClear();
+  });
 
   test('resolves an exact match from a part type or a bare tool name', () => {
     expect(findTool('tool-foo', { foo })).toBe(foo);
     expect(findTool('foo', { foo })).toBe(foo);
-  });
-
-  test('resolves a name suffixed by the index name', () => {
-    expect(findTool('tool-foo_products', { foo })).toBe(foo);
-  });
-
-  test('prefers the longest match over registration order', () => {
-    expect(findTool('tool-foo_bar_products', { foo, foo_bar: fooBar })).toBe(
-      fooBar
-    );
-    expect(findTool('tool-foo_bar_products', { foo_bar: fooBar, foo })).toBe(
-      fooBar
-    );
-  });
-
-  test('prefers an exact match over a shorter prefix', () => {
-    expect(findTool('tool-foo_bar', { foo, foo_bar: fooBar })).toBe(fooBar);
   });
 
   test('only strips a leading `tool-`', () => {
@@ -152,9 +148,75 @@ describe('findTool', () => {
     );
   });
 
+  test('resolves a derived name only for a tool that claims it', () => {
+    expect(findTool('tool-foo_products', { foo: suffixedFoo })).toBe(
+      suffixedFoo
+    );
+    expect(findTool('tool-foo_products', { foo })).toBeUndefined();
+  });
+
+  test('prefers an exact registration over a claim', () => {
+    expect(
+      findTool('tool-foo_bar', { foo: suffixedFoo, foo_bar: fooBar })
+    ).toBe(fooBar);
+    expect(
+      findTool('tool-foo_bar', { foo_bar: fooBar, foo: suffixedFoo })
+    ).toBe(fooBar);
+  });
+
+  test('registering overlapping names is unambiguous', () => {
+    // Neither `foo` nor `foo_bar` claims names beyond its own, so registration
+    // order cannot decide which one renders `foo_bar_products`.
+    expect(
+      findTool('tool-foo_bar_products', { foo, foo_bar: fooBar })
+    ).toBeUndefined();
+    expect(
+      findTool('tool-foo_bar_products', { foo_bar: fooBar, foo })
+    ).toBeUndefined();
+  });
+
+  test('resolves the most specific claim, whatever the registration order', () => {
+    const suffixedFooBar = {
+      name: 'foo_bar',
+      matchesToolName: (toolName: string) => startsWith(toolName, 'foo_bar_'),
+    };
+    const tools = { foo: suffixedFoo, foo_bar: suffixedFooBar };
+
+    expect(findTool('tool-foo_bar_products', tools)).toBe(suffixedFooBar);
+    expect(
+      findTool('tool-foo_bar_products', {
+        foo_bar: suffixedFooBar,
+        foo: suffixedFoo,
+      })
+    ).toBe(suffixedFooBar);
+  });
+
+  test('warns when several unrelated tools claim the same name', () => {
+    const other = {
+      name: 'other',
+      matchesToolName: (toolName: string) => startsWith(toolName, 'foo_'),
+    };
+
+    // A conflict the resolver cannot arbitrate: it settles it deterministically
+    // and says so, rather than letting registration order decide silently.
+    expect(findTool('tool-foo_products', { foo: suffixedFoo, other })).toBe(
+      other
+    );
+    expect(global.console.warn).toHaveBeenCalledWith(
+      '[instantsearch-ui-components] Multiple tools claim "foo_products" through `matchesToolName`: "other", "foo". "other" handles it.'
+    );
+  });
+
   test('returns undefined when nothing matches', () => {
     expect(findTool('tool-other', { foo })).toBeUndefined();
     // A shared prefix is not a match without the `_` separator.
-    expect(findTool('tool-foobar', { foo })).toBeUndefined();
+    expect(findTool('tool-foobar', { foo: suffixedFoo })).toBeUndefined();
+  });
+
+  test('points at `matchesToolName` when a registered name is a prefix', () => {
+    expect(findTool('tool-foo_products', { foo })).toBeUndefined();
+    expect(global.console.warn).toHaveBeenCalledWith(
+      '[instantsearch-ui-components] No tool is registered for "foo_products". The registered "foo" is a prefix of it, but a prefix alone doesn\'t resolve: declare `matchesToolName` on it to also handle "foo_products".'
+    );
   });
 });

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -123,8 +123,7 @@ describe('getApplyFiltersParamsFromToolInput', () => {
 describe('findTool', () => {
   const foo = { name: 'foo' };
   const fooBar = { name: 'foo_bar' };
-  // Opts in to the names a server derives from `foo`, the way the MCP Server
-  // suffixes the search tool with the index name.
+  // Claims index-suffixed names, like the MCP Server's search tool.
   const suffixedFoo = {
     name: 'foo',
     matchesToolName: (toolName: string) => startsWith(toolName, 'foo_'),
@@ -165,8 +164,7 @@ describe('findTool', () => {
   });
 
   test('registering overlapping names is unambiguous', () => {
-    // Neither `foo` nor `foo_bar` claims names beyond its own, so registration
-    // order cannot decide which one renders `foo_bar_products`.
+    // Neither claims beyond its own name, so neither renders it.
     expect(
       findTool('tool-foo_bar_products', { foo, foo_bar: fooBar })
     ).toBeUndefined();
@@ -197,8 +195,7 @@ describe('findTool', () => {
       matchesToolName: (toolName: string) => startsWith(toolName, 'foo_'),
     };
 
-    // A conflict the resolver cannot arbitrate: it settles it deterministically
-    // and says so, rather than letting registration order decide silently.
+    // Settled deterministically, and warned about.
     expect(findTool('tool-foo_products', { foo: suffixedFoo, other })).toBe(
       other
     );

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -1,3 +1,5 @@
+import { warn } from '../../warn';
+
 import { startsWith } from './startsWith';
 
 import type { ChatMessageBase } from '../../components';
@@ -97,13 +99,30 @@ export const findLastProgressPart = (
 
 const TOOL_PART_PREFIX = 'tool-';
 
+type ToolNameMatcher = {
+  matchesToolName?: (toolName: string) => boolean;
+};
+
 /**
  * Resolves the tool a message part belongs to, from either a part type
  * (`tool-algolia_search_index`) or a bare tool name.
  *
- * Generic over the tool shape so the renderer, the loader and the connector —
- * which hold different subsets of the tool contract — all resolve names the same
- * way.
+ * A tool registered under the exact name always wins. Failing that, only tools
+ * that opted in through `matchesToolName` can claim the name, which is how a
+ * server that derives the name it sends from the registered one is supported —
+ * the Algolia MCP Server exposes the search tool once per index and appends the
+ * index name (`algolia_search_index_products`).
+ *
+ * Claiming is explicit rather than inferred from the name because `a_b` is
+ * genuinely ambiguous between the tool `a_b` and the tool `a` addressing `b`.
+ * No naming rule tells those apart, so guessing picks the wrong tool for
+ * somebody: preferring the shorter key breaks `foo_bar` when `foo` is also
+ * registered, preferring the longer one breaks `search_index` on the `products`
+ * index when `search_index_products` is also registered.
+ *
+ * Generic over the tool shape so the renderer, the loader, the widget and the
+ * connector — which hold different subsets of the tool contract — all resolve
+ * names the same way.
  */
 export const findTool = <TTool>(
   partType: string,
@@ -117,22 +136,45 @@ export const findTool = <TTool>(
     return tools[toolName];
   }
 
-  // Compatibility shim for tool names suffixed by the index name, as the Algolia
-  // MCP Server does (`algolia_search_index_products`). The longest matching key
-  // wins, so registering both `foo` and `foo_bar` resolves `foo_bar_products` to
-  // `foo_bar` — otherwise the winner would depend on registration order.
-  let match: string | undefined;
+  const claimants = Object.keys(tools).filter((key) =>
+    Boolean(
+      (tools[key] as ToolNameMatcher | undefined)?.matchesToolName?.(toolName)
+    )
+  );
 
-  Object.keys(tools).forEach((key) => {
-    if (
-      startsWith(toolName, `${key}_`) &&
-      (match === undefined || key.length > match.length)
-    ) {
-      match = key;
+  if (claimants.length === 0) {
+    if (__DEV__) {
+      const prefixes = Object.keys(tools)
+        .filter((key) => startsWith(toolName, `${key}_`))
+        .sort();
+
+      warn(
+        prefixes.length === 0,
+        `No tool is registered for "${toolName}". The registered ${prefixes
+          .map((key) => `"${key}"`)
+          .join(
+            ', '
+          )} is a prefix of it, but a prefix alone doesn't resolve: declare \`matchesToolName\` on it to also handle "${toolName}".`
+      );
     }
-  });
 
-  return match === undefined ? undefined : tools[match];
+    return undefined;
+  }
+
+  // Sorted rather than first-found, so the winner never depends on the order
+  // tools were registered in: the most specific claim wins, ties by name.
+  claimants.sort((a, b) => b.length - a.length || (a < b ? -1 : 1));
+
+  if (__DEV__) {
+    warn(
+      claimants.length === 1,
+      `Multiple tools claim "${toolName}" through \`matchesToolName\`: ${claimants
+        .map((key) => `"${key}"`)
+        .join(', ')}. "${claimants[0]}" handles it.`
+    );
+  }
+
+  return tools[claimants[0]];
 };
 
 const FACET_KEY_PREFIX = 'facet_';

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -107,22 +107,13 @@ type ToolNameMatcher = {
  * Resolves the tool a message part belongs to, from either a part type
  * (`tool-algolia_search_index`) or a bare tool name.
  *
- * A tool registered under the exact name always wins. Failing that, only tools
- * that opted in through `matchesToolName` can claim the name, which is how a
- * server that derives the name it sends from the registered one is supported —
- * the Algolia MCP Server exposes the search tool once per index and appends the
- * index name (`algolia_search_index_products`).
+ * An exact registration wins. Otherwise only tools whose `matchesToolName`
+ * claims the name are considered, most specific first, for servers that name a
+ * call after the registered tool: the Algolia MCP Server appends the index name
+ * (`algolia_search_index_products`).
  *
- * Claiming is explicit rather than inferred from the name because `a_b` is
- * genuinely ambiguous between the tool `a_b` and the tool `a` addressing `b`.
- * No naming rule tells those apart, so guessing picks the wrong tool for
- * somebody: preferring the shorter key breaks `foo_bar` when `foo` is also
- * registered, preferring the longer one breaks `search_index` on the `products`
- * index when `search_index_products` is also registered.
- *
- * Generic over the tool shape so the renderer, the loader, the widget and the
- * connector — which hold different subsets of the tool contract — all resolve
- * names the same way.
+ * Generic over the tool shape: the renderer, the loader, the widget and the
+ * connector hold different subsets of the tool contract.
  */
 export const findTool = <TTool>(
   partType: string,
@@ -163,8 +154,8 @@ export const findTool = <TTool>(
     return undefined;
   }
 
-  // Sorted rather than first-found, so the winner never depends on the order
-  // tools were registered in: the most specific claim wins, ties by name.
+  // Most specific claim wins, ties by name, so the winner doesn't depend on
+  // registration order.
   claimants.sort((a, b) => b.length - a.length || (a < b ? -1 : 1));
 
   if (__DEV__) {

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -148,13 +148,15 @@ export const findTool = <TTool>(
         .filter((key) => startsWith(toolName, `${key}_`))
         .sort();
 
+      const registered = prefixes.map((key) => `"${key}"`).join(', ');
+
       warn(
         prefixes.length === 0,
-        `No tool is registered for "${toolName}". The registered ${prefixes
-          .map((key) => `"${key}"`)
-          .join(
-            ', '
-          )} is a prefix of it, but a prefix alone doesn't resolve: declare \`matchesToolName\` on it to also handle "${toolName}".`
+        `No tool is registered for "${toolName}". ${
+          prefixes.length > 1
+            ? `The registered tools ${registered} are prefixes of it`
+            : `The registered tool ${registered} is a prefix of it`
+        }, but a prefix alone doesn't resolve: declare \`matchesToolName\` on the tool that should handle "${toolName}".`
       );
     }
 

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1926,8 +1926,7 @@ data: [DONE]`,
               )
             ),
         },
-        // `my_tool` and `my_tool_movies` are two different tools as far as the
-        // registry is concerned, so registration order can't decide this.
+        // `my_tool` and `my_tool_movies` are separate tools to the registry.
         tools: { my_tool: { onToolCall } },
       });
 

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1848,6 +1848,98 @@ data: [DONE]`,
       });
     });
 
+    it('lets a tool claim the names a server derives from it', async () => {
+      const onToolCall = jest.fn();
+
+      const { widget } = getInitializedWidget({
+        agentId: undefined,
+        transport: {
+          fetch: () =>
+            Promise.resolve(
+              new Response(
+                `data: {"type": "start", "messageId": "test-id"}
+
+data: {"type": "start-step"}
+
+data: {"type": "tool-input-available", "toolCallId": "call_1", "toolName": "my_tool_movies", "input": {}}
+
+data: {"type":"tool-output-available","toolCallId":"call_1","output":{}}
+
+data: {"type": "finish-step"}
+
+data: {"type": "finish"}
+
+data: [DONE]`,
+                {
+                  headers: { 'Content-Type': 'text/event-stream' },
+                }
+              )
+            ),
+        },
+        tools: {
+          my_tool: {
+            onToolCall,
+            matchesToolName: (toolName: string) =>
+              toolName.startsWith('my_tool_'),
+          },
+        },
+      });
+
+      await widget.chatInstance.sendMessage({
+        id: 'message-id',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Trigger tool call' }],
+      });
+
+      await waitFor(() => {
+        expect(onToolCall).toHaveBeenCalledWith(
+          expect.objectContaining({ toolName: 'my_tool_movies' })
+        );
+      });
+    });
+
+    it('does not resolve a derived name for a tool that does not claim it', async () => {
+      const onToolCall = jest.fn();
+
+      const { widget } = getInitializedWidget({
+        agentId: undefined,
+        transport: {
+          fetch: () =>
+            Promise.resolve(
+              new Response(
+                `data: {"type": "start", "messageId": "test-id"}
+
+data: {"type": "start-step"}
+
+data: {"type": "tool-input-available", "toolCallId": "call_1", "toolName": "my_tool_movies", "input": {}}
+
+data: {"type":"tool-output-available","toolCallId":"call_1","output":{}}
+
+data: {"type": "finish-step"}
+
+data: {"type": "finish"}
+
+data: [DONE]`,
+                {
+                  headers: { 'Content-Type': 'text/event-stream' },
+                }
+              )
+            ),
+        },
+        // `my_tool` and `my_tool_movies` are two different tools as far as the
+        // registry is concerned, so registration order can't decide this.
+        tools: { my_tool: { onToolCall } },
+      });
+
+      await widget.chatInstance.sendMessage({
+        id: 'message-id',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Trigger tool call' }],
+      });
+
+      expect(onToolCall).not.toHaveBeenCalled();
+    });
+
     it('streams tool input parts from tool-input-delta without tool-input-available', async () => {
       const { widget } = getInitializedWidget({
         agentId: undefined,

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -494,12 +494,9 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       'chat' in options
     );
 
-    // The Algolia MCP Server exposes the search tool once per index and names it
-    // after the index (`algolia_search_index_products`). That naming convention
-    // is Algolia's, so it's declared here rather than guessed by the resolver:
-    // `findTool` only lets a tool answer to a name it claims. An explicit
-    // `matchesToolName` wins, and so does a tool registered under the derived
-    // name itself.
+    // The Algolia MCP Server exposes the search tool once per index and names
+    // it after the index (`algolia_search_index_products`). A `matchesToolName`
+    // set by the user wins, as does a tool registered under the derived name.
     const tools =
       tools_[SearchIndexToolType] &&
       tools_[SearchIndexToolType].matchesToolName === undefined

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -8,7 +8,11 @@ import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithToolCalls,
 } from '../../lib/ai-lite';
-import { Chat } from '../../lib/chat';
+import {
+  Chat,
+  matchesSearchIndexToolName,
+  SearchIndexToolType,
+} from '../../lib/chat';
 import {
   checkRendering,
   clearRefinements,
@@ -474,7 +478,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
 
     const {
       resume = false,
-      tools = {},
+      tools: tools_ = {},
       type = 'chat',
       persistence,
       context,
@@ -489,6 +493,24 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
       persistence,
       'chat' in options
     );
+
+    // The Algolia MCP Server exposes the search tool once per index and names it
+    // after the index (`algolia_search_index_products`). That naming convention
+    // is Algolia's, so it's declared here rather than guessed by the resolver:
+    // `findTool` only lets a tool answer to a name it claims. An explicit
+    // `matchesToolName` wins, and so does a tool registered under the derived
+    // name itself.
+    const tools =
+      tools_[SearchIndexToolType] &&
+      tools_[SearchIndexToolType].matchesToolName === undefined
+        ? {
+            ...tools_,
+            [SearchIndexToolType]: {
+              ...tools_[SearchIndexToolType],
+              matchesToolName: matchesSearchIndexToolName,
+            },
+          }
+        : tools_;
 
     let _chatInstance: Chat<TUiMessage>;
     let input = '';

--- a/packages/instantsearch.js/src/lib/chat/index.ts
+++ b/packages/instantsearch.js/src/lib/chat/index.ts
@@ -13,3 +13,14 @@ export const MemorizeToolType = 'algolia_memorize';
 export const MemorySearchToolType = 'algolia_memory_search';
 export const PonderToolType = 'algolia_ponder';
 export const DisplayResultsToolType = 'algolia_display_results';
+
+/**
+ * Whether `toolName` is the search tool as the Algolia MCP Server exposes it:
+ * one tool per index, named after the index it searches
+ * (`algolia_search_index_products`).
+ *
+ * Meant to be passed as a tool's `matchesToolName`, so the suffix is only ever
+ * interpreted for the tool that actually gets named that way.
+ */
+export const matchesSearchIndexToolName = (toolName: string) =>
+  toolName.startsWith(`${SearchIndexToolType}_`);

--- a/packages/instantsearch.js/src/lib/chat/index.ts
+++ b/packages/instantsearch.js/src/lib/chat/index.ts
@@ -18,9 +18,6 @@ export const DisplayResultsToolType = 'algolia_display_results';
  * Whether `toolName` is the search tool as the Algolia MCP Server exposes it:
  * one tool per index, named after the index it searches
  * (`algolia_search_index_products`).
- *
- * Meant to be passed as a tool's `matchesToolName`, so the suffix is only ever
- * interpreted for the tool that actually gets named that way.
  */
 export const matchesSearchIndexToolName = (toolName: string) =>
   toolName.startsWith(`${SearchIndexToolType}_`);

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -1,6 +1,6 @@
 /** @jsx h */
 
-import { createChatComponent } from 'instantsearch-ui-components';
+import { createChatComponent, findTool } from 'instantsearch-ui-components';
 import { Fragment, h, render } from 'preact';
 import { useEffect, useMemo, useState } from 'preact/hooks';
 
@@ -676,18 +676,10 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
 
     const toolsForUi: ClientSideTools = {};
     Object.entries(toolsFromConnector).forEach(([key, connectorTool]) => {
-      let widgetTool = tools[key];
-
-      // Compatibility shim with tool names suffixed by the index name, as the
-      // Algolia MCP Server does (`algolia_search_index_products`).
-      if (!widgetTool) {
-        const prefixedKey = Object.keys(tools).find((toolKey) =>
-          key.startsWith(`${toolKey}_`)
-        );
-        if (prefixedKey) {
-          widgetTool = tools[prefixedKey];
-        }
-      }
+      // The connector keys its tools the same way the widget does, so this is
+      // an exact hit today. Going through `findTool` keeps the widget on the
+      // same resolution rule as the renderer, the loader and the connector.
+      const widgetTool = findTool(key, tools);
 
       let layoutComponent:
         | ((props: ClientSideToolComponentProps) => JSX.Element)

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -676,9 +676,8 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
 
     const toolsForUi: ClientSideTools = {};
     Object.entries(toolsFromConnector).forEach(([key, connectorTool]) => {
-      // The connector keys its tools the same way the widget does, so this is
-      // an exact hit today. Going through `findTool` keeps the widget on the
-      // same resolution rule as the renderer, the loader and the connector.
+      // The connector keys its tools the way the widget does, so this is an
+      // exact hit; `findTool` keeps one resolution rule across the flavors.
       const widgetTool = findTool(key, tools);
 
       let layoutComponent:

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -1605,10 +1605,8 @@ export function createOptionsTests(
           id: 'chat-id',
         });
 
-        // Only `hello` opts in to the names a server derives from it, so
-        // `goodbye_products` stays unresolved even though `goodbye` is a prefix
-        // of it. Which of two overlapping names wins is the registration
-        // site's call, not the resolver's guess.
+        // `goodbye_products` stays unresolved: `goodbye` is a prefix of it
+        // but claims nothing.
         const matchesToolName = (toolName: string) =>
           toolName.startsWith('hello_');
 

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -1576,6 +1576,90 @@ export function createOptionsTests(
         );
       });
 
+      test('renders a tool part under a name the tool claims with `matchesToolName`', async () => {
+        const searchClient = createSearchClient();
+
+        const chat = new Chat({
+          messages: [
+            {
+              id: '1',
+              role: 'assistant',
+              parts: [
+                {
+                  type: 'tool-hello_products',
+                  toolCallId: '1',
+                  input: { text: 'hello' },
+                  state: 'output-available',
+                  output: 'hello',
+                },
+                {
+                  type: 'tool-goodbye_products',
+                  toolCallId: '2',
+                  input: {},
+                  state: 'output-available',
+                  output: 'goodbye',
+                },
+              ],
+            },
+          ] as any,
+          id: 'chat-id',
+        });
+
+        // Only `hello` opts in to the names a server derives from it, so
+        // `goodbye_products` stays unresolved even though `goodbye` is a prefix
+        // of it. Which of two overlapping names wins is the registration
+        // site's call, not the resolver's guess.
+        const matchesToolName = (toolName: string) =>
+          toolName.startsWith('hello_');
+
+        await setup({
+          instantSearchOptions: {
+            indexName: 'indexName',
+            searchClient,
+          },
+          widgetParams: {
+            javascript: {
+              ...createDefaultWidgetParams(chat),
+              tools: {
+                hello: {
+                  matchesToolName,
+                  templates: {
+                    layout: '<div id="tool-content">Hello!</div>',
+                  },
+                },
+                goodbye: {
+                  templates: {
+                    layout: '<div id="other-tool-content">Goodbye!</div>',
+                  },
+                },
+              },
+            },
+            react: {
+              ...createDefaultWidgetParams(chat),
+              tools: {
+                hello: {
+                  matchesToolName,
+                  layoutComponent: () => <div id="tool-content">Hello!</div>,
+                },
+                goodbye: {
+                  layoutComponent: () => (
+                    <div id="other-tool-content">Goodbye!</div>
+                  ),
+                },
+              },
+            },
+            vue: {},
+          },
+        });
+
+        await openChat(act);
+
+        expect(document.querySelector('#tool-content')).toBeInTheDocument();
+        expect(
+          document.querySelector('#other-tool-content')
+        ).not.toBeInTheDocument();
+      });
+
       test('re-evaluates `shouldRender` of an older message when the chat changes', async () => {
         const searchClient = createSearchClient();
 


### PR DESCRIPTION
## Summary

Resolving a tool part by name prefix is a guess: `a_b` is ambiguous between the tool `a_b` and the tool `a` addressing `b`. Both directions pick the wrong tool for someone — shortest-prefix rendered `foo_bar_products` with `foo`, longest-prefix hands `search_index` on the `products` index to `search_index_products`. So tools now opt in to the names a server derives from them, rather than the resolver inferring them.

- Add `matchesToolName?: (toolName: string) => boolean` to the tool contract, alongside `shouldRender`
- `findTool` resolves an exact registration first, then only tools that claim the name — overlapping registrations no longer collide at all
- Among claimants the most specific one wins, with a dev warning, so registration order never decides
- Declare the Algolia MCP Server's per-index search tool naming (`algolia_search_index_products`) in `connectChat`, leaving `instantsearch-ui-components` with no tool names at all
- Drop the third copy of the resolution rule in `chat.tsx` — first-match-wins, and unreachable
- Warn in development when a name goes unresolved while a registered tool is a prefix of it

Follow-up to #7172, addressing https://github.com/algolia/instantsearch/pull/7172#discussion_r3814344270.

## Public API

Additive, one optional property (semver minor):

```tsx
<Chat
  tools={{
    my_tool: {
      layoutComponent: MyPanel,
      matchesToolName: (toolName) => toolName.startsWith('my_tool_'),
    },
  }}
/>
```

## Behavior change

`findTool` used to prefix-match any tool, so the loader and connector resolved `foo_bar` to a registered `foo`. That now needs an explicit claim, and the dev warning names both the tool and the property to add. `algolia_search_index` is unaffected — its existing compatibility test passes unmodified.

## Testing

- `findTool` unit tests rewritten around the new contract, covering both failure directions
- Connector tests for a claimed and an unclaimed derived name
- Common JS + React test: a tool claiming `hello_products` renders, one not claiming `goodbye_products` doesn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)
