### PR TITLE
feat(prompt-suggestions): make configuration ID optional

### DIFF
--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -780,6 +780,7 @@ describe('connectPromptSuggestions', () => {
       const prepare = jest.fn(
         (request: {
           task?: string;
+          kind?: string;
           input: Record<string, unknown>;
           stream: boolean;
           body: Record<string, unknown> | undefined;
@@ -789,6 +790,7 @@ describe('connectPromptSuggestions', () => {
         }) => ({
           body: {
             task: request.task,
+            kind: request.kind,
             input: request.input,
             ...request.body,
             injected: true,
@@ -812,6 +814,7 @@ describe('connectPromptSuggestions', () => {
       const preparedRequest = prepare.mock.calls[0][0];
       expect({
         task: preparedRequest.task,
+        kind: preparedRequest.kind,
         input: preparedRequest.input,
         stream: preparedRequest.stream,
         body: preparedRequest.body,
@@ -820,6 +823,7 @@ describe('connectPromptSuggestions', () => {
         api: preparedRequest.api,
       }).toEqual({
         task: 'prompt-suggestions',
+        kind: 'prompt_suggestions',
         input: expect.any(Object),
         stream: true,
         body: undefined,

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -779,7 +779,7 @@ describe('connectPromptSuggestions', () => {
     it('lets transport.prepareSendMessagesRequest mutate the body', async () => {
       const prepare = jest.fn(
         (request: {
-          task: string;
+          task?: string;
           input: Record<string, unknown>;
           stream: boolean;
           body: Record<string, unknown> | undefined;

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -100,10 +100,10 @@ export type PromptSuggestionsSource =
 
 export type PromptSuggestionsConnectorParams = PromptSuggestionsSource & {
   /**
-   * Agent Studio configuration to invoke, sent as the `task` field. Identifies
-   * the prompt-suggestions configuration created in the dashboard.
+   * Agent Studio configuration to invoke, sent as the `task` field. Defaults
+   * to the agent's first configured task.
    */
-  configurationId: string;
+  configurationId?: string;
   /** Transforms hits before use as context (default: first 5, metadata stripped). Ignored with `context`. */
   transformHits?: PromptSuggestionsTransformHits;
   /** Explicit context, replacing the auto-extracted `{ query, filters, hitsSample }`. Object or per-fetch function. */
@@ -208,10 +208,6 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
             'The `agentId` option is required unless a custom `transport` is provided.'
           )
         );
-      }
-
-      if (!configurationId) {
-        throw new Error(withUsage('The `configurationId` option is required.'));
       }
 
       let tasksState: TasksRenderState | undefined;

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -32,6 +32,7 @@ const withUsage = createDocumentationMessageGenerator({
 
 const RENDER_STATE_KEY = 'promptSuggestions' as const;
 const CHAT_RENDER_STATE_KEY = 'chat' as const;
+const PROMPT_SUGGESTIONS_TASK_KIND = 'prompt_suggestions';
 const DEBOUNCE_MS = 300;
 
 function parseSuggestions(data: unknown): string[] {
@@ -100,8 +101,8 @@ export type PromptSuggestionsSource =
 
 export type PromptSuggestionsConnectorParams = PromptSuggestionsSource & {
   /**
-   * Agent Studio configuration to invoke, sent as the `task` field. Defaults
-   * to the agent's first configured task.
+   * Agent Studio configuration to invoke, sent as the `task` field. When
+   * omitted, the agent's enabled Prompt Suggestions configuration is used.
    */
   configurationId?: string;
   /** Transforms hits before use as context (default: first 5, metadata stripped). Ignored with `context`. */
@@ -414,12 +415,14 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           agentId,
           transport,
           task: configurationId,
+          kind: PROMPT_SUGGESTIONS_TASK_KIND,
           stream: true,
         };
       } else if (transport) {
         tasksParams = {
           transport,
           task: configurationId,
+          kind: PROMPT_SUGGESTIONS_TASK_KIND,
           stream: true,
         };
       } else {

--- a/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
@@ -88,11 +88,13 @@ describe('connectTasks', () => {
       ).toThrowError(/agentId.*transport/);
     });
 
-    it('throws when task is missing', () => {
-      const makeWidget = connectTasks(jest.fn());
-      expect(() =>
-        makeWidget({ agentId: 'a' } as TasksConnectorParams)
-      ).toThrowError(/task/);
+    it('accepts a missing task to use the agent default', () => {
+      const widget = connectTasks(jest.fn())({ agentId: 'a' });
+      expect(widget).toEqual(
+        expect.objectContaining({
+          $$type: 'ais.tasks',
+        })
+      );
     });
 
     it('returns the widget descriptor', () => {
@@ -150,6 +152,18 @@ describe('connectTasks', () => {
       expect(url).toContain('stream=true');
       expect(JSON.parse(request.body)).toEqual({
         task: 'my_task',
+        input: { query: 'shoes' },
+      });
+    });
+
+    it('omits the task to use the agent default', async () => {
+      const { lastState } = init({ agentId: 'my-agent' });
+
+      lastState().submit({ query: 'shoes' });
+      await flush(0);
+
+      const [[, request]] = (global.fetch as jest.Mock).mock.calls;
+      expect(JSON.parse(request.body)).toEqual({
         input: { query: 'shoes' },
       });
     });
@@ -329,7 +343,7 @@ describe('connectTasks', () => {
       ) as unknown as typeof fetch;
       const prepareSendMessagesRequest = jest.fn(
         (request: {
-          task: string;
+          task?: string;
           input: Record<string, unknown>;
           stream: boolean;
           body: Record<string, unknown> | undefined;
@@ -444,7 +458,7 @@ describe('connectTasks', () => {
       });
       const prepareSendMessagesRequest = jest.fn(
         (request: {
-          task: string;
+          task?: string;
           input: Record<string, unknown>;
           stream: boolean;
           body: Record<string, unknown> | undefined;

--- a/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/__tests__/connectTasks-test.ts
@@ -88,8 +88,18 @@ describe('connectTasks', () => {
       ).toThrowError(/agentId.*transport/);
     });
 
-    it('accepts a missing task to use the agent default', () => {
-      const widget = connectTasks(jest.fn())({ agentId: 'a' });
+    it('throws when neither task nor kind is provided', () => {
+      const makeWidget = connectTasks(jest.fn());
+      expect(() => makeWidget({ agentId: 'a' })).toThrowError(
+        /Either the `task` or `kind` option is required/
+      );
+    });
+
+    it('accepts a kind without a task ID', () => {
+      const widget = connectTasks(jest.fn())({
+        agentId: 'a',
+        kind: 'prompt_suggestions',
+      });
       expect(widget).toEqual(
         expect.objectContaining({
           $$type: 'ais.tasks',
@@ -156,14 +166,18 @@ describe('connectTasks', () => {
       });
     });
 
-    it('omits the task to use the agent default', async () => {
-      const { lastState } = init({ agentId: 'my-agent' });
+    it('selects a task by kind without sending a task ID', async () => {
+      const { lastState } = init({
+        agentId: 'my-agent',
+        kind: 'prompt_suggestions',
+      });
 
       lastState().submit({ query: 'shoes' });
       await flush(0);
 
       const [[, request]] = (global.fetch as jest.Mock).mock.calls;
       expect(JSON.parse(request.body)).toEqual({
+        kind: 'prompt_suggestions',
         input: { query: 'shoes' },
       });
     });

--- a/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
@@ -61,8 +61,10 @@ export type TasksSource =
     };
 
 export type TasksConnectorParams = TasksSource & {
-  /** ID of the configured task to run. Defaults to the first configured task. */
+  /** ID of the configured task to run. Either `task` or `kind` is required. */
   task?: string;
+  /** Kind of configured task to run. Either `task` or `kind` is required. */
+  kind?: string;
   stream?: boolean;
 };
 
@@ -87,7 +89,7 @@ const connectTasks: TasksConnector = function connectTasks<TOutput = unknown>(
   checkRendering(renderFn, withUsage());
 
   return (widgetParams) => {
-    const { agentId, transport, task, stream = true } = widgetParams;
+    const { agentId, transport, task, kind, stream = true } = widgetParams;
 
     if (!agentId && !transport) {
       throw new Error(
@@ -95,6 +97,10 @@ const connectTasks: TasksConnector = function connectTasks<TOutput = unknown>(
           'The `agentId` option is required unless a custom `transport` is provided.'
         )
       );
+    }
+
+    if (!task && !kind) {
+      throw new Error(withUsage('Either the `task` or `kind` option is required.'));
     }
 
     let runner: TaskRunner;
@@ -200,12 +206,14 @@ const connectTasks: TasksConnector = function connectTasks<TOutput = unknown>(
           runner = createTaskRunner({
             transport: taskTransport,
             task,
+            kind,
             stream,
           });
         } else {
           runner = createTaskRunner({
             transport: createTaskTransport({ transport }),
             task,
+            kind,
             stream,
           });
         }

--- a/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
@@ -100,7 +100,9 @@ const connectTasks: TasksConnector = function connectTasks<TOutput = unknown>(
     }
 
     if (!task && !kind) {
-      throw new Error(withUsage('Either the `task` or `kind` option is required.'));
+      throw new Error(
+        withUsage('Either the `task` or `kind` option is required.')
+      );
     }
 
     let runner: TaskRunner;

--- a/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
+++ b/packages/instantsearch.js/src/connectors/tasks/connectTasks.ts
@@ -61,7 +61,8 @@ export type TasksSource =
     };
 
 export type TasksConnectorParams = TasksSource & {
-  task: string;
+  /** ID of the configured task to run. Defaults to the first configured task. */
+  task?: string;
   stream?: boolean;
 };
 
@@ -94,10 +95,6 @@ const connectTasks: TasksConnector = function connectTasks<TOutput = unknown>(
           'The `agentId` option is required unless a custom `transport` is provided.'
         )
       );
-    }
-
-    if (!task) {
-      throw new Error(withUsage('The `task` option is required.'));
     }
 
     let runner: TaskRunner;

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/endpoint-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/endpoint-test.ts
@@ -110,7 +110,7 @@ describe('createTaskTransport', () => {
       const customFetch = createFetch();
       const prepareSendMessagesRequest = jest.fn(
         (request: {
-          task: string;
+          task?: string;
           input: Record<string, unknown>;
           stream: boolean;
           body: Record<string, unknown> | undefined;

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/fetchTask-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/fetchTask-test.ts
@@ -11,8 +11,14 @@ describe('fetchTask compatibility', () => {
     global.fetch = originalFetch;
   });
 
-  it('omits the task from a payload when none is specified', () => {
-    expect(buildTaskPayload({ input: { query: 'shoes' } })).toEqual({
+  it('builds a kind-only payload when no task ID is specified', () => {
+    expect(
+      buildTaskPayload({
+        kind: 'prompt_suggestions',
+        input: { query: 'shoes' },
+      })
+    ).toEqual({
+      kind: 'prompt_suggestions',
       input: { query: 'shoes' },
     });
   });

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/fetchTask-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/fetchTask-test.ts
@@ -2,13 +2,19 @@
  * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
  */
 
-import { fetchTask } from '..';
+import { buildTaskPayload, fetchTask } from '..';
 
 describe('fetchTask compatibility', () => {
   const originalFetch = global.fetch;
 
   afterEach(() => {
     global.fetch = originalFetch;
+  });
+
+  it('omits the task from a payload when none is specified', () => {
+    expect(buildTaskPayload({ input: { query: 'shoes' } })).toEqual({
+      input: { query: 'shoes' },
+    });
   });
 
   it('performs one request and returns the response envelope', async () => {

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/public-types.test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/public-types.test.ts
@@ -31,6 +31,7 @@ describe('tasks public types', () => {
           headers: request.headers,
           body: {
             task: request.task,
+            kind: request.kind,
             input: request.input,
             ...request.body,
           },
@@ -42,6 +43,7 @@ describe('tasks public types', () => {
       agentId: 'agent',
       transport,
       task: 'generate',
+      kind: 'prompt_suggestions',
     };
     const releasedTransport: TaskTransport = {
       api: '/custom/tasks',
@@ -87,6 +89,7 @@ describe('tasks public types', () => {
     });
     const payloadOptions: BuildTaskPayloadOptions = {
       task: 'recommend',
+      kind: 'prompt_suggestions',
       input: { query: 'shoes' },
       prepareRequest,
     };
@@ -115,6 +118,7 @@ describe('tasks public types', () => {
 
     expect(fetchOptions.payload).toEqual({
       task: 'recommend',
+      kind: 'prompt_suggestions',
       input: { query: 'shoes' },
       locale: 'en',
     });

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/taskRunner-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/taskRunner-test.ts
@@ -40,6 +40,7 @@ describe('createTaskRunner', () => {
       endpoint: 'https://example.test/tasks',
       headers: { 'x-custom': '1' },
       task: 'recommend',
+      kind: 'prompt_suggestions',
       stream: false,
       prepareRequest,
     });
@@ -50,6 +51,7 @@ describe('createTaskRunner', () => {
 
     expect(prepareRequest).toHaveBeenCalledWith({
       task: 'recommend',
+      kind: 'prompt_suggestions',
       input: { query: 'shoes' },
     });
     expect(customFetch).toHaveBeenCalledTimes(1);
@@ -61,6 +63,7 @@ describe('createTaskRunner', () => {
       },
       body: JSON.stringify({
         task: 'recommend',
+        kind: 'prompt_suggestions',
         input: { query: 'shoes' },
         locale: 'en',
       }),

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
@@ -124,6 +124,28 @@ describe('DefaultTaskTransport', () => {
     );
   });
 
+  it('omits the task when none is specified', async () => {
+    const customFetch = jest.fn(
+      (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
+        Promise.resolve(jsonResponse({ output: { ok: true } }))
+    );
+    const transport = new DefaultTaskTransport({ fetch: customFetch });
+
+    await transport.sendTask({
+      input: { query: 'shoes' },
+      stream: false,
+    });
+
+    expect(customFetch).toHaveBeenCalledWith('/api/tasks', {
+      method: 'POST',
+      credentials: undefined,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        input: { query: 'shoes' },
+      }),
+    });
+  });
+
   it('preserves the exact error thrown by a custom fetch', async () => {
     class StructuredTaskError extends Error {
       constructor(

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
@@ -50,7 +50,7 @@ describe('DefaultTaskTransport', () => {
     );
     const prepareSendMessagesRequest = jest.fn(
       async (request: {
-        task: string;
+        task?: string;
         input: Record<string, unknown>;
         stream: boolean;
         body: Record<string, unknown> | undefined;

--- a/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
+++ b/packages/instantsearch.js/src/lib/tasks/__tests__/transport-test.ts
@@ -124,7 +124,7 @@ describe('DefaultTaskTransport', () => {
     );
   });
 
-  it('omits the task when none is specified', async () => {
+  it('forwards the kind without a task ID', async () => {
     const customFetch = jest.fn(
       (..._args: Parameters<typeof fetch>): ReturnType<typeof fetch> =>
         Promise.resolve(jsonResponse({ output: { ok: true } }))
@@ -132,6 +132,7 @@ describe('DefaultTaskTransport', () => {
     const transport = new DefaultTaskTransport({ fetch: customFetch });
 
     await transport.sendTask({
+      kind: 'prompt_suggestions',
       input: { query: 'shoes' },
       stream: false,
     });
@@ -141,6 +142,7 @@ describe('DefaultTaskTransport', () => {
       credentials: undefined,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
+        kind: 'prompt_suggestions',
         input: { query: 'shoes' },
       }),
     });

--- a/packages/instantsearch.js/src/lib/tasks/fetchTask.ts
+++ b/packages/instantsearch.js/src/lib/tasks/fetchTask.ts
@@ -13,7 +13,10 @@ export function buildTaskPayload({
   input,
   prepareRequest,
 }: BuildTaskPayloadOptions): Record<string, unknown> {
-  const payload: Record<string, unknown> = { task, input };
+  const payload: Record<string, unknown> = {
+    ...(task === undefined ? {} : { task }),
+    input,
+  };
 
   return prepareRequest ? prepareRequest(payload).body : payload;
 }

--- a/packages/instantsearch.js/src/lib/tasks/fetchTask.ts
+++ b/packages/instantsearch.js/src/lib/tasks/fetchTask.ts
@@ -3,7 +3,7 @@ import { DefaultTaskTransport } from './transport';
 import type { TaskPrepareRequest } from './endpoint';
 
 export type BuildTaskPayloadOptions = {
-  task: string;
+  task?: string;
   input: Record<string, unknown>;
   prepareRequest?: TaskPrepareRequest;
 };

--- a/packages/instantsearch.js/src/lib/tasks/fetchTask.ts
+++ b/packages/instantsearch.js/src/lib/tasks/fetchTask.ts
@@ -4,17 +4,20 @@ import type { TaskPrepareRequest } from './endpoint';
 
 export type BuildTaskPayloadOptions = {
   task?: string;
+  kind?: string;
   input: Record<string, unknown>;
   prepareRequest?: TaskPrepareRequest;
 };
 
 export function buildTaskPayload({
   task,
+  kind,
   input,
   prepareRequest,
 }: BuildTaskPayloadOptions): Record<string, unknown> {
   const payload: Record<string, unknown> = {
     ...(task === undefined ? {} : { task }),
+    ...(kind === undefined ? {} : { kind }),
     input,
   };
 

--- a/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
+++ b/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
@@ -7,7 +7,7 @@ export type TaskRunnerOptions = {
   endpoint: string;
   headers: Record<string, string>;
   fetch?: typeof fetch;
-  task: string;
+  task?: string;
   stream?: boolean;
   prepareRequest?: TaskPrepareRequest;
 };
@@ -25,7 +25,7 @@ export type TaskRunner = {
 
 export function createTaskRunner(options: {
   transport: DefaultTaskTransport;
-  task: string;
+  task?: string;
   stream?: boolean;
 }): TaskRunner;
 export function createTaskRunner(options: TaskRunnerOptions): TaskRunner;
@@ -34,7 +34,7 @@ export function createTaskRunner(
     | TaskRunnerOptions
     | {
         transport: DefaultTaskTransport;
-        task: string;
+        task?: string;
         stream?: boolean;
       }
 ): TaskRunner {

--- a/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
+++ b/packages/instantsearch.js/src/lib/tasks/taskRunner.ts
@@ -8,6 +8,7 @@ export type TaskRunnerOptions = {
   headers: Record<string, string>;
   fetch?: typeof fetch;
   task?: string;
+  kind?: string;
   stream?: boolean;
   prepareRequest?: TaskPrepareRequest;
 };
@@ -26,6 +27,7 @@ export type TaskRunner = {
 export function createTaskRunner(options: {
   transport: DefaultTaskTransport;
   task?: string;
+  kind?: string;
   stream?: boolean;
 }): TaskRunner;
 export function createTaskRunner(options: TaskRunnerOptions): TaskRunner;
@@ -35,10 +37,11 @@ export function createTaskRunner(
     | {
         transport: DefaultTaskTransport;
         task?: string;
+        kind?: string;
         stream?: boolean;
       }
 ): TaskRunner {
-  const { task, stream = true } = options;
+  const { task, kind, stream = true } = options;
   let transport: DefaultTaskTransport;
 
   if (options.transport !== undefined) {
@@ -50,15 +53,19 @@ export function createTaskRunner(
       headers: options.headers,
       fetch: options.fetch,
       prepareSendMessagesRequest: prepareRequest
-        ? ({ task: requestTask, input }) =>
-            prepareRequest({ task: requestTask, input })
+        ? ({ task: requestTask, kind: requestKind, input }) =>
+            prepareRequest({
+              ...(requestTask === undefined ? {} : { task: requestTask }),
+              ...(requestKind === undefined ? {} : { kind: requestKind }),
+              input,
+            })
         : undefined,
     });
   }
 
   return {
     submit(input, { onData } = {}) {
-      return transport.sendTask({ task, input, stream, onData });
+      return transport.sendTask({ task, kind, input, stream, onData });
     },
   };
 }

--- a/packages/instantsearch.js/src/lib/tasks/transport.ts
+++ b/packages/instantsearch.js/src/lib/tasks/transport.ts
@@ -8,7 +8,7 @@ import { resolveValue } from '../ai-lite/utils';
 import type { Resolvable } from '../ai-lite';
 
 export type TaskPrepareSendMessagesRequest = (options: {
-  task: string;
+  task?: string;
   input: Record<string, unknown>;
   stream: boolean;
   body: Record<string, unknown> | undefined;
@@ -39,7 +39,7 @@ export type TaskTransportOptions = {
 };
 
 export type TaskSendOptions = {
-  task: string;
+  task?: string;
   input: Record<string, unknown>;
   stream: boolean;
   onData?: (output: unknown) => void;

--- a/packages/instantsearch.js/src/lib/tasks/transport.ts
+++ b/packages/instantsearch.js/src/lib/tasks/transport.ts
@@ -212,7 +212,7 @@ export class DefaultTaskTransport {
       let credentials = resolvedCredentials;
       let headers: HeadersInit = withJsonContentType(resolvedHeaders);
       let body: object = {
-        task,
+        ...(task === undefined ? {} : { task }),
         input,
         ...resolvedBody,
       };

--- a/packages/instantsearch.js/src/lib/tasks/transport.ts
+++ b/packages/instantsearch.js/src/lib/tasks/transport.ts
@@ -9,6 +9,7 @@ import type { Resolvable } from '../ai-lite';
 
 export type TaskPrepareSendMessagesRequest = (options: {
   task?: string;
+  kind?: string;
   input: Record<string, unknown>;
   stream: boolean;
   body: Record<string, unknown> | undefined;
@@ -40,6 +41,7 @@ export type TaskTransportOptions = {
 
 export type TaskSendOptions = {
   task?: string;
+  kind?: string;
   input: Record<string, unknown>;
   stream: boolean;
   onData?: (output: unknown) => void;
@@ -185,9 +187,16 @@ export class DefaultTaskTransport {
     this.prepareSendMessagesRequest = prepareSendMessagesRequest;
   }
 
-  sendTask({ task, input, stream, onData }: TaskSendOptions): Promise<unknown> {
+  sendTask({
+    task,
+    kind,
+    input,
+    stream,
+    onData,
+  }: TaskSendOptions): Promise<unknown> {
     return this.sendTaskRequest({
       task,
+      kind,
       input,
       stream,
       onData: onData ? (data) => onData(unwrap(data)) : undefined,
@@ -197,6 +206,7 @@ export class DefaultTaskTransport {
   /** @internal */
   sendTaskRequest({
     task,
+    kind,
     input,
     stream,
     onData,
@@ -213,6 +223,7 @@ export class DefaultTaskTransport {
       let headers: HeadersInit = withJsonContentType(resolvedHeaders);
       let body: object = {
         ...(task === undefined ? {} : { task }),
+        ...(kind === undefined ? {} : { kind }),
         input,
         ...resolvedBody,
       };
@@ -222,6 +233,7 @@ export class DefaultTaskTransport {
             this.prepareSendMessagesRequest(
               createTaskPreparationContext({
                 task,
+                kind,
                 input,
                 stream,
                 body: preparedBody,

--- a/tests/common/widgets/prompt-suggestions/options.ts
+++ b/tests/common/widgets/prompt-suggestions/options.ts
@@ -391,22 +391,30 @@ export function createOptionsTests(
       expect(body.input.hitsSample).toBeUndefined();
     });
 
-    test('throws without configurationId', () => {
-      const searchClient = createSearchClient({});
+    test('omits the task to use the agent default without configurationId', async () => {
+      const searchClient = createResultsClient([
+        { objectID: '1', name: 'Product 1' },
+      ]);
+      const fetchMock = mockAgentFetch();
 
-      expect(() =>
-        setup({
-          instantSearchOptions: {
-            indexName: 'indexName',
-            searchClient,
-          },
-          widgetParams: {
-            javascript: { agentId: 'test-agent-id' } as any,
-            react: { agentId: 'test-agent-id' } as any,
-            vue: {},
-          },
-        })
-      ).toThrow('The `configurationId` option is required.');
+      await setup({
+        instantSearchOptions: { indexName: 'indexName', searchClient },
+        widgetParams: {
+          javascript: { agentId: 'test-agent-id' },
+          react: { agentId: 'test-agent-id' },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(DEBOUNCE_MS + 50);
+      });
+
+      const [, init] = fetchMock.mock.calls[0] as unknown as [
+        string,
+        RequestInit,
+      ];
+      expect(JSON.parse(init.body as string)).not.toHaveProperty('task');
     });
 
     test('forwards a custom configurationId to the request payload', async () => {

--- a/tests/common/widgets/prompt-suggestions/options.ts
+++ b/tests/common/widgets/prompt-suggestions/options.ts
@@ -391,7 +391,7 @@ export function createOptionsTests(
       expect(body.input.hitsSample).toBeUndefined();
     });
 
-    test('omits the task to use the agent default without configurationId', async () => {
+    test('selects the Prompt Suggestions task kind without configurationId', async () => {
       const searchClient = createResultsClient([
         { objectID: '1', name: 'Product 1' },
       ]);
@@ -414,7 +414,9 @@ export function createOptionsTests(
         string,
         RequestInit,
       ];
-      expect(JSON.parse(init.body as string)).not.toHaveProperty('task');
+      const body = JSON.parse(init.body as string);
+      expect(body).toMatchObject({ kind: 'prompt_suggestions' });
+      expect(body).not.toHaveProperty('task');
     });
 
     test('forwards a custom configurationId to the request payload', async () => {
@@ -449,6 +451,7 @@ export function createOptionsTests(
       ];
       const body = JSON.parse(init.body as string);
       expect(body.task).toBe('my_custom_task');
+      expect(body.kind).toBe('prompt_suggestions');
     });
 
     test('applies transformItems to the rendered suggestions', async () => {


### PR DESCRIPTION
**Summary**

- Make `configurationId` optional in Prompt Suggestions.
- Select an enabled Prompt Suggestions task with `kind: "prompt_suggestions"` when the configuration ID is omitted.
- Send both `task` and `kind` when an explicit configuration ID is provided so the backend can validate they match.
- Thread task kinds through the Tasks connector, runner, transport, and request preparation APIs.
- Cover kind-only and explicit-ID requests across JavaScript and React.
- [FX-3908](https://algolia.atlassian.net/browse/FX-3908)

**Related PRs**

- Backend: [algolia/conversational-ai#1630](https://github.com/algolia/conversational-ai/pull/1630)
- Dashboard: [algolia/AlgoliaWeb#30003](https://github.com/algolia/AlgoliaWeb/pull/30003)

**Result**

- `yarn jest packages/instantsearch.js/src/lib/tasks packages/instantsearch.js/src/connectors/tasks packages/instantsearch.js/src/connectors/prompt-suggestions --runInBand` — 83 passed.
- `yarn jest --runTestsByPath packages/instantsearch.js/src/__tests__/common-widgets.test.tsx packages/react-instantsearch/src/__tests__/common-widgets.test.tsx packages/vue-instantsearch/src/__tests__/common-widgets.test.js -t "PromptSuggestions widget common tests" --runInBand` — 34 passed, Vue suite skipped.
- `yarn lint:changed`.
- `yarn workspace instantsearch.js build:types`.

[FX-3908]: https://algolia.atlassian.net/browse/FX-3908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ