### PR TITLE
feat(prompt-suggestions): make the automatic fetch optional

### DIFF
--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -847,7 +847,7 @@ describe('connectPromptSuggestions', () => {
         configurationId: 'prompt-suggestions',
         autoFetch: false,
         // The playground models "nothing selected yet" as `undefined`.
-        context: () => undefined as unknown as Record<string, unknown>,
+        context: () => undefined,
       });
       const helper = algoliasearchHelper(createSearchClient(), '');
       widget.init!(createInitOptions({ helper }));
@@ -866,7 +866,7 @@ describe('connectPromptSuggestions', () => {
       const widget = connectPromptSuggestions(renderFn)({
         agentId: 'a',
         configurationId: 'prompt-suggestions',
-        context: () => undefined as unknown as Record<string, unknown>,
+        context: () => undefined,
       });
       const helper = algoliasearchHelper(createSearchClient(), '');
       widget.init!(createInitOptions({ helper }));
@@ -882,7 +882,7 @@ describe('connectPromptSuggestions', () => {
       const widget = connectPromptSuggestions(jest.fn())({
         agentId: 'a',
         configurationId: 'prompt-suggestions',
-        context: () => undefined as unknown as Record<string, unknown>,
+        context: () => undefined,
       });
       const helper = algoliasearchHelper(createSearchClient(), '');
       widget.init!(createInitOptions({ helper }));
@@ -895,6 +895,49 @@ describe('connectPromptSuggestions', () => {
         (global.fetch as jest.Mock).mock.calls[0][1].body as string
       );
       expect(body.input).toHaveProperty('hitsSample');
+    });
+
+    it('does not fetch on an empty `context` object, even with results', async () => {
+      // Asymmetry with `context: () => undefined`, which falls back to
+      // auto-extraction and does send. Pinned deliberately: an explicit context
+      // is a mode opt-out, so substituting search-state input would hand the
+      // task a shape it was not configured for. Unifying the two spellings is a
+      // separate decision for the task-contract owner.
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: () => ({}),
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not double-fetch when `refresh()` runs before the first results', async () => {
+      // `refresh()` without results cannot record a state signature, so the
+      // first render carrying results used to read as a change and schedule a
+      // second, identical request.
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: { focalProduct: { id: '42' } },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      lastCall.refresh();
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
     it('still auto-fetches when `autoFetch` is omitted', async () => {
@@ -1214,6 +1257,55 @@ describe('connectPromptSuggestions', () => {
             },
           },
         },
+        { headers: { 'x-algolia-referer': 'prompt-suggestions-widget' } }
+      );
+    });
+
+    it('still hands the query to the chat on a page with no hits', async () => {
+      // The suggestions themselves are gated on having something worth a model
+      // call, but the chat handoff is not — a zero-hit page is exactly when the
+      // agent needs to know what the user searched for.
+      const sendMessage = jest.fn();
+      const setOpen = jest.fn();
+      const search = createInstantSearch();
+      search.renderState = {
+        [search.helper!.state.index]: {
+          chat: { sendMessage, setOpen, status: 'ready' },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      widget.init!(
+        createInitOptions({
+          instantSearchInstance: search,
+          helper: search.helper!,
+        })
+      );
+      widget.render!(
+        createRenderOptions({
+          instantSearchInstance: search,
+          helper: search.helper!,
+          results: makeResults({ hits: [], query: 'shoes' }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      lastCall.sendToChat('try this');
+
+      expect(sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: {
+            turnContext: { query: 'shoes', hitsSample: JSON.stringify([]) },
+          },
+        }),
         { headers: { 'x-algolia-referer': 'prompt-suggestions-widget' } }
       );
     });

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -840,6 +840,63 @@ describe('connectPromptSuggestions', () => {
       expect(body.input).toEqual({ focalProduct: { id: '42' } });
     });
 
+    it('does not fetch when a `context` function resolves to nothing and there are no results', async () => {
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        autoFetch: false,
+        // The playground models "nothing selected yet" as `undefined`.
+        context: () => undefined as unknown as Record<string, unknown>,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      lastCall.refresh();
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch on an empty resolved context even when `autoFetch` is on', async () => {
+      // `autoFetch` is never read by `refresh()`, so the default path reaches
+      // this too whenever `refresh()` runs before any results exist.
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: () => undefined as unknown as Record<string, unknown>,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      lastCall.refresh();
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('still fetches when a `context` function resolves to nothing but results exist', async () => {
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: () => undefined as unknown as Record<string, unknown>,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+
+      // Falls back to auto-extraction, so there is still something to send.
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string
+      );
+      expect(body.input).toHaveProperty('hitsSample');
+    });
+
     it('still auto-fetches when `autoFetch` is omitted', async () => {
       const widget = connectPromptSuggestions(jest.fn())({
         agentId: 'a',

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -959,6 +959,251 @@ describe('connectPromptSuggestions', () => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
+    it('supersedes an in-flight fetch instead of queueing behind it', async () => {
+      // Regression: `refresh()` used to return early while a fetch was in
+      // flight, so a surface whose inputs changed mid-fetch had to wait out the
+      // call it had already abandoned before the replacement could leave. Both
+      // requests are observed here without ever releasing the first.
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      // Hold the first fetch open for the whole test.
+      let resolveFirst: (response: Response) => void = () => {};
+      (global.fetch as jest.Mock).mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFirst = resolve;
+          })
+      );
+
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      // The replacement leaves without the first one settling and without any
+      // debounce window elapsing.
+      renderFn.mock.calls[renderFn.mock.calls.length - 1][0].refresh();
+      await flush(0);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      // The replacement's own pills paint.
+      const afterSecond =
+        renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      expect(afterSecond.suggestions).toEqual(['a', 'b', 'c']);
+      expect(afterSecond.isLoading).toBe(false);
+
+      // The abandoned response can never paint, however late it arrives.
+      resolveFirst(textStreamResponse(['{"suggestions":["stale"]}']));
+      await flush(0);
+      const afterStale = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      expect(afterStale.suggestions).toEqual(['a', 'b', 'c']);
+      expect(afterStale.isLoading).toBe(false);
+    });
+
+    it('keeps the loading state on across a superseding `refresh()`', async () => {
+      // The swap must not flicker `isLoading` to `false`, or a consumer's
+      // spinner blinks between the abandoned call and its replacement.
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      let resolveFirst: (response: Response) => void = () => {};
+      let resolveSecond: (response: Response) => void = () => {};
+      (global.fetch as jest.Mock)
+        .mockImplementationOnce(
+          () =>
+            new Promise<Response>((resolve) => {
+              resolveFirst = resolve;
+            })
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise<Response>((resolve) => {
+              resolveSecond = resolve;
+            })
+        );
+
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+      expect(
+        renderFn.mock.calls[renderFn.mock.calls.length - 1][0].isLoading
+      ).toBe(true);
+
+      const before = renderFn.mock.calls.length;
+      renderFn.mock.calls[before - 1][0].refresh();
+      await flush(0);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      // Every render emitted across the swap still reports loading.
+      const acrossSwap = renderFn.mock.calls
+        .slice(before)
+        .map((call) => call[0].isLoading);
+      expect(acrossSwap).not.toContain(false);
+
+      // The abandoned call settling must not clear it either.
+      resolveFirst(textStreamResponse(['{"suggestions":["stale"]}']));
+      await flush(0);
+      expect(
+        renderFn.mock.calls[renderFn.mock.calls.length - 1][0].isLoading
+      ).toBe(true);
+
+      resolveSecond(textStreamResponse(['{"suggestions":["x"]}']));
+      await flush(0);
+      const settled = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      expect(settled.isLoading).toBe(false);
+      expect(settled.suggestions).toEqual(['x']);
+    });
+
+    it('schedules no duplicate after a superseding `refresh()` with results', async () => {
+      // The superseding fetch re-records the state signature, so the render
+      // that follows it reads as unchanged and adds no third request.
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      (global.fetch as jest.Mock).mockImplementationOnce(
+        () => new Promise<Response>(() => {})
+      );
+
+      const results = makeResults();
+      widget.render!(createRenderOptions({ helper, results }));
+      await flush(DEBOUNCE_WAIT);
+      renderFn.mock.calls[renderFn.mock.calls.length - 1][0].refresh();
+      await flush(0);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      widget.render!(createRenderOptions({ helper, results }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('abandons an in-flight fetch when a superseding `refresh()` has nothing to send', async () => {
+      // Newly reachable: the inputs became empty while a call was out, so the
+      // pending result is stale and the widget clears rather than painting it.
+      const renderFn = jest.fn();
+      let pageContext: Record<string, unknown> | undefined = {
+        focalProduct: { id: '42' },
+      };
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        autoFetch: false,
+        context: () => pageContext,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      let resolveFirst: (response: Response) => void = () => {};
+      (global.fetch as jest.Mock).mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFirst = resolve;
+          })
+      );
+
+      renderFn.mock.calls[renderFn.mock.calls.length - 1][0].refresh();
+      await flush(0);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(
+        renderFn.mock.calls[renderFn.mock.calls.length - 1][0].isLoading
+      ).toBe(true);
+
+      // Nothing selected any more: no second request, and the in-flight one is
+      // dropped rather than left to paint.
+      pageContext = {};
+      renderFn.mock.calls[renderFn.mock.calls.length - 1][0].refresh();
+      await flush(0);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const afterEmpty = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      expect(afterEmpty.isLoading).toBe(false);
+      expect(afterEmpty.suggestions).toEqual([]);
+
+      resolveFirst(textStreamResponse(['{"suggestions":["stale"]}']));
+      await flush(0);
+      const afterStale = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      expect(afterStale.suggestions).toEqual([]);
+      expect(afterStale.isLoading).toBe(false);
+    });
+
+    it('arms the auto-fetch skip once across two `refresh()` calls before results', async () => {
+      // Each pre-results fetch arms `skipNextAutoFetch`; arming it twice must
+      // still be consumed by one render, not leave a suppression behind.
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: { focalProduct: { id: '42' } },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      (global.fetch as jest.Mock).mockImplementationOnce(
+        () => new Promise<Response>(() => {})
+      );
+
+      renderFn.mock.calls[renderFn.mock.calls.length - 1][0].refresh();
+      await flush(0);
+      renderFn.mock.calls[renderFn.mock.calls.length - 1][0].refresh();
+      await flush(0);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      // The first render with results is the one the skip covers.
+      widget.render!(
+        createRenderOptions({ helper, results: makeResults({ query: 'one' }) })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      // A later, genuinely new state still fetches.
+      widget.render!(
+        createRenderOptions({ helper, results: makeResults({ query: 'two' }) })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not loop when `refresh()` re-enters from its own render', async () => {
+      // `submit` renders synchronously, so a consumer that calls `refresh()`
+      // from a layout body instead of an event handler re-enters it. That must
+      // stay bounded: one request, not one per render.
+      const renderFn = jest.fn((renderState: { refresh: () => void }) => {
+        if (renderFn.mock.calls.length > 200) return;
+        renderState.refresh();
+      });
+      const widget = connectPromptSuggestions(
+        renderFn as unknown as Parameters<typeof connectPromptSuggestions>[0]
+      )({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: { focalProduct: { id: '42' } },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+
+      (global.fetch as jest.Mock).mockImplementation(
+        () => new Promise<Response>(() => {})
+      );
+
+      widget.init!(createInitOptions({ helper }));
+      await flush(0);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(renderFn.mock.calls.length).toBeLessThan(10);
+    });
+
     it('still auto-fetches when `autoFetch` is omitted', async () => {
       const widget = connectPromptSuggestions(jest.fn())({
         agentId: 'a',

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -897,6 +897,25 @@ describe('connectPromptSuggestions', () => {
       expect(body.input).toHaveProperty('hitsSample');
     });
 
+    it('does not fetch when a `context` function resolves to nothing and there are no hits', async () => {
+      // A `context` that resolved to nothing is not an explicit context, so the
+      // "no hits to derive one from" rule has to apply to it exactly as it does
+      // to an omitted `context`.
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: () => undefined,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      widget.render!(
+        createRenderOptions({ helper, results: makeResults({ hits: [] }) })
+      );
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     it('does not fetch on an empty `context` object, even with results', async () => {
       // Asymmetry with `context: () => undefined`, which falls back to
       // auto-extraction and does send. Pinned deliberately: an explicit context

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -761,6 +761,98 @@ describe('connectPromptSuggestions', () => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
+    it('does not fetch on a state change when `autoFetch` is false', async () => {
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        autoFetch: false,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch on a later query change when `autoFetch` is false', async () => {
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        autoFetch: false,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      widget.render!(
+        createRenderOptions({ helper, results: makeResults({ query: 'one' }) })
+      );
+      await flush(DEBOUNCE_WAIT);
+      widget.render!(
+        createRenderOptions({ helper, results: makeResults({ query: 'two' }) })
+      );
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('fires exactly one request from `refresh()` when `autoFetch` is false', async () => {
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        autoFetch: false,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      lastCall.refresh();
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes after `init()` alone, with no `render()` and no results', async () => {
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        autoFetch: false,
+        context: { focalProduct: { id: '42' } },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      // No `render()` at all: this is the no-search-index mount, where the
+      // widget never receives results.
+      widget.init!(createInitOptions({ helper }));
+      expect(global.fetch).not.toHaveBeenCalled();
+
+      const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      lastCall.refresh();
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string
+      );
+      expect(body.input).toEqual({ focalProduct: { id: '42' } });
+    });
+
+    it('still auto-fetches when `autoFetch` is omitted', async () => {
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
     it('lets transport.prepareSendMessagesRequest mutate the body', async () => {
       const prepare = jest.fn(
         (request: {

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -112,8 +112,14 @@ export type PromptSuggestionsConnectorParams = PromptSuggestionsSource & {
   configurationId: string;
   /** Transforms hits before use as context (default: first 5, metadata stripped). Ignored with `context`. */
   transformHits?: PromptSuggestionsTransformHits;
-  /** Explicit context, replacing the auto-extracted `{ query, filters, hitsSample }`. Object or per-fetch function. */
-  context?: Record<string, unknown> | (() => Record<string, unknown>);
+  /**
+   * Explicit context, replacing the auto-extracted `{ query, filters, hitsSample }`.
+   * Object or per-fetch function. A function that returns `undefined` falls back
+   * to auto-extraction, so a surface with nothing selected yet can say so.
+   */
+  context?:
+    | Record<string, unknown>
+    | (() => Record<string, unknown> | undefined);
   /** Transforms the parsed suggestions before exposing them. Receives `{ query, results }`. */
   transformItems?: PromptSuggestionsTransformItems;
   /**
@@ -238,6 +244,16 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       let debounceTimer: ReturnType<typeof setTimeout> | undefined;
       let lastStateSignature: string | null = null;
       let latestRenderOptions: InitOptions | RenderOptions | null = null;
+      // Set when a fetch goes out before any results exist, which is only
+      // reachable through `refresh()`. Such a fetch has no state signature to
+      // record, so the first render that does carry results would otherwise
+      // read as a change and schedule a second request on top of it.
+      //
+      // Two accepted consequences: a function `context` that changes value in
+      // that window has its newer value dropped until the next `refresh()`, and
+      // a failed pre-results fetch is not retried by the first render — the
+      // error stays on screen instead.
+      let skipNextAutoFetch = false;
       // Set in `dispose()`. A debounced or in-flight `fetch()` can resolve after
       // the widget is unmounted; this guard stops those late callbacks from
       // calling `renderFn` into a torn-down container.
@@ -385,6 +401,9 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           return;
         }
 
+        if (!results) {
+          skipNextAutoFetch = true;
+        }
         tasksState.submit(input);
       };
 
@@ -515,6 +534,14 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           }
 
           const stateSignature = getStateSignature(results);
+
+          if (skipNextAutoFetch) {
+            // A `refresh()` already sent this mount's request before any
+            // results existed. Adopt the first signature instead of spending a
+            // second call on it.
+            skipNextAutoFetch = false;
+            lastStateSignature = stateSignature;
+          }
 
           if (autoFetch && stateSignature !== lastStateSignature) {
             lastStateSignature = stateSignature;

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -78,7 +78,11 @@ export type PromptSuggestionsRenderState = {
   onSuggestionClick: (prompt: string) => void;
   /** Hands the prompt to the `connectChat` widget on the same index. `true` if dispatched, else `false`. */
   sendToChat: (prompt: string) => boolean;
-  /** Imperative refetch that bypasses the debounce. No-op with no results or a fetch in-flight. */
+  /**
+   * Imperative refetch that bypasses the debounce. Usable from `init()` onwards,
+   * including in a mount that never produces search results, as long as
+   * `context` is set. No-op while a fetch is in flight.
+   */
   refresh: () => void;
   /**
    * Whether the chat widget is currently busy (mid-stream) — surface as `disabled` on the pills.
@@ -112,6 +116,16 @@ export type PromptSuggestionsConnectorParams = PromptSuggestionsSource & {
   context?: Record<string, unknown> | (() => Record<string, unknown>);
   /** Transforms the parsed suggestions before exposing them. Receives `{ query, results }`. */
   transformItems?: PromptSuggestionsTransformItems;
+  /**
+   * Whether a change in the search state automatically triggers a debounced
+   * fetch (default: `true`). Set to `false` to make `refresh()` the only
+   * trigger — every fetch is a model call, so this lets the surface spend one
+   * only when the user asks for it.
+   *
+   * Read once per widget instance: changing it at runtime takes effect through
+   * the remount that any widget-params change already causes.
+   */
+  autoFetch?: boolean;
 };
 
 export type PromptSuggestionsWidgetDescription = {
@@ -202,6 +216,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         context,
         transformItems = (items) => items,
         transport,
+        autoFetch = true,
       } = widgetParams;
 
       if (!agentId && !transport) {
@@ -222,7 +237,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       let error: Error | undefined;
       let debounceTimer: ReturnType<typeof setTimeout> | undefined;
       let lastStateSignature: string | null = null;
-      let latestRenderOptions: RenderOptions | null = null;
+      let latestRenderOptions: InitOptions | RenderOptions | null = null;
       // Set in `dispose()`. A debounced or in-flight `fetch()` can resolve after
       // the widget is unmounted; this guard stops those late callbacks from
       // calling `renderFn` into a torn-down container.
@@ -304,8 +319,9 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         };
       };
 
-      const buildInput = (results: SearchResults): Record<string, unknown> =>
-        resolvePageContext(results) ?? {};
+      const buildInput = (
+        results: SearchResults | null
+      ): Record<string, unknown> => resolvePageContext(results) ?? {};
 
       // The same page context, flattened for the chat handoff: `turnContext` is
       // a flat `Record<string, string>` per the Agent Studio contract, so
@@ -337,9 +353,18 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         );
       };
 
+      // `latestRenderOptions` may be the `init()` options, which carry no
+      // results at all, so the read has to be narrowed rather than optional.
+      const getLatestResults = (): SearchResults | null => {
+        if (!latestRenderOptions || !('results' in latestRenderOptions)) {
+          return null;
+        }
+        return latestRenderOptions.results ?? null;
+      };
+
       const fetchAndRender = (
-        results: SearchResults,
-        renderOptions: RenderOptions
+        results: SearchResults | null,
+        renderOptions: InitOptions | RenderOptions
       ) => {
         if (disposed || !tasksState) return;
         refetchPending = false;
@@ -356,11 +381,14 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       };
 
       const refresh = () => {
-        if (isLoading) return;
-        const results = latestRenderOptions?.results;
-        if (!results || !latestRenderOptions) return;
+        if (isLoading || !latestRenderOptions) return;
+        const results = getLatestResults();
         clearTimeout(debounceTimer);
-        lastStateSignature = getStateSignature(results);
+        // Only meaningful with results; without them there is no signature to
+        // suppress a later automatic fetch against.
+        if (results) {
+          lastStateSignature = getStateSignature(results);
+        }
         fetchAndRender(results, latestRenderOptions);
       };
 
@@ -448,6 +476,11 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
 
           tasksWidget.init!(initOptions);
 
+          // Set after the inner init so its initial no-op render is still
+          // ignored, and before the first outward render so `refresh()` has a
+          // render target even when `render()` never runs with results.
+          latestRenderOptions = initOptions;
+
           renderFn(
             {
               ...getWidgetRenderState(initOptions),
@@ -475,17 +508,15 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
 
           const stateSignature = getStateSignature(results);
 
-          if (stateSignature !== lastStateSignature) {
+          if (autoFetch && stateSignature !== lastStateSignature) {
             lastStateSignature = stateSignature;
             refetchPending = true;
             error = undefined;
             clearTimeout(debounceTimer);
             debounceTimer = setTimeout(() => {
-              if (latestRenderOptions?.results) {
-                fetchAndRender(
-                  latestRenderOptions.results,
-                  latestRenderOptions
-                );
+              const latestResults = getLatestResults();
+              if (latestResults && latestRenderOptions) {
+                fetchAndRender(latestResults, latestRenderOptions);
               }
             }, DEBOUNCE_MS);
           }

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -368,8 +368,16 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       ) => {
         if (disposed || !tasksState) return;
         refetchPending = false;
-        const hasContext = context !== undefined;
-        if (!hasContext && !results?.hits?.length) {
+        const input = buildInput(results);
+        // Two ways there is nothing worth sending: no explicit `context` and no
+        // hits to derive one from, or a `context` that resolved to nothing with
+        // no results to fall back on. The second is reachable because `context`
+        // may be a function, so receiving one says nothing about what it
+        // returns. Sending an empty input spends a model call on no information.
+        const hasNothingToSend =
+          (context === undefined && !results?.hits?.length) ||
+          Object.keys(input).length === 0;
+        if (hasNothingToSend) {
           tasksState.invalidate();
           suggestions = [];
           isLoading = false;
@@ -377,7 +385,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           return;
         }
 
-        tasksState.submit(buildInput(results));
+        tasksState.submit(input);
       };
 
       const refresh = () => {

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -80,8 +80,12 @@ export type PromptSuggestionsRenderState = {
   sendToChat: (prompt: string) => boolean;
   /**
    * Imperative refetch that bypasses the debounce. Usable from `init()` onwards,
-   * including in a mount that never produces search results, as long as
-   * `context` is set. No-op while a fetch is in flight.
+   * including in a mount that never produces search results.
+   *
+   * Supersedes a fetch that is still in flight rather than queueing behind it:
+   * the earlier response is discarded and the replacement request leaves in the
+   * same tick, so a surface whose inputs changed never waits out the call it
+   * already abandoned. Still sends nothing when there is nothing to send.
    */
   refresh: () => void;
   /**
@@ -114,8 +118,12 @@ export type PromptSuggestionsConnectorParams = PromptSuggestionsSource & {
   transformHits?: PromptSuggestionsTransformHits;
   /**
    * Explicit context, replacing the auto-extracted `{ query, filters, hitsSample }`.
-   * Object or per-fetch function. A function that returns `undefined` falls back
-   * to auto-extraction, so a surface with nothing selected yet can say so.
+   * Object or per-fetch function.
+   *
+   * A function returning `undefined` falls back to auto-extraction, which needs
+   * results carrying at least one hit: before those arrive, or on a page with no
+   * hits, nothing is sent. An empty object sends nothing even when there are
+   * hits, so `() => ({})` is how a surface says it has nothing to describe yet.
    */
   context?:
     | Record<string, unknown>
@@ -262,6 +270,13 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       // the widget is unmounted; this guard stops those late callbacks from
       // calling `renderFn` into a torn-down container.
       let disposed = false;
+      // Guards against a `refresh()` that re-enters from inside its own render
+      // cascade: `submit` renders synchronously, so a consumer calling
+      // `refresh()` from a layout body rather than an event handler would
+      // otherwise loop, spending a model call per iteration. The `isLoading`
+      // check this replaced bounded that by accident. Only synchronous
+      // re-entry is blocked; a later call still supersedes.
+      let refreshing = false;
       // True between a state-signature change and the debounced refetch that
       // follows it. While pending, the search state has already moved on, so a
       // still-in-flight request from the previous state must not paint its
@@ -415,7 +430,12 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       };
 
       const refresh = () => {
-        if (isLoading || !latestRenderOptions) return;
+        // Deliberately not gated on `isLoading`. `tasksState.submit` bumps its
+        // own request id, so an in-flight call is abandoned by the new one: it
+        // can neither paint suggestions nor clear the loading state. Returning
+        // early instead would force the caller to wait out a response it has
+        // already discarded.
+        if (refreshing || !latestRenderOptions) return;
         const results = getLatestResults();
         clearTimeout(debounceTimer);
         // Only meaningful with results; without them there is no signature to
@@ -423,7 +443,12 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         if (results) {
           lastStateSignature = getStateSignature(results);
         }
-        fetchAndRender(results, latestRenderOptions);
+        refreshing = true;
+        try {
+          fetchAndRender(results, latestRenderOptions);
+        } finally {
+          refreshing = false;
+        }
       };
 
       const getWidgetRenderState = (

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -313,11 +313,16 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           });
         };
 
-      const resolvePageContext = (
+      // `context` may be a function, so the option alone says nothing about
+      // what a given fetch actually has. Resolve it once per fetch and let
+      // callers read the value rather than the option.
+      const resolveContext = (): Record<string, unknown> | undefined =>
+        typeof context === 'function' ? context() : context;
+
+      const buildPageContext = (
+        resolvedContext: Record<string, unknown> | undefined,
         results: SearchResults | null
       ): Record<string, unknown> | undefined => {
-        const resolvedContext =
-          typeof context === 'function' ? context() : context;
         // Explicit context replaces auto-extraction; otherwise derive it from
         // the current search state. The task's server-owned instructions decide
         // how to interpret the shape — the client doesn't label it.
@@ -335,17 +340,13 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         };
       };
 
-      const buildInput = (
-        results: SearchResults | null
-      ): Record<string, unknown> => resolvePageContext(results) ?? {};
-
       // The same page context, flattened for the chat handoff: `turnContext` is
       // a flat `Record<string, string>` per the Agent Studio contract, so
       // non-string values (e.g. `hitsSample`) are serialized.
       const buildTurnContext = (
         results: SearchResults | null
       ): Record<string, string> | undefined => {
-        const pageContext = resolvePageContext(results);
+        const pageContext = buildPageContext(resolveContext(), results);
         if (!pageContext) {
           return undefined;
         }
@@ -384,14 +385,16 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       ) => {
         if (disposed || !tasksState) return;
         refetchPending = false;
-        const input = buildInput(results);
-        // Two ways there is nothing worth sending: no explicit `context` and no
-        // hits to derive one from, or a `context` that resolved to nothing with
-        // no results to fall back on. The second is reachable because `context`
-        // may be a function, so receiving one says nothing about what it
-        // returns. Sending an empty input spends a model call on no information.
+        const resolvedContext = resolveContext();
+        const input = buildPageContext(resolvedContext, results) ?? {};
+        // Two ways there is nothing worth sending: no context for this fetch
+        // and no hits to derive one from, or a context that resolved to
+        // something empty. The first reads the resolved value, not the option,
+        // so `context: () => undefined` is gated exactly like an omitted
+        // `context`. Sending an empty input spends a model call on no
+        // information.
         const hasNothingToSend =
-          (context === undefined && !results?.hits?.length) ||
+          (resolvedContext === undefined && !results?.hits?.length) ||
           Object.keys(input).length === 0;
         if (hasNothingToSend) {
           tasksState.invalidate();

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -130,6 +130,10 @@ export type PromptSuggestionsConnectorParams = PromptSuggestionsSource & {
    *
    * Read once per widget instance: changing it at runtime takes effect through
    * the remount that any widget-params change already causes.
+   *
+   * `refresh` reaches a custom layout only (`layoutComponent` in React,
+   * `templates.layout` in JS). The default layout has no trigger, so pairing
+   * `autoFetch: false` with it gives a widget that never fetches.
    */
   autoFetch?: boolean;
 };

--- a/packages/instantsearch.js/src/widgets/prompt-suggestions/prompt-suggestions.tsx
+++ b/packages/instantsearch.js/src/widgets/prompt-suggestions/prompt-suggestions.tsx
@@ -45,6 +45,8 @@ export type PromptSuggestionsLayoutTemplateProps = {
   error: Error | undefined;
   onSuggestionClick: (prompt: string) => void;
   isChatBusy: boolean;
+  /** Triggers a fetch. The only trigger when `autoFetch` is `false`. */
+  refresh: () => void;
 };
 
 export type PromptSuggestionsTemplates = {
@@ -122,6 +124,7 @@ const createRenderer =
       onSuggestionClick,
       isChatBusy,
       sendToChat,
+      refresh,
       instantSearchInstance,
     },
     isFirstRendering
@@ -152,6 +155,7 @@ const createRenderer =
             error,
             onSuggestionClick: handleClick,
             isChatBusy,
+            refresh,
           }}
         />,
         containerNode

--- a/packages/react-instantsearch/src/widgets/PromptSuggestions.tsx
+++ b/packages/react-instantsearch/src/widgets/PromptSuggestions.tsx
@@ -23,6 +23,8 @@ export type PromptSuggestionsLayoutComponentProps = {
   error: Error | undefined;
   onSuggestionClick: (prompt: string) => void;
   isChatBusy: boolean;
+  /** Triggers a fetch. The only trigger when `autoFetch` is `false`. */
+  refresh: () => void;
 };
 
 export type PromptSuggestionsOnSuggestionClick = (
@@ -59,6 +61,7 @@ export function PromptSuggestions({
   transformHits,
   context,
   transformItems,
+  autoFetch,
   ...props
 }: PromptSuggestionsProps) {
   const source = agentId !== undefined ? { agentId, transport } : { transport };
@@ -69,6 +72,7 @@ export function PromptSuggestions({
     onSuggestionClick,
     isChatBusy,
     sendToChat,
+    refresh,
   } = usePromptSuggestions(
     {
       ...source,
@@ -76,6 +80,7 @@ export function PromptSuggestions({
       transformHits,
       context,
       transformItems,
+      autoFetch,
     },
     {
       $$widgetType: 'ais.promptSuggestions',
@@ -94,6 +99,7 @@ export function PromptSuggestions({
         error={error}
         onSuggestionClick={handleClick}
         isChatBusy={isChatBusy}
+        refresh={refresh}
       />
     );
   }

--- a/tests/common/widgets/prompt-suggestions/options.ts
+++ b/tests/common/widgets/prompt-suggestions/options.ts
@@ -559,6 +559,109 @@ export function createOptionsTests(
       );
     });
 
+    test('a second `refresh()` from the layout supersedes the first fetch', async () => {
+      // Public-seam proof for the connector's supersede behaviour: a surface
+      // whose inputs changed mid-fetch must be able to send the replacement
+      // straight away, and the abandoned response must never paint.
+      const searchClient = createResultsClient([
+        { objectID: '1', name: 'Product 1' },
+      ]);
+      let releaseFirst: (response: Response) => void = () => {};
+      const fetchMock = jest
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<Response>((resolve) => {
+              releaseFirst = resolve;
+            })
+        )
+        .mockImplementation(() =>
+          Promise.resolve(textStreamResponse(SUGGESTIONS))
+        );
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const layoutParams = {
+        agentId: 'test-agent-id',
+        configurationId: 'prompt-suggestions',
+        autoFetch: false,
+      };
+
+      await setup({
+        instantSearchOptions: { indexName: 'indexName', searchClient },
+        widgetParams: {
+          javascript: {
+            ...layoutParams,
+            templates: {
+              layout: ({ suggestions, refresh }, { html }) =>
+                html`<div>
+                  <button
+                    type="button"
+                    class="generate"
+                    onClick=${() => refresh()}
+                  >
+                    Generate
+                  </button>
+                  <span class="output">${suggestions.join(', ')}</span>
+                </div>`,
+            },
+          },
+          react: {
+            ...layoutParams,
+            layoutComponent: ({ suggestions, refresh }) =>
+              createElement('div', null, [
+                createElement(
+                  'button',
+                  {
+                    key: 'generate',
+                    type: 'button',
+                    className: 'generate',
+                    onClick: () => refresh(),
+                  },
+                  'Generate'
+                ),
+                createElement(
+                  'span',
+                  { key: 'output', className: 'output' },
+                  suggestions.join(', ')
+                ),
+              ]),
+          },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(DEBOUNCE_MS + 50);
+      });
+
+      // First ask: the request goes out and stays open.
+      await act(async () => {
+        userEvent.click(document.querySelector('.generate')!);
+        await wait(0);
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(document.querySelector('.output')!.textContent).toBe('');
+
+      // Second ask while the first is still open: it leaves without waiting.
+      await act(async () => {
+        userEvent.click(document.querySelector('.generate')!);
+        await wait(0);
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(document.querySelector('.output')!.textContent).toBe(
+        SUGGESTIONS.join(', ')
+      );
+
+      // The abandoned response arrives last and is discarded.
+      await act(async () => {
+        releaseFirst(textStreamResponse(['stale suggestion']));
+        await wait(0);
+      });
+      expect(document.querySelector('.output')!.textContent).toBe(
+        SUGGESTIONS.join(', ')
+      );
+    });
+
     test('runs the onSuggestionClick override when a pill is clicked', async () => {
       const searchClient = createResultsClient([
         { objectID: '1', name: 'Product 1' },

--- a/tests/common/widgets/prompt-suggestions/options.ts
+++ b/tests/common/widgets/prompt-suggestions/options.ts
@@ -1,6 +1,7 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils';
 import userEvent from '@testing-library/user-event';
+import { createElement } from 'react';
 
 import type { PromptSuggestionsWidgetSetup } from '.';
 import type { TestOptions } from '../../common';
@@ -483,6 +484,79 @@ export function createOptionsTests(
         expect.objectContaining({ query: expect.any(String) })
       );
       expect(document.body.textContent).toContain('Custom Suggestion A');
+    });
+
+    test('with `autoFetch: false`, only `refresh()` from the layout fetches', async () => {
+      const searchClient = createResultsClient([
+        { objectID: '1', name: 'Product 1' },
+      ]);
+      const fetchMock = mockAgentFetch();
+
+      await setup({
+        instantSearchOptions: { indexName: 'indexName', searchClient },
+        widgetParams: {
+          javascript: {
+            agentId: 'test-agent-id',
+            configurationId: 'prompt-suggestions',
+            autoFetch: false,
+            templates: {
+              layout: ({ suggestions, refresh }, { html }) =>
+                html`<div>
+                  <button
+                    type="button"
+                    class="generate"
+                    onClick=${() => refresh()}
+                  >
+                    Generate
+                  </button>
+                  <span class="output">${suggestions.join(', ')}</span>
+                </div>`,
+            },
+          },
+          react: {
+            agentId: 'test-agent-id',
+            configurationId: 'prompt-suggestions',
+            autoFetch: false,
+            layoutComponent: ({ suggestions, refresh }) =>
+              createElement('div', null, [
+                createElement(
+                  'button',
+                  {
+                    key: 'generate',
+                    type: 'button',
+                    className: 'generate',
+                    onClick: () => refresh(),
+                  },
+                  'Generate'
+                ),
+                createElement(
+                  'span',
+                  { key: 'output', className: 'output' },
+                  suggestions.join(', ')
+                ),
+              ]),
+          },
+          vue: {},
+        },
+      });
+
+      // Results have arrived and the debounce window has passed, but nothing
+      // asked for suggestions, so no model call was spent.
+      await act(async () => {
+        await wait(DEBOUNCE_MS + 50);
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(document.querySelector('.output')!.textContent).toBe('');
+
+      await act(async () => {
+        userEvent.click(document.querySelector('.generate')!);
+        await wait(DEBOUNCE_MS + 50);
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(document.querySelector('.output')!.textContent).toBe(
+        SUGGESTIONS.join(', ')
+      );
     });
 
     test('runs the onSuggestionClick override when a pill is clicked', async () => {


### PR DESCRIPTION
**Summary**

Prompt Suggestions fetches on its own whenever the search state changes and every fetch is a model call. A surface that generates on demand spends calls nobody asked for.

The Agent Studio playground is that surface. Suggestions sit behind Generate and Regenerate, against a draft configuration nobody has saved. It has three context modes: `searchResults` has a search index, `singleRecord` has one and refetches while the user types in the record picker and `customContext` has no index at all.

`autoFetch` makes the automatic fetch optional. It defaults to `true`, so current behavior is unchanged. With `autoFetch: false`, `refresh()` is the only trigger.

`refresh()` now also works where there is no search index. It needed results that only arrive through `render()`, so in a mount like `customContext` it was a permanent no-op.

It also stops queueing behind a fetch that is already out. It used to return early while one was in flight, so a surface whose inputs changed mid-fetch had to sit through the response it had already given up on before the replacement could leave. The Agent Studio preview hits this today and shows the user two generations' worth of spinner. The replacement now leaves at once and the older response is discarded.

**Result**

- Adds `autoFetch` to the connector, `usePromptSuggestions` and the React widget.
- Passes `refresh` to `layoutComponent` and `templates.layout`, so a custom layout can start a fetch.
- Keeps the default path unchanged. Automatic debounced fetching stays on when `autoFetch` is unset.
- Makes `refresh()` supersede an in-flight fetch. Calling it from a layout body rather than an event handler still sends one request, not one per render.
- Adds connector coverage and shared JavaScript and React coverage for both triggers.

**Why not cache on unchanged parameters**

Unchanged search state already sends no fetch. A cache would go further than we can afford: Regenerate has to resend the same parameters and get a new answer. It also would not help `customContext`, which has no results to compare and the first fetch still goes out either way.

**Not in this PR**

The automatic trigger reads the search results but an explicit `context` replaces them, so `singleRecord` refetches on record-picker input while the payload is identical. Separate fix.

`refresh` in the layout props is not in the shape we agreed for the Dashboard. Say if you would rather the consumer call `usePromptSuggestions` directly.

Related: [FX-3995](https://algolia.atlassian.net/browse/FX-3995)



[FX-3995]: https://algolia.atlassian.net/browse/FX-3995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ