### PR TITLE
feat(chat): show reasoning progress

### DIFF
--- a/packages/instantsearch-ui-components/__tests__/types.test.ts
+++ b/packages/instantsearch-ui-components/__tests__/types.test.ts
@@ -305,6 +305,62 @@ test('exposes Chat text component types from the public entry point', () => {
   expect(errors).toEqual([]);
 });
 
+test('exposes Chat reasoning component types from the public entry point', () => {
+  const fileName = path.join(__dirname, 'chat-message-reasoning-component.ts');
+  const source = `
+    import type {
+      ChatComponentContext,
+      ChatMessageBase,
+      ChatMessageProps,
+      ChatMessageReasoningComponentProps,
+      ChatMessageReasoningPart,
+      ReasoningUIPart,
+    } from '../dist/es';
+
+    const reasoningComponent: ChatMessageProps['reasoningComponent'] = (props) => {
+      const parts: ChatMessageReasoningPart[] = props.parts;
+      const part: ReasoningUIPart = props.parts[0].part;
+      const partIndex: number = props.parts[0].partIndex;
+      const isStreaming: boolean = props.parts[0].isStreaming;
+      const message: ChatMessageBase = props.message;
+      const context: ChatComponentContext = props.context;
+      const exactProps: ChatMessageReasoningComponentProps = props;
+      void parts;
+      void part;
+      void partIndex;
+      void isStreaming;
+      void message;
+      void context;
+      void exactProps;
+      return null;
+    };
+    void reasoningComponent;
+  `;
+  const compilerOptions: ts.CompilerOptions = {
+    module: ts.ModuleKind.CommonJS,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2020,
+  };
+  const host = ts.createCompilerHost(compilerOptions);
+  const getSourceFile = host.getSourceFile.bind(host);
+  host.getSourceFile = (sourceName, languageVersion, onError) =>
+    sourceName === fileName
+      ? ts.createSourceFile(fileName, source, languageVersion, true)
+      : getSourceFile(sourceName, languageVersion, onError);
+
+  const program = ts.createProgram([fileName], compilerOptions, host);
+  const errors = ts
+    .getPreEmitDiagnostics(program)
+    .map((diagnostic) =>
+      ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')
+    );
+
+  expect(errors).toEqual([]);
+});
+
 test('preserves custom message types in Chat text component props', () => {
   const fileName = path.join(
     __dirname,
@@ -353,6 +409,15 @@ test('preserves custom message types in Chat text component props', () => {
           const conversation: AppMessage[] = messages;
           void conversation;
         }
+        return null;
+      },
+      reasoningComponent({ parts, message, context }) {
+        const typedMessage: AppMessage = message;
+        const typedConversation: AppMessage[] = context.messages;
+        const partIndex: number = parts[0].partIndex;
+        void typedMessage.metadata?.sourceIds;
+        void typedConversation;
+        void partIndex;
         return null;
       },
     };

--- a/packages/instantsearch-ui-components/__tests__/types.test.ts
+++ b/packages/instantsearch-ui-components/__tests__/types.test.ts
@@ -318,14 +318,18 @@ test('exposes Chat reasoning component types from the public entry point', () =>
     } from '../dist/es';
 
     const reasoningComponent: ChatMessageProps['reasoningComponent'] = (props) => {
-      const parts: ChatMessageReasoningPart[] = props.parts;
-      const part: ReasoningUIPart = props.parts[0].part;
-      const partIndex: number = props.parts[0].partIndex;
-      const isStreaming: boolean = props.parts[0].isStreaming;
+      const part: ReasoningUIPart = props.part;
+      const partIndex: number = props.partIndex;
+      const isStreaming: boolean = props.isStreaming;
       const message: ChatMessageBase = props.message;
       const context: ChatComponentContext = props.context;
       const exactProps: ChatMessageReasoningComponentProps = props;
-      void parts;
+      const receivedPart: ChatMessageReasoningPart = {
+        part,
+        partIndex,
+        isStreaming,
+      };
+      void receivedPart;
       void part;
       void partIndex;
       void isStreaming;
@@ -411,13 +415,14 @@ test('preserves custom message types in Chat text component props', () => {
         }
         return null;
       },
-      reasoningComponent({ parts, message, context }) {
+      reasoningComponent({ part, partIndex, message, context }) {
         const typedMessage: AppMessage = message;
         const typedConversation: AppMessage[] = context.messages;
-        const partIndex: number = parts[0].partIndex;
+        const typedIndex: number = partIndex;
         void typedMessage.metadata?.sourceIds;
         void typedConversation;
-        void partIndex;
+        void part.text;
+        void typedIndex;
         return null;
       },
     };

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -229,7 +229,10 @@ export type ChatMessageProps<
     props: ChatMessageTextComponentProps<TMessage>
   ) => JSX.Element | null;
   /**
-   * Custom reasoning renderer
+   * Custom reasoning renderer, called once per reasoning part at that part's own
+   * stream position. It changes how reasoning renders, not whether: parts are
+   * only collected when `showReasoning` is `true`, so a renderer set on its own
+   * is never called.
    */
   reasoningComponent?: (
     props: ChatMessageReasoningComponentProps<TMessage>

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -9,6 +9,7 @@ import { createButtonComponent } from '../Button';
 import {
   createChatMessageReasoningComponent,
   type ChatMessageReasoningClassNames,
+  type ChatMessageReasoningPart,
   type ChatMessageReasoningTranslations,
 } from './ChatMessageReasoning';
 import { MenuIcon } from './icons';
@@ -154,6 +155,24 @@ export type ChatMessageTextComponentProps<
   partIndex: number;
 };
 
+export type { ChatMessageReasoningPart } from './ChatMessageReasoning';
+
+export type ChatMessageReasoningComponentProps<
+  TMessage extends ChatMessageBase = ChatMessageBase,
+> = ChatComponentPropsWithContext<
+  {
+    /**
+     * The framework-eligible reasoning parts in message order
+     */
+    parts: ChatMessageReasoningPart[];
+    /**
+     * The message containing the reasoning parts
+     */
+    message: TMessage;
+  },
+  TMessage
+>;
+
 export type ChatMessageProps<
   TMessage extends ChatMessageBase = ChatMessageBase,
 > = ComponentProps<'article'> & {
@@ -199,6 +218,12 @@ export type ChatMessageProps<
    */
   textComponent?: (
     props: ChatMessageTextComponentProps<TMessage>
+  ) => JSX.Element | null;
+  /**
+   * Custom reasoning renderer
+   */
+  reasoningComponent?: (
+    props: ChatMessageReasoningComponentProps<TMessage>
   ) => JSX.Element | null;
   /**
    * The index UI state
@@ -291,6 +316,7 @@ export function createChatMessageComponent({
       actionsComponent: ActionsComponent,
       footerComponent: FooterComponent,
       textComponent: TextComponent,
+      reasoningComponent: ReasoningComponent,
       indexUiState,
       setIndexUiState,
       translations: userTranslations,
@@ -344,6 +370,43 @@ export function createChatMessageComponent({
       messages === undefined ||
       messages[messages.length - 1]?.id === message.id;
 
+    const reasoningParts = showReasoning
+      ? message.parts.reduce<ChatMessageReasoningPart[]>(
+          (receivedParts, part, partIndex) => {
+            if (part.type !== 'reasoning') {
+              return receivedParts;
+            }
+
+            const isStreaming =
+              status === 'streaming' &&
+              isCurrentMessage &&
+              isReasoningPartActive(message.parts, partIndex);
+
+            if (!isStreaming && part.text.trim().length === 0) {
+              return receivedParts;
+            }
+
+            receivedParts.push({ part, partIndex, isStreaming });
+            return receivedParts;
+          },
+          []
+        )
+      : [];
+    const firstReasoningPartIndex = reasoningParts[0]?.partIndex;
+    // Keep the built-in native disclosure mounted through a temporary
+    // eligibility gap so its reader-owned state survives resumed reasoning.
+    const reasoningPartIndex =
+      firstReasoningPartIndex ??
+      (showReasoning &&
+      !ReasoningComponent &&
+      status === 'streaming' &&
+      isCurrentMessage
+        ? message.parts.findIndex((part) => part.type === 'reasoning')
+        : -1);
+    const isReasoningStreaming = reasoningParts.some(
+      (part) => part.isStreaming
+    );
+
     const showActions =
       Boolean(actions.length > 0 || ActionsComponent) && status === 'ready';
 
@@ -396,33 +459,40 @@ export function createChatMessageComponent({
         return null;
       }
       if (part.type === 'reasoning') {
-        if (!showReasoning) {
+        if (index !== reasoningPartIndex) {
           return null;
         }
 
-        const isReasoningStreaming =
-          status === 'streaming' &&
-          isCurrentMessage &&
-          isReasoningPartActive(message.parts, index);
-
-        if (!isReasoningStreaming && part.text.trim().length === 0) {
-          return null;
+        if (ReasoningComponent) {
+          return (
+            <Fragment key={`${message.id}-reasoning`}>
+              <ReasoningComponent
+                parts={reasoningParts}
+                message={message}
+                context={context}
+              />
+            </Fragment>
+          );
         }
 
         return (
           <ChatMessageReasoning
-            key={`${message.id}-${index}`}
-            part={part}
-            isStreaming={isReasoningStreaming}
+            key={`${message.id}-reasoning`}
+            parts={reasoningParts}
+            hidden={reasoningParts.length === 0}
             parseMarkdown={parseMarkdown}
             translations={translations}
             classNames={{
               ...cssClasses,
-              reasoningLabel: cx(
-                'ais-ChatMessageReasoning-label',
+              reasoningIcon: cx(
+                cssClasses.reasoningIcon,
                 isReasoningStreaming &&
-                  'ais-ChatMessageReasoning-label--streaming',
-                classNames.reasoningLabel
+                  'ais-ChatMessageReasoning-icon--streaming'
+              ),
+              reasoningLabel: cx(
+                cssClasses.reasoningLabel,
+                isReasoningStreaming &&
+                  'ais-ChatMessageReasoning-label--streaming'
               ),
             }}
           />

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -230,9 +230,9 @@ export type ChatMessageProps<
   ) => JSX.Element | null;
   /**
    * Custom reasoning renderer, called once per reasoning part at that part's own
-   * stream position. It changes how reasoning renders, not whether: parts are
-   * only collected when `showReasoning` is `true`, so a renderer set on its own
-   * is never called.
+   * stream position. It changes how reasoning renders, not whether: reasoning
+   * renders by default, and `showReasoning: false` suppresses this renderer
+   * along with it.
    */
   reasoningComponent?: (
     props: ChatMessageReasoningComponentProps<TMessage>
@@ -276,7 +276,10 @@ export type ChatMessageProps<
    */
   loaderElement?: VNode;
   /**
-   * Whether to render reasoning parts
+   * Whether to render the reasoning an agent sends. `true` by default, so
+   * reasoning that arrives is shown. Pass `false` to suppress it in this
+   * widget. It cannot make an agent send reasoning: whether reasoning reaches
+   * the client at all is the agent's own `sendReasoning` setting.
    */
   showReasoning?: boolean;
   /**
@@ -334,7 +337,7 @@ export function createChatMessageComponent({
       translations: userTranslations,
       suggestionsElement,
       loaderElement,
-      showReasoning = false,
+      showReasoning = true,
       parseMarkdown = true,
       messages: ownMessages,
       /* eslint-disable typescript/no-deprecated -- reading the

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -25,6 +25,7 @@ import type {
   ClientSideTool,
   ClientSideToolContext,
   ClientSideTools,
+  ReasoningUIPart,
   TextUIPart,
 } from './types';
 import type { ChatRecordsStore } from '../../lib/utils/chatRecords';
@@ -162,11 +163,19 @@ export type ChatMessageReasoningComponentProps<
 > = ChatComponentPropsWithContext<
   {
     /**
-     * The framework-eligible reasoning parts in message order
+     * The reasoning part to render
      */
-    parts: ChatMessageReasoningPart[];
+    part: ReasoningUIPart;
     /**
-     * The message containing the reasoning parts
+     * The reasoning part's index in the full `message.parts` array
+     */
+    partIndex: number;
+    /**
+     * Whether this reasoning part is currently being produced
+     */
+    isStreaming: boolean;
+    /**
+     * The message containing the reasoning part
      */
     message: TMessage;
   },
@@ -459,20 +468,34 @@ export function createChatMessageComponent({
         return null;
       }
       if (part.type === 'reasoning') {
-        if (index !== reasoningPartIndex) {
-          return null;
-        }
-
+        // A custom component renders each step where it arrived, so the rendered
+        // order matches the stream. The built-in disclosure below aggregates the
+        // whole message into a single row, which is why only it is placed by
+        // index.
         if (ReasoningComponent) {
+          const receivedPart = reasoningParts.find(
+            (candidate) => candidate.partIndex === index
+          );
+
+          if (!receivedPart) {
+            return null;
+          }
+
           return (
-            <Fragment key={`${message.id}-reasoning`}>
+            <Fragment key={`${message.id}-reasoning-${index}`}>
               <ReasoningComponent
-                parts={reasoningParts}
+                part={receivedPart.part}
+                partIndex={index}
+                isStreaming={receivedPart.isStreaming}
                 message={message}
                 context={context}
               />
             </Fragment>
           );
+        }
+
+        if (index !== reasoningPartIndex) {
+          return null;
         }
 
         return (

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
@@ -1,5 +1,5 @@
 /** @jsx createElement */
-import { compiler } from 'markdown-to-jsx';
+import { RuleType, compiler } from 'markdown-to-jsx';
 
 import { cx } from '../../lib';
 
@@ -46,16 +46,28 @@ export type ChatMessageReasoningClassNames = {
   reasoningText: string | string[];
 };
 
-type ChatMessageReasoningProps = {
-  key?: string | number;
+export type ChatMessageReasoningPart = {
   /**
-   * The reasoning part to render
+   * The received reasoning part
    */
   part: ReasoningUIPart;
   /**
-   * Whether this part is the one currently being produced
+   * The reasoning part's index in the full message parts array
+   */
+  partIndex: number;
+  /**
+   * Whether this reasoning part is currently being produced
    */
   isStreaming: boolean;
+};
+
+type ChatMessageReasoningProps = {
+  key?: string | number;
+  hidden?: boolean;
+  /**
+   * The received reasoning parts to render
+   */
+  parts: ChatMessageReasoningPart[];
   /**
    * Whether to parse the reasoning text as Markdown
    */
@@ -69,28 +81,51 @@ export function createChatMessageReasoningComponent({
 }: Pick<Renderer, 'createElement'>) {
   return function ChatMessageReasoning(userProps: ChatMessageReasoningProps) {
     const {
-      part,
-      isStreaming,
+      parts,
+      hidden,
       parseMarkdown = true,
       translations,
       classNames,
     } = userProps;
-    const body = parseMarkdown ? (
-      compiler(part.text, {
-        createElement: createElement as any,
-        disableParsingRawHTML: true,
-      })
-    ) : (
-      // Borrowed from text parts for its `white-space: pre-wrap`, which keeps the
-      // newlines markdown would collapse.
-      <p className="ais-ChatMessage-text">{part.text}</p>
-    );
+    const activePart = parts.find(({ isStreaming }) => isStreaming);
+    const isStreaming = Boolean(activePart);
+
+    const renderPart = ({ part }: ChatMessageReasoningPart) =>
+      parseMarkdown ? (
+        compiler(part.text, {
+          createElement: createElement as any,
+          disableParsingRawHTML: true,
+        })
+      ) : (
+        // Preserve newlines in plain-text reasoning.
+        <p className="ais-ChatMessage-text">{part.text}</p>
+      );
+
+    const renderHint = (part: ReasoningUIPart) =>
+      parseMarkdown
+        ? compiler(part.text, {
+            createElement: createElement as any,
+            forceInline: true,
+            renderRule(next, node) {
+              if (
+                node.type === RuleType.htmlBlock ||
+                node.type === RuleType.htmlComment ||
+                node.type === RuleType.htmlSelfClosing
+              ) {
+                return null;
+              }
+
+              return next();
+            },
+          })
+        : part.text;
 
     return (
       <details
         className={cx(classNames.reasoning)}
         aria-label={translations.reasoningLabel}
         aria-busy={isStreaming}
+        hidden={hidden}
       >
         <summary className={cx(classNames.reasoningHeader)}>
           <span className={cx(classNames.reasoningIcon)} aria-hidden="true">
@@ -99,13 +134,36 @@ export function createChatMessageReasoningComponent({
           <span className={cx(classNames.reasoningLabel)}>
             {translations.reasoningLabel}
           </span>
+          {activePart && (
+            <span className="ais-ChatMessageReasoning-status">
+              <span
+                className="ais-ChatMessageReasoning-separator"
+                aria-hidden="true"
+              >
+                ·
+              </span>
+              <span className="ais-ChatMessageReasoning-hint">
+                {renderHint(activePart.part)}
+              </span>
+            </span>
+          )}
           <span className={cx(classNames.reasoningChevron)} aria-hidden="true">
             <ChevronDownIcon createElement={createElement} />
           </span>
         </summary>
 
-        <div className={cx(classNames.reasoningBody)} tabIndex={0}>
-          <div className={cx(classNames.reasoningText)}>{body}</div>
+        <div className={cx(classNames.reasoningBody)}>
+          <ol className={cx(classNames.reasoningText)}>
+            {parts.map((reasoningPart) => (
+              <li
+                key={reasoningPart.partIndex}
+                className="ais-ChatMessageReasoning-item"
+                aria-current={reasoningPart.isStreaming ? 'step' : undefined}
+              >
+                {renderPart(reasoningPart)}
+              </li>
+            ))}
+          </ol>
         </div>
       </details>
     );

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
@@ -89,6 +89,7 @@ export function createChatMessageReasoningComponent({
     } = userProps;
     const activePart = parts.find(({ isStreaming }) => isStreaming);
     const isStreaming = Boolean(activePart);
+    const hasActiveHint = Boolean(activePart?.part.text.trim());
 
     const renderPart = ({ part }: ChatMessageReasoningPart) =>
       parseMarkdown ? (
@@ -134,7 +135,7 @@ export function createChatMessageReasoningComponent({
           <span className={cx(classNames.reasoningLabel)}>
             {translations.reasoningLabel}
           </span>
-          {activePart && (
+          {activePart && hasActiveHint && (
             <span className="ais-ChatMessageReasoning-status">
               <span
                 className="ais-ChatMessageReasoning-separator"

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessageReasoning.tsx
@@ -135,14 +135,16 @@ export function createChatMessageReasoningComponent({
           <span className={cx(classNames.reasoningLabel)}>
             {translations.reasoningLabel}
           </span>
+          {/* A `<summary>` takes its accessible name from its own contents, so
+              leaving the hint exposed would rewrite the toggle's name on every
+              streamed delta. `aria-busy` on the `<details>` carries the
+              activity, and the reasoning text itself stays in the body. */}
           {activePart && hasActiveHint && (
-            <span className="ais-ChatMessageReasoning-status">
-              <span
-                className="ais-ChatMessageReasoning-separator"
-                aria-hidden="true"
-              >
-                ·
-              </span>
+            <span
+              className="ais-ChatMessageReasoning-status"
+              aria-hidden="true"
+            >
+              <span className="ais-ChatMessageReasoning-separator">·</span>
               <span className="ais-ChatMessageReasoning-hint">
                 {renderHint(activePart.part)}
               </span>

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -699,12 +699,6 @@ export function createChatMessagesComponent({
     const reasoningComponentIsClearing = reasoningComponent
       ? props.context.isClearing
       : undefined;
-    const reasoningComponentOpen = reasoningComponent
-      ? props.context.open
-      : undefined;
-    const reasoningComponentMaximized = reasoningComponent
-      ? props.context.maximized
-      : undefined;
     const reasoningComponentActivePart = reasoningComponent
       ? props.context.activePart
       : undefined;
@@ -756,8 +750,6 @@ export function createChatMessagesComponent({
         reasoningComponentStatus,
         reasoningComponentError,
         reasoningComponentIsClearing,
-        reasoningComponentOpen,
-        reasoningComponentMaximized,
         reasoningComponentActivePart,
         reasoningComponentTools,
         reasoningLabel,

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -667,6 +667,7 @@ export function createChatMessagesComponent({
     const showReasoning = messageProps?.showReasoning;
     const parseMarkdown = messageProps?.parseMarkdown;
     const textComponent = messageProps?.textComponent;
+    const reasoningComponent = messageProps?.reasoningComponent;
     // A completed row is memoized against its own message, but `shouldRender`
     // reads the whole `context`: a predicate can hide an older tool result once a
     // newer message arrives. Track the verdicts themselves rather than
@@ -680,6 +681,11 @@ export function createChatMessagesComponent({
     // must update with it. Keep the default renderer's streaming optimization.
     const textComponentMessages = textComponent
       ? props.context.messages
+      : undefined;
+    // A custom reasoning component receives the full context, so all context
+    // changes are observable inputs. Default rows keep the narrower memo.
+    const reasoningComponentContext = reasoningComponent
+      ? props.context
       : undefined;
     // Object-level fallback, matching the render: the spread replaces
     // `translations` wholesale, and it copies a key holding `undefined` too. Both
@@ -721,6 +727,8 @@ export function createChatMessagesComponent({
         parseMarkdown,
         textComponent,
         textComponentMessages,
+        reasoningComponent,
+        reasoningComponentContext,
         reasoningLabel,
         reasoningClassName,
         reasoningHeaderClassName,

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -682,10 +682,32 @@ export function createChatMessagesComponent({
     const textComponentMessages = textComponent
       ? props.context.messages
       : undefined;
-    // A custom reasoning component receives the full context, so all context
-    // changes are observable inputs. Default rows keep the narrower memo.
-    const reasoningComponentContext = reasoningComponent
-      ? props.context
+    // A custom reasoning component receives the full context, but completed
+    // rows only need to update for its semantic state. Callback identity and
+    // scroll-only changes are intentionally excluded from the memo.
+    const reasoningComponentMessages = reasoningComponent
+      ? props.context.messages
+      : undefined;
+    const reasoningComponentStatus = reasoningComponent
+      ? props.context.status
+      : undefined;
+    const reasoningComponentError = reasoningComponent
+      ? props.context.error
+      : undefined;
+    const reasoningComponentIsClearing = reasoningComponent
+      ? props.context.isClearing
+      : undefined;
+    const reasoningComponentOpen = reasoningComponent
+      ? props.context.open
+      : undefined;
+    const reasoningComponentMaximized = reasoningComponent
+      ? props.context.maximized
+      : undefined;
+    const reasoningComponentActivePart = reasoningComponent
+      ? props.context.activePart
+      : undefined;
+    const reasoningComponentTools = reasoningComponent
+      ? props.context.tools
       : undefined;
     // Object-level fallback, matching the render: the spread replaces
     // `translations` wholesale, and it copies a key holding `undefined` too. Both
@@ -728,7 +750,14 @@ export function createChatMessagesComponent({
         textComponent,
         textComponentMessages,
         reasoningComponent,
-        reasoningComponentContext,
+        reasoningComponentMessages,
+        reasoningComponentStatus,
+        reasoningComponentError,
+        reasoningComponentIsClearing,
+        reasoningComponentOpen,
+        reasoningComponentMaximized,
+        reasoningComponentActivePart,
+        reasoningComponentTools,
         reasoningLabel,
         reasoningClassName,
         reasoningHeaderClassName,

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -683,8 +683,10 @@ export function createChatMessagesComponent({
       ? props.context.messages
       : undefined;
     // A custom reasoning component receives the full context, but completed
-    // rows only need to update for its semantic state. Callback identity and
-    // scroll-only changes are intentionally excluded from the memo.
+    // rows only need to update for its semantic state, so the memo tracks those
+    // fields rather than `props.context`. The context's callback identities and
+    // its scroll-only changes stay out. `reasoningComponent` is tracked, so
+    // replacing the component still takes effect.
     const reasoningComponentMessages = reasoningComponent
       ? props.context.messages
       : undefined;

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -664,7 +664,7 @@ export function createChatMessagesComponent({
       props.message.role === 'user'
         ? props.userMessageProps
         : props.assistantMessageProps;
-    const showReasoning = messageProps?.showReasoning;
+    const showReasoning = messageProps?.showReasoning !== false;
     const parseMarkdown = messageProps?.parseMarkdown;
     const textComponent = messageProps?.textComponent;
     const reasoningComponent = messageProps?.reasoningComponent;
@@ -844,7 +844,7 @@ export function createChatMessagesComponent({
     };
 
     const lastMessage = messages[messages.length - 1];
-    const showReasoning = assistantMessageProps?.showReasoning;
+    const showReasoning = assistantMessageProps?.showReasoning !== false;
     const lastPart = lastMessage?.parts?.[lastMessage.parts.length - 1];
     // `activePart` means "the part currently being processed". It must clear
     // when nothing is in progress: once the response settles (`ready`/`error`),
@@ -855,7 +855,7 @@ export function createChatMessagesComponent({
     const activePart =
       isProcessing && lastMessage?.role === 'assistant' ? lastPart : undefined;
     // The scan slices the remaining parts per candidate, and only the loader reads
-    // it, so skip it entirely while the opt-in is off.
+    // it, so skip it entirely once `showReasoning` is off.
     // The loader reports on the assistant's turn, so it only ever belongs to an
     // assistant message. While `submitted` the last message is still the user's
     // own, and the loader belongs to no message at all.
@@ -1060,7 +1060,7 @@ export function createChatMessagesComponent({
 const getLoaderPhase = (
   status: ChatStatus,
   message: ChatMessageBase | undefined,
-  showReasoning: boolean | undefined
+  showReasoning: boolean
 ): ChatLoaderPhase => {
   if (status === 'submitted') return 'submitted';
 
@@ -1106,7 +1106,7 @@ const getShouldRenderVerdicts = <TMessage extends ChatMessageBase>(
 
 const getShowLoader = <TMessage extends ChatMessageBase>(
   context: ChatComponentContext<TMessage>,
-  showReasoning: boolean | undefined,
+  showReasoning: boolean,
   hasActiveReasoning: boolean
 ): boolean => {
   const { status, messages, tools } = context;

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -563,6 +563,43 @@ describe('ChatMessage', () => {
     });
   });
 
+  test('does not call a custom reasoning renderer without `showReasoning`', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'First thought',
+          state: 'done' as const,
+        },
+        { type: 'text' as const, text: 'Answer', state: 'done' as const },
+      ],
+    };
+    const reasoningComponent = jest.fn(
+      ({ part }: ChatMessageReasoningComponentProps) => (
+        <div data-testid="custom-reasoning">{part.text}</div>
+      )
+    );
+
+    // The renderer replaces the built-in disclosure; it does not enable
+    // reasoning. `showReasoning` stays the single opt-in, and the JSDoc on all
+    // three public surfaces says so.
+    const { queryByTestId, getByText } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={message}
+        context={createContext({ messages: [message] })}
+        reasoningComponent={reasoningComponent}
+      />
+    );
+
+    expect(reasoningComponent).not.toHaveBeenCalled();
+    expect(queryByTestId('custom-reasoning')).not.toBeInTheDocument();
+    expect(getByText('Answer')).toBeInTheDocument();
+  });
+
   test('keeps custom reasoning in stream order around tool calls', () => {
     const message = {
       role: 'assistant' as const,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -317,7 +317,25 @@ describe('ChatMessage', () => {
     expect(body).not.toHaveFocus();
   });
 
-  test('does not render reasoning unless it is enabled', () => {
+  test('renders reasoning without being asked to', () => {
+    const { getByRole, getByText } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'reasoning', text: 'Public reasoning' }],
+        }}
+        context={createContext()}
+      />
+    );
+
+    expect(getByRole('group', { name: 'Reasoning' })).toBeInTheDocument();
+    expect(getByText('Public reasoning')).toBeInTheDocument();
+  });
+
+  test('does not render reasoning once it is suppressed', () => {
     const { queryByRole, queryByText } = render(
       <ChatMessage
         indexUiState={{}}
@@ -328,6 +346,7 @@ describe('ChatMessage', () => {
           parts: [{ type: 'reasoning', text: 'Private reasoning' }],
         }}
         context={createContext()}
+        showReasoning={false}
       />
     );
 
@@ -563,7 +582,7 @@ describe('ChatMessage', () => {
     });
   });
 
-  test('does not call a custom reasoning renderer without `showReasoning`', () => {
+  test('does not call a custom reasoning renderer once reasoning is suppressed', () => {
     const message = {
       role: 'assistant' as const,
       id: '1',
@@ -582,9 +601,9 @@ describe('ChatMessage', () => {
       )
     );
 
-    // The renderer replaces the built-in disclosure; it does not enable
-    // reasoning. `showReasoning` stays the single opt-in, and the JSDoc on all
-    // three public surfaces says so.
+    // The renderer replaces the built-in disclosure; it does not decide whether
+    // reasoning renders at all. `showReasoning` stays the single switch, and
+    // the JSDoc on all three public surfaces says so.
     const { queryByTestId, getByText } = render(
       <ChatMessage
         indexUiState={{}}
@@ -592,6 +611,7 @@ describe('ChatMessage', () => {
         message={message}
         context={createContext({ messages: [message] })}
         reasoningComponent={reasoningComponent}
+        showReasoning={false}
       />
     );
 

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -389,29 +389,45 @@ describe('ChatMessage', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('renders empty reasoning while the response is active', () => {
-    const { getByRole } = render(
-      <ChatMessage
-        indexUiState={{}}
-        setIndexUiState={jest.fn()}
-        message={{
-          role: 'assistant',
-          id: '1',
-          parts: [{ type: 'reasoning', text: '', state: 'streaming' }],
-        }}
-        context={createContext({
-          status: 'streaming',
-          messages: [{ role: 'assistant', id: '1', parts: [] }],
-        })}
-        showReasoning={true}
-      />
-    );
+  test.each(['', ' \n '])(
+    'keeps blank reasoning active without rendering an empty status',
+    (text) => {
+      const { getByRole } = render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={{
+            role: 'assistant',
+            id: '1',
+            parts: [{ type: 'reasoning', text, state: 'streaming' }],
+          }}
+          context={createContext({
+            status: 'streaming',
+            messages: [{ role: 'assistant', id: '1', parts: [] }],
+          })}
+          showReasoning={true}
+        />
+      );
 
-    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute(
-      'aria-busy',
-      'true'
-    );
-  });
+      const disclosure = getByRole('group', { name: 'Reasoning' });
+      expect(disclosure).toHaveAttribute('aria-busy', 'true');
+      expect(
+        disclosure.querySelector('.ais-ChatMessageReasoning-icon')
+      ).toHaveClass('ais-ChatMessageReasoning-icon--streaming');
+      expect(
+        disclosure.querySelector('.ais-ChatMessageReasoning-label')
+      ).toHaveClass('ais-ChatMessageReasoning-label--streaming');
+      expect(
+        disclosure.querySelector('.ais-ChatMessageReasoning-status')
+      ).not.toBeInTheDocument();
+      expect(
+        disclosure.querySelector('.ais-ChatMessageReasoning-separator')
+      ).not.toBeInTheDocument();
+      expect(
+        disclosure.querySelector('.ais-ChatMessageReasoning-hint')
+      ).not.toBeInTheDocument();
+    }
+  );
 
   test('aggregates reasoning around a tool without absorbing the tool', () => {
     const textComponent = jest.fn(({ part }: ChatMessageTextComponentProps) => (

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -794,6 +794,9 @@ describe('ChatMessage', () => {
     expect(summary).toHaveTextContent(
       /^Raisonnement de la demande en cours·Working$/
     );
+    // The hint is visible but must stay out of the toggle's accessible name,
+    // which would otherwise change on every streamed delta.
+    expect(summary).toHaveAccessibleName('Raisonnement de la demande en cours');
   });
 
   test('renders the current Markdown hint without exposing markup', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -488,7 +488,7 @@ describe('ChatMessage', () => {
     expect(queryAllByRole('region')).toHaveLength(0);
   });
 
-  test('routes one eligible aggregate to a custom reasoning component', () => {
+  test('renders a custom reasoning component once per eligible part', () => {
     const message = {
       role: 'assistant' as const,
       id: '1',
@@ -525,14 +525,12 @@ describe('ChatMessage', () => {
       },
     });
     const reasoningComponent = jest.fn(
-      ({ parts }: ChatMessageReasoningComponentProps) => (
-        <div data-testid="custom-reasoning">
-          {parts.map(({ part }) => part.text).join(' / ')}
-        </div>
+      ({ part }: ChatMessageReasoningComponentProps) => (
+        <div data-testid="custom-reasoning">{part.text}</div>
       )
     );
 
-    const { getByTestId, getByText } = render(
+    const { getAllByTestId, getByText } = render(
       <ChatMessage
         indexUiState={{}}
         setIndexUiState={jest.fn()}
@@ -543,19 +541,105 @@ describe('ChatMessage', () => {
       />
     );
 
-    expect(getByTestId('custom-reasoning')).toHaveTextContent(
-      'First thought / Current thought'
-    );
+    // The blank part at index 2 stays ineligible, so it gets no call.
+    expect(
+      getAllByTestId('custom-reasoning').map((node) => node.textContent)
+    ).toEqual(['First thought', 'Current thought']);
     expect(getByText('Tool result')).toBeInTheDocument();
-    expect(reasoningComponent).toHaveBeenCalledTimes(1);
+    expect(reasoningComponent).toHaveBeenCalledTimes(2);
     expect(reasoningComponent.mock.calls[0][0]).toEqual({
-      parts: [
-        { part: message.parts[0], partIndex: 0, isStreaming: false },
-        { part: message.parts[3], partIndex: 3, isStreaming: true },
-      ],
+      part: message.parts[0],
+      partIndex: 0,
+      isStreaming: false,
       message,
       context,
     });
+    expect(reasoningComponent.mock.calls[1][0]).toEqual({
+      part: message.parts[3],
+      partIndex: 3,
+      isStreaming: true,
+      message,
+      context,
+    });
+  });
+
+  test('keeps custom reasoning in stream order around tool calls', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'First thought',
+          state: 'done' as const,
+        },
+        {
+          type: 'tool-first_tool' as const,
+          toolCallId: 'a',
+          input: {},
+          state: 'output-available' as const,
+          output: {},
+        },
+        {
+          type: 'reasoning' as const,
+          text: 'Second thought',
+          state: 'done' as const,
+        },
+        {
+          type: 'tool-second_tool' as const,
+          toolCallId: 'b',
+          input: {},
+          state: 'output-available' as const,
+          output: {},
+        },
+        {
+          type: 'reasoning' as const,
+          text: 'Third thought',
+          state: 'done' as const,
+        },
+        { type: 'text' as const, text: 'Final answer' },
+      ],
+    };
+
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={message}
+        context={createContext({
+          messages: [message],
+          tools: {
+            first_tool: {
+              layoutComponent: () => <div>TOOL a</div>,
+              addToolResult: jest.fn(),
+              applyFilters: jest.fn(),
+            },
+            second_tool: {
+              layoutComponent: () => <div>TOOL b</div>,
+              addToolResult: jest.fn(),
+              applyFilters: jest.fn(),
+            },
+          },
+        })}
+        showReasoning={true}
+        reasoningComponent={({ part }: ChatMessageReasoningComponentProps) => (
+          <div>{part.text}</div>
+        )}
+      />
+    );
+
+    const rendered = container.querySelector('.ais-ChatMessage-message')!;
+
+    expect(
+      Array.from(rendered.children).map((child) => child.textContent)
+    ).toEqual([
+      'First thought',
+      'TOOL a',
+      'Second thought',
+      'TOOL b',
+      'Third thought',
+      'Final answer',
+    ]);
   });
 
   test('marks the aggregate disclosure busy while reasoning streams', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -9,6 +9,7 @@ import { Fragment, createElement } from 'preact';
 import {
   createChatMessageComponent,
   type ChatMessageClassNames,
+  type ChatMessageReasoningComponentProps,
   type ChatMessageTextComponentProps,
   type ChatMessageTranslations,
 } from '../ChatMessage';
@@ -278,7 +279,7 @@ describe('ChatMessage', () => {
     expect(getByText('I should search the catalog first.')).toBeInTheDocument();
   });
 
-  test('makes overflowing reasoning keyboard reachable', () => {
+  test('keeps the non-scrollable reasoning body out of the tab order', () => {
     const { getByRole, queryByRole } = render(
       <ChatMessage
         indexUiState={{}}
@@ -307,12 +308,13 @@ describe('ChatMessage', () => {
     userEvent.click(summary);
 
     const body = disclosure.querySelector('.ais-ChatMessageReasoning-body')!;
-    expect(body).toHaveAttribute('tabindex', '0');
+    expect(body).not.toHaveAttribute('tabindex');
     expect(queryByRole('region', { hidden: true })).not.toBeInTheDocument();
 
     summary.focus();
+    expect(summary).toHaveFocus();
     userEvent.tab();
-    expect(body).toHaveFocus();
+    expect(body).not.toHaveFocus();
   });
 
   test('does not render reasoning unless it is enabled', () => {
@@ -340,7 +342,7 @@ describe('ChatMessage', () => {
   ])(
     'does not render blank reasoning after a response is %s',
     (_responseState, status, text) => {
-      const { queryByRole } = render(
+      const { container, queryByRole } = render(
         <ChatMessage
           indexUiState={{}}
           setIndexUiState={jest.fn()}
@@ -357,8 +359,35 @@ describe('ChatMessage', () => {
       expect(
         queryByRole('group', { name: 'Reasoning' })
       ).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.ais-ChatMessageReasoning')
+      ).not.toBeInTheDocument();
     }
   );
+
+  test('does not mount blank reasoning for a non-current response', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [{ type: 'reasoning' as const, text: '', state: 'done' as const }],
+    };
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={message}
+        context={createContext({
+          status: 'streaming',
+          messages: [message, { role: 'assistant', id: '2', parts: [] }],
+        })}
+        showReasoning={true}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessageReasoning')
+    ).not.toBeInTheDocument();
+  });
 
   test('renders empty reasoning while the response is active', () => {
     const { getByRole } = render(
@@ -384,7 +413,7 @@ describe('ChatMessage', () => {
     );
   });
 
-  test('keeps reasoning and tool renderers in message part order with a custom text component', () => {
+  test('aggregates reasoning around a tool without absorbing the tool', () => {
     const textComponent = jest.fn(({ part }: ChatMessageTextComponentProps) => (
       <span data-testid="custom-text">{part.text}</span>
     ));
@@ -425,20 +454,95 @@ describe('ChatMessage', () => {
     const message = container.querySelector('.ais-ChatMessage-message')!;
     const children = Array.from(message.children);
     const disclosures = getAllByRole('group', { name: 'Reasoning' });
+    const entries = getAllByRole('listitem');
 
-    expect(children).toHaveLength(4);
+    expect(children).toHaveLength(3);
+    expect(disclosures).toHaveLength(1);
     expect(children[0]).toBe(disclosures[0]);
     expect(children[1]).toContainElement(getByText('Tool result'));
-    expect(children[2]).toBe(disclosures[1]);
-    expect(children[3]).toContainElement(getByText('Final answer'));
-    expect(children[3]).toContainElement(
+    expect(children[2]).toContainElement(getByText('Final answer'));
+    expect(children[2]).toContainElement(
       container.querySelector('[data-testid="custom-text"]')
     );
+    expect(entries.map((entry) => entry.textContent)).toEqual([
+      'First thought',
+      'Second thought',
+    ]);
     expect(textComponent).toHaveBeenCalledTimes(1);
     expect(queryAllByRole('region')).toHaveLength(0);
   });
 
-  test('marks only the streaming reasoning disclosure as busy', () => {
+  test('routes one eligible aggregate to a custom reasoning component', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: '1',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'First thought',
+          state: 'done' as const,
+        },
+        {
+          type: 'tool-test_tool' as const,
+          toolCallId: '123',
+          input: {},
+          state: 'output-available' as const,
+          output: {},
+        },
+        { type: 'reasoning' as const, text: '   ', state: 'done' as const },
+        {
+          type: 'reasoning' as const,
+          text: 'Current thought',
+          state: 'streaming' as const,
+        },
+      ],
+    };
+    const context = createContext({
+      status: 'streaming',
+      messages: [message],
+      tools: {
+        test_tool: {
+          layoutComponent: () => <div>Tool result</div>,
+          addToolResult: jest.fn(),
+          applyFilters: jest.fn(),
+        },
+      },
+    });
+    const reasoningComponent = jest.fn(
+      ({ parts }: ChatMessageReasoningComponentProps) => (
+        <div data-testid="custom-reasoning">
+          {parts.map(({ part }) => part.text).join(' / ')}
+        </div>
+      )
+    );
+
+    const { getByTestId, getByText } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={message}
+        context={context}
+        showReasoning={true}
+        reasoningComponent={reasoningComponent}
+      />
+    );
+
+    expect(getByTestId('custom-reasoning')).toHaveTextContent(
+      'First thought / Current thought'
+    );
+    expect(getByText('Tool result')).toBeInTheDocument();
+    expect(reasoningComponent).toHaveBeenCalledTimes(1);
+    expect(reasoningComponent.mock.calls[0][0]).toEqual({
+      parts: [
+        { part: message.parts[0], partIndex: 0, isStreaming: false },
+        { part: message.parts[3], partIndex: 3, isStreaming: true },
+      ],
+      message,
+      context,
+    });
+  });
+
+  test('marks the aggregate disclosure busy while reasoning streams', () => {
     const message = {
       role: 'assistant' as const,
       id: '1',
@@ -466,20 +570,15 @@ describe('ChatMessage', () => {
     );
 
     let disclosures = getAllByRole('group', { name: 'Reasoning' });
-    expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
-    expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+    expect(disclosures).toHaveLength(1);
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'true');
     expect(disclosures[0]).not.toHaveAttribute('open');
-    expect(disclosures[1]).not.toHaveAttribute('open');
     expect(
       disclosures[0].querySelector('.ais-ChatMessageReasoning-label')
     ).toHaveTextContent(/^Reasoning$/);
     expect(
-      disclosures[1].querySelector('.ais-ChatMessageReasoning-label')
-    ).toHaveTextContent(/^Reasoning$/);
-    expect(
-      disclosures[1].querySelector('.ais-ChatMessageReasoning-label')!
-        .nextElementSibling
-    ).toHaveClass('ais-ChatMessageReasoning-chevron');
+      disclosures[0].querySelector('.ais-ChatMessageReasoning-hint')
+    ).toHaveTextContent('Second thought');
 
     rerender(
       <ChatMessage
@@ -495,20 +594,18 @@ describe('ChatMessage', () => {
     );
 
     disclosures = getAllByRole('group', { name: 'Reasoning' });
+    expect(disclosures).toHaveLength(1);
     expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
-    expect(disclosures[1]).toHaveAttribute('aria-busy', 'false');
     expect(disclosures[0]).not.toHaveAttribute('open');
-    expect(disclosures[1]).not.toHaveAttribute('open');
     expect(
-      disclosures[1].querySelector('.ais-ChatMessageReasoning-label')
+      disclosures[0].querySelector('.ais-ChatMessageReasoning-label')
     ).toHaveTextContent(/^Reasoning$/);
     expect(
-      disclosures[1].querySelector('.ais-ChatMessageReasoning-label')!
-        .nextElementSibling
-    ).toHaveClass('ais-ChatMessageReasoning-chevron');
+      disclosures[0].querySelector('.ais-ChatMessageReasoning-hint')
+    ).not.toBeInTheDocument();
   });
 
-  test('signals activity on the label alone while streaming', () => {
+  test('signals activity on the icon and shows the current hint', () => {
     const { getByRole } = render(
       <ChatMessage
         indexUiState={{}}
@@ -542,19 +639,55 @@ describe('ChatMessage', () => {
     });
     const summary = disclosure.querySelector('summary')!;
     const label = summary.querySelector('.ais-ChatMessageReasoning-label')!;
+    const hint = summary.querySelector('.ais-ChatMessageReasoning-hint')!;
 
     expect(disclosure).toHaveAttribute('aria-busy', 'true');
     expect(label).toHaveTextContent(/^Raisonnement de la demande en cours$/);
     expect(label).toHaveClass('ais-ChatMessageReasoning-label--streaming');
+    expect(hint).toHaveTextContent('Working');
 
     expect(
       Array.from(summary.children).map((child) => child.className)
     ).toEqual([
-      'ais-ChatMessageReasoning-icon',
+      'ais-ChatMessageReasoning-icon ais-ChatMessageReasoning-icon--streaming',
       'ais-ChatMessageReasoning-label ais-ChatMessageReasoning-label--streaming',
+      'ais-ChatMessageReasoning-status',
       'ais-ChatMessageReasoning-chevron',
     ]);
-    expect(summary).toHaveTextContent(/^Raisonnement de la demande en cours$/);
+    expect(summary).toHaveTextContent(
+      /^Raisonnement de la demande en cours·Working$/
+    );
+  });
+
+  test('renders the current Markdown hint without exposing markup', () => {
+    const hint = '**Searching for TVs** I need… <img src=x onerror=alert(1)>';
+    const { getByRole } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'reasoning', text: hint, state: 'streaming' }],
+        }}
+        context={createContext({
+          status: 'streaming',
+          messages: [{ role: 'assistant', id: '1', parts: [] }],
+        })}
+        showReasoning={true}
+      />
+    );
+
+    const hintElement = getByRole('group', {
+      name: 'Reasoning',
+    }).querySelector('.ais-ChatMessageReasoning-hint')!;
+    expect(hintElement).toHaveTextContent('Searching for TVs I need…');
+    expect(hintElement).not.toHaveTextContent('**');
+    expect(hintElement).not.toHaveTextContent('<img');
+    expect(hintElement.querySelector('strong')).toHaveTextContent(
+      'Searching for TVs'
+    );
+    expect(hintElement.querySelector('img')).toBeNull();
   });
 
   test('routes custom header and label class names to their own elements', () => {
@@ -600,7 +733,7 @@ describe('ChatMessage', () => {
     ).not.toHaveClass('custom-label');
   });
 
-  test('marks only the latest unfinished reasoning block as busy', () => {
+  test('marks only the current reasoning entry as active', () => {
     const { getAllByRole } = render(
       <ChatMessage
         indexUiState={{}}
@@ -630,14 +763,14 @@ describe('ChatMessage', () => {
     );
 
     const disclosures = getAllByRole('group', { name: 'Reasoning' });
-    expect(disclosures[0]).toHaveAttribute('aria-busy', 'false');
-    expect(disclosures[1]).toHaveAttribute('aria-busy', 'true');
+    const entries = getAllByRole('listitem');
+    expect(disclosures).toHaveLength(1);
+    expect(disclosures[0]).toHaveAttribute('aria-busy', 'true');
+    expect(entries[0]).not.toHaveAttribute('aria-current');
+    expect(entries[1]).toHaveAttribute('aria-current', 'step');
     expect(
-      disclosures[0].querySelector('.ais-ChatMessageReasoning-label--streaming')
-    ).not.toBeInTheDocument();
-    expect(
-      disclosures[1].querySelector('.ais-ChatMessageReasoning-label--streaming')
-    ).toBeInTheDocument();
+      disclosures[0].querySelector('.ais-ChatMessageReasoning-hint')
+    ).toHaveTextContent('Check one candidate');
   });
 
   test('marks reasoning as busy only on the active response', () => {
@@ -722,7 +855,7 @@ describe('ChatMessage', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('marks an earlier unfinished reasoning block as busy after a later block ends', () => {
+  test('keeps an earlier unfinished reasoning entry active after a later block ends', () => {
     const { getAllByRole } = render(
       <ChatMessage
         indexUiState={{}}
@@ -752,8 +885,132 @@ describe('ChatMessage', () => {
     );
 
     const disclosures = getAllByRole('group', { name: 'Reasoning' });
+    const entries = getAllByRole('listitem');
+    expect(disclosures).toHaveLength(1);
     expect(disclosures[0]).toHaveAttribute('aria-busy', 'true');
-    expect(disclosures[1]).toHaveAttribute('aria-busy', 'false');
+    expect(entries[0]).toHaveAttribute('aria-current', 'step');
+    expect(entries[1]).not.toHaveAttribute('aria-current');
+    expect(
+      disclosures[0].querySelector('.ais-ChatMessageReasoning-hint')
+    ).toHaveTextContent('Compare the candidates');
+  });
+
+  test('keeps the reader choice through interleaved updates and completion', () => {
+    const renderMessage = (
+      parts: ChatMessageBase['parts'],
+      status: 'streaming' | 'ready' = 'streaming'
+    ) => (
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{ role: 'assistant', id: '1', parts }}
+        context={createContext({
+          status,
+          messages: [{ role: 'assistant', id: '1', parts }],
+          tools: {
+            test_tool: {
+              layoutComponent: () => <div>Tool result</div>,
+              addToolResult: jest.fn(),
+              applyFilters: jest.fn(),
+            },
+          },
+        })}
+        showReasoning={true}
+      />
+    );
+    const firstParts: ChatMessageBase['parts'] = [
+      { type: 'reasoning', text: 'First thought', state: 'streaming' },
+    ];
+    const interleavedParts: ChatMessageBase['parts'] = [
+      { type: 'reasoning', text: 'First thought', state: 'done' },
+      {
+        type: 'tool-test_tool',
+        toolCallId: '123',
+        input: {},
+        state: 'output-available',
+        output: {},
+      },
+      { type: 'reasoning', text: 'Second thought', state: 'streaming' },
+    ];
+    const answeringParts: ChatMessageBase['parts'] = [
+      ...interleavedParts.slice(0, -1),
+      { type: 'reasoning', text: 'Second thought', state: 'done' },
+      { type: 'text', text: 'Final answer', state: 'streaming' },
+    ];
+    const { getByRole, rerender } = render(renderMessage(firstParts));
+    const disclosure = getByRole('group', { name: 'Reasoning' });
+
+    userEvent.click(disclosure.querySelector('summary')!);
+    expect(disclosure).toHaveAttribute('open');
+
+    rerender(renderMessage(interleavedParts));
+    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute('open');
+
+    userEvent.click(
+      getByRole('group', { name: 'Reasoning' }).querySelector('summary')!
+    );
+    expect(getByRole('group', { name: 'Reasoning' })).not.toHaveAttribute(
+      'open'
+    );
+
+    rerender(renderMessage(answeringParts));
+    expect(getByRole('group', { name: 'Reasoning' })).not.toHaveAttribute(
+      'open'
+    );
+    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute(
+      'aria-busy',
+      'false'
+    );
+
+    rerender(renderMessage(answeringParts, 'ready'));
+    expect(getByRole('group', { name: 'Reasoning' })).not.toHaveAttribute(
+      'open'
+    );
+  });
+
+  test('mounts restored completed history static and reader-owned', () => {
+    const message = {
+      role: 'assistant' as const,
+      id: 'restored',
+      parts: [
+        {
+          type: 'reasoning' as const,
+          text: 'Restored thought',
+          state: 'done' as const,
+        },
+        {
+          type: 'text' as const,
+          text: 'Restored answer',
+          state: 'done' as const,
+        },
+      ],
+    };
+    const renderMessage = () => (
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{ ...message, parts: [...message.parts] }}
+        context={createContext({ status: 'ready', messages: [message] })}
+        showReasoning={true}
+      />
+    );
+    const { getByRole, rerender } = render(renderMessage());
+    const disclosure = getByRole('group', { name: 'Reasoning' });
+
+    expect(disclosure).not.toHaveAttribute('open');
+    expect(disclosure).toHaveAttribute('aria-busy', 'false');
+    expect(
+      disclosure.querySelector('.ais-ChatMessageReasoning-hint')
+    ).not.toBeInTheDocument();
+    expect(
+      disclosure.querySelector('.ais-ChatMessageReasoning-icon--streaming')
+    ).not.toBeInTheDocument();
+
+    userEvent.click(disclosure.querySelector('summary')!);
+    expect(disclosure).toHaveAttribute('open');
+
+    rerender(renderMessage());
+    expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute('open');
   });
 
   test('preserves an open disclosure while reasoning text streams', () => {
@@ -781,6 +1038,66 @@ describe('ChatMessage', () => {
 
     rerender(renderMessage('First second'));
     expect(getByRole('group', { name: 'Reasoning' })).toHaveAttribute('open');
+  });
+
+  test('preserves an open disclosure across a textless reasoning-to-tool gap', () => {
+    const renderMessage = (parts: ChatMessageBase['parts']) => (
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{ role: 'assistant', id: '1', parts }}
+        context={createContext({
+          status: 'streaming',
+          messages: [{ role: 'assistant', id: '1', parts }],
+          tools: {
+            test_tool: {
+              layoutComponent: () => <div>Tool result</div>,
+              addToolResult: jest.fn(),
+              applyFilters: jest.fn(),
+            },
+          },
+        })}
+        showReasoning={true}
+      />
+    );
+    const { getByRole, getByText, queryByRole, rerender } = render(
+      renderMessage([{ type: 'reasoning', text: '', state: 'streaming' }])
+    );
+    const disclosure = getByRole('group', { name: 'Reasoning' });
+    const toolPart = {
+      type: 'tool-test_tool' as const,
+      toolCallId: '123',
+      input: {},
+      state: 'output-available' as const,
+      output: {},
+    };
+
+    userEvent.click(disclosure.querySelector('summary')!);
+    expect(disclosure).toHaveAttribute('open');
+
+    rerender(
+      renderMessage([{ type: 'reasoning', text: '', state: 'done' }, toolPart])
+    );
+    expect(queryByRole('group', { name: 'Reasoning' })).not.toBeInTheDocument();
+    expect(disclosure).toBeInTheDocument();
+    expect(disclosure).toHaveAttribute('hidden');
+    expect(disclosure).toHaveAttribute('open');
+    expect(getByText('Tool result').closest('.ais-ChatMessage-tool')).not.toBe(
+      null
+    );
+
+    rerender(
+      renderMessage([
+        { type: 'reasoning', text: '', state: 'done' },
+        toolPart,
+        { type: 'reasoning', text: 'Next thought', state: 'streaming' },
+      ])
+    );
+    const resumedDisclosure = getByRole('group', { name: 'Reasoning' });
+
+    expect(resumedDisclosure).toHaveAttribute('open');
+    expect(resumedDisclosure).toBe(disclosure);
+    expect(resumedDisclosure).not.toContainElement(getByText('Tool result'));
   });
 
   test('keeps a reader-opened disclosure open once the answer starts and the response completes', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -10,7 +10,10 @@ import * as chatUtils from '../../../lib/utils/chat';
 import { createChatMessageErrorComponent } from '../ChatMessageError';
 import { createChatMessagesComponent } from '../ChatMessages';
 
-import type { ChatMessageTextComponentProps } from '../ChatMessage';
+import type {
+  ChatMessageReasoningComponentProps,
+  ChatMessageTextComponentProps,
+} from '../ChatMessage';
 import type { ChatMessageErrorProps } from '../ChatMessageError';
 import type { ChatComponentPropsWithContext } from '../types';
 
@@ -945,6 +948,113 @@ describe('ChatMessages', () => {
 
       expect(screen.queryByTestId('first-text')).not.toBeInTheDocument();
       expect(screen.getByTestId('second-text')).toHaveTextContent('Answer');
+    });
+
+    test('updates completed messages when the reasoning component changes', () => {
+      const message = {
+        role: 'assistant' as const,
+        id: 'assistant-1',
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Thought',
+            state: 'done' as const,
+          },
+        ],
+      };
+      const messages = [message];
+      const FirstReasoningComponent = ({
+        parts,
+      }: ChatMessageReasoningComponentProps) => (
+        <span data-testid="first-reasoning">{parts[0].part.text}</span>
+      );
+      const SecondReasoningComponent = ({
+        parts,
+      }: ChatMessageReasoningComponentProps) => (
+        <span data-testid="second-reasoning">{parts[0].part.text}</span>
+      );
+      const createProps = (
+        reasoningComponent: (
+          props: ChatMessageReasoningComponentProps
+        ) => JSX.Element
+      ) => ({
+        messages,
+        indexUiState: {},
+        setIndexUiState: jest.fn(),
+        assistantMessageProps: {
+          showReasoning: true,
+          reasoningComponent,
+        },
+        tools: {},
+        onReload: jest.fn(),
+        onClose: jest.fn(),
+      });
+
+      const { rerender } = render(
+        <MemoizedChatMessages {...createProps(FirstReasoningComponent)} />
+      );
+      expect(screen.getByTestId('first-reasoning')).toHaveTextContent(
+        'Thought'
+      );
+
+      rerender(
+        <MemoizedChatMessages {...createProps(SecondReasoningComponent)} />
+      );
+
+      expect(screen.queryByTestId('first-reasoning')).not.toBeInTheDocument();
+      expect(screen.getByTestId('second-reasoning')).toHaveTextContent(
+        'Thought'
+      );
+    });
+
+    test('keeps the full reasoning component context current for completed messages', () => {
+      const message = {
+        role: 'assistant' as const,
+        id: 'assistant-1',
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Thought',
+            state: 'done' as const,
+          },
+        ],
+      };
+      const messages = [message];
+      const ReasoningComponent = ({
+        context,
+      }: ChatMessageReasoningComponentProps) => (
+        <span data-testid="reasoning-state">
+          {context.isClearing ? 'clearing' : 'idle'}:
+          {context.open ? 'open' : 'closed'}
+        </span>
+      );
+      const createProps = (isClearing: boolean) => ({
+        messages,
+        indexUiState: {},
+        setIndexUiState: jest.fn(),
+        assistantMessageProps: {
+          showReasoning: true,
+          reasoningComponent: ReasoningComponent,
+        },
+        tools: {},
+        isClearing,
+        open: true,
+        onReload: jest.fn(),
+        onClose: jest.fn(),
+      });
+
+      const { rerender } = render(
+        <MemoizedChatMessages {...createProps(false)} />
+      );
+      expect(screen.getByTestId('reasoning-state')).toHaveTextContent(
+        'idle:open'
+      );
+
+      rerender(<MemoizedChatMessages {...createProps(true)} />);
+
+      expect(screen.getByTestId('reasoning-state')).toHaveTextContent(
+        'clearing:open'
+      );
     });
 
     test('updates completed tool rows when the panel is maximized', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -964,14 +964,14 @@ describe('ChatMessages', () => {
       };
       const messages = [message];
       const FirstReasoningComponent = ({
-        parts,
+        part,
       }: ChatMessageReasoningComponentProps) => (
-        <span data-testid="first-reasoning">{parts[0].part.text}</span>
+        <span data-testid="first-reasoning">{part.text}</span>
       );
       const SecondReasoningComponent = ({
-        parts,
+        part,
       }: ChatMessageReasoningComponentProps) => (
-        <span data-testid="second-reasoning">{parts[0].part.text}</span>
+        <span data-testid="second-reasoning">{part.text}</span>
       );
       const createProps = (
         reasoningComponent: (
@@ -1022,8 +1022,8 @@ describe('ChatMessages', () => {
       const messages = [message];
       const tools = {};
       const ReasoningComponent = jest.fn(
-        ({ parts }: ChatMessageReasoningComponentProps) => (
-          <span data-testid="reasoning-render">{parts[0].part.text}</span>
+        ({ part }: ChatMessageReasoningComponentProps) => (
+          <span data-testid="reasoning-render">{part.text}</span>
         )
       );
       const firstCallbacks = {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -1007,6 +1007,63 @@ describe('ChatMessages', () => {
       );
     });
 
+    test('does not rerender completed custom reasoning for scroll or callback-only changes', () => {
+      const message = {
+        role: 'assistant' as const,
+        id: 'assistant-1',
+        parts: [
+          {
+            type: 'reasoning' as const,
+            text: 'Thought',
+            state: 'done' as const,
+          },
+        ],
+      };
+      const messages = [message];
+      const tools = {};
+      const ReasoningComponent = jest.fn(
+        ({ parts }: ChatMessageReasoningComponentProps) => (
+          <span data-testid="reasoning-render">{parts[0].part.text}</span>
+        )
+      );
+      const firstCallbacks = {
+        onReload: jest.fn(),
+        onClose: jest.fn(),
+      };
+      const secondCallbacks = {
+        onReload: jest.fn(),
+        onClose: jest.fn(),
+      };
+      const createProps = (
+        isScrollAtBottom: boolean,
+        callbacks: typeof firstCallbacks
+      ) => ({
+        messages,
+        indexUiState: {},
+        setIndexUiState: jest.fn(),
+        assistantMessageProps: {
+          showReasoning: true,
+          reasoningComponent: ReasoningComponent,
+        },
+        tools,
+        isScrollAtBottom,
+        ...callbacks,
+      });
+
+      const { rerender } = render(
+        <MemoizedChatMessages {...createProps(false, firstCallbacks)} />
+      );
+      expect(ReasoningComponent).toHaveBeenCalledTimes(1);
+
+      rerender(<MemoizedChatMessages {...createProps(true, firstCallbacks)} />);
+      expect(ReasoningComponent).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <MemoizedChatMessages {...createProps(true, secondCallbacks)} />
+      );
+      expect(ReasoningComponent).toHaveBeenCalledTimes(1);
+    });
+
     test('keeps the full reasoning component context current for completed messages', () => {
       const message = {
         role: 'assistant' as const,

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -160,7 +160,7 @@ describe('ChatMessages', () => {
     `);
   });
 
-  test('shows the loader while streaming reasoning is hidden', () => {
+  test('shows the loader while streaming reasoning is suppressed', () => {
     const { container } = render(
       <ChatMessages
         messages={[
@@ -179,6 +179,7 @@ describe('ChatMessages', () => {
         indexUiState={{}}
         setIndexUiState={jest.fn()}
         status="streaming"
+        assistantMessageProps={{ showReasoning: false }}
         tools={{}}
         onReload={jest.fn()}
         onClose={jest.fn()}
@@ -770,7 +771,7 @@ describe('ChatMessages', () => {
     );
   });
 
-  test('does not scan for active reasoning while the disclosure is off', () => {
+  test('does not scan for active reasoning once the disclosure is off', () => {
     const isReasoningPartActive = jest.spyOn(
       chatUtils,
       'isReasoningPartActive'
@@ -801,19 +802,19 @@ describe('ChatMessages', () => {
       onClose: jest.fn(),
     };
 
-    const { unmount } = render(<ChatMessages {...props} />);
+    const { unmount } = render(
+      <ChatMessages
+        {...props}
+        assistantMessageProps={{ showReasoning: false }}
+      />
+    );
 
-    // The scan slices the remaining parts per candidate, so it must not run while
-    // the opt-in is off.
+    // The scan slices the remaining parts per candidate, so it must not run once
+    // reasoning is suppressed.
     expect(isReasoningPartActive).not.toHaveBeenCalled();
 
     unmount();
-    render(
-      <ChatMessages
-        {...props}
-        assistantMessageProps={{ showReasoning: true }}
-      />
-    );
+    render(<ChatMessages {...props} />);
 
     expect(isReasoningPartActive).toHaveBeenCalled();
     isReasoningPartActive.mockRestore();

--- a/packages/instantsearch.css/src/components/chat/__tests__/chat-message-reasoning.test.ts
+++ b/packages/instantsearch.css/src/components/chat/__tests__/chat-message-reasoning.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { compileString } from 'sass';
+
+describe('Chat reasoning styles', () => {
+  test('points the disclosure chevron down when closed and up when open', () => {
+    const source = readFileSync(
+      resolve(__dirname, '../_chat-message-reasoning.scss'),
+      'utf8'
+    );
+    const style = document.createElement('style');
+    style.textContent = compileString(source).css;
+    document.head.appendChild(style);
+
+    const disclosure = document.createElement('details');
+    disclosure.className = 'ais-ChatMessageReasoning';
+    disclosure.innerHTML = `
+      <summary>
+        <span class="ais-ChatMessageReasoning-chevron"></span>
+      </summary>
+    `;
+    document.body.appendChild(disclosure);
+    const chevron = disclosure.querySelector<HTMLElement>(
+      '.ais-ChatMessageReasoning-chevron'
+    )!;
+
+    expect(getComputedStyle(chevron).transform).toBe('none');
+
+    disclosure.open = true;
+    expect(getComputedStyle(chevron).transform).toBe('rotate(180deg)');
+  });
+});

--- a/packages/instantsearch.css/src/components/chat/__tests__/chat-message.test.ts
+++ b/packages/instantsearch.css/src/components/chat/__tests__/chat-message.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { compileString } from 'sass';
+
+const CHAT_DIR = resolve(__dirname, '..');
+
+// Sass cannot reach the filesystem itself under the jsdom environment, so `@use`
+// is resolved here with Node's own reader. The URL is built from the environment's
+// own `URL` global because Sass rejects one from another realm.
+const scssImporter = {
+  canonicalize(url: string) {
+    const path = resolve(CHAT_DIR, url.replace(/^file:\/\//, ''));
+    const candidates = [path, `${path}.scss`, resolve(path, 'index.scss')];
+    const found = candidates.find((candidate) => existsSync(candidate));
+    return found ? new URL(`file://${found}`) : null;
+  },
+  load(canonicalUrl: URL) {
+    return {
+      contents: readFileSync(canonicalUrl.pathname, 'utf8'),
+      syntax: 'scss' as const,
+    };
+  },
+};
+
+function compileChatStylesheet(name: string) {
+  const path = resolve(CHAT_DIR, name);
+  return compileString(readFileSync(path, 'utf8'), {
+    importers: [scssImporter],
+  }).css;
+}
+
+describe('Chat message styles', () => {
+  test('spaces adjacent message parts without the built-in reasoning element', () => {
+    const style = document.createElement('style');
+    style.textContent = compileChatStylesheet('_chat-message.scss');
+    document.head.appendChild(style);
+
+    // A custom reasoning renderer replaces `.ais-ChatMessageReasoning`, so the
+    // spacing must not depend on that element being in the message.
+    const message = document.createElement('div');
+    message.className = 'ais-ChatMessage-message';
+    message.innerHTML = `
+      <div class="custom-reasoning">first thought</div>
+      <div class="ais-ChatMessage-tool">tool</div>
+    `;
+    document.body.appendChild(message);
+
+    const computed = getComputedStyle(message);
+    expect(computed.display).toBe('flex');
+    expect(computed.flexDirection).toBe('column');
+    // The spacing is the one the built-in disclosure already used, not a new value.
+    expect(computed.gap).toBe('calc(var(--ais-spacing) * 0.5)');
+  });
+
+  test('leaves the inline loader to the container spacing', () => {
+    // The inline loader is a direct child of `.ais-ChatMessage-message`, so it is
+    // a part row like any other. Flex gap does not collapse with an item's own
+    // margin, so a `margin-top` here would add to the container gap instead of
+    // replacing it. Asserted against the compiled rule rather than a computed
+    // style because jsdom drops `calc()` margins, which would pass either way.
+    const css = compileChatStylesheet('_chat-message-loader.scss');
+    const inlineRule = css
+      .split('}')
+      .find((rule) => rule.includes('.ais-ChatMessageLoader--inline'))!;
+
+    expect(inlineRule).toContain('gap:');
+    expect(inlineRule).not.toContain('margin-top');
+  });
+});

--- a/packages/instantsearch.css/src/components/chat/_chat-message-loader.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-loader.scss
@@ -70,7 +70,6 @@
   display: flex;
   align-items: flex-start;
   gap: calc(var(--ais-spacing) * 0.5);
-  margin-top: calc(var(--ais-spacing) * 0.5);
 
   .ais-ChatMessageLoader-spinner {
     flex: none;

--- a/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
@@ -79,6 +79,10 @@
   animation: ais-chat-reasoning-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
+.ais-ChatMessageReasoning-label--streaming {
+  animation: ais-chat-reasoning-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
 .ais-ChatMessageReasoning-label {
   flex-shrink: 0;
   color: rgba(var(--ais-text-color-rgb), 0.9);
@@ -117,6 +121,7 @@
 
   // Keep the chevron at the end when the active hint is absent.
   margin-inline-start: auto;
+  transform: rotate(-90deg);
   transition: transform var(--ais-transition-duration)
     var(--ais-transition-timing-function);
 
@@ -133,7 +138,7 @@
 }
 
 .ais-ChatMessageReasoning[open] .ais-ChatMessageReasoning-chevron {
-  transform: rotate(180deg);
+  transform: none;
 }
 
 .ais-ChatMessageReasoning[open] .ais-ChatMessageReasoning-status {
@@ -160,12 +165,16 @@
   gap: calc(var(--ais-spacing) * 0.625);
   list-style: none;
   overflow-wrap: anywhere;
+}
 
-  // Block margins collapse through padding-free ancestors, so the one meeting the
-  // body's padding box can sit at any depth. Reset the whole leading (trailing)
-  // chain; the `:not()` spares gaps between siblings that are not themselves first
-  // (last). `#{&}` is required: a literal `&` inside `:where()` makes Sass drop the
-  // parent prefix, and the selector then matches the document.
+.ais-ChatMessageReasoning-item {
+  position: relative;
+  min-width: 0;
+  padding-inline-start: calc(var(--ais-spacing) * 1.25);
+
+  // Markdown can wrap multiple blocks in a `div`. Reset the leading and
+  // trailing child chains inside each item so every marker aligns with its own
+  // first visible block without removing margins between sibling blocks.
   :first-child:not(:where(#{&} :not(:first-child) *)) {
     margin-block-start: 0;
   }
@@ -173,12 +182,6 @@
   :last-child:not(:where(#{&} :not(:last-child) *)) {
     margin-block-end: 0;
   }
-}
-
-.ais-ChatMessageReasoning-item {
-  position: relative;
-  min-width: 0;
-  padding-inline-start: calc(var(--ais-spacing) * 1.25);
 
   &::before {
     position: absolute;
@@ -221,6 +224,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .ais-ChatMessageReasoning-icon--streaming,
+  .ais-ChatMessageReasoning-label--streaming,
   .ais-ChatMessageReasoning-chevron {
     animation: none;
     transition: none;

--- a/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
@@ -121,7 +121,7 @@
 
   // Keep the chevron at the end when the active hint is absent.
   margin-inline-start: auto;
-  transform: rotate(-90deg);
+  transform: none;
   transition: transform var(--ais-transition-duration)
     var(--ais-transition-timing-function);
 
@@ -138,7 +138,7 @@
 }
 
 .ais-ChatMessageReasoning[open] .ais-ChatMessageReasoning-chevron {
-  transform: none;
+  transform: rotate(180deg);
 }
 
 .ais-ChatMessageReasoning[open] .ais-ChatMessageReasoning-status {

--- a/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
@@ -14,30 +14,25 @@
 .ais-ChatMessageReasoning {
   box-sizing: border-box;
   width: 100%;
-  border: 1px solid rgba(var(--ais-muted-color-rgb), 0.25);
-  border-radius: var(--ais-border-radius-sm);
-  background-color: rgba(
-    var(--ais-background-color-rgb),
-    var(--ais-background-color-alpha)
-  );
-  overflow: hidden;
+  color: rgba(var(--ais-muted-color-rgb), 0.95);
 }
 
 .ais-ChatMessageReasoning-header {
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  gap: calc(var(--ais-spacing) * 0.25);
+  min-width: 0;
+  gap: calc(var(--ais-spacing) * 0.375);
   width: 100%;
-  padding: calc(var(--ais-spacing) * 0.125) calc(var(--ais-spacing) * 0.5);
+  padding: calc(var(--ais-spacing) * 0.125) 0;
+  border-radius: var(--ais-border-radius-sm);
   cursor: pointer;
   list-style: none;
   user-select: none;
 
   // On the header rather than the label so `reasoningHeader` restyles the whole
-  // row while `reasoningLabel` reaches the label alone. The icon and chevron set
-  // their own colour and are sized in px.
-  color: rgba(var(--ais-muted-color-rgb), 0.95);
+  // row while `reasoningLabel` reaches the label alone.
+  color: inherit;
   font-size: calc(var(--ais-spacing) * 0.75);
   line-height: var(--ais-spacing);
 
@@ -56,7 +51,7 @@
   &:focus-visible {
     outline: 2px solid
       rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
-    outline-offset: -2px;
+    outline-offset: 2px;
   }
 }
 
@@ -80,15 +75,37 @@
   }
 }
 
-.ais-ChatMessageReasoning-label {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.ais-ChatMessageReasoning-icon--streaming {
+  animation: ais-chat-reasoning-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
-.ais-ChatMessageReasoning-label--streaming {
-  animation: ais-chat-reasoning-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+.ais-ChatMessageReasoning-label {
+  flex-shrink: 0;
+  color: rgba(var(--ais-text-color-rgb), 0.9);
+  font-weight: var(--ais-font-weight-semibold);
+}
+
+.ais-ChatMessageReasoning-status {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: calc(var(--ais-spacing) * 0.375);
+}
+
+.ais-ChatMessageReasoning-separator {
+  flex-shrink: 0;
+  color: rgba(var(--ais-muted-color-rgb), 0.55);
+}
+
+.ais-ChatMessageReasoning-hint {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: rgba(var(--ais-muted-color-rgb), 0.78);
+  opacity: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ais-ChatMessageReasoning-chevron {
@@ -98,8 +115,7 @@
   color: rgba(var(--ais-muted-color-rgb), 0.9);
   flex-shrink: 0;
 
-  // The label is the only header item that shrinks, so this absorbs the free space
-  // and keeps the chevron at the end.
+  // Keep the chevron at the end when the active hint is absent.
   margin-inline-start: auto;
   transition: transform var(--ais-transition-duration)
     var(--ais-transition-timing-function);
@@ -120,24 +136,29 @@
   transform: rotate(180deg);
 }
 
+.ais-ChatMessageReasoning[open] .ais-ChatMessageReasoning-status {
+  display: none;
+}
+
 .ais-ChatMessageReasoning-body {
-  max-height: 9rem;
-  padding: calc(var(--ais-spacing) * 0.5) calc(var(--ais-spacing) * 0.75);
-  border-block-start: 1px solid rgba(var(--ais-muted-color-rgb), 0.2);
-  background-color: rgba(var(--ais-muted-color-rgb), 0.06);
+  padding: calc(var(--ais-spacing) * 0.5) 0 0 calc(var(--ais-spacing) * 0.375);
   color: rgba(var(--ais-text-color-rgb), 0.7);
   font-size: calc(var(--ais-spacing) * 0.875);
   line-height: calc(var(--ais-spacing) * 1.25);
-  overflow-y: auto;
 
   &:focus-visible {
     outline: 2px solid
       rgba(var(--ais-primary-color-rgb), var(--ais-primary-color-alpha));
-    outline-offset: -2px;
+    outline-offset: 2px;
   }
 }
 
 .ais-ChatMessageReasoning-text {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  gap: calc(var(--ais-spacing) * 0.625);
+  list-style: none;
   overflow-wrap: anywhere;
 
   // Block margins collapse through padding-free ancestors, so the one meeting the
@@ -154,6 +175,44 @@
   }
 }
 
+.ais-ChatMessageReasoning-item {
+  position: relative;
+  min-width: 0;
+  padding-inline-start: calc(var(--ais-spacing) * 1.25);
+
+  &::before {
+    position: absolute;
+    inset-block-start: calc(var(--ais-spacing) * 0.375);
+    inset-inline-start: calc(var(--ais-spacing) * 0.25);
+    width: calc(var(--ais-spacing) * 0.375);
+    height: calc(var(--ais-spacing) * 0.375);
+    border-radius: var(--ais-border-radius-full);
+    background-color: rgba(var(--ais-muted-color-rgb), 0.45);
+    content: '';
+  }
+
+  &:not(:last-child)::after {
+    position: absolute;
+    inset-block: calc(var(--ais-spacing) * 0.75)
+      calc(var(--ais-spacing) * -0.625);
+    inset-inline-start: calc(var(--ais-spacing) * 0.40625);
+    width: 1px;
+    background-color: rgba(var(--ais-muted-color-rgb), 0.18);
+    content: '';
+  }
+
+  &[aria-current='step'] {
+    color: rgba(var(--ais-text-color-rgb), 0.82);
+
+    &::before {
+      background-color: rgba(
+        var(--ais-primary-color-rgb),
+        var(--ais-primary-color-alpha)
+      );
+    }
+  }
+}
+
 @keyframes ais-chat-reasoning-pulse {
   50% {
     opacity: 0.5;
@@ -161,7 +220,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .ais-ChatMessageReasoning-label,
+  .ais-ChatMessageReasoning-icon--streaming,
   .ais-ChatMessageReasoning-chevron {
     animation: none;
     transition: none;

--- a/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message-reasoning.scss
@@ -3,10 +3,9 @@
     flex-grow: 1;
   }
 
+  // Part spacing lives unconditionally in `_chat-message.scss`; the disclosure
+  // only needs the row to span the message.
   .ais-ChatMessage-message {
-    display: flex;
-    flex-direction: column;
-    gap: calc(var(--ais-spacing) * 0.5);
     width: 100%;
   }
 }

--- a/packages/instantsearch.css/src/components/chat/_chat-message.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message.scss
@@ -43,6 +43,12 @@
   font-size: calc(var(--ais-spacing) * 0.875);
   line-height: calc(var(--ais-spacing) * 1.25);
 
+  // Space the message parts here rather than on each part, so a part replaced by
+  // a custom renderer is spaced without the consumer having to know to do it.
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--ais-spacing) * 0.5);
+
   img {
     max-width: 100%;
     height: auto;

--- a/packages/instantsearch.js/src/widgets/chat/__tests__/chat.test.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/__tests__/chat.test.tsx
@@ -193,17 +193,15 @@ describe('chat', () => {
   });
 
   describe('templates', () => {
-    test('renders aggregate reasoning with the assistant message template', async () => {
+    test('renders reasoning per part with the assistant message template', async () => {
       const container = document.createElement('div');
       document.body.appendChild(container);
       const calls: Array<{
         messageId: string;
         messageCount: number;
-        parts: Array<{
-          text: string;
-          partIndex: number;
-          isStreaming: boolean;
-        }>;
+        text: string;
+        partIndex: number;
+        isStreaming: boolean;
       }> = [];
       const search = instantsearch({
         indexName: 'indexName',
@@ -229,15 +227,16 @@ describe('chat', () => {
           ],
           templates: {
             assistantMessage: {
-              reasoning: ({ parts, message, context }, { html }) => {
+              reasoning: (
+                { part, partIndex, isStreaming, message, context },
+                { html }
+              ) => {
                 calls.push({
                   messageId: message.id,
                   messageCount: context.messages.length,
-                  parts: parts.map(({ part, partIndex, isStreaming }) => ({
-                    text: part.text,
-                    partIndex,
-                    isStreaming,
-                  })),
+                  text: part.text,
+                  partIndex,
+                  isStreaming,
                 });
                 return html`<div data-testid="custom-reasoning">
                   Custom reasoning
@@ -251,19 +250,25 @@ describe('chat', () => {
       search.start();
       await wait(0);
 
-      expect(screen.getByTestId('custom-reasoning')).toHaveTextContent(
-        'Custom reasoning'
-      );
-      expect(calls[calls.length - 1]).toEqual({
-        messageId: 'assistant-message-id',
-        messageCount: 1,
-        parts: [
-          { text: 'First thought', partIndex: 0, isStreaming: false },
-          { text: 'Second thought', partIndex: 1, isStreaming: false },
-        ],
-      });
+      expect(screen.getAllByTestId('custom-reasoning')).toHaveLength(2);
+      expect(calls.slice(-2)).toEqual([
+        {
+          messageId: 'assistant-message-id',
+          messageCount: 1,
+          text: 'First thought',
+          partIndex: 0,
+          isStreaming: false,
+        },
+        {
+          messageId: 'assistant-message-id',
+          messageCount: 1,
+          text: 'Second thought',
+          partIndex: 1,
+          isStreaming: false,
+        },
+      ]);
 
-      const reasoningBefore = screen.getByTestId('custom-reasoning');
+      const reasoningBefore = screen.getAllByTestId('custom-reasoning')[0];
       search.renderState.indexName.chat!.setMessages([
         {
           id: 'assistant-message-id',
@@ -277,16 +282,34 @@ describe('chat', () => {
       ]);
       await wait(0);
 
-      expect(screen.getByTestId('custom-reasoning')).toBe(reasoningBefore);
-      expect(calls[calls.length - 1]).toEqual({
-        messageId: 'assistant-message-id',
-        messageCount: 1,
-        parts: [
-          { text: 'First thought', partIndex: 0, isStreaming: false },
-          { text: 'Second thought', partIndex: 1, isStreaming: false },
-          { text: 'Third thought', partIndex: 2, isStreaming: false },
-        ],
-      });
+      // A new step must not remount the steps already on screen.
+      expect(screen.getAllByTestId('custom-reasoning')[0]).toBe(
+        reasoningBefore
+      );
+      expect(screen.getAllByTestId('custom-reasoning')).toHaveLength(3);
+      expect(calls.slice(-3)).toEqual([
+        {
+          messageId: 'assistant-message-id',
+          messageCount: 1,
+          text: 'First thought',
+          partIndex: 0,
+          isStreaming: false,
+        },
+        {
+          messageId: 'assistant-message-id',
+          messageCount: 1,
+          text: 'Second thought',
+          partIndex: 1,
+          isStreaming: false,
+        },
+        {
+          messageId: 'assistant-message-id',
+          messageCount: 1,
+          text: 'Third thought',
+          partIndex: 2,
+          isStreaming: false,
+        },
+      ]);
     });
   });
 

--- a/packages/instantsearch.js/src/widgets/chat/__tests__/chat.test.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/__tests__/chat.test.tsx
@@ -192,6 +192,104 @@ describe('chat', () => {
     });
   });
 
+  describe('templates', () => {
+    test('renders aggregate reasoning with the assistant message template', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+      const calls: Array<{
+        messageId: string;
+        messageCount: number;
+        parts: Array<{
+          text: string;
+          partIndex: number;
+          isStreaming: boolean;
+        }>;
+      }> = [];
+      const search = instantsearch({
+        indexName: 'indexName',
+        searchClient: createSearchClient(),
+      });
+
+      search.addWidgets([
+        chat({
+          container,
+          agentId: 'test-agent-id',
+          disableTriggerValidation: true,
+          requiresSearch: false,
+          showReasoning: true,
+          messages: [
+            {
+              id: 'assistant-message-id',
+              role: 'assistant',
+              parts: [
+                { type: 'reasoning', text: 'First thought', state: 'done' },
+                { type: 'reasoning', text: 'Second thought', state: 'done' },
+              ],
+            },
+          ],
+          templates: {
+            assistantMessage: {
+              reasoning: ({ parts, message, context }, { html }) => {
+                calls.push({
+                  messageId: message.id,
+                  messageCount: context.messages.length,
+                  parts: parts.map(({ part, partIndex, isStreaming }) => ({
+                    text: part.text,
+                    partIndex,
+                    isStreaming,
+                  })),
+                });
+                return html`<div data-testid="custom-reasoning">
+                  Custom reasoning
+                </div>`;
+              },
+            },
+          },
+        }),
+      ]);
+
+      search.start();
+      await wait(0);
+
+      expect(screen.getByTestId('custom-reasoning')).toHaveTextContent(
+        'Custom reasoning'
+      );
+      expect(calls[calls.length - 1]).toEqual({
+        messageId: 'assistant-message-id',
+        messageCount: 1,
+        parts: [
+          { text: 'First thought', partIndex: 0, isStreaming: false },
+          { text: 'Second thought', partIndex: 1, isStreaming: false },
+        ],
+      });
+
+      const reasoningBefore = screen.getByTestId('custom-reasoning');
+      search.renderState.indexName.chat!.setMessages([
+        {
+          id: 'assistant-message-id',
+          role: 'assistant',
+          parts: [
+            { type: 'reasoning', text: 'First thought', state: 'done' },
+            { type: 'reasoning', text: 'Second thought', state: 'done' },
+            { type: 'reasoning', text: 'Third thought', state: 'done' },
+          ],
+        },
+      ]);
+      await wait(0);
+
+      expect(screen.getByTestId('custom-reasoning')).toBe(reasoningBefore);
+      expect(calls[calls.length - 1]).toEqual({
+        messageId: 'assistant-message-id',
+        messageCount: 1,
+        parts: [
+          { text: 'First thought', partIndex: 0, isStreaming: false },
+          { text: 'Second thought', partIndex: 1, isStreaming: false },
+          { text: 'Third thought', partIndex: 2, isStreaming: false },
+        ],
+      });
+    });
+  });
+
   describe('search tool compatibility', () => {
     test('renders search results from Agent Studio', async () => {
       const container = document.createElement('div');

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -1101,8 +1101,8 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
       text: Template<ChatMessageTextComponentProps>;
       /**
        * Template to use for assistant message reasoning. It replaces the
-       * built-in disclosure rather than enabling reasoning, so it also needs
-       * `showReasoning`; on its own it is never used.
+       * built-in disclosure rather than enabling reasoning: reasoning renders by
+       * default, and `showReasoning: false` suppresses this template too.
        */
       reasoning: Template<ChatMessageReasoningComponentProps>;
       /**
@@ -1233,7 +1233,10 @@ type ChatWidgetParams<THit extends RecordWithObjectID = RecordWithObjectID> = {
   disableTriggerValidation?: boolean;
 
   /**
-   * Whether to render reasoning parts
+   * Whether to render the reasoning an agent sends. `true` by default, so
+   * reasoning that arrives is shown. Pass `false` to suppress it in this
+   * widget. It cannot make an agent send reasoning: whether reasoning reaches
+   * the client at all is the agent's own `sendReasoning` setting.
    */
   showReasoning?: boolean;
 
@@ -1286,7 +1289,7 @@ export default (function chat<
     tools: userTools,
     getSearchPageURL,
     disableTriggerValidation = false,
-    showReasoning = false,
+    showReasoning = true,
     loaderPosition,
     shouldShowLoader,
     loaderShowDelay,

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -60,6 +60,7 @@ import type {
   ChatMessageErrorProps,
   ChatMessageLoaderPropsWithContext,
   ChatMessageProps,
+  ChatMessageReasoningComponentProps,
   ChatMessageTextComponentProps,
   ChatMessagesProps,
   ChatMessagesTranslations,
@@ -224,6 +225,7 @@ type ChatWrapperProps = {
       | undefined;
     assistantMessageProps: {
       leadingComponent: ChatMessageProps['leadingComponent'];
+      reasoningComponent: ChatMessageProps['reasoningComponent'];
       textComponent: ChatMessageProps['textComponent'];
       footerComponent: ChatMessageProps['footerComponent'];
       showReasoning: ChatMessageProps['showReasoning'];
@@ -530,6 +532,14 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
     ? createStableTemplateComponent<ChatMessageTextComponentProps>(
         assistantMessageTemplateRef,
         'text',
+        'fragment'
+      )
+    : undefined;
+  const stableAssistantMessageReasoningComponent = templates.assistantMessage
+    ?.reasoning
+    ? createStableTemplateComponent<ChatMessageReasoningComponentProps>(
+        assistantMessageTemplateRef,
+        'reasoning',
         'fragment'
       )
     : undefined;
@@ -860,6 +870,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
             actionsComponent: stableActionsComponent,
             assistantMessageProps: {
               leadingComponent: stableAssistantMessageLeadingComponent,
+              reasoningComponent: stableAssistantMessageReasoningComponent,
               textComponent: stableAssistantMessageTextComponent,
               footerComponent: stableAssistantMessageFooterComponent,
               showReasoning,
@@ -1088,6 +1099,10 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
        * Template to use for assistant message text parts.
        */
       text: Template<ChatMessageTextComponentProps>;
+      /**
+       * Template to use for assistant message reasoning.
+       */
+      reasoning: Template<ChatMessageReasoningComponentProps>;
       /**
        * Template to use for the assistant message footer content.
        */

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -1100,7 +1100,9 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
        */
       text: Template<ChatMessageTextComponentProps>;
       /**
-       * Template to use for assistant message reasoning.
+       * Template to use for assistant message reasoning. It replaces the
+       * built-in disclosure rather than enabling reasoning, so it also needs
+       * `showReasoning`; on its own it is never used.
        */
       reasoning: Template<ChatMessageReasoningComponentProps>;
       /**

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -242,13 +242,16 @@ export type ChatProps<TObject, TUiMessage extends UIMessage = UIMessage> = Omit<
     userMessageFooterComponent?: ChatMessageProps['footerComponent'];
     suggestionsComponent?: ChatUiProps['suggestionsComponent'];
     /**
-     * Whether to render reasoning parts
+     * Whether to render the reasoning an agent sends. `true` by default, so
+     * reasoning that arrives is shown. Pass `false` to suppress it in this
+     * widget. It cannot make an agent send reasoning: whether reasoning reaches
+     * the client at all is the agent's own `sendReasoning` setting.
      */
     showReasoning?: boolean;
     /**
      * Custom reasoning renderer. It replaces the built-in disclosure rather than
-     * enabling reasoning, so it also needs `showReasoning`; on its own it is
-     * never called.
+     * enabling reasoning: reasoning renders by default, and
+     * `showReasoning: false` suppresses this renderer along with it.
      */
     reasoningComponent?: ChatMessageProps<TUiMessage>['reasoningComponent'];
     translations?: Partial<{

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -246,7 +246,9 @@ export type ChatProps<TObject, TUiMessage extends UIMessage = UIMessage> = Omit<
      */
     showReasoning?: boolean;
     /**
-     * Custom reasoning renderer
+     * Custom reasoning renderer. It replaces the built-in disclosure rather than
+     * enabling reasoning, so it also needs `showReasoning`; on its own it is
+     * never called.
      */
     reasoningComponent?: ChatMessageProps<TUiMessage>['reasoningComponent'];
     translations?: Partial<{

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -245,6 +245,10 @@ export type ChatProps<TObject, TUiMessage extends UIMessage = UIMessage> = Omit<
      * Whether to render reasoning parts
      */
     showReasoning?: boolean;
+    /**
+     * Custom reasoning renderer
+     */
+    reasoningComponent?: ChatMessageProps<TUiMessage>['reasoningComponent'];
     translations?: Partial<{
       prompt: ChatUiProps['promptProps']['translations'];
       header: ChatUiProps['headerProps']['translations'];
@@ -326,6 +330,7 @@ function ChatInner<
     getSearchPageURL,
     disableTriggerValidation = false,
     showReasoning,
+    reasoningComponent,
     ...props
   }: ChatProps<TObject, TUiMessage>,
   ref: React.ForwardedRef<ChatHandle>
@@ -523,6 +528,7 @@ function ChatInner<
           leadingComponent: assistantMessageLeadingComponent,
           footerComponent: assistantMessageFooterComponent,
           showReasoning,
+          reasoningComponent,
           ...callerAssistantMessageProps,
         },
         userMessageProps: {

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
@@ -647,16 +647,14 @@ describe('Chat', () => {
     );
   });
 
-  test('routes the top-level reasoning component with aggregate context', async () => {
+  test('routes the top-level reasoning component per part with context', async () => {
     const chat = createChat();
     const calls: Array<{
       messageId: string;
       messageCount: number;
-      parts: Array<{
-        text: string;
-        partIndex: number;
-        isStreaming: boolean;
-      }>;
+      text: string;
+      partIndex: number;
+      isStreaming: boolean;
     }> = [];
 
     render(
@@ -671,15 +669,19 @@ describe('Chat', () => {
           layoutComponent={ChatInlineLayout}
           requiresSearch={false}
           showReasoning={true}
-          reasoningComponent={({ parts, message, context }) => {
+          reasoningComponent={({
+            part,
+            partIndex,
+            isStreaming,
+            message,
+            context,
+          }) => {
             calls.push({
               messageId: message.id,
               messageCount: context.messages.length,
-              parts: parts.map(({ part, partIndex, isStreaming }) => ({
-                text: part.text,
-                partIndex,
-                isStreaming,
-              })),
+              text: part.text,
+              partIndex,
+              isStreaming,
             });
             return <div data-testid="custom-reasoning">Custom reasoning</div>;
           }}
@@ -691,16 +693,14 @@ describe('Chat', () => {
     });
 
     expect(screen.getAllByTestId('custom-reasoning')).toHaveLength(2);
+    // React can re-render a completed row, so assert the shape of a call
+    // rather than the number of them.
     expect(calls.find(({ messageId }) => messageId === 'assistant-1')).toEqual({
       messageId: 'assistant-1',
       messageCount: 4,
-      parts: [
-        {
-          text: 'Check the catalog.',
-          partIndex: 0,
-          isStreaming: false,
-        },
-      ],
+      text: 'Check the catalog.',
+      partIndex: 0,
+      isStreaming: false,
     });
   });
 

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.test.tsx
@@ -647,6 +647,63 @@ describe('Chat', () => {
     );
   });
 
+  test('routes the top-level reasoning component with aggregate context', async () => {
+    const chat = createChat();
+    const calls: Array<{
+      messageId: string;
+      messageCount: number;
+      parts: Array<{
+        text: string;
+        partIndex: number;
+        isStreaming: boolean;
+      }>;
+    }> = [];
+
+    render(
+      <InstantSearch
+        searchClient={searchClient}
+        indexName="indexName"
+        future={{ preserveSharedStateOnUnmount: true }}
+      >
+        <Chat
+          chat={chat}
+          transport={{ api: 'http://unused' }}
+          layoutComponent={ChatInlineLayout}
+          requiresSearch={false}
+          showReasoning={true}
+          reasoningComponent={({ parts, message, context }) => {
+            calls.push({
+              messageId: message.id,
+              messageCount: context.messages.length,
+              parts: parts.map(({ part, partIndex, isStreaming }) => ({
+                text: part.text,
+                partIndex,
+                isStreaming,
+              })),
+            });
+            return <div data-testid="custom-reasoning">Custom reasoning</div>;
+          }}
+        />
+      </InstantSearch>
+    );
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(screen.getAllByTestId('custom-reasoning')).toHaveLength(2);
+    expect(calls.find(({ messageId }) => messageId === 'assistant-1')).toEqual({
+      messageId: 'assistant-1',
+      messageCount: 4,
+      parts: [
+        {
+          text: 'Check the catalog.',
+          partIndex: 0,
+          isStreaming: false,
+        },
+      ],
+    });
+  });
+
   test('merges messagesProps.assistantMessageProps with the dedicated props', async () => {
     const chat = createChat();
     const { container } = render(
@@ -682,6 +739,46 @@ describe('Chat', () => {
     expect(
       container.querySelectorAll('.ais-ChatMessage--auto-hide-actions')
     ).toHaveLength(2);
+  });
+
+  test('lets the nested reasoning component override the dedicated prop', async () => {
+    const chat = createChat();
+    const dedicatedReasoning = jest.fn(() => (
+      <span data-testid="dedicated-reasoning" />
+    ));
+    const nestedReasoning = jest.fn(() => (
+      <span data-testid="nested-reasoning" />
+    ));
+
+    render(
+      <InstantSearch
+        searchClient={searchClient}
+        indexName="indexName"
+        future={{ preserveSharedStateOnUnmount: true }}
+      >
+        <Chat
+          chat={chat}
+          transport={{ api: 'http://unused' }}
+          layoutComponent={ChatInlineLayout}
+          requiresSearch={false}
+          showReasoning={true}
+          reasoningComponent={dedicatedReasoning}
+          messagesProps={{
+            assistantMessageProps: {
+              reasoningComponent: nestedReasoning,
+            },
+          }}
+        />
+      </InstantSearch>
+    );
+    await act(async () => {
+      await wait(0);
+    });
+
+    expect(screen.getAllByTestId('nested-reasoning')).toHaveLength(2);
+    expect(screen.queryByTestId('dedicated-reasoning')).not.toBeInTheDocument();
+    expect(nestedReasoning).toHaveBeenCalled();
+    expect(dedicatedReasoning).not.toHaveBeenCalled();
   });
 
   test('routes parseMarkdown from messagesProps into reasoning', async () => {

--- a/tests/common/widgets/chat/reasoning.tsx
+++ b/tests/common/widgets/chat/reasoning.tsx
@@ -40,7 +40,7 @@ export function createReasoningTests(
   { act }: Required<TestOptions>
 ) {
   describe('reasoning', () => {
-    test('does not render reasoning by default', async () => {
+    test('renders reasoning by default', async () => {
       const searchClient = createSearchClient();
 
       await setup({
@@ -51,6 +51,36 @@ export function createReasoningTests(
         widgetParams: {
           javascript: createDefaultWidgetParams(createChatWithReasoning()),
           react: createDefaultWidgetParams(createChatWithReasoning()),
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      const disclosure = within(document.body).getByRole('group', {
+        name: 'Reasoning',
+      });
+      expect(disclosure).toHaveTextContent('Check the catalog.');
+      expect(disclosure).toHaveTextContent('Compare release dates.');
+    });
+
+    test('does not render reasoning when suppressed', async () => {
+      const searchClient = createSearchClient();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: false,
+          },
+          react: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: false,
+          },
           vue: {},
         },
       });
@@ -77,8 +107,14 @@ export function createReasoningTests(
           searchClient,
         },
         widgetParams: {
-          javascript: createDefaultWidgetParams(createChatWithReasoning()),
-          react: createDefaultWidgetParams(createChatWithReasoning()),
+          javascript: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: false,
+          },
+          react: {
+            ...createDefaultWidgetParams(createChatWithReasoning()),
+            showReasoning: false,
+          },
           vue: {},
         },
       });
@@ -118,8 +154,14 @@ export function createReasoningTests(
           searchClient,
         },
         widgetParams: {
-          javascript: createDefaultWidgetParams(chat),
-          react: createDefaultWidgetParams(chat),
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: false,
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: false,
+          },
           vue: {},
         },
       });

--- a/tests/common/widgets/chat/reasoning.tsx
+++ b/tests/common/widgets/chat/reasoning.tsx
@@ -3,6 +3,7 @@ import { wait } from '@instantsearch/testutils';
 import { within } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { Chat } from 'instantsearch.js/es/lib/chat';
+import React from 'react';
 
 import { createDefaultWidgetParams, openChat } from './utils';
 
@@ -399,6 +400,183 @@ export function createReasoningTests(
           name: 'Raisonnement',
         })
       ).toHaveLength(1);
+    });
+
+    test('renders a custom reasoning renderer once per part, in stream order', async () => {
+      const searchClient = createSearchClient();
+      // Reasoning and text alternate, so a renderer that received the whole
+      // array at the first reasoning position would produce
+      // `R1, R2, T1, T2` instead of the stream's own order.
+      const chat = new Chat({
+        messages: [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [
+              { type: 'reasoning', text: 'R1', state: 'done' },
+              { type: 'text', text: 'T1' },
+              { type: 'reasoning', text: 'R2', state: 'done' },
+              { type: 'text', text: 'T2' },
+            ],
+          },
+        ],
+      });
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+            templates: {
+              assistantMessage: {
+                reasoning: ({ part, partIndex }, { html }) =>
+                  html`<span
+                    class="custom-reasoning-part"
+                    data-part-index="${partIndex}"
+                    >${part.text}</span
+                  >`,
+              },
+            },
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+            messagesProps: {
+              assistantMessageProps: {
+                reasoningComponent: ({ part, partIndex }) => (
+                  <span
+                    className="custom-reasoning-part"
+                    data-part-index={partIndex}
+                  >
+                    {part.text}
+                  </span>
+                ),
+              },
+            },
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      expect(
+        Array.from(document.querySelectorAll('.custom-reasoning-part')).map(
+          (element) => ({
+            text: element.textContent,
+            partIndex: Number(element.getAttribute('data-part-index')),
+          })
+        )
+      ).toEqual([
+        { text: 'R1', partIndex: 0 },
+        { text: 'R2', partIndex: 2 },
+      ]);
+
+      // The built-in disclosure must not also render.
+      expect(
+        within(document.body).queryAllByRole('group', { name: 'Reasoning' })
+      ).toHaveLength(0);
+
+      const message = document.querySelector('.ais-ChatMessage-message')!;
+      expect(
+        Array.from(message.children).map((child) => child.textContent)
+      ).toEqual(['R1', 'T1', 'R2', 'T2']);
+    });
+
+    test('keeps a custom renderer disclosure state across a part ending', async () => {
+      const searchClient = createSearchClient();
+      const firstPart = {
+        type: 'reasoning' as const,
+        text: 'R1',
+        state: 'done' as const,
+      };
+      const chat = new Chat({
+        messages: [
+          { id: 'assistant-1', role: 'assistant' as const, parts: [firstPart] },
+        ],
+      });
+
+      // A consumer rendering its own disclosure owns the open state. The library
+      // must not remount an earlier step when a later one arrives.
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+        },
+        widgetParams: {
+          javascript: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+            templates: {
+              assistantMessage: {
+                reasoning: ({ part, partIndex }, { html }) =>
+                  html`<details
+                    class="custom-reasoning-disclosure"
+                    data-part-index="${partIndex}"
+                  >
+                    <summary>Step</summary>
+                    ${part.text}
+                  </details>`,
+              },
+            },
+          },
+          react: {
+            ...createDefaultWidgetParams(chat),
+            showReasoning: true,
+            messagesProps: {
+              assistantMessageProps: {
+                reasoningComponent: ({ part, partIndex }) => (
+                  <details
+                    className="custom-reasoning-disclosure"
+                    data-part-index={partIndex}
+                  >
+                    <summary>Step</summary>
+                    {part.text}
+                  </details>
+                ),
+              },
+            },
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      const opened = document.querySelector<HTMLDetailsElement>(
+        '.custom-reasoning-disclosure'
+      )!;
+      await act(async () => {
+        await userEvent.click(within(opened).getByText('Step'));
+        await wait(0);
+      });
+      expect(opened.open).toBe(true);
+
+      await act(async () => {
+        chat.messages = [
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            parts: [
+              firstPart,
+              { type: 'reasoning', text: 'R2', state: 'done' },
+            ],
+          },
+        ];
+        await wait(0);
+      });
+
+      const disclosures = document.querySelectorAll<HTMLDetailsElement>(
+        '.custom-reasoning-disclosure'
+      );
+      expect(disclosures).toHaveLength(2);
+      expect(disclosures[0]).toBe(opened);
+      expect(disclosures[0].open).toBe(true);
+      expect(disclosures[1].open).toBe(false);
     });
   });
 }

--- a/tests/common/widgets/chat/reasoning.tsx
+++ b/tests/common/widgets/chat/reasoning.tsx
@@ -132,7 +132,7 @@ export function createReasoningTests(
       ).not.toBeInTheDocument();
     });
 
-    test('renders each reasoning part in a collapsed disclosure when enabled', async () => {
+    test('renders received reasoning in one collapsed timeline when enabled', async () => {
       const searchClient = createSearchClient();
 
       await setup({
@@ -163,14 +163,18 @@ export function createReasoningTests(
       const disclosures = within(document.body).getAllByRole('group', {
         name: 'Reasoning',
       });
-      expect(disclosures).toHaveLength(2);
+      expect(disclosures).toHaveLength(1);
       expect(disclosures[0]).not.toHaveAttribute('open');
-      expect(disclosures[1]).not.toHaveAttribute('open');
       expect(disclosures[0]).toHaveTextContent('Check the catalog.');
       expect(disclosures[0].querySelector('strong')).toHaveTextContent(
         'catalog'
       );
-      expect(disclosures[1]).toHaveTextContent('Compare release dates.');
+      expect(disclosures[0]).toHaveTextContent('Compare release dates.');
+      expect(
+        within(disclosures[0])
+          .getAllByRole('listitem')
+          .map((entry) => entry.textContent)
+      ).toEqual(['Check the catalog.', 'Compare release dates.']);
     });
 
     test('keeps an active reasoning disclosure collapsed until the reader opens it', async () => {
@@ -394,7 +398,7 @@ export function createReasoningTests(
         within(document.body).getAllByRole('group', {
           name: 'Raisonnement',
         })
-      ).toHaveLength(2);
+      ).toHaveLength(1);
     });
   });
 }


### PR DESCRIPTION
**Summary**

Chat renders the reasoning an agent sends as one compact, expandable row per assistant message. While reasoning is active the row shows the latest update with a restrained pulse; opening it reveals the received updates in order. The reader's open or closed choice survives tools running, the answer starting and the message completing. Tool cards stay separate.

Whether reasoning exists is the agent's decision — Agent Studio streams `reasoning` parts only when the agent config carries `sendReasoning: true`, which is off by default. The widget can therefore only suppress what arrives, never request it, so `showReasoning` defaults to `true` and `showReasoning: false` hides reasoning for that widget.

The built-in row is available in InstantSearch.js and React InstantSearch, and `templates.assistantMessage.reasoning` / `reasoningComponent` replaces it. A custom renderer is called once per reasoning part at that part's own stream position, so custom rows keep stream order alongside the tool cards; the built-in row stays one per message. A renderer changes the presentation only — `showReasoning: false` suppresses it too.

The row and the loader read one resolved boolean, so the loader is suppressed exactly while a disclosure is carrying progress (`getShowLoader`) and labels that phase while it is (`getLoaderPhase`).

**Result**

With an agent that sends reasoning, active reasoning is visible without Dashboard-specific card styling and completed reasoning remains available as a quiet disclosure. A site that does not want chain-of-thought on the page passes `showReasoning: false`.

**Preview**
reasoning in the JS showcase, inline layout. recorded by @FabienMotte 

https://github.com/user-attachments/assets/d89c10f2-c7b0-45d1-9da0-9eb7e2ec9546




Related: [FX-3928](https://algolia.atlassian.net/browse/FX-3928)


[FX-3928]: https://algolia.atlassian.net/browse/FX-3928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
