### PR TITLE
chore(claude): correct the e2e guide and load it only for e2e files

### DIFF
--- a/.claude/rules/e2e.md
+++ b/.claude/rules/e2e.md
@@ -1,3 +1,16 @@
+---
+paths:
+  - 'tests/e2e/**'
+  - '.github/workflows/e2e.yml'
+  - '.github/workflows/ci.yml'
+  - 'website/serve.json'
+  - 'examples/*/e-commerce*/**'
+  - 'packages/react-instantsearch-nextjs/playwright.config.ts'
+  - 'packages/react-instantsearch-nextjs/__tests__/e2e/**'
+  - 'packages/react-instantsearch-router-nextjs/playwright.config.ts'
+  - 'packages/react-instantsearch-router-nextjs/__tests__/e2e/**'
+---
+
 # E2E Testing Guide
 
 ## Test Locations and Frameworks
@@ -8,6 +21,8 @@
 | `tests/e2e/` (wdio files) | WebdriverIO | IE11 tests only (via Sauce Labs) |
 | `packages/react-instantsearch-nextjs/__tests__/e2e/` | Playwright | App Router Next.js e2e tests |
 | `packages/react-instantsearch-router-nextjs/__tests__/e2e/` | Playwright | Pages Router Next.js e2e tests |
+
+`.github/workflows/e2e.yml` runs on a weekday schedule and is called from `ci.yml` on pushes to master, never on pull requests. Run the suites locally before you push.
 
 ## Running Tests Locally
 
@@ -84,64 +99,20 @@ test.describe('feature name', () => {
 
 ### Available Helper Methods
 
-The `helpers` fixture provides these methods:
+The `helpers` fixture provides these methods. Full signatures in `tests/e2e/playwright/fixtures.ts`.
 
-**RefinementList:**
-
-- `clickRefinementListItem(label)` - Click a refinement list item
-- `getSelectedRefinementListItem()` - Get the selected item's text
-
-**SearchBox:**
-
-- `setSearchBoxValue(value)` - Set the search input value
-- `getSearchBoxValue()` - Get the current search value
-
-**Hits:**
-
-- `getHitsTitles()` - Get all hit titles as an array
-
-**HierarchicalMenu:**
-
-- `clickHierarchicalMenuItem(label)` - Click a menu item
-- `getSelectedHierarchicalMenuItems()` - Get selected items
-
-**RangeSlider:**
-
-- `dragRangeSliderLowerBoundTo(value)` - Drag lower handle
-- `dragRangeSliderUpperBoundTo(value)` - Drag upper handle
-- `getRangeSliderLowerBoundValue()` - Get lower bound value
-- `getRangeSliderUpperBoundValue()` - Get upper bound value
-
-**Pagination:**
-
-- `clickPage(n)` - Navigate to page n
-- `clickNextPage()` - Go to next page
-- `clickPreviousPage()` - Go to previous page
-- `getCurrentPage()` - Get current page number
-
-**ToggleRefinement:**
-
-- `clickToggleRefinement()` - Toggle the refinement
-- `getToggleRefinementStatus()` - Get checked status
-
-**RatingMenu:**
-
-- `clickRatingMenuItem(label)` - Click rating (e.g., "4 & up")
-- `getSelectedRatingMenuItem()` - Get selected rating label
-
-**SortBy:**
-
-- `setSortByValue(label)` - Select sort option by label
-- `getSortByValue()` - Get current sort value
-
-**HitsPerPage:**
-
-- `setHitsPerPage(label)` - Select hits per page
-- `getHitsPerPage()` - Get current value
-
-**ClearRefinements:**
-
-- `clickClearRefinements()` - Click clear button
+- **RefinementList:** `clickRefinementListItem(label)`, `getSelectedRefinementListItem()`
+- **SearchBox:** `setSearchBoxValue(value)`, `getSearchBoxValue()`
+- **Hits:** `getHitsTitles()`
+- **HierarchicalMenu:** `clickHierarchicalMenuItem(label)`, `getSelectedHierarchicalMenuItems()`
+- **RangeSlider:** `dragRangeSliderLowerBoundTo(value)`, `dragRangeSliderUpperBoundTo(value)`, `getRangeSliderLowerBoundValue()`, `getRangeSliderUpperBoundValue()`
+- **Pagination:** `clickPage(number)`, `clickNextPage()`, `clickPreviousPage()`, `getCurrentPage()`
+- **ToggleRefinement:** `clickToggleRefinement()`, `getToggleRefinementStatus()`
+- **RatingMenu:** `clickRatingMenuItem(label)`, `getSelectedRatingMenuItem()`. `label` is the link's `aria-label`, such as `4 & up`.
+- **SortBy:** `setSortByValue(label)`, `getSortByValue()`
+- **HitsPerPage:** `setHitsPerPage(label)`, `getHitsPerPage()`
+- **ClearRefinements:** `clickClearRefinements()`
+- **Any selector:** `waitForElement(selector)`, `getTextFromSelector(selector)`
 
 ### Best Practices
 
@@ -240,7 +211,7 @@ The e-commerce examples use History API routing (e.g., `/search/Appliances/`). T
 
 The static server can handle 2 parallel workers. All configs use 2 workers for both CI and local runs.
 
-Tests have 1 retry locally and 2 retries in CI to handle occasional flakiness.
+The main suite retries once locally and twice in CI. The Next.js suites retry twice in CI and not at all locally.
 
 ### Multiple elements matched
 
@@ -309,14 +280,3 @@ test.describe('browser back/forward buttons', () => {
 ```
 
 This gives the browser enough time to process JavaScript events like popstate handlers used by InstantSearch routing, while keeping other tests fast.
-
-## CI Integration
-
-Tests run in CircleCI:
-
-- **e2e tests playwright** - Main suite with Chromium + Firefox
-- **e2e tests ie11** - IE11 via Sauce Labs
-- **e2e tests router nextjs** - Pages Router Next.js tests
-- **e2e tests app router nextjs** - App Router Next.js tests
-
-JUnit reports are stored for test results visualization. Playwright HTML reports are stored as artifacts.


### PR DESCRIPTION
## Summary

`.claude/rules/e2e.md` loads as project instructions in every session in this repo and parts of it had gone out of date.

- `CI Integration` said the e2e jobs run in CircleCI. #7184 moved them to GitHub Actions. The section is gone; one sentence under Test Locations now says where e2e runs and that it does not run on pull requests, which is the part worth knowing.
- `Available Helper Methods` listed 24 of the 26 helpers `tests/e2e/playwright/fixtures.ts` declares and called `clickPage`'s argument `n` rather than `number`. The list stays, now complete and grouped one line per widget, with the fixture named for full signatures.
- The flakiness section said all configs retry once locally. Both Next.js configs are `retries: CI ? 2 : 0`.

The file also had no frontmatter, so all 322 lines loaded whatever the task. It now has a `paths` block listing the files its sections are actually about: `tests/e2e/`, `website/serve.json`, `e2e.yml` and the `ci.yml` job that gates it, the two Next.js e2e directories and Playwright configs and the e-commerce example apps, since `fixtures.ts` hardcodes their header selectors and the section explaining that is worth having in context when you edit them.

## Result

322 lines to 282. No other section changed and every path, directory and yarn script the guide still references resolves.

The IE11 sections are left alone on purpose.  #7194 unwired that job because the tests do not pass, so whether the guide should still describe them is a separate call

