### PR TITLE
fix(chat): keep the search status when the chat re-renders

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  createControlledSearchClient,
   createSearchClient,
   createSingleSearchResponse,
 } from '@instantsearch/mocks';
@@ -3139,6 +3140,185 @@ data: [DONE]`,
       // all. This is the escape hatch for the runaway auto-continuation loop: a
       // resolved tool no longer forces another completions request.
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('main search status', () => {
+    const openStateKey = 'instantsearch-chat-open-state-chat';
+
+    const chatStream = (chunks: UIMessageChunk[]) =>
+      new Response(
+        `${chunks
+          .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
+          .join('')}data: [DONE]`,
+        { headers: { 'Content-Type': 'text/event-stream' } }
+      );
+
+    const startFailingSearch = (widgetParams: ChatConnectorParams) => {
+      const { searches, searchClient } = createControlledSearchClient();
+      const search = instantsearch({ indexName: 'indexName', searchClient });
+      const errorEvent = new Promise<void>((resolve) => {
+        search.on('error', () => resolve());
+      });
+      const widget = connectChat(jest.fn())({
+        disableTriggerValidation: true,
+        persistence: false,
+        ...widgetParams,
+      } as ChatConnectorParams);
+
+      search.addWidgets([widget]);
+      search.start();
+
+      return { errorEvent, search, searchClient, searches, widget };
+    };
+
+    beforeEach(() => {
+      sessionStorage.clear();
+    });
+
+    it('schedules sibling renders that never reset the main search status', () => {
+      sessionStorage.setItem(openStateKey, 'true');
+      const scheduleRender = jest.fn();
+      const instantSearchInstance = createInstantSearch({
+        scheduleRender:
+          scheduleRender as unknown as InstantSearch['scheduleRender'],
+      });
+      const widget = connectChat(jest.fn())({
+        agentId: 'agentId',
+        disableTriggerValidation: true,
+        persistence: { messages: false, open: true },
+      } as ChatConnectorParams);
+
+      // `init`, with the open panel restored from the previous session.
+      widget.init(createInitOptions({ instantSearchInstance }));
+
+      expect(scheduleRender).toHaveBeenCalledTimes(1);
+      expect(scheduleRender).toHaveBeenLastCalledWith(false);
+
+      // `updateOpen`.
+      widget
+        .getWidgetRenderState(createInitOptions({ instantSearchInstance }))
+        .setOpen(false);
+
+      expect(scheduleRender).toHaveBeenCalledTimes(2);
+      expect(scheduleRender).toHaveBeenLastCalledWith(false);
+
+      // `renderOnStatusChange`.
+      widget.chatInstance._state.status = 'streaming';
+
+      expect(scheduleRender).toHaveBeenCalledTimes(3);
+      expect(scheduleRender).toHaveBeenLastCalledWith(false);
+    });
+
+    it('leaves a failed main search in error when the chat opens', async () => {
+      const { errorEvent, search, searchClient, searches } = startFailingSearch(
+        {
+          agentId: 'agentId',
+        } as ChatConnectorParams
+      );
+
+      await wait(0);
+      searches[0].rejecter(new Error('SERVER_ERROR'));
+      await errorEvent;
+      await wait(0);
+
+      expect(search.status).toBe('error');
+      expect(search.error).toEqual(new Error('SERVER_ERROR'));
+
+      search.renderState.indexName.chat!.setOpen(true);
+      await wait(0);
+
+      expect(search.status).toBe('error');
+      expect(search.error).toEqual(new Error('SERVER_ERROR'));
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves a failed main search in error across a chat turn', async () => {
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValue(
+          chatStream([
+            { type: 'start', messageId: 'assistant-1' },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Hello' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish' },
+          ])
+        );
+      const { errorEvent, search, searchClient, searches, widget } =
+        startFailingSearch({
+          agentId: undefined,
+          transport: { fetch: fetchMock },
+        } as ChatConnectorParams);
+
+      await wait(0);
+      searches[0].rejecter(new Error('SERVER_ERROR'));
+      await errorEvent;
+      await wait(0);
+
+      expect(search.status).toBe('error');
+      expect(search.error).toEqual(new Error('SERVER_ERROR'));
+
+      await widget.chatInstance.sendMessage({ text: 'hello' });
+      await wait(0);
+
+      expect(widget.chatInstance.messages).toHaveLength(2);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(search.status).toBe('error');
+      expect(search.error).toEqual(new Error('SERVER_ERROR'));
+      expect(searchClient.search).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the error state stable when the chat renders after a late failure', async () => {
+      const { errorEvent, search, searchClient, searches } = startFailingSearch(
+        {
+          agentId: 'agentId',
+        } as ChatConnectorParams
+      );
+
+      await wait(0);
+      searches[0].resolver();
+      await wait(0);
+
+      expect(search.status).toBe('idle');
+
+      search.mainHelper!.search();
+      await wait(0);
+      searches[1].rejecter(new Error('SERVER_ERROR'));
+      await errorEvent;
+      await wait(0);
+
+      expect(search.status).toBe('error');
+
+      // The index restores the last valid search parameters while the status is
+      // `error`, and it now sees that status on a chat render too. Restoring
+      // them must not turn into another request.
+      search.renderState.indexName.chat!.setOpen(true);
+      await wait(0);
+
+      expect(search.status).toBe('error');
+      expect(search.error).toEqual(new Error('SERVER_ERROR'));
+      expect(searchClient.search).toHaveBeenCalledTimes(2);
+    });
+
+    it('still settles the main search once its results arrive after a chat render', async () => {
+      const { search, searches, widget } = startFailingSearch({
+        agentId: 'agentId',
+      } as ChatConnectorParams);
+
+      await wait(0);
+
+      expect(search.status).toBe('loading');
+
+      // A chat render lands while the search it knows nothing about is still
+      // in flight. Suppressing the status reset must not strand it on
+      // `loading`.
+      widget.chatInstance._state.status = 'streaming';
+      searches[0].resolver();
+      await wait(0);
+
+      expect(search.status).toBe('idle');
+      expect(search.error).toBeUndefined();
     });
   });
 });

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../test/createWidget';
 import instantsearch from '../../../index.es';
 import { Chat } from '../../../lib/chat';
+import connectSearchBox from '../../search-box/connectSearchBox';
 import connectChat from '../connectChat';
 
 import type {
@@ -25,7 +26,7 @@ import type {
   UIMessageChunk,
   ChatTransport,
 } from '../../../lib/ai-lite';
-import type { InstantSearch, IndexWidget } from '../../../types';
+import type { InstantSearch, IndexWidget, Widget } from '../../../types';
 import type { ChatConnectorParams } from '../connectChat';
 
 jest.mock('../../../lib/utils/sendChatMessageFeedback', () => ({
@@ -3154,7 +3155,10 @@ data: [DONE]`,
         { headers: { 'Content-Type': 'text/event-stream' } }
       );
 
-    const startFailingSearch = (widgetParams: ChatConnectorParams) => {
+    const startFailingSearch = (
+      widgetParams: ChatConnectorParams,
+      extraWidgets: Widget[] = []
+    ) => {
       const { searches, searchClient } = createControlledSearchClient();
       const search = instantsearch({ indexName: 'indexName', searchClient });
       const errorEvent = new Promise<void>((resolve) => {
@@ -3166,7 +3170,7 @@ data: [DONE]`,
         ...widgetParams,
       } as ChatConnectorParams);
 
-      search.addWidgets([widget]);
+      search.addWidgets([widget, ...extraWidgets]);
       search.start();
 
       return { errorEvent, search, searchClient, searches, widget };
@@ -3290,15 +3294,83 @@ data: [DONE]`,
 
       expect(search.status).toBe('error');
 
-      // The index restores the last valid search parameters while the status is
-      // `error`, and it now sees that status on a chat render too. Restoring
-      // them must not turn into another request.
+      // A chat render now sees the `error` status, which is what the index
+      // reads to restore the last valid search parameters. Neither the render
+      // nor that restore may turn into another request.
       search.renderState.indexName.chat!.setOpen(true);
       await wait(0);
 
       expect(search.status).toBe('error');
       expect(search.error).toEqual(new Error('SERVER_ERROR'));
       expect(searchClient.search).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps a refinement made after a failure that a chat render shares a tick with', async () => {
+      const { errorEvent, search, searchClient, searches } = startFailingSearch(
+        {
+          agentId: 'agentId',
+        } as ChatConnectorParams,
+        [connectSearchBox(jest.fn())({})]
+      );
+
+      await wait(0);
+      searches[0].resolver();
+      await wait(0);
+
+      search.mainHelper!.search();
+      await wait(0);
+      searches[1].rejecter(new Error('SERVER_ERROR'));
+      await errorEvent;
+      await wait(0);
+
+      expect(search.status).toBe('error');
+
+      // A chat render and a refinement land in the same tick. The chat render
+      // runs before the search `setUiState` defers, so the index must not roll
+      // the refinement back on it.
+      search.renderState.indexName.chat!.setOpen(false);
+      search.setUiState({ indexName: { query: 'shoes' } });
+      await wait(0);
+
+      expect(search.getUiState()).toEqual({ indexName: { query: 'shoes' } });
+      expect(searchClient.search).toHaveBeenCalledTimes(3);
+      expect(
+        (searchClient.search as jest.Mock).mock.calls[2][0][0].params.query
+      ).toBe('shoes');
+    });
+
+    it('does not restore the previous search parameters again on later chat renders', async () => {
+      const { errorEvent, search, searches } = startFailingSearch({
+        agentId: 'agentId',
+      } as ChatConnectorParams);
+
+      await wait(0);
+      searches[0].resolver();
+      await wait(0);
+
+      search.mainHelper!.search();
+      await wait(0);
+      searches[1].rejecter(new Error('SERVER_ERROR'));
+      await errorEvent;
+      await wait(0);
+
+      expect(search.status).toBe('error');
+
+      // The failed search already rolled the parameters back. Repeated chat
+      // renders must not keep re-emitting that write, or every middleware
+      // `onStateChange` fires for chat panel activity.
+      const onChange = jest.fn();
+      search.mainIndex.getHelper()!.on('change', onChange);
+
+      search.renderState.indexName.chat!.setOpen(true);
+      await wait(0);
+      search.renderState.indexName.chat!.setOpen(false);
+      await wait(0);
+      search.renderState.indexName.chat!.setOpen(true);
+      await wait(0);
+
+      expect(search.status).toBe('error');
+      expect(onChange).not.toHaveBeenCalled();
     });
 
     it('still settles the main search once its results arrive after a chat render', async () => {

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -877,7 +877,8 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           // `open` is read by sibling widgets (e.g. `chatTrigger`) via the
           // shared `renderState`. Schedule a full re-render so they pick up
           // the new value instead of staying frozen on their initial state.
-          initOptions.instantSearchInstance.scheduleRender();
+          // No search runs here, so it must not settle the main search.
+          initOptions.instantSearchInstance.scheduleRender(false);
         };
 
         setOpen = (nextOpen) => {
@@ -946,14 +947,15 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
         // disable themselves, so a transition has to escape this widget's own
         // render. Message deltas deliberately don't: they stay local to keep
         // streaming cheap. The `status` setter notifies on every write, hence
-        // the comparison.
+        // the comparison. A chat turn is not a search, so the render it
+        // schedules must not settle the main search.
         let lastStatus = _chatInstance.status;
         const renderOnStatusChange = () => {
           const statusChanged = _chatInstance.status !== lastStatus;
           lastStatus = _chatInstance.status;
           render();
           if (statusChanged) {
-            initOptions.instantSearchInstance.scheduleRender();
+            initOptions.instantSearchInstance.scheduleRender(false);
           }
         };
 
@@ -990,8 +992,10 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           true
         );
 
+        // A restored open panel is new to the sibling entry points, but it is
+        // not a search result.
         if (open) {
-          instantSearchInstance.scheduleRender();
+          instantSearchInstance.scheduleRender(false);
         }
       },
 

--- a/packages/instantsearch.js/src/lib/InstantSearch.ts
+++ b/packages/instantsearch.js/src/lib/InstantSearch.ts
@@ -808,23 +808,35 @@ See documentation: ${createDocumentationLink({
     }
   });
 
-  public scheduleRender = defer((shouldResetStatus: boolean = true) => {
-    if (!this.mainHelper?.hasPendingRequests()) {
-      clearTimeout(this._searchStalledTimer);
-      this._searchStalledTimer = null;
+  public scheduleRender = defer(
+    (shouldResetStatus: boolean = true) => {
+      if (!this.mainHelper?.hasPendingRequests()) {
+        clearTimeout(this._searchStalledTimer);
+        this._searchStalledTimer = null;
 
-      if (shouldResetStatus) {
-        this.status = 'idle';
-        this.error = undefined;
+        if (shouldResetStatus) {
+          this.status = 'idle';
+          this.error = undefined;
+        }
       }
-    }
 
-    this.mainIndex.render({
-      instantSearchInstance: this as unknown as InstantSearch<UiState, UiState>,
-    });
+      this.mainIndex.render({
+        instantSearchInstance: this as unknown as InstantSearch<
+          UiState,
+          UiState
+        >,
+      });
 
-    this.emit('render');
-  });
+      this.emit('render');
+    },
+    // Renders scheduled in the same microtask collapse into one run, so the
+    // status reset accumulates instead of letting the first caller decide: a
+    // render scheduled for a reason unrelated to the search must not cancel the
+    // one a search result asks for, or it would strand the status on `loading`.
+    ([shouldResetStatus = true], [nextShouldResetStatus = true]): [boolean] => [
+      shouldResetStatus || nextShouldResetStatus,
+    ]
+  );
 
   public scheduleStalledRender() {
     if (!this._searchStalledTimer) {

--- a/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
+++ b/packages/instantsearch.js/src/lib/__tests__/InstantSearch-test.tsx
@@ -1769,6 +1769,147 @@ describe('scheduleRender', () => {
     expect(renderSpy).toHaveBeenNthCalledWith(1, { widgetRenderTimes: 0 });
     expect(renderSpy).toHaveBeenNthCalledWith(2, { widgetRenderTimes: 1 });
   });
+
+  it('keeps the status and the error when the render is not search-driven', async () => {
+    const { searches, searchClient } = createControlledSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+    const errorEvent = new Promise<void>((resolve) => {
+      search.on('error', () => resolve());
+    });
+
+    search.addWidgets([virtualSearchBox({})]);
+    search.start();
+    await wait(0);
+
+    searches[0].rejecter(new Error('SERVER_ERROR'));
+    await errorEvent;
+    await wait(0);
+
+    expect(search.status).toBe('error');
+    expect(search.error).toEqual(new Error('SERVER_ERROR'));
+
+    search.scheduleRender(false);
+    await wait(0);
+
+    expect(search.status).toBe('error');
+    expect(search.error).toEqual(new Error('SERVER_ERROR'));
+    expect(searchClient.search).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the stalled timer even when the render is not search-driven', async () => {
+    const { searches, searchClient } = createControlledSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+
+    search.addWidgets([virtualSearchBox({})]);
+    search.start();
+    await wait(0);
+
+    searches[0].resolver();
+    await wait(0);
+
+    search.scheduleStalledRender();
+    expect(search._searchStalledTimer).not.toBeNull();
+
+    search.scheduleRender(false);
+    await wait(0);
+
+    expect(search._searchStalledTimer).toBeNull();
+    expect(search.status).toBe('idle');
+  });
+
+  it('resets the status when a search-driven render shares the deferred window', async () => {
+    const { searches, searchClient } = createControlledSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+    const errorEvent = new Promise<void>((resolve) => {
+      search.on('error', () => resolve());
+    });
+
+    search.addWidgets([virtualSearchBox({})]);
+    search.start();
+    await wait(0);
+
+    searches[0].rejecter(new Error('SERVER_ERROR'));
+    await errorEvent;
+    await wait(0);
+
+    expect(search.status).toBe('error');
+
+    // Both renders collapse into one run, and the caller opting out of the
+    // reset must not decide for the search-driven one next to it.
+    search.scheduleRender(false);
+    search.scheduleRender();
+    await wait(0);
+
+    expect(search.status).toBe('idle');
+    expect(search.error).toBeUndefined();
+  });
+
+  it('resets the status whichever render fills the deferred window first', async () => {
+    const { searches, searchClient } = createControlledSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+    const errorEvent = new Promise<void>((resolve) => {
+      search.on('error', () => resolve());
+    });
+
+    search.addWidgets([virtualSearchBox({})]);
+    search.start();
+    await wait(0);
+
+    searches[0].rejecter(new Error('SERVER_ERROR'));
+    await errorEvent;
+    await wait(0);
+
+    expect(search.status).toBe('error');
+
+    search.scheduleRender();
+    search.scheduleRender(false);
+    await wait(0);
+
+    expect(search.status).toBe('idle');
+    expect(search.error).toBeUndefined();
+  });
+
+  it('clears a previous error once new results arrive', async () => {
+    const { searches, searchClient } = createControlledSearchClient();
+    const search = new InstantSearch({
+      indexName: 'indexName',
+      searchClient,
+    });
+    const errorEvent = new Promise<void>((resolve) => {
+      search.on('error', () => resolve());
+    });
+
+    search.addWidgets([virtualSearchBox({})]);
+    search.start();
+    await wait(0);
+
+    searches[0].rejecter(new Error('SERVER_ERROR'));
+    await errorEvent;
+    await wait(0);
+
+    expect(search.status).toBe('error');
+
+    search.mainHelper!.search();
+    expect(search.status).toBe('loading');
+
+    searches[1].resolver();
+    await wait(0);
+
+    expect(search.status).toBe('idle');
+    expect(search.error).toBeUndefined();
+  });
 });
 
 describe('scheduleStalledRender', () => {

--- a/packages/instantsearch.js/src/lib/utils/__tests__/defer.ts
+++ b/packages/instantsearch.js/src/lib/utils/__tests__/defer.ts
@@ -1,6 +1,12 @@
 import { defer } from '../defer';
 
 describe('defer', () => {
+  // Joins the pending and the next arguments so a single assertion on the
+  // callback shows the whole fold, not just the last pair.
+  const joinArguments = ([pending]: [string], [next]: [string]): [string] => [
+    `${pending}+${next}`,
+  ];
+
   it('defers the call to the function', async () => {
     const fn = jest.fn();
     const deferred = defer(fn);
@@ -148,5 +154,117 @@ describe('defer', () => {
     await deferred.wait();
 
     expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the arguments of the first call of the window', async () => {
+    const fn = jest.fn((value: string) => value);
+    const deferred = defer(fn);
+
+    deferred('first');
+    deferred('second');
+    deferred('third');
+
+    await deferred.wait();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('first');
+  });
+
+  it('folds the arguments of later calls with `mergeArguments`', async () => {
+    const fn = jest.fn((value: string) => value);
+    const mergeArguments = jest.fn(joinArguments);
+    const deferred = defer(fn, mergeArguments);
+
+    deferred('a');
+    deferred('b');
+    deferred('c');
+
+    await deferred.wait();
+
+    // The merger folds the pending arguments with the next ones, so the third
+    // call sees the result of the second fold rather than the original call.
+    expect(mergeArguments).toHaveBeenCalledTimes(2);
+    expect(mergeArguments).toHaveBeenNthCalledWith(1, ['a'], ['b']);
+    expect(mergeArguments).toHaveBeenNthCalledWith(2, ['a+b'], ['c']);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('a+b+c');
+  });
+
+  it('does not call `mergeArguments` for a window of one call', async () => {
+    const fn = jest.fn((value: string) => value);
+    const mergeArguments = jest.fn(joinArguments);
+    const deferred = defer(fn, mergeArguments);
+
+    deferred('only');
+
+    await deferred.wait();
+
+    expect(mergeArguments).not.toHaveBeenCalled();
+    expect(fn).toHaveBeenCalledWith('only');
+  });
+
+  it('starts every window from the arguments of its own first call', async () => {
+    const fn = jest.fn((value: string) => value);
+    const mergeArguments = jest.fn(joinArguments);
+    const deferred = defer(fn, mergeArguments);
+
+    deferred('a');
+    deferred('b');
+
+    await deferred.wait();
+
+    expect(fn).toHaveBeenNthCalledWith(1, 'a+b');
+
+    deferred('c');
+    deferred('d');
+
+    await deferred.wait();
+
+    // The second window folds `c` with `d`, not the previous window's result.
+    expect(mergeArguments).toHaveBeenNthCalledWith(2, ['c'], ['d']);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenNthCalledWith(2, 'c+d');
+  });
+
+  it('cancels a merged run and leaves no arguments behind', async () => {
+    const fn = jest.fn((value: string) => value);
+    const mergeArguments = jest.fn(joinArguments);
+    const deferred = defer(fn, mergeArguments);
+
+    deferred('a');
+    deferred('b');
+    deferred.cancel();
+
+    await deferred.wait();
+
+    expect(mergeArguments).toHaveBeenCalledTimes(1);
+    expect(fn).not.toHaveBeenCalled();
+
+    deferred('c');
+
+    await deferred.wait();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('c');
+  });
+
+  it('merges every argument of a multi-argument callback', async () => {
+    const fn = jest.fn((label: string, count: number) => `${label}${count}`);
+    const deferred = defer(
+      fn,
+      ([label, count], [nextLabel, nextCount]): [string, number] => [
+        `${label}|${nextLabel}`,
+        count + nextCount,
+      ]
+    );
+
+    deferred('a', 1);
+    deferred('b', 2);
+    deferred('c', 3);
+
+    await deferred.wait();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('a|b|c', 6);
   });
 });

--- a/packages/instantsearch.js/src/lib/utils/defer.ts
+++ b/packages/instantsearch.js/src/lib/utils/defer.ts
@@ -7,25 +7,41 @@ type Defer = {
 };
 
 export function defer<TCallback extends Callback>(
-  callback: TCallback
+  callback: TCallback,
+  // A call that lands while a run is already pending is dropped, and so are its
+  // arguments: the first caller of the window decides what the single run
+  // receives. Pass this to fold every later argument into the pending ones
+  // instead.
+  mergeArguments?: (
+    pending: Parameters<TCallback>,
+    next: Parameters<TCallback>
+  ) => Parameters<TCallback>
 ): TCallback & Defer {
   let progress: Promise<void> | null = null;
   let cancelled = false;
+  let pendingArgs: Parameters<TCallback> | null = null;
 
   const fn = ((...args: Parameters<TCallback>) => {
     if (progress !== null) {
+      if (mergeArguments && pendingArgs !== null) {
+        pendingArgs = mergeArguments(pendingArgs, args);
+      }
       return;
     }
 
+    pendingArgs = args;
+
     progress = nextMicroTask.then(() => {
       progress = null;
+      const runArgs = pendingArgs as Parameters<TCallback>;
+      pendingArgs = null;
 
       if (cancelled) {
         cancelled = false;
         return;
       }
 
-      callback(...args);
+      callback(...runArgs);
     });
   }) as TCallback & Defer;
 

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -4137,5 +4137,38 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
       // state has reverted
       expect(search.getUiState()).toEqual({ indexName: { query: 'iphone' } });
     });
+
+    it('resets the state again when a second search fails', async () => {
+      const searchClient = createSearchClient();
+      const search = instantsearch({
+        indexName: 'indexName',
+        searchClient,
+      }).addWidgets([virtualSearchBox({})]);
+
+      search.start();
+      // suppress global error
+      search.on('error', () => {});
+
+      search.setUiState({ indexName: { query: 'iphone' } });
+      await wait(0);
+
+      expect(search.getUiState()).toEqual({ indexName: { query: 'iphone' } });
+
+      castToJestMock(searchClient.search).mockRejectedValue(
+        new Error('search error')
+      );
+
+      search.setUiState({ indexName: { query: 'iphone 2' } });
+      await wait(0);
+
+      expect(search.getUiState()).toEqual({ indexName: { query: 'iphone' } });
+
+      // The roll-back runs once per failed search, not once per error state, so
+      // the next failure reverts too.
+      search.setUiState({ indexName: { query: 'iphone 3' } });
+      await wait(0);
+
+      expect(search.getUiState()).toEqual({ indexName: { query: 'iphone' } });
+    });
   });
 });

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -431,6 +431,11 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
   let helper: Helper | null = null;
   let derivedHelper: DerivedHelper | null = null;
   let lastValidSearchParameters: SearchParameters | null = null;
+  // The error this index has already rolled back for. Renders also happen for
+  // reasons unrelated to a search (a chat panel opening, a recommend result,
+  // the stalled timer), and rolling back on every one of them would discard
+  // state written after the failed search.
+  let restoredForError: Error | undefined;
 
   const recomputeLocalRequestDependencies = () => {
     if (localInstantSearchInstance) {
@@ -978,11 +983,14 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
     render({ instantSearchInstance }: IndexRenderOptions) {
       // we can't attach a listener to the error event of search, as the error
       // then would no longer be thrown for global handlers.
-      if (
-        instantSearchInstance.status === 'error' &&
+      if (instantSearchInstance.status !== 'error') {
+        restoredForError = undefined;
+      } else if (
+        instantSearchInstance.error !== restoredForError &&
         !instantSearchInstance.mainHelper!.hasPendingRequests() &&
         lastValidSearchParameters
       ) {
+        restoredForError = instantSearchInstance.error;
         helper!.setState(lastValidSearchParameters);
       }
 


### PR DESCRIPTION
## Summary

Opening the Chat panel or sending one message reset `instantSearchInstance.status` to `idle` and cleared `instantSearchInstance.error`, even though no search ran. An app showing an error from a failed search lost it as soon as the user touched the chat. Both call paths are already released and #7166 made it fire on every turn.

`scheduleRender(shouldResetStatus = true)` treats "no pending requests" as "the search succeeded". Every core caller says whether its render came from a search. Chat is the only widget that renders for other reasons and it passed no argument, so it took the default.

The three chat renders that are not search results now opt out of that reset. `scheduleRender` also accumulates the intent across a deferred window, because `defer` drops the arguments of any call arriving while a run is pending. Without that, a chat render winning the race would swallow the reset a real result asks for and leave `status` on `loading`. Every other `defer` caller keeps its current behavior.

Adds core, connector and `defer` coverage for the error surviving a chat turn, for a result that shares the window still settling and for the unchanged `stalled` path. No public API change and no markup change. No common-suite test, since Vue has no Chat widget and the shared chat setup cannot read `status`.

Related: [FX-3933](https://algolia.atlassian.net/browse/FX-3933)

[FX-3933]: https://algolia.atlassian.net/browse/FX-3933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
