### PR TITLE
feat(prompt-suggestions): support plain JSON task streams

### DIFF
--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -973,6 +973,41 @@ describe('connectPromptSuggestions', () => {
         renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
       expect(afterInvalidation.error).toBeUndefined();
     });
+
+    it('clears the previous error when the search state changes', async () => {
+      const streamError = new Error('stream failed');
+      global.fetch = jest.fn(() =>
+        Promise.resolve(textStreamResponse([], streamError))
+      ) as unknown as typeof fetch;
+
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      widget.render!(
+        createRenderOptions({ helper, results: makeResults({ query: 'a' }) })
+      );
+      await flush(DEBOUNCE_WAIT);
+      await flush(10);
+
+      expect(renderFn.mock.calls[renderFn.mock.calls.length - 1][0].error).toBe(
+        streamError
+      );
+
+      widget.render!(
+        createRenderOptions({ helper, results: makeResults({ query: 'b' }) })
+      );
+
+      expect(
+        renderFn.mock.calls[renderFn.mock.calls.length - 1][0].error
+      ).toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      widget.dispose!(createDisposeOptions({ helper }));
+    });
   });
 
   describe('handoff', () => {

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -42,24 +42,19 @@ function makeResults(
   return new algoliasearchHelper.SearchResults(helper.state, [response]);
 }
 
-function jsonResponse(body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  });
-}
-
-// Builds a fake `text/event-stream` response whose body replays `events` as
-// SSE `data:` lines. Kept as a plain object (not a real `Response`) so the test
-// doesn't depend on `Response.body` support in the jsdom environment.
-function sseResponse(events: string[]): Response {
+function textStreamResponse(chunks: string[], error?: Error): Response {
   const encoder = new TextEncoder();
+  let index = 0;
   const body = new ReadableStream<Uint8Array>({
-    start(controller) {
-      events.forEach((event) => {
-        controller.enqueue(encoder.encode(`data: ${event}\n\n`));
-      });
-      controller.close();
+    pull(controller) {
+      const chunk = chunks[index++];
+      if (chunk !== undefined) {
+        controller.enqueue(encoder.encode(chunk));
+      } else if (error) {
+        controller.error(error);
+      } else {
+        controller.close();
+      }
     },
   });
   return {
@@ -67,17 +62,12 @@ function sseResponse(events: string[]): Response {
     status: 200,
     headers: {
       get: (name: string) =>
-        name.toLowerCase() === 'content-type' ? 'text/event-stream' : null,
+        name.toLowerCase() === 'content-type'
+          ? 'text/plain; charset=utf-8'
+          : null,
     },
     body,
   } as unknown as Response;
-}
-
-function taskOutputEvent(suggestions: string[]): string {
-  return JSON.stringify({
-    type: 'data-task-output',
-    data: { output: { suggestions } },
-  });
 }
 
 function flush(ms = 0) {
@@ -89,11 +79,7 @@ describe('connectPromptSuggestions', () => {
 
   beforeEach(() => {
     global.fetch = jest.fn(() =>
-      Promise.resolve(
-        jsonResponse({
-          output: { suggestions: ['a', 'b', 'c'] },
-        })
-      )
+      Promise.resolve(textStreamResponse(['{"suggestions":["a","b","c"]}']))
     ) as unknown as typeof fetch;
   });
 
@@ -162,6 +148,7 @@ describe('connectPromptSuggestions', () => {
       const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
       expect(lastCall.suggestions).toEqual(['a', 'b', 'c']);
       expect(lastCall.isLoading).toBe(false);
+      expect(lastCall.error).toBeUndefined();
     });
 
     it('skips the request when there are no hits', async () => {
@@ -222,9 +209,7 @@ describe('connectPromptSuggestions', () => {
       await flush(DEBOUNCE_WAIT);
 
       // The now-stale request resolves late; its suggestions must be ignored.
-      resolveFetch(
-        jsonResponse({ output: { suggestions: ['stale', 'pills'] } })
-      );
+      resolveFetch(textStreamResponse(['{"suggestions":["stale","pills"]}']));
       await flush(10);
 
       const last = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
@@ -449,7 +434,7 @@ describe('connectPromptSuggestions', () => {
       expect(midFlight.isLoading).toBe(true);
       expect(midFlight.suggestions).toEqual([]);
 
-      resolveSecond(jsonResponse({ output: { suggestions: ['x', 'y'] } }));
+      resolveSecond(textStreamResponse(['{"suggestions":["x","y"]}']));
       await flush(0);
       const afterSecond =
         renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
@@ -491,7 +476,7 @@ describe('connectPromptSuggestions', () => {
       );
 
       // The stale 'a' response arrives during the debounce window.
-      resolveFirst(jsonResponse({ output: { suggestions: ['stale'] } }));
+      resolveFirst(textStreamResponse(['{"suggestions":["stale"]}']));
       await flush(0);
 
       // It must not paint stale pills.
@@ -536,7 +521,7 @@ describe('connectPromptSuggestions', () => {
       const callsAfterDispose = renderFn.mock.calls.length;
 
       // The late resolution must not trigger a render into the torn-down tree.
-      resolveFetch(jsonResponse({ output: { suggestions: ['x', 'y'] } }));
+      resolveFetch(textStreamResponse(['{"suggestions":["x","y"]}']));
       await flush(0);
       expect(renderFn).toHaveBeenCalledTimes(callsAfterDispose);
     });
@@ -836,7 +821,7 @@ describe('connectPromptSuggestions', () => {
 
     it('forwards combined agent and transport options to one task request', async () => {
       const customFetch = jest.fn(() =>
-        Promise.resolve(jsonResponse({ output: { suggestions: ['combined'] } }))
+        Promise.resolve(textStreamResponse(['{"suggestions":["combined"]}']))
       ) as unknown as typeof fetch;
       const widget = connectPromptSuggestions(jest.fn())({
         agentId: 'agent',
@@ -873,7 +858,7 @@ describe('connectPromptSuggestions', () => {
   describe('streaming', () => {
     it('requests the streaming endpoint with `stream=true`', async () => {
       global.fetch = jest.fn(() =>
-        Promise.resolve(sseResponse([taskOutputEvent(['a', 'b'])]))
+        Promise.resolve(textStreamResponse(['{"suggestions":["a","b"]}']))
       ) as unknown as typeof fetch;
 
       const widget = connectPromptSuggestions(jest.fn())({
@@ -893,15 +878,11 @@ describe('connectPromptSuggestions', () => {
     it('renders each accumulated snapshot and resolves with the final list', async () => {
       global.fetch = jest.fn(() =>
         Promise.resolve(
-          sseResponse([
-            JSON.stringify({ type: 'start' }),
-            // Early partial while the model is still streaming the first item.
-            taskOutputEvent(['']),
-            taskOutputEvent(['What']),
-            taskOutputEvent(['What phones?']),
-            taskOutputEvent(['What phones?', 'Any deals?']),
-            JSON.stringify({ type: 'finish' }),
-            '[DONE]',
+          textStreamResponse([
+            '{"suggestions":["',
+            'What',
+            ' phones?',
+            '","Any deals?"]}',
           ])
         )
       ) as unknown as typeof fetch;
@@ -928,23 +909,9 @@ describe('connectPromptSuggestions', () => {
       expect(last.isLoading).toBe(false);
     });
 
-    it('repairs a raw partial-JSON output payload while streaming', async () => {
-      // Here `data` is the raw (still-incomplete) JSON text the model emits,
-      // not a pre-parsed object — exercising the shared repair logic.
+    it('repairs partial JSON while streaming', async () => {
       global.fetch = jest.fn(() =>
-        Promise.resolve(
-          sseResponse([
-            JSON.stringify({
-              type: 'data-task-output',
-              data: '{"output":{"suggestions":["Wh',
-            }),
-            JSON.stringify({
-              type: 'data-task-output',
-              data: '{"output":{"suggestions":["What?"]}}',
-            }),
-            '[DONE]',
-          ])
-        )
+        Promise.resolve(textStreamResponse(['{"suggestions":["Wh', 'at?"]}']))
       ) as unknown as typeof fetch;
 
       const renderFn = jest.fn();
@@ -966,13 +933,10 @@ describe('connectPromptSuggestions', () => {
     });
 
     it('clears streamed partials when the stream emits a terminal error', async () => {
+      const streamError = new Error('stream failed');
       global.fetch = jest.fn(() =>
         Promise.resolve(
-          sseResponse([
-            taskOutputEvent(['What phones?']),
-            JSON.stringify({ type: 'error', errorText: 'stream failed' }),
-            '[DONE]',
-          ])
+          textStreamResponse(['{"suggestions":["What phones?"]}'], streamError)
         )
       ) as unknown as typeof fetch;
 
@@ -991,34 +955,23 @@ describe('connectPromptSuggestions', () => {
       const snapshots = renderFn.mock.calls.map((c) => c[0].suggestions);
       expect(snapshots).toContainEqual(['What phones?']);
 
-      // ...but the terminal error clears it. There's no error UI, so a blank
-      // state is the intended outcome — no partial pills survive.
+      // ...but the terminal error clears it and is exposed to consumers.
       const last = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
       expect(last.suggestions).toEqual([]);
       expect(last.isLoading).toBe(false);
-    });
+      expect(last.error).toBe(streamError);
 
-    it('falls back to a buffered JSON body when the response is not a stream', async () => {
-      // A custom transport / non-streaming backend ignores `stream=true` and
-      // returns a plain JSON body; the connector must still parse it.
-      global.fetch = jest.fn(() =>
-        Promise.resolve(jsonResponse({ output: { suggestions: ['a', 'b'] } }))
-      ) as unknown as typeof fetch;
-
-      const renderFn = jest.fn();
-      const widget = connectPromptSuggestions(renderFn)({
-        agentId: 'a',
-        configurationId: 'prompt-suggestions',
-      });
-      const helper = algoliasearchHelper(createSearchClient(), '');
-      widget.init!(createInitOptions({ helper }));
-      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ hits: [], query: '' }),
+        })
+      );
       await flush(DEBOUNCE_WAIT);
-      await flush(10);
 
-      const last = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
-      expect(last.suggestions).toEqual(['a', 'b']);
-      expect(last.isLoading).toBe(false);
+      const afterInvalidation =
+        renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      expect(afterInvalidation.error).toBeUndefined();
     });
   });
 

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -478,6 +478,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           if (stateSignature !== lastStateSignature) {
             lastStateSignature = stateSignature;
             refetchPending = true;
+            error = undefined;
             clearTimeout(debounceTimer);
             debounceTimer = setTimeout(() => {
               if (latestRenderOptions?.results) {

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -72,6 +72,8 @@ export type PromptSuggestionsRenderState = {
   suggestions: string[];
   /** Whether suggestions are currently being fetched. */
   isLoading: boolean;
+  /** The error thrown by the latest suggestions request, or `undefined`. */
+  error: Error | undefined;
   /** Default click handler, calling `sendToChat(prompt)`. Override via the `onSuggestionClick` prop. */
   onSuggestionClick: (prompt: string) => void;
   /** Hands the prompt to the `connectChat` widget on the same index. `true` if dispatched, else `false`. */
@@ -217,6 +219,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       let tasksState: TasksRenderState | undefined;
       let suggestions: string[] = [];
       let isLoading = false;
+      let error: Error | undefined;
       let debounceTimer: ReturnType<typeof setTimeout> | undefined;
       let lastStateSignature: string | null = null;
       let latestRenderOptions: RenderOptions | null = null;
@@ -384,6 +387,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         return {
           suggestions: transformed,
           isLoading,
+          error,
           onSuggestionClick: send,
           sendToChat: send,
           refresh,
@@ -397,10 +401,10 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       const handleInnerRender = (renderState: TasksRenderState) => {
         tasksState = renderState;
         if (refetchPending) return;
+        error = renderState.error;
         if (renderState.error) {
           // A failed task (including a mid-stream `error` event) must not leave
-          // any streamed partial visible. There's no error UI for now, so fall
-          // back to a blank suggestions state.
+          // any streamed partial visible.
           suggestions = [];
         } else if (renderState.isLoading || renderState.output !== undefined) {
           // Only adopt the inner output once a request is loading or has

--- a/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
@@ -595,6 +595,29 @@ describe('connectTasks', () => {
       expect(lastState().isLoading).toBe(false);
     });
 
+    it('invalidate() clears output and error from previous submits', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce(textStreamResponse(['{"done":true}']))
+        .mockResolvedValueOnce(
+          new Response('nope', { status: 500 })
+        ) as unknown as typeof fetch;
+
+      const { lastState } = init({ agentId: 'a', task: 't' });
+
+      await lastState().submit({});
+      expect(lastState().output).toEqual({ done: true });
+
+      lastState().invalidate();
+      expect(lastState().output).toBeUndefined();
+
+      await lastState().submit({});
+      expect(lastState().error).toBeInstanceOf(Error);
+
+      lastState().invalidate();
+      expect(lastState().error).toBeUndefined();
+      expect(lastState().isLoading).toBe(false);
+    });
   });
 
   describe('dispose', () => {

--- a/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
@@ -18,17 +18,17 @@ function jsonResponse(body: unknown): Response {
   });
 }
 
-// Builds a fake `text/event-stream` response whose body replays `events` as SSE
-// `data:` lines. Kept as a plain object (not a real `Response`) so the test
-// doesn't depend on `Response.body` support in the jsdom environment.
-function sseResponse(events: string[]): Response {
+function textStreamResponse(chunks: string[]): Response {
   const encoder = new TextEncoder();
+  let index = 0;
   const body = new ReadableStream<Uint8Array>({
-    start(controller) {
-      events.forEach((event) => {
-        controller.enqueue(encoder.encode(`data: ${event}\n\n`));
-      });
-      controller.close();
+    pull(controller) {
+      const chunk = chunks[index++];
+      if (chunk === undefined) {
+        controller.close();
+      } else {
+        controller.enqueue(encoder.encode(chunk));
+      }
     },
   });
   return {
@@ -36,14 +36,12 @@ function sseResponse(events: string[]): Response {
     status: 200,
     headers: {
       get: (name: string) =>
-        name.toLowerCase() === 'content-type' ? 'text/event-stream' : null,
+        name.toLowerCase() === 'content-type'
+          ? 'text/plain; charset=utf-8'
+          : null,
     },
     body,
   } as unknown as Response;
-}
-
-function outputEvent(output: unknown): string {
-  return JSON.stringify({ type: 'data-task-output', data: { output } });
 }
 
 function flush(ms = 0) {
@@ -65,7 +63,7 @@ describe('connectTasks', () => {
 
   beforeEach(() => {
     global.fetch = jest.fn(() =>
-      Promise.resolve(jsonResponse({ output: { suggestions: ['a'] } }))
+      Promise.resolve(textStreamResponse(['{"suggestions":["a"]}']))
     ) as unknown as typeof fetch;
   });
 
@@ -156,15 +154,7 @@ describe('connectTasks', () => {
 
     it('surfaces streamed partial outputs through the render state', async () => {
       global.fetch = jest.fn(() =>
-        Promise.resolve(
-          sseResponse([
-            JSON.stringify({ type: 'start' }),
-            outputEvent({ value: 'a' }),
-            outputEvent({ value: 'ab' }),
-            JSON.stringify({ type: 'finish' }),
-            '[DONE]',
-          ])
-        )
+        Promise.resolve(textStreamResponse(['{"value":"a', 'b"}']))
       ) as unknown as typeof fetch;
 
       const { renderFn, lastState } = init({ agentId: 'a', task: 't' });
@@ -540,9 +530,9 @@ describe('connectTasks', () => {
       await flush(0);
 
       // Resolve the newer request (2) first, then the stale one (1).
-      resolvers[1](jsonResponse({ output: { winner: 2 } }));
+      resolvers[1](textStreamResponse(['{"winner":2}']));
       await flush(0);
-      resolvers[0](jsonResponse({ output: { winner: 1 } }));
+      resolvers[0](textStreamResponse(['{"winner":1}']));
       await flush(0);
 
       // The stale (first) response must not overwrite the latest output.
@@ -566,8 +556,8 @@ describe('connectTasks', () => {
       const second = lastState().submit({ n: 2 });
       await flush(0);
 
-      resolvers[1](jsonResponse({ output: { winner: 2 } }));
-      resolvers[0](jsonResponse({ output: { winner: 1 } }));
+      resolvers[1](textStreamResponse(['{"winner":2}']));
+      resolvers[0](textStreamResponse(['{"winner":1}']));
 
       // Each promise resolves with its own output — the stale (first) call must
       // not adopt the newer call's result just because it settled later.
@@ -598,12 +588,13 @@ describe('connectTasks', () => {
       expect(lastState().isLoading).toBe(false);
 
       // The now-stale request resolves late; its output must be ignored.
-      resolveFetch(jsonResponse({ output: { late: true } }));
+      resolveFetch(textStreamResponse(['{"late":true}']));
       await flush(0);
 
       expect(lastState().output).toBeUndefined();
       expect(lastState().isLoading).toBe(false);
     });
+
   });
 
   describe('dispose', () => {
@@ -622,7 +613,7 @@ describe('connectTasks', () => {
       const callsBeforeDispose = renderFn.mock.calls.length;
       widget.dispose!({} as any);
 
-      resolveFetch(jsonResponse({ output: { late: true } }));
+      resolveFetch(textStreamResponse(['{"late":true}']));
       await flush(0);
 
       // The post-dispose resolution must not trigger another render.

--- a/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
@@ -41,8 +41,9 @@ export type TasksRenderState<TOutput = unknown> = {
   submit: (variables: Record<string, unknown>) => Promise<TOutput | undefined>;
   /**
    * Supersedes any in-flight `submit` so its pending result is ignored (the
-   * underlying request is not aborted, just abandoned) and clears the loading
-   * flag. Use when the inputs that produced the request are no longer valid.
+   * underlying request is not aborted, just abandoned) and clears the output,
+   * error, and loading state. Use when the inputs that produced the request are
+   * no longer valid.
    */
   invalidate: () => void;
 };
@@ -159,6 +160,8 @@ const connectTasks: TasksConnector = function connectTasks<TOutput = unknown>(
       // Bump the request id so any in-flight request's callbacks see
       // `isStale()` and are ignored. The fetch itself is left to complete.
       requestId += 1;
+      output = undefined;
+      error = undefined;
       isLoading = false;
       triggerRender();
     };

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
@@ -203,6 +203,20 @@ describe('DefaultTaskTransport', () => {
     );
   });
 
+  it('uses buffered JSON when a streaming request receives JSON', async () => {
+    const customFetch = jest.fn(
+      (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+        Promise.resolve(jsonResponse({ output: { suggestions: ['a'] } }))
+    );
+    const onData = jest.fn();
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+
+    await expect(
+      transport.sendTask({ task: 't', input: {}, stream: true, onData })
+    ).resolves.toEqual({ suggestions: ['a'] });
+    expect(onData).not.toHaveBeenCalled();
+  });
+
   it('streams unwrapped partial outputs and resolves the final output', async () => {
     const customFetch = jest.fn(() =>
       Promise.resolve(textStreamResponse(['{"value":"a', 'b"}']))

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
@@ -11,14 +11,24 @@ function jsonResponse(body: unknown): Response {
   });
 }
 
-function sseResponse(events: string[]): Response {
+function textStreamResponse(
+  chunks: Array<string | Uint8Array>,
+  error?: Error
+): Response {
   const encoder = new TextEncoder();
+  let index = 0;
   const body = new ReadableStream<Uint8Array>({
-    start(controller) {
-      events.forEach((event) => {
-        controller.enqueue(encoder.encode(`data: ${event}\n\n`));
-      });
-      controller.close();
+    pull(controller) {
+      const chunk = chunks[index++];
+      if (chunk !== undefined) {
+        controller.enqueue(
+          typeof chunk === 'string' ? encoder.encode(chunk) : chunk
+        );
+      } else if (error) {
+        controller.error(error);
+      } else {
+        controller.close();
+      }
     },
   });
   return {
@@ -26,14 +36,12 @@ function sseResponse(events: string[]): Response {
     status: 200,
     headers: {
       get: (name: string) =>
-        name.toLowerCase() === 'content-type' ? 'text/event-stream' : null,
+        name.toLowerCase() === 'content-type'
+          ? 'text/plain; charset=utf-8'
+          : null,
     },
     body,
   } as unknown as Response;
-}
-
-function outputEvent(output: unknown): string {
-  return JSON.stringify({ type: 'data-task-output', data: { output } });
 }
 
 describe('DefaultTaskTransport', () => {
@@ -46,7 +54,7 @@ describe('DefaultTaskTransport', () => {
   it('owns async request preparation and performs exactly one request', async () => {
     const customFetch = jest.fn(
       (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
-        Promise.resolve(jsonResponse({ output: { suggestions: ['a'] } }))
+        Promise.resolve(textStreamResponse(['{"suggestions":["a"]}']))
     );
     const prepareSendMessagesRequest = jest.fn(
       async (request: {
@@ -180,7 +188,7 @@ describe('DefaultTaskTransport', () => {
   it('appends streaming to an API that already has query parameters', async () => {
     const customFetch = jest.fn(
       (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
-        Promise.resolve(jsonResponse({ output: { ok: true } }))
+        Promise.resolve(textStreamResponse(['{"ok":true}']))
     );
     const transport = new DefaultTaskTransport({
       api: 'https://example.test/tasks?version=1',
@@ -195,17 +203,9 @@ describe('DefaultTaskTransport', () => {
     );
   });
 
-  it('streams unwrapped snapshots and resolves the final output', async () => {
+  it('streams unwrapped partial outputs and resolves the final output', async () => {
     const customFetch = jest.fn(() =>
-      Promise.resolve(
-        sseResponse([
-          JSON.stringify({ type: 'start' }),
-          outputEvent({ value: 'a' }),
-          outputEvent({ value: 'ab' }),
-          JSON.stringify({ type: 'finish' }),
-          '[DONE]',
-        ])
-      )
+      Promise.resolve(textStreamResponse(['{"value":"a', 'b"}']))
     ) as unknown as typeof fetch;
     const onData = jest.fn();
     const transport = new DefaultTaskTransport({ fetch: customFetch });
@@ -218,19 +218,7 @@ describe('DefaultTaskTransport', () => {
 
   it('repairs partial JSON while streaming', async () => {
     const customFetch = jest.fn(() =>
-      Promise.resolve(
-        sseResponse([
-          JSON.stringify({
-            type: 'data-task-output',
-            data: '{"output":{"suggestions":["Wh',
-          }),
-          JSON.stringify({
-            type: 'data-task-output',
-            data: '{"output":{"suggestions":["What?"]}}',
-          }),
-          '[DONE]',
-        ])
-      )
+      Promise.resolve(textStreamResponse(['{"suggestions":["Wh', 'at?"]}']))
     ) as unknown as typeof fetch;
     const onData = jest.fn();
     const transport = new DefaultTaskTransport({ fetch: customFetch });
@@ -239,6 +227,49 @@ describe('DefaultTaskTransport', () => {
       transport.sendTask({ task: 't', input: {}, stream: true, onData })
     ).resolves.toEqual({ suggestions: ['What?'] });
     expect(onData.mock.calls[0][0]).toEqual({ suggestions: ['Wh'] });
+  });
+
+  it('ignores keepalive whitespace that does not change the output', async () => {
+    const customFetch = jest.fn(() =>
+      Promise.resolve(textStreamResponse([' ', '{"value":"complete"}', ' ']))
+    ) as unknown as typeof fetch;
+    const onData = jest.fn();
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+
+    await expect(
+      transport.sendTask({ task: 't', input: {}, stream: true, onData })
+    ).resolves.toEqual({ value: 'complete' });
+    expect(onData).toHaveBeenCalledTimes(1);
+    expect(onData).toHaveBeenCalledWith({ value: 'complete' });
+  });
+
+  it('decodes multi-byte characters split across chunks', async () => {
+    const bytes = new TextEncoder().encode('{"value":"café"}');
+    const splitIndex = bytes.indexOf(0xc3) + 1;
+    const customFetch = jest.fn(() =>
+      Promise.resolve(
+        textStreamResponse([
+          bytes.slice(0, splitIndex),
+          bytes.slice(splitIndex),
+        ])
+      )
+    ) as unknown as typeof fetch;
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+
+    await expect(
+      transport.sendTask({ task: 't', input: {}, stream: true })
+    ).resolves.toEqual({ value: 'café' });
+  });
+
+  it('rejects a stream that closes with incomplete JSON', async () => {
+    const customFetch = jest.fn(() =>
+      Promise.resolve(textStreamResponse(['{"value":']))
+    ) as unknown as typeof fetch;
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+
+    await expect(
+      transport.sendTask({ task: 't', input: {}, stream: true })
+    ).rejects.toBeInstanceOf(SyntaxError);
   });
 
   it('uses buffered JSON and does not emit partial data when streaming is disabled', async () => {
@@ -266,25 +297,17 @@ describe('DefaultTaskTransport', () => {
     ).rejects.toThrow('HTTP error 503');
   });
 
-  it('streams unwrapped partial outputs and rejects terminal errors', async () => {
+  it('streams unwrapped partial outputs and rejects stream errors', async () => {
     const onData = jest.fn();
+    const streamError = new Error('stream failed');
     const customFetch = jest.fn(() =>
-      Promise.resolve(
-        sseResponse([
-          JSON.stringify({
-            type: 'data-task-output',
-            data: { output: { value: 'partial' } },
-          }),
-          JSON.stringify({ type: 'error', errorText: 'stream failed' }),
-          '[DONE]',
-        ])
-      )
+      Promise.resolve(textStreamResponse(['{"value":"partial"}'], streamError))
     ) as unknown as typeof fetch;
     const transport = new DefaultTaskTransport({ fetch: customFetch });
 
     await expect(
       transport.sendTask({ task: 't', input: {}, stream: true, onData })
-    ).rejects.toThrow('stream failed');
+    ).rejects.toBe(streamError);
     expect(onData).toHaveBeenCalledWith({ value: 'partial' });
   });
 });

--- a/packages/instantsearch.js/src/lib/tasks/transport.ts
+++ b/packages/instantsearch.js/src/lib/tasks/transport.ts
@@ -1,9 +1,6 @@
-import {
-  parseJsonEventStream,
-  parsePartialJson,
-  processStream,
-} from '../ai-lite';
+import { parsePartialJson } from '../ai-lite';
 import { resolveValue } from '../ai-lite/utils';
+import { isEqual } from '../utils/isEqual';
 
 import type { Resolvable } from '../ai-lite';
 
@@ -81,10 +78,6 @@ function withStreamParam(url: string): string {
   return url.includes('?') ? `${url}&stream=true` : `${url}?stream=true`;
 }
 
-function resolveStreamedOutput(data: unknown, previous: unknown): unknown {
-  return typeof data === 'string' ? parsePartialJson(data, previous) : data;
-}
-
 function createTaskPreparationContext(
   context: Parameters<TaskPrepareSendMessagesRequest>[0]
 ): Parameters<TaskPrepareSendMessagesRequest>[0] {
@@ -128,33 +121,59 @@ function unwrap(envelope: unknown): unknown {
   return undefined;
 }
 
-function consumeTaskStream(
+function consumeTaskTextStream(
   body: ReadableStream<Uint8Array>,
   onData?: (data: unknown) => void
 ): Promise<unknown> {
   return new Promise<unknown>((resolve, reject) => {
-    const chunkStream = parseJsonEventStream(body);
+    const decoder = new TextDecoder();
+    const reader = body.getReader();
+    let accumulatedText = '';
     let latest: unknown;
-    processStream(
-      chunkStream,
-      (chunk) => {
-        if (!chunk) {
-          return;
+
+    const publish = (output: unknown) => {
+      if (!isEqual(output, latest)) {
+        latest = output;
+        onData?.({ output });
+      }
+    };
+
+    const read = (): void => {
+      reader.read().then(
+        ({ done, value }) => {
+          if (done) {
+            accumulatedText += decoder.decode();
+            reader.releaseLock();
+            try {
+              const output = JSON.parse(accumulatedText);
+              publish(output);
+              resolve({ output });
+            } catch (error) {
+              reject(error);
+            }
+            return;
+          }
+
+          try {
+            accumulatedText += decoder.decode(value, { stream: true });
+            const partial = parsePartialJson(accumulatedText, latest);
+            if (partial !== undefined) {
+              publish(partial);
+            }
+            read();
+          } catch (error) {
+            reader.releaseLock();
+            reject(error);
+          }
+        },
+        (error) => {
+          reader.releaseLock();
+          reject(error);
         }
-        if (chunk.type === 'error') {
-          throw new Error(chunk.errorText || 'Task stream error');
-        }
-        if (chunk.type !== 'data-task-output') {
-          return;
-        }
-        latest = resolveStreamedOutput(chunk.data, latest);
-        if (onData) {
-          onData(latest);
-        }
-      },
-      () => resolve(latest),
-      reject
-    );
+      );
+    };
+
+    read();
   });
 }
 
@@ -261,13 +280,11 @@ export class DefaultTaskTransport {
             if (!response.ok) {
               throw new Error(`HTTP error ${response.status}`);
             }
-            const contentType = response.headers?.get?.('content-type') || '';
-            if (
-              stream &&
-              response.body &&
-              contentType.includes('text/event-stream')
-            ) {
-              return consumeTaskStream(response.body, onData);
+            if (stream) {
+              if (!response.body) {
+                throw new Error('Response body is empty');
+              }
+              return consumeTaskTextStream(response.body, onData);
             }
             return response.json();
           }

--- a/packages/instantsearch.js/src/lib/tasks/transport.ts
+++ b/packages/instantsearch.js/src/lib/tasks/transport.ts
@@ -280,7 +280,8 @@ export class DefaultTaskTransport {
             if (!response.ok) {
               throw new Error(`HTTP error ${response.status}`);
             }
-            if (stream) {
+            const contentType = response.headers?.get?.('content-type') || '';
+            if (stream && contentType.includes('text/plain')) {
               if (!response.body) {
                 throw new Error('Response body is empty');
               }

--- a/packages/instantsearch.js/src/widgets/prompt-suggestions/prompt-suggestions.tsx
+++ b/packages/instantsearch.js/src/widgets/prompt-suggestions/prompt-suggestions.tsx
@@ -42,6 +42,7 @@ export type PromptSuggestionsCSSClasses = Partial<PromptSuggestionsClassNames>;
 export type PromptSuggestionsLayoutTemplateProps = {
   suggestions: string[];
   isLoading: boolean;
+  error: Error | undefined;
   onSuggestionClick: (prompt: string) => void;
   isChatBusy: boolean;
 };
@@ -117,6 +118,7 @@ const createRenderer =
     {
       suggestions,
       isLoading,
+      error,
       onSuggestionClick,
       isChatBusy,
       sendToChat,
@@ -147,6 +149,7 @@ const createRenderer =
           data={{
             suggestions,
             isLoading,
+            error,
             onSuggestionClick: handleClick,
             isChatBusy,
           }}

--- a/packages/react-instantsearch/src/widgets/PromptSuggestions.tsx
+++ b/packages/react-instantsearch/src/widgets/PromptSuggestions.tsx
@@ -20,6 +20,7 @@ const PromptSuggestionsUi = createPromptSuggestionsComponent({
 export type PromptSuggestionsLayoutComponentProps = {
   suggestions: string[];
   isLoading: boolean;
+  error: Error | undefined;
   onSuggestionClick: (prompt: string) => void;
   isChatBusy: boolean;
 };
@@ -61,19 +62,25 @@ export function PromptSuggestions({
   ...props
 }: PromptSuggestionsProps) {
   const source = agentId !== undefined ? { agentId, transport } : { transport };
-  const { suggestions, isLoading, onSuggestionClick, isChatBusy, sendToChat } =
-    usePromptSuggestions(
-      {
-        ...source,
-        configurationId,
-        transformHits,
-        context,
-        transformItems,
-      },
-      {
-        $$widgetType: 'ais.promptSuggestions',
-      }
-    );
+  const {
+    suggestions,
+    isLoading,
+    error,
+    onSuggestionClick,
+    isChatBusy,
+    sendToChat,
+  } = usePromptSuggestions(
+    {
+      ...source,
+      configurationId,
+      transformHits,
+      context,
+      transformItems,
+    },
+    {
+      $$widgetType: 'ais.promptSuggestions',
+    }
+  );
 
   const handleClick = onSuggestionClickOverride
     ? (prompt: string) => onSuggestionClickOverride(prompt, { sendToChat })
@@ -84,6 +91,7 @@ export function PromptSuggestions({
       <LayoutComponent
         suggestions={suggestions}
         isLoading={isLoading}
+        error={error}
         onSuggestionClick={handleClick}
         isChatBusy={isChatBusy}
       />

--- a/tests/common/widgets/prompt-suggestions/options.ts
+++ b/tests/common/widgets/prompt-suggestions/options.ts
@@ -12,6 +12,27 @@ const DEBOUNCE_MS = 300;
 
 const SUGGESTIONS = ['Suggestion A', 'Suggestion B', 'Suggestion C'];
 
+function textStreamResponse(suggestions: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(JSON.stringify({ suggestions })));
+      controller.close();
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type'
+          ? 'text/plain; charset=utf-8'
+          : null,
+    },
+    body,
+  } as unknown as Response;
+}
+
 function createResultsClient(hits: Array<Record<string, unknown>>) {
   return createSearchClient({
     search: jest.fn(() =>
@@ -36,14 +57,11 @@ function createResultsClient(hits: Array<Record<string, unknown>>) {
 
 /**
  * Mocks `global.fetch` (the agent-studio transport, not the search client)
- * with the Agent Studio `tasks` response shape `{ output: { suggestions } }`.
+ * with the Agent Studio streaming `tasks` response.
  */
 function mockAgentFetch(suggestions: string[] = SUGGESTIONS) {
   const fetchMock = jest.fn(() =>
-    Promise.resolve({
-      ok: true,
-      json: () => Promise.resolve({ output: { suggestions } }),
-    } as Response)
+    Promise.resolve(textStreamResponse(suggestions))
   );
   global.fetch = fetchMock as unknown as typeof fetch;
   return fetchMock;
@@ -130,12 +148,7 @@ export function createOptionsTests(
       global.fetch = jest.fn(
         () =>
           new Promise<Response>((resolve) => {
-            resolveFetch = () =>
-              resolve({
-                ok: true,
-                json: () =>
-                  Promise.resolve({ output: { suggestions: SUGGESTIONS } }),
-              } as Response);
+            resolveFetch = () => resolve(textStreamResponse(SUGGESTIONS));
           })
       ) as unknown as typeof fetch;
 
@@ -292,15 +305,7 @@ export function createOptionsTests(
       );
       const fetchMock = jest.fn(
         (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
-          Promise.resolve(
-            new Response(
-              JSON.stringify({ output: { suggestions: SUGGESTIONS } }),
-              {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' },
-              }
-            )
-          )
+          Promise.resolve(textStreamResponse(SUGGESTIONS))
       );
       const transport = {
         fetch: fetchMock,

--- a/tests/common/widgets/prompt-suggestions/templates.tsx
+++ b/tests/common/widgets/prompt-suggestions/templates.tsx
@@ -12,6 +12,29 @@ const DEBOUNCE_MS = 300;
 
 const SUGGESTIONS = ['Suggestion A', 'Suggestion B', 'Suggestion C'];
 
+function textStreamResponse(): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(JSON.stringify({ suggestions: SUGGESTIONS }))
+      );
+      controller.close();
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type'
+          ? 'text/plain; charset=utf-8'
+          : null,
+    },
+    body,
+  } as unknown as Response;
+}
+
 function createResultsClient() {
   return createSearchClient({
     search: jest.fn(() =>
@@ -36,10 +59,7 @@ function createResultsClient() {
 
 function mockAgentFetch() {
   global.fetch = jest.fn(() =>
-    Promise.resolve({
-      ok: true,
-      json: () => Promise.resolve({ output: { suggestions: SUGGESTIONS } }),
-    } as Response)
+    Promise.resolve(textStreamResponse())
   ) as unknown as typeof fetch;
 }
 


### PR DESCRIPTION
**Summary**

- Consume append-only `text/plain` JSON task streams instead of SSE.
- Expose Prompt Suggestions task failures through connector state, hooks, and custom layouts.
- Clear task output and errors when their originating inputs are invalidated.

[FX-3960](https://algolia.atlassian.net/browse/FX-3960)

Backend: https://github.com/algolia/conversational-ai/pull/1340

**Result**

- `yarn jest packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts --runInBand --no-watchman`
- `yarn lint:changed`
- Type declarations build successfully for `instantsearch-ui-components`, `instantsearch.js`, `react-instantsearch-core`, and `react-instantsearch`.

[FX-3960]: https://algolia.atlassian.net/browse/FX-3960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ