### PR TITLE
fix(chat): apply MCP boolean and numeric facets on view all

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/tools/CarouselTool.tsx
@@ -1,6 +1,9 @@
 /** @jsx createElement */
 
-import { getApplyFiltersParamsFromToolInput } from '../../../lib/utils/chat';
+import {
+  getApplyFiltersParamsFromToolInput,
+  getResolvedSearchParams,
+} from '../../../lib/utils/chat';
 import { addAbsolutePosition, addQueryID } from '../../../lib/utils/hits';
 import { createButtonComponent } from '../../Button';
 import { createCarouselComponent, generateCarouselId } from '../../Carousel';
@@ -11,7 +14,11 @@ import type {
   CarouselProps,
   HeaderComponentProps as CarouselHeaderComponentProps,
 } from '../../Carousel';
-import type { ClientSideToolComponentProps, SearchToolInput } from '../types';
+import type {
+  ClientSideToolComponentProps,
+  ResolvedSearchParams,
+  SearchToolInput,
+} from '../types';
 import type { SearchParameters } from 'algoliasearch-helper';
 
 type HeaderProps = {
@@ -22,6 +29,11 @@ type HeaderProps = {
   scrollRight: () => void;
   nbHits?: number;
   input?: SearchToolInput;
+  /**
+   * The filters the search tool was actually answered with, when the server
+   * sent them. Preferred over `input`, which cannot express a numeric filter.
+   */
+  resolvedSearchParams?: ResolvedSearchParams;
   nbItems: number;
   applyFilters: ClientSideToolComponentProps['context']['applyFilters'];
   getSearchPageURL?: (params: SearchParameters) => string;
@@ -47,6 +59,7 @@ function createHeaderComponent({ createElement }: Renderer) {
     scrollRight,
     nbHits,
     input,
+    resolvedSearchParams,
     nbItems,
     applyFilters,
     getSearchPageURL,
@@ -73,7 +86,10 @@ function createHeaderComponent({ createElement }: Renderer) {
                 if (!input || !applyFilters) return;
 
                 const params = applyFilters(
-                  getApplyFiltersParamsFromToolInput(input)
+                  getApplyFiltersParamsFromToolInput(
+                    input,
+                    resolvedSearchParams
+                  )
                 );
 
                 if (getSearchPageURL) {
@@ -160,6 +176,13 @@ export function createCarouselToolComponent<
 
     const input = message?.input as SearchToolInput | undefined;
 
+    // What the server actually searched with, when it sent it. Absent for the
+    // default search tool and whenever the MCP server emits no `_meta`.
+    const resolvedSearchParams = useMemo(
+      () => getResolvedSearchParams(context.messages, message?.toolCallId),
+      [context.messages, message?.toolCallId]
+    );
+
     const output = message?.output as
       | {
           hits?: Array<RecordWithObjectID<TObject>>;
@@ -233,6 +256,7 @@ export function createCarouselToolComponent<
             showViewAll={showViewAll}
             nbHits={output?.nbHits}
             input={input}
+            resolvedSearchParams={resolvedSearchParams}
             applyFilters={applyFilters}
             getSearchPageURL={getSearchPageURL}
             onClose={onClose}
@@ -246,6 +270,7 @@ export function createCarouselToolComponent<
           showViewAll={showViewAll}
           nbHits={output?.nbHits}
           input={input}
+          resolvedSearchParams={resolvedSearchParams}
           applyFilters={applyFilters}
           getSearchPageURL={getSearchPageURL}
           onClose={onClose}
@@ -257,6 +282,7 @@ export function createCarouselToolComponent<
       HeaderComponent,
       output?.nbHits,
       input,
+      resolvedSearchParams,
       applyFilters,
       getSearchPageURL,
       onClose,

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -459,7 +459,7 @@ type FacetFiltersSearchToolQuery = SearchToolQueryBase & {
 
 type FacetKeysSearchToolQuery = SearchToolQueryBase & {
   facet_filters?: undefined;
-  [facetKey: `facet_${string}`]: string[] | undefined;
+  [facetKey: `facet_${string}`]: string[] | boolean | undefined;
 };
 
 /**

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -488,6 +488,26 @@ export type SearchToolInput =
 export type ApplyFiltersParams = {
   query?: string;
   facetFilters?: string[][];
+  /**
+   * Numeric refinements, in the Algolia `numericFilters` format
+   * (e.g. `['price <= 1500']`). Only the search tool's resolved search params
+   * can express these; the raw `facet_<attribute>` keys cannot.
+   */
+  numericFilters?: string[];
+};
+
+/**
+ * The search parameters a search tool call was actually answered with, as the
+ * Algolia MCP Server resolved them: after defaults, clamping and the
+ * allow-list, and including parameters the model never sent.
+ *
+ * Read with `getResolvedSearchParams`. Absent whenever the server emits no
+ * `_meta` for the tool result.
+ */
+export type ResolvedSearchParams = {
+  query?: string;
+  facetFilters?: string[][];
+  numericFilters?: string[];
 };
 
 export type ChatLayoutOwnProps<

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -1,5 +1,9 @@
 import { warnCache } from '../../../warn';
-import { findTool, getApplyFiltersParamsFromToolInput } from '../chat';
+import {
+  findTool,
+  getApplyFiltersParamsFromToolInput,
+  getResolvedSearchParams,
+} from '../chat';
 import { startsWith } from '../startsWith';
 
 describe('getApplyFiltersParamsFromToolInput', () => {
@@ -156,6 +160,52 @@ describe('getApplyFiltersParamsFromToolInput', () => {
     });
   });
 
+  test('prefers the resolved search params over the raw facet keys', () => {
+    expect(
+      getApplyFiltersParamsFromToolInput(
+        {
+          query: 'phone',
+          facet_brand: ['Apple'],
+          facet_price: ['<=1500'],
+        },
+        {
+          query: 'phone',
+          facetFilters: [['brand:Apple']],
+          numericFilters: ['price <= 1500'],
+        }
+      )
+    ).toEqual({
+      query: 'phone',
+      facetFilters: [['brand:Apple']],
+      numericFilters: ['price <= 1500'],
+    });
+  });
+
+  test('keeps the tool input query when the resolved params omit it', () => {
+    expect(
+      getApplyFiltersParamsFromToolInput(
+        { query: 'phone', facet_price: ['<=1500'] },
+        { numericFilters: ['price <= 1500'] }
+      )
+    ).toEqual({
+      query: 'phone',
+      facetFilters: undefined,
+      numericFilters: ['price <= 1500'],
+    });
+  });
+
+  test('falls back to skipping numeric facets when resolved params are absent', () => {
+    expect(
+      getApplyFiltersParamsFromToolInput({
+        query: 'phone',
+        facet_price: ['<=1500'],
+      })
+    ).toEqual({
+      query: 'phone',
+      facetFilters: undefined,
+    });
+  });
+
   // Payload copied from the Algolia MCP Server's own test:
   // mcp-server/src/tools/search/__tests__/algoliaSearchSingleIndexTool.test.ts:135-170
   test('maps the MCP payload, dropping what this shape cannot express', () => {
@@ -175,6 +225,105 @@ describe('getApplyFiltersParamsFromToolInput', () => {
         ['category:Electronics'],
         ['inStock:true'],
       ],
+    });
+  });
+});
+
+describe('getResolvedSearchParams', () => {
+  const metadataPart = (toolCallId: string, resolved: unknown) => ({
+    type: 'data-tool-output-metadata',
+    data: {
+      toolCallId,
+      metadata: { 'com.algolia/resolved-search-params': resolved },
+    },
+  });
+
+  test('reads the params matching the tool call', () => {
+    const messages = [
+      {
+        parts: [
+          { type: 'text', text: 'here you go' },
+          metadataPart('call-1', {
+            query: 'shoes',
+            facetFilters: [['brand:Nike']],
+            numericFilters: ['price <= 100'],
+          }),
+        ],
+      },
+    ];
+
+    expect(getResolvedSearchParams(messages, 'call-1')).toEqual({
+      query: 'shoes',
+      facetFilters: [['brand:Nike']],
+      numericFilters: ['price <= 100'],
+    });
+  });
+
+  test('ignores metadata belonging to another tool call', () => {
+    const messages = [
+      {
+        parts: [metadataPart('call-other', { numericFilters: ['price <= 1'] })],
+      },
+    ];
+
+    expect(getResolvedSearchParams(messages, 'call-1')).toBeUndefined();
+  });
+
+  test('prefers the newest metadata for a re-answered tool call', () => {
+    const messages = [
+      { parts: [metadataPart('call-1', { numericFilters: ['price <= 100'] })] },
+      { parts: [metadataPart('call-1', { numericFilters: ['price <= 50'] })] },
+    ];
+
+    expect(getResolvedSearchParams(messages, 'call-1')?.numericFilters).toEqual(
+      ['price <= 50']
+    );
+  });
+
+  test('returns nothing without messages or a tool call id', () => {
+    expect(getResolvedSearchParams(undefined, 'call-1')).toBeUndefined();
+    expect(getResolvedSearchParams([], 'call-1')).toBeUndefined();
+    expect(
+      getResolvedSearchParams(
+        [{ parts: [metadataPart('call-1', { query: 'x' })] }],
+        undefined
+      )
+    ).toBeUndefined();
+  });
+
+  test('drops values that are not the expected shape', () => {
+    const messages = [
+      {
+        parts: [
+          metadataPart('call-1', {
+            query: 42,
+            facetFilters: [['brand:Nike'], 'not-a-group'],
+            numericFilters: 'price <= 100',
+          }),
+        ],
+      },
+    ];
+
+    expect(getResolvedSearchParams(messages, 'call-1')).toEqual({
+      query: undefined,
+      facetFilters: [['brand:Nike']],
+      numericFilters: undefined,
+    });
+  });
+
+  test('treats an empty resolved list as absent', () => {
+    const messages = [
+      {
+        parts: [
+          metadataPart('call-1', { facetFilters: [], numericFilters: [] }),
+        ],
+      },
+    ];
+
+    expect(getResolvedSearchParams(messages, 'call-1')).toEqual({
+      query: undefined,
+      facetFilters: undefined,
+      numericFilters: undefined,
     });
   });
 });

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -118,6 +118,65 @@ describe('getApplyFiltersParamsFromToolInput', () => {
       }).facetFilters
     ).toBeUndefined();
   });
+
+  test('builds a facet filter from an MCP boolean facet', () => {
+    expect(
+      getApplyFiltersParamsFromToolInput({
+        query: 'phone',
+        facet_inStock: true,
+      })
+    ).toEqual({
+      query: 'phone',
+      facetFilters: [['inStock:true']],
+    });
+  });
+
+  test('skips a numeric facet instead of refining on the operator string', () => {
+    expect(
+      getApplyFiltersParamsFromToolInput({
+        query: 'phone',
+        facet_brand: ['Apple'],
+        facet_price: ['<=1500', '>=500'],
+      })
+    ).toEqual({
+      query: 'phone',
+      facetFilters: [['brand:Apple']],
+    });
+  });
+
+  test('keeps a string facet whose values are not numeric operators', () => {
+    expect(
+      getApplyFiltersParamsFromToolInput({
+        query: '',
+        facet_size: ['XL', 'L'],
+      })
+    ).toEqual({
+      query: '',
+      facetFilters: [['size:XL', 'size:L']],
+    });
+  });
+
+  // Payload copied from the Algolia MCP Server's own test:
+  // mcp-server/src/tools/search/__tests__/algoliaSearchSingleIndexTool.test.ts:135-170
+  test('maps the MCP payload, dropping what this shape cannot express', () => {
+    expect(
+      getApplyFiltersParamsFromToolInput({
+        query: 'phone',
+        facet_brand: ['Samsung', 'Apple'],
+        facet_price: ['<=1500', '>=500'],
+        facet_rating: ['>=3', '<=5'],
+        facet_category: ['Electronics'],
+        facet_inStock: true,
+      })
+    ).toEqual({
+      query: 'phone',
+      facetFilters: [
+        ['brand:Samsung', 'brand:Apple'],
+        ['category:Electronics'],
+        ['inStock:true'],
+      ],
+    });
+  });
 });
 
 describe('findTool', () => {

--- a/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/__tests__/chat-test.ts
@@ -297,7 +297,7 @@ describe('getResolvedSearchParams', () => {
         parts: [
           metadataPart('call-1', {
             query: 42,
-            facetFilters: [['brand:Nike'], 'not-a-group'],
+            facetFilters: [['brand:Nike'], 42],
             numericFilters: 'price <= 100',
           }),
         ],
@@ -309,6 +309,52 @@ describe('getResolvedSearchParams', () => {
       facetFilters: [['brand:Nike']],
       numericFilters: undefined,
     });
+  });
+
+  test('reads a plain string facet entry as its own group', () => {
+    const messages = [
+      {
+        parts: [
+          metadataPart('call-1', {
+            facetFilters: ['brand:Nike', ['category:Books', 'category:Toys']],
+          }),
+        ],
+      },
+    ];
+
+    expect(getResolvedSearchParams(messages, 'call-1')?.facetFilters).toEqual([
+      ['brand:Nike'],
+      ['category:Books', 'category:Toys'],
+    ]);
+  });
+
+  test('ignores the bulk array shape so the raw keys still apply', () => {
+    const messages = [
+      {
+        parts: [
+          metadataPart('call-1', [
+            { query: 'shoes', facetFilters: [['brand:Nike']] },
+            { query: 'boots', facetFilters: [['brand:Adidas']] },
+          ]),
+        ],
+      },
+    ];
+
+    expect(getResolvedSearchParams(messages, 'call-1')).toBeUndefined();
+  });
+
+  test('ignores the multi-index map shape', () => {
+    const messages = [
+      {
+        parts: [
+          metadataPart('call-1', {
+            products: [{ query: 'shoes', facetFilters: [['brand:Nike']] }],
+          }),
+        ],
+      },
+    ];
+
+    expect(getResolvedSearchParams(messages, 'call-1')).toBeUndefined();
   });
 
   test('treats an empty resolved list as absent', () => {

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -210,14 +210,40 @@ const TOOL_OUTPUT_METADATA_PART_TYPE = 'data-tool-output-metadata';
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === 'string');
 
+const RESOLVED_SEARCH_PARAMS_KEYS = [
+  'query',
+  'facetFilters',
+  'numericFilters',
+] as const;
+
+/**
+ * Recognizes a single resolved-params bag by shape.
+ *
+ * The server attaches the same `_meta` key in three shapes: one bag for a
+ * single-index search, one bag per variation (an array) for a bulk search, and
+ * a per-index map for a multi-index search. Only the single bag can be read
+ * here. An array or a map parses to nothing, and an empty bag would still beat
+ * the raw `facet_` keys and search with the query alone — so the other two
+ * shapes are left to the fallback path instead.
+ */
+const isResolvedSearchParamsBag = (
+  value: unknown
+): value is Record<string, unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  RESOLVED_SEARCH_PARAMS_KEYS.some((key) => key in value);
+
 /**
  * Reads the resolved search params a search tool call was answered with.
  *
  * The metadata arrives as a transient data part next to the tool call. It is
  * read from `messages` rather than through `onData` because the chat retains
  * every `data-*` part on the message, which covers the live and the replayed
- * conversation with one path. Returns `undefined` when the part is absent,
- * which is the case whenever the server does not emit `_meta`.
+ * conversation with one path. Returns `undefined` when the part is absent —
+ * the case whenever the server does not emit `_meta` — or when its value is
+ * not a single params bag, so that the caller falls back to the raw
+ * `facet_` keys instead of searching with no filters at all.
  */
 export const getResolvedSearchParams = (
   messages: readonly ChatMessageWithParts[] | undefined,
@@ -250,16 +276,20 @@ export const getResolvedSearchParams = (
         continue;
       }
 
-      const resolved = data.metadata?.[RESOLVED_SEARCH_PARAMS_META_KEY] as
-        | Record<string, unknown>
-        | undefined;
+      const resolved = data.metadata?.[RESOLVED_SEARCH_PARAMS_META_KEY];
 
-      if (!resolved) {
+      if (!isResolvedSearchParamsBag(resolved)) {
         continue;
       }
 
+      // Algolia reads a plain string entry as its own group, and the search
+      // tool's schema accepts that mixed form
+      // (`['category:Books', ['author:Alice', 'author:Bob']]`), so a flat
+      // entry is a normal producer output.
       const facetFilters = Array.isArray(resolved.facetFilters)
-        ? resolved.facetFilters.filter(isStringArray)
+        ? resolved.facetFilters
+            .map((entry) => (typeof entry === 'string' ? [entry] : entry))
+            .filter(isStringArray)
         : undefined;
       const numericFilters = isStringArray(resolved.numericFilters)
         ? resolved.numericFilters
@@ -338,8 +368,9 @@ const getFacetFilters = (
       // A numeric facet needs a numeric refinement, which this shape cannot
       // express. `price:<=1500` would refine on a value no record holds, so the
       // search would quietly return the wrong results. Dropping it loses the
-      // filter instead, which the user can see. Track 2 applies it properly
-      // from the tool's resolved search params.
+      // filter instead, which the user can see. Where the tool's resolved
+      // search params are available, `getResolvedSearchParams` applies the
+      // numeric refinement properly and this path is not reached.
       if (isNumericFacetValues(values)) {
         return acc;
       }

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -6,9 +6,20 @@ import type { ChatMessageBase } from '../../components';
 import type {
   ApplyFiltersParams,
   ChatToolMessage,
+  ResolvedSearchParams,
   SearchToolInput,
   SearchToolQuery,
 } from '../../components/chat/types';
+
+/**
+ * The shape `getResolvedSearchParams` needs from a chat message: just its
+ * parts, structurally. Kept local so the lookup works against any message
+ * list, including one whose data-part registry does not declare
+ * `tool-output-metadata`.
+ */
+type ChatMessageWithParts = {
+  parts?: ReadonlyArray<{ type: string; data?: unknown }>;
+};
 
 export const getTextContent = (message: ChatMessageBase) => {
   return message.parts
@@ -182,6 +193,93 @@ const NUMERIC_FACET_VALUE = /^(<=|>=|=|!=|<|>)\s*(-?\d+(\.\d+)?)$/;
 const isNumericFacetValues = (values: string[]): boolean =>
   values.length > 0 && values.every((value) => NUMERIC_FACET_VALUE.test(value));
 
+/**
+ * The key the Algolia MCP Server attaches its resolved search parameters under,
+ * on the tool result's `_meta`. Agent Studio forwards this one key to the
+ * browser by allowlist, as a `data-tool-output-metadata` part correlated by
+ * `toolCallId`.
+ *
+ * These params are the filters the server actually searched with, after
+ * defaults, clamping and the allow-list — including ones the model never saw.
+ * That makes them exact where the raw `facet_` keys are ambiguous.
+ */
+const RESOLVED_SEARCH_PARAMS_META_KEY = 'com.algolia/resolved-search-params';
+
+const TOOL_OUTPUT_METADATA_PART_TYPE = 'data-tool-output-metadata';
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+/**
+ * Reads the resolved search params a search tool call was answered with.
+ *
+ * The metadata arrives as a transient data part next to the tool call. It is
+ * read from `messages` rather than through `onData` because the chat retains
+ * every `data-*` part on the message, which covers the live and the replayed
+ * conversation with one path. Returns `undefined` when the part is absent,
+ * which is the case whenever the server does not emit `_meta`.
+ */
+export const getResolvedSearchParams = (
+  messages: readonly ChatMessageWithParts[] | undefined,
+  toolCallId: string | undefined
+): ResolvedSearchParams | undefined => {
+  if (!messages || !toolCallId) {
+    return undefined;
+  }
+
+  // Newest first: a re-answered tool call should win over its earlier result.
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const parts = messages[i]?.parts;
+
+    if (!Array.isArray(parts)) {
+      continue;
+    }
+
+    for (let j = parts.length - 1; j >= 0; j--) {
+      const part = parts[j];
+
+      if (!part || part.type !== TOOL_OUTPUT_METADATA_PART_TYPE) {
+        continue;
+      }
+
+      const data = part.data as
+        | { toolCallId?: string; metadata?: Record<string, unknown> }
+        | undefined;
+
+      if (data?.toolCallId !== toolCallId) {
+        continue;
+      }
+
+      const resolved = data.metadata?.[RESOLVED_SEARCH_PARAMS_META_KEY] as
+        | Record<string, unknown>
+        | undefined;
+
+      if (!resolved) {
+        continue;
+      }
+
+      const facetFilters = Array.isArray(resolved.facetFilters)
+        ? resolved.facetFilters.filter(isStringArray)
+        : undefined;
+      const numericFilters = isStringArray(resolved.numericFilters)
+        ? resolved.numericFilters
+        : undefined;
+
+      return {
+        query: typeof resolved.query === 'string' ? resolved.query : undefined,
+        facetFilters:
+          facetFilters && facetFilters.length > 0 ? facetFilters : undefined,
+        numericFilters:
+          numericFilters && numericFilters.length > 0
+            ? numericFilters
+            : undefined,
+      };
+    }
+  }
+
+  return undefined;
+};
+
 const hasQueries = (
   input: SearchToolInput
 ): input is { queries: SearchToolQuery[] } => Array.isArray(input.queries);
@@ -264,11 +362,28 @@ const getFacetFilters = (
  * Algolia MCP Server search tool instead expresses refinements as individual
  * `facet_<attribute>` keys (e.g. `facet_categories: ['Books', 'Toys']`), which
  * are converted here into `[['attribute:value']]`.
+ *
+ * Pass `resolved` (from `getResolvedSearchParams`) to use the filters the
+ * server actually searched with instead of re-deriving them from the raw keys.
+ * That is the only way to apply a numeric refinement.
  */
 export const getApplyFiltersParamsFromToolInput = (
-  input: SearchToolInput | undefined
+  input: SearchToolInput | undefined,
+  resolved?: ResolvedSearchParams
 ): ApplyFiltersParams => {
   const query = getSearchToolQuery(input);
+
+  // The resolved params are what the server actually searched with, so they win
+  // wherever they exist. Only they can express a numeric refinement: a numeric
+  // facet and a string facet whose value is literally `'<=1500'` are identical
+  // in the raw `facet_` keys.
+  if (resolved) {
+    return {
+      query: resolved.query ?? query?.query,
+      facetFilters: resolved.facetFilters,
+      numericFilters: resolved.numericFilters,
+    };
+  }
 
   return {
     query: query?.query,

--- a/packages/instantsearch-ui-components/src/lib/utils/chat.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/chat.ts
@@ -172,6 +172,16 @@ export const findTool = <TTool>(
 
 const FACET_KEY_PREFIX = 'facet_';
 
+/**
+ * A numeric facet value as the Algolia MCP Server emits it: an operator
+ * followed by a number (`'<=1500'`). Mirrors that server's own
+ * `NUMERIC_FILTER_REGEX` so the two sides cannot drift.
+ */
+const NUMERIC_FACET_VALUE = /^(<=|>=|=|!=|<|>)\s*(-?\d+(\.\d+)?)$/;
+
+const isNumericFacetValues = (values: string[]): boolean =>
+  values.length > 0 && values.every((value) => NUMERIC_FACET_VALUE.test(value));
+
 const hasQueries = (
   input: SearchToolInput
 ): input is { queries: SearchToolQuery[] } => Array.isArray(input.queries);
@@ -199,18 +209,44 @@ const getFacetFilters = (
 
   const facetFilters = Object.entries(query).reduce<string[][]>(
     (acc, [key, value]) => {
-      if (!startsWith(key, FACET_KEY_PREFIX) || !Array.isArray(value)) {
+      if (!startsWith(key, FACET_KEY_PREFIX)) {
         return acc;
       }
 
       const attribute = key.slice(FACET_KEY_PREFIX.length);
+
+      if (!attribute) {
+        return acc;
+      }
+
+      // A boolean facet arrives as a primitive, not an array.
+      if (typeof value === 'boolean') {
+        acc.push([`${attribute}:${value}`]);
+        return acc;
+      }
+
+      if (!Array.isArray(value)) {
+        return acc;
+      }
+
       const values = value.filter(
         (item): item is string => typeof item === 'string'
       );
 
-      if (attribute && values.length > 0) {
-        acc.push(values.map((item) => `${attribute}:${item}`));
+      if (values.length === 0) {
+        return acc;
       }
+
+      // A numeric facet needs a numeric refinement, which this shape cannot
+      // express. `price:<=1500` would refine on a value no record holds, so the
+      // search would quietly return the wrong results. Dropping it loses the
+      // filter instead, which the user can see. Track 2 applies it properly
+      // from the tool's resolved search params.
+      if (isNumericFacetValues(values)) {
+        return acc;
+      }
+
+      acc.push(values.map((item) => `${attribute}:${item}`));
 
       return acc;
     },

--- a/packages/instantsearch-ui-components/src/lib/utils/index.ts
+++ b/packages/instantsearch-ui-components/src/lib/utils/index.ts
@@ -1,4 +1,8 @@
-export { findTool, getApplyFiltersParamsFromToolInput } from './chat';
+export {
+  findTool,
+  getApplyFiltersParamsFromToolInput,
+  getResolvedSearchParams,
+} from './chat';
 export {
   collectChatRecords,
   createChatRecordsStore,

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -51,7 +51,11 @@ import type {
   WidgetRenderState,
   IndexRenderState,
 } from '../../types';
-import type { AlgoliaSearchHelper, SearchResults } from 'algoliasearch-helper';
+import type {
+  AlgoliaSearchHelper,
+  SearchParameters,
+  SearchResults,
+} from 'algoliasearch-helper';
 import type {
   AddToolResultWithOutput,
   UserClientSideTool,
@@ -224,6 +228,15 @@ export type ChatCustomInstance<TUiMessage extends UIMessage> = {
 export type ApplyFiltersParams = {
   query?: string;
   facetFilters?: string[][];
+  /**
+   * Numeric refinements, in the Algolia `numericFilters` format
+   * (e.g. `['price <= 1500']`). Only the search tool's resolved search params
+   * can express these; the raw `facet_<attribute>` keys cannot.
+   *
+   * Kept in sync with `ApplyFiltersParams` in `instantsearch-ui-components`,
+   * which declares the same contract for the component layer.
+   */
+  numericFilters?: string[];
 };
 
 export type ChatInit<TUiMessage extends UIMessage> =
@@ -388,6 +401,13 @@ function getAttributesToClear({
   );
 }
 
+/**
+ * One Algolia `numericFilters` entry: `'price <= 1500'`. The operators are
+ * exactly the set `helper.addNumericRefinement` accepts, and exactly the set
+ * the Algolia MCP Server emits.
+ */
+const NUMERIC_FILTER = /^(.+?)\s*(<=|>=|!=|=|<|>)\s*(-?\d+(?:\.\d+)?)$/;
+
 function updateStateFromSearchToolInput(
   params: ApplyFiltersParams,
   helper: AlgoliaSearchHelper
@@ -453,6 +473,24 @@ function updateStateFromSearchToolInput(
 
     hierarchicalRefinements.forEach((value, name) => {
       helper.toggleFacetRefinement(name, value);
+    });
+  }
+
+  if (params.numericFilters) {
+    params.numericFilters.forEach((filter) => {
+      const match = filter.match(NUMERIC_FILTER);
+
+      if (!match) {
+        return;
+      }
+
+      const [, attribute, operator, value] = match;
+
+      helper.addNumericRefinement(
+        attribute,
+        operator as SearchParameters.Operator,
+        Number(value)
+      );
     });
   }
 

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -2138,6 +2138,108 @@ export function createOptionsTests(
         );
       });
 
+      test('falls back to the raw facet keys on view all when the resolved search params are not a single bag', async () => {
+        const searchClient = createSearchClient();
+
+        const chat = new Chat({
+          messages: [
+            {
+              id: '1',
+              role: 'assistant',
+              parts: [
+                {
+                  type: `tool-${SearchIndexToolType}`,
+                  toolCallId: '1',
+                  input: {
+                    query: 'test',
+                    facet_brand: ['Apple'],
+                    facet_price: ['<=1500'],
+                  },
+                  state: 'output-available',
+                  output: {
+                    hits: [
+                      {
+                        objectID: '123',
+                      },
+                    ],
+                  },
+                },
+                {
+                  type: 'data-tool-output-metadata',
+                  data: {
+                    toolCallId: '1',
+                    metadata: {
+                      // A bulk search resolves one bag per variation, so this
+                      // value is an array. Nothing can be read out of it, and
+                      // an empty bag would drop every refinement.
+                      'com.algolia/resolved-search-params': [
+                        {
+                          query: 'test',
+                          facetFilters: [['brand:Apple']],
+                          numericFilters: ['price <= 1500'],
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          id: 'chat-id',
+        });
+
+        await setup({
+          instantSearchOptions: {
+            indexName: 'indexName',
+            searchClient,
+          },
+          widgetParams: {
+            javascript: {
+              ...createDefaultWidgetParams(chat),
+              renderRefinements: true,
+            },
+            react: {
+              ...createDefaultWidgetParams(chat),
+              renderRefinements: true,
+            },
+            vue: {},
+          },
+        });
+
+        await openChat(act);
+
+        userEvent.click(
+          document.querySelector(
+            '.ais-ChatToolSearchIndexCarouselHeaderViewAll'
+          )!
+        );
+
+        await act(async () => {
+          await wait(0);
+        });
+
+        expect(searchClient.search).toHaveBeenCalledTimes(2);
+        expect(searchClient.search).toHaveBeenLastCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              params: expect.objectContaining({
+                query: 'test',
+                facetFilters: [['brand:Apple']],
+              }),
+            }),
+          ])
+        );
+        expect(searchClient.search).toHaveBeenLastCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              params: expect.not.objectContaining({
+                numericFilters: expect.anything(),
+              }),
+            }),
+          ])
+        );
+      });
+
       test('applies filters for custom tools', async () => {
         const searchClient = createSearchClient();
 

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -2046,6 +2046,98 @@ export function createOptionsTests(
         );
       });
 
+      test('applies numeric filters from the MCP search tool resolved search params on view all', async () => {
+        const searchClient = createSearchClient();
+
+        const chat = new Chat({
+          messages: [
+            {
+              id: '1',
+              role: 'assistant',
+              parts: [
+                {
+                  type: `tool-${SearchIndexToolType}`,
+                  toolCallId: '1',
+                  input: {
+                    query: 'test',
+                    facet_brand: ['Apple'],
+                    // Cannot be expressed as a facet refinement; only the
+                    // resolved params below can apply it.
+                    facet_price: ['<=1500'],
+                  },
+                  state: 'output-available',
+                  output: {
+                    hits: [
+                      {
+                        objectID: '123',
+                      },
+                    ],
+                  },
+                },
+                // Agent Studio forwards the MCP result `_meta` as this part.
+                {
+                  type: 'data-tool-output-metadata',
+                  data: {
+                    toolCallId: '1',
+                    metadata: {
+                      'com.algolia/resolved-search-params': {
+                        query: 'test',
+                        facetFilters: [['brand:Apple']],
+                        numericFilters: ['price <= 1500'],
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          id: 'chat-id',
+        });
+
+        await setup({
+          instantSearchOptions: {
+            indexName: 'indexName',
+            searchClient,
+          },
+          widgetParams: {
+            javascript: {
+              ...createDefaultWidgetParams(chat),
+              renderRefinements: true,
+            },
+            react: {
+              ...createDefaultWidgetParams(chat),
+              renderRefinements: true,
+            },
+            vue: {},
+          },
+        });
+
+        await openChat(act);
+
+        userEvent.click(
+          document.querySelector(
+            '.ais-ChatToolSearchIndexCarouselHeaderViewAll'
+          )!
+        );
+
+        await act(async () => {
+          await wait(0);
+        });
+
+        expect(searchClient.search).toHaveBeenCalledTimes(2);
+        expect(searchClient.search).toHaveBeenLastCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({
+              params: expect.objectContaining({
+                query: 'test',
+                facetFilters: [['brand:Apple']],
+                numericFilters: ['price<=1500'],
+              }),
+            }),
+          ])
+        );
+      });
+
       test('applies filters for custom tools', async () => {
         const searchClient = createSearchClient();
 


### PR DESCRIPTION
## Summary

The Algolia MCP search tool sends filters in three shapes and "View all" handled one.

- A boolean facet was dropped. `facet_inStock: true` now refines on `inStock:true`, which is byte-identical to the server's own translation.
- A numeric facet was turned into a text refinement. `facet_price: ['<=1500']` became `price:<=1500`, which no record matches, so "View all" returned the wrong results rather than none.

Numeric facets are now applied properly, from the filters the server actually searched with. The MCP result carries `com.algolia/resolved-search-params` and Agent Studio forwards that key to the browser; Agent Studio's own playground already reads it and we didn't. Guessing cannot replace it: `facet_price: ['<=1500']` and a text facet whose value is literally `'<=1500'` are identical on the wire.

`ApplyFiltersParams` gains `numericFilters` and the connector applies each entry with `addNumericRefinement`. Without a single resolved-params bag the raw `facet_` keys still apply the string facets and the numeric value is skipped rather than turned into a refinement that matches nothing. That path covers a missing key and the bulk-search and multi-index shapes, which are not read here. A plain string entry in the server's `facetFilters` becomes its own single-value group, which is how Algolia reads it. The `facet_filters` path, the clear path and multi-query inputs are unchanged.

Two notes for review:
- The metadata is read from the message's `data-*` parts rather than through `onData`. That covers the live and the replayed conversation with one path and needs no new connector surface but it relies on the chat retaining transient data parts. `onData` exists in ai-lite and is not exposed by `connectChat`; exposing it would be a separate public-API change. Agent Studio uses `onData` for its live path and the persisted part for history ([AlgoliaWeb #29415](https://github.com/algolia/AlgoliaWeb/pull/29415)).
- The shape is implemented against the MCP server's own tests and Agent Studio's consumer, not against a payload captured from a live request. The LaunchDarkly flag `resolved-search-params-meta` gates it server-side, so behaviour with the flag off is the skip path above.

Related: [FX-3934](https://algolia.atlassian.net/browse/FX-3934)

[FX-3934]: https://algolia.atlassian.net/browse/FX-3934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
