### PR TITLE
fix(chat): keep loader timing stable across React renders

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/Chat.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/Chat.tsx
@@ -109,8 +109,7 @@ export function createChatComponent({
   useMemo,
   useState,
   useEffect,
-  useRef,
-}: Renderer & Pick<Hooks, 'useMemo' | 'useState' | 'useEffect' | 'useRef'>) {
+}: Renderer & Pick<Hooks, 'useMemo' | 'useState' | 'useEffect'>) {
   const ChatHeader = createChatHeaderComponent({ createElement, Fragment });
   const ChatMessages = createChatMessagesComponent({
     createElement,
@@ -118,7 +117,6 @@ export function createChatComponent({
     useMemo,
     useState,
     useEffect,
-    useRef,
   });
   const ChatPrompt = createChatPromptComponent({ createElement, Fragment });
   const ChatPromptSuggestions = createChatPromptSuggestionsComponent({

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -481,7 +481,7 @@ export function createChatMessagesComponent({
   useMemo,
   useState,
   useEffect,
-}: Renderer & Pick<Hooks, 'useMemo' | 'useState' | 'useEffect' | 'useRef'>) {
+}: Renderer & Pick<Hooks, 'useMemo' | 'useState' | 'useEffect'>) {
   const Button = createButtonComponent({ createElement });
 
   /**

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -481,7 +481,6 @@ export function createChatMessagesComponent({
   useMemo,
   useState,
   useEffect,
-  useRef,
 }: Renderer & Pick<Hooks, 'useMemo' | 'useState' | 'useEffect' | 'useRef'>) {
   const Button = createButtonComponent({ createElement });
 
@@ -502,75 +501,144 @@ export function createChatMessagesComponent({
     showDelay: number;
     minDuration: number;
   }) {
-    // The visibility is derived during render rather than committed from an
-    // effect, because an effect-driven show lands a frame late. State is only
-    // here to wake on a deadline.
-    const [, scheduleRerender] = useState(0);
-    const stateRef = useRef({
-      isVisible: false,
-      shownAt: 0,
-      pendingSince: 0,
-      hasHiddenInTurn: false,
+    type LoaderState =
+      | { phase: 'idle' }
+      | { phase: 'visible'; shownAt: number; elapsedDuration: number }
+      | { phase: 'hidden' }
+      | { phase: 'ready'; shownAt: number; elapsedDuration: number }
+      | { phase: 'waiting'; pendingSince: number };
+
+    const [loaderState, setLoaderState] = useState<LoaderState>({
+      phase: 'idle',
     });
 
-    // Read-only during render. React can start a render and throw it away, so a
-    // render that wrote here would let a discarded pass decide a later one's
-    // timing — the next turn's first loader waiting out `showDelay` it never
-    // earned. Everything below is a local derivation; the commit happens in the
-    // effect, once the render is real.
-    const committed = stateRef.current;
-    const now = Date.now();
-
-    const hasHiddenInTurn = isTurnActive ? committed.hasHiddenInTurn : false;
-    const pendingSince = isLoading ? committed.pendingSince || now : 0;
-
-    let isVisible = committed.isVisible;
-
-    if (isLoading) {
-      // Only a loader coming *back* waits; the first one must be immediate.
-      const delay = hasHiddenInTurn ? showDelay : 0;
-      isVisible = now - pendingSince >= delay;
-    } else if (isVisible) {
-      // The minimum only applies while the turn is still running.
-      isVisible = isTurnActive && now - committed.shownAt < minDuration;
-    }
-
-    const shownAt = isVisible && !committed.isVisible ? now : committed.shownAt;
-
-    let deadline = 0;
-    if (isLoading && !isVisible) {
-      deadline = pendingSince + showDelay;
-    } else if (!isLoading && isVisible) {
-      deadline = shownAt + minDuration;
-    }
+    const isVisible =
+      isTurnActive &&
+      ((isLoading &&
+        (loaderState.phase === 'idle' ||
+          loaderState.phase === 'ready' ||
+          (loaderState.phase === 'hidden' && showDelay <= 0))) ||
+        (loaderState.phase === 'visible' &&
+          (isLoading || minDuration > loaderState.elapsedDuration)));
 
     useEffect(() => {
-      // Only a hide *within* the turn arms the delay. The turn ending hides the
-      // loader too, and arming on that would delay the next turn's first
-      // loader, which has to be immediate.
       if (!isTurnActive) {
-        committed.hasHiddenInTurn = false;
-      } else if (!isVisible && committed.isVisible) {
-        committed.hasHiddenInTurn = true;
-      }
-
-      committed.isVisible = isVisible;
-      committed.shownAt = shownAt;
-      committed.pendingSince = pendingSince;
-    });
-
-    useEffect(() => {
-      if (!deadline) {
+        if (loaderState.phase !== 'idle') {
+          setLoaderState({ phase: 'idle' });
+        }
         return undefined;
       }
 
-      const timer = setTimeout(
-        () => scheduleRerender((tick) => tick + 1),
-        Math.max(0, deadline - Date.now())
+      if (loaderState.phase === 'idle') {
+        if (isLoading) {
+          setLoaderState({
+            phase: 'visible',
+            shownAt: Date.now(),
+            elapsedDuration: 0,
+          });
+        }
+        return undefined;
+      }
+
+      if (loaderState.phase === 'visible') {
+        if (!isLoading && minDuration <= loaderState.elapsedDuration) {
+          setLoaderState({ phase: 'hidden' });
+          return undefined;
+        }
+
+        if (minDuration <= loaderState.elapsedDuration) {
+          return undefined;
+        }
+
+        const remaining = Math.max(
+          0,
+          loaderState.shownAt + minDuration - Date.now()
+        );
+        if (remaining === 0) {
+          setLoaderState({ ...loaderState, elapsedDuration: minDuration });
+          return undefined;
+        }
+
+        const timer = setTimeout(() => {
+          setLoaderState((current) =>
+            current.phase === 'visible' &&
+            current.shownAt === loaderState.shownAt
+              ? {
+                  ...current,
+                  elapsedDuration: Math.max(
+                    current.elapsedDuration,
+                    minDuration
+                  ),
+                }
+              : current
+          );
+        }, remaining);
+
+        return () => clearTimeout(timer);
+      }
+
+      if (loaderState.phase === 'hidden') {
+        if (isLoading) {
+          const now = Date.now();
+          setLoaderState(
+            showDelay <= 0
+              ? {
+                  phase: 'visible',
+                  shownAt: now,
+                  elapsedDuration: 0,
+                }
+              : { phase: 'waiting', pendingSince: now }
+          );
+        }
+        return undefined;
+      }
+
+      if (loaderState.phase === 'ready') {
+        setLoaderState(
+          isLoading
+            ? {
+                phase: 'visible',
+                shownAt: loaderState.shownAt,
+                elapsedDuration: loaderState.elapsedDuration,
+              }
+            : { phase: 'hidden' }
+        );
+        return undefined;
+      }
+
+      if (!isLoading) {
+        setLoaderState({ phase: 'hidden' });
+        return undefined;
+      }
+
+      const remaining = Math.max(
+        0,
+        loaderState.pendingSince + showDelay - Date.now()
       );
+      if (remaining === 0) {
+        setLoaderState({
+          phase: 'visible',
+          shownAt: Date.now(),
+          elapsedDuration: 0,
+        });
+        return undefined;
+      }
+
+      const timer = setTimeout(() => {
+        setLoaderState((current) =>
+          current.phase === 'waiting' &&
+          current.pendingSince === loaderState.pendingSince
+            ? {
+                phase: 'ready',
+                shownAt: Date.now(),
+                elapsedDuration: 0,
+              }
+            : current
+        );
+      }, remaining);
 
       return () => clearTimeout(timer);
-    }, [deadline]);
+    }, [isLoading, isTurnActive, loaderState, minDuration, showDelay]);
 
     return isVisible;
   }

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/Chat.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/Chat.test.tsx
@@ -4,7 +4,7 @@
 /** @jsx createElement */
 import { fireEvent, render } from '@testing-library/preact';
 import { Fragment, createElement } from 'preact';
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 
 import { createChatComponent } from '../Chat';
 
@@ -16,7 +16,6 @@ const Chat = createChatComponent({
   useMemo,
   useState,
   useEffect,
-  useRef,
 });
 
 describe('Chat', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.react.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.react.test.tsx
@@ -7,7 +7,6 @@ import React, {
   createElement,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react';
 
@@ -21,7 +20,6 @@ const ChatMessages = createChatMessagesComponent({
   useMemo,
   useState,
   useEffect,
-  useRef,
 });
 
 describe('ChatMessages with React', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.react.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.react.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+import { act, render } from '@testing-library/react';
+import React, {
+  Fragment,
+  createElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { createChatMessagesComponent } from '../ChatMessages';
+
+import type { Pragma } from '../../../types';
+
+const ChatMessages = createChatMessagesComponent({
+  createElement: createElement as Pragma,
+  Fragment,
+  useMemo,
+  useState,
+  useEffect,
+  useRef,
+});
+
+describe('ChatMessages with React', () => {
+  const baseProps = {
+    indexUiState: {},
+    setIndexUiState: jest.fn(),
+    tools: {},
+    onReload: jest.fn(),
+    onClose: jest.fn(),
+  };
+
+  const answered = [
+    {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'text' as const,
+          text: 'Working on it.',
+          state: 'done' as const,
+        },
+      ],
+    },
+  ];
+
+  const waiting = [
+    {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'text' as const,
+          text: 'Working on it.',
+          state: 'done' as const,
+        },
+        {
+          type: 'tool-some_tool' as const,
+          toolCallId: '1',
+          input: undefined,
+          state: 'input-streaming' as const,
+        },
+      ],
+    },
+  ];
+
+  const loader = (container: Element) =>
+    container.querySelector('.ais-ChatMessageLoader');
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('keeps a delayed loader hidden across identical renders until its timer fires', () => {
+    const { container, rerender } = render(
+      <ChatMessages {...baseProps} status="streaming" messages={[]} />
+    );
+
+    expect(loader(container)).not.toBeNull();
+
+    rerender(
+      <ChatMessages {...baseProps} status="streaming" messages={answered} />
+    );
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(loader(container)).toBeNull();
+
+    const delayedProps = {
+      ...baseProps,
+      status: 'streaming' as const,
+      messages: waiting,
+    };
+    rerender(<ChatMessages {...delayedProps} />);
+
+    expect(loader(container)).toBeNull();
+
+    act(() => {
+      jest.setSystemTime(Date.now() + 250);
+    });
+    rerender(<ChatMessages {...delayedProps} />);
+
+    expect(loader(container)).toBeNull();
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(loader(container)).not.toBeNull();
+  });
+
+  test('keeps a delayed loader hidden when loading stops before its timer commits', () => {
+    const { container, rerender } = render(
+      <ChatMessages {...baseProps} status="streaming" messages={[]} />
+    );
+
+    rerender(
+      <ChatMessages {...baseProps} status="streaming" messages={answered} />
+    );
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(loader(container)).toBeNull();
+
+    rerender(
+      <ChatMessages {...baseProps} status="streaming" messages={waiting} />
+    );
+
+    expect(loader(container)).toBeNull();
+
+    act(() => {
+      rerender(
+        <ChatMessages {...baseProps} status="streaming" messages={answered} />
+      );
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(loader(container)).toBeNull();
+  });
+
+  test('extends a visible loader hold when its minimum duration increases', () => {
+    const { container, rerender } = render(
+      <ChatMessages
+        {...baseProps}
+        status="streaming"
+        messages={[]}
+        loaderMinDuration={100}
+      />
+    );
+
+    expect(loader(container)).not.toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    rerender(
+      <ChatMessages
+        {...baseProps}
+        status="streaming"
+        messages={[]}
+        loaderMinDuration={1000}
+      />
+    );
+    rerender(
+      <ChatMessages
+        {...baseProps}
+        status="streaming"
+        messages={answered}
+        loaderMinDuration={1000}
+      />
+    );
+
+    expect(loader(container)).not.toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(899);
+    });
+    expect(loader(container)).not.toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(loader(container)).toBeNull();
+  });
+});

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -4,7 +4,7 @@
 /** @jsx createElement */
 import { act, render, screen } from '@testing-library/preact';
 import { Fragment, createElement } from 'preact';
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 
 import * as chatUtils from '../../../lib/utils/chat';
 import { createChatMessageErrorComponent } from '../ChatMessageError';
@@ -20,7 +20,6 @@ const ChatMessages = createChatMessagesComponent({
   useMemo: (factory) => factory(),
   useState,
   useEffect,
-  useRef,
 });
 const MemoizedChatMessages = createChatMessagesComponent({
   createElement,
@@ -28,7 +27,6 @@ const MemoizedChatMessages = createChatMessagesComponent({
   useMemo,
   useState,
   useEffect,
-  useRef,
 });
 const ChatMessageError = createChatMessageErrorComponent({ createElement });
 

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -2,7 +2,7 @@
 
 import { createChatComponent } from 'instantsearch-ui-components';
 import { Fragment, h, render } from 'preact';
-import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useState } from 'preact/hooks';
 
 import TemplateComponent from '../../components/Template/Template';
 import connectChat from '../../connectors/chat/connectChat';
@@ -75,7 +75,6 @@ const Chat = createChatComponent({
   useMemo,
   useState,
   useEffect,
-  useRef,
 });
 
 export { SearchIndexToolType, RecommendToolType, DisplayResultsToolType };

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -53,7 +53,6 @@ const ChatUiComponent = createChatComponent({
   useMemo,
   useState,
   useEffect,
-  useRef,
 });
 
 export function createDefaultTools<TObject extends RecordWithObjectID>(


### PR DESCRIPTION
## What the PR does

The Chat loader used to decide whether it should be visible by reading the clock during React rendering. React can render the same inputs more than once, so two identical renders could produce different results. That caused the bug

The loader now tracks an explicit timing state: `idle`, `visible`, `waiting`, `ready` or `hidden`. Timers and effects update the state. Rendering only reads it, so the same inputs produce the same result

## Summary

- Move Chat loader timing updates out of render so repeated React renders keep the same visibility
- Prevent cancelled delays from showing a stale loader and honor increases to `loaderMinDuration`
- Add React regression coverage while preserving first-load, empty-state and suggestion-skeleton timing

Related: [FX-3991](https://algolia.atlassian.net/browse/FX-3991)

[FX-3991]: https://algolia.atlassian.net/browse/FX-3991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ