### PR TITLE
fix(index): keep widget uiState when its parameters change

### DIFF
--- a/packages/instantsearch.js/src/connectors/feeds/FeedContainer.ts
+++ b/packages/instantsearch.js/src/connectors/feeds/FeedContainer.ts
@@ -297,6 +297,13 @@ export function createFeedContainer(
       );
     },
 
+    updateWidget(previousWidget, nextWidget) {
+      // FeedContainer doesn't own UI state, so there's nothing to hand over
+      // from the previous widget to the next one.
+      container.removeWidgets([previousWidget]);
+      return container.addWidgets([nextWidget]);
+    },
+
     refreshUiState() {
       // no-op: FeedContainer doesn't own UI state
     },

--- a/packages/instantsearch.js/src/connectors/feeds/FeedContainer.ts
+++ b/packages/instantsearch.js/src/connectors/feeds/FeedContainer.ts
@@ -15,7 +15,27 @@ import type {
   DisposeOptions,
   RenderOptions,
 } from '../../types';
-import type { SearchParameters } from 'algoliasearch-helper';
+import type {
+  AlgoliaSearchHelper,
+  SearchParameters,
+} from 'algoliasearch-helper';
+
+function reduceChildrenUiState(
+  widgets: Array<Widget | IndexWidget>,
+  uiState: IndexUiState,
+  widgetUiStateOptions: {
+    searchParameters: SearchParameters;
+    helper: AlgoliaSearchHelper;
+  }
+): IndexUiState {
+  return widgets.reduce<IndexUiState>(
+    (state, widget) =>
+      widget.getWidgetUiState
+        ? widget.getWidgetUiState(state, widgetUiStateOptions)
+        : state,
+    uiState
+  );
+}
 
 export function createFeedContainer(
   feedID: string,
@@ -271,17 +291,10 @@ export function createFeedContainer(
       uiState: TUiState
     ): TUiState {
       const helper = parentIndex.getHelper()!;
-      const widgetUiStateOptions = {
+      return reduceChildrenUiState(localWidgets, uiState, {
         searchParameters: helper.state,
         helper,
-      };
-      return localWidgets.reduce<TUiState>(
-        (state, widget) =>
-          widget.getWidgetUiState
-            ? (widget.getWidgetUiState(state, widgetUiStateOptions) as TUiState)
-            : state,
-        uiState
-      );
+      }) as TUiState;
     },
 
     getWidgetSearchParameters(
@@ -298,10 +311,106 @@ export function createFeedContainer(
     },
 
     updateWidget(previousWidget, nextWidget) {
-      // FeedContainer doesn't own UI state, so there's nothing to hand over
-      // from the previous widget to the next one.
-      container.removeWidgets([previousWidget]);
-      return container.addWidgets([nextWidget]);
+      const helper = parentIndex.getHelper();
+
+      // The `uiState` the children own, read before the previous widget is
+      // detached, so that the state it owns can be handed over to the next one.
+      const previousUiState = helper
+        ? reduceChildrenUiState(
+            localWidgets,
+            {},
+            { searchParameters: helper.state, helper }
+          )
+        : {};
+
+      previousWidget.parent = undefined;
+      nextWidget.parent = container;
+
+      // The next widget takes the place of the previous one, so that the order
+      // in which children contribute to the search parameters is unchanged.
+      const nextWidgets = localWidgets.slice();
+      const position = nextWidgets.indexOf(previousWidget);
+      if (position === -1) {
+        nextWidgets.push(nextWidget);
+      } else {
+        nextWidgets[position] = nextWidget;
+      }
+      localWidgets = nextWidgets;
+
+      if (!helper || !initialized) {
+        return container;
+      }
+
+      // We still dispose the previous widget, for its side effects and so that
+      // it drops the search parameters it declared on the parent helper.
+      let cleanedState = helper.state;
+      if (previousWidget.dispose) {
+        const next = previousWidget.dispose({
+          helper,
+          state: cleanedState,
+          recommendState: helper.recommendState,
+          parent: container,
+        });
+
+        if (
+          next &&
+          !(next instanceof algoliasearchHelper.RecommendParameters)
+        ) {
+          cleanedState = next;
+        }
+      }
+
+      // We hand the previous `uiState` over to the children, then read the
+      // `uiState` back from them, so that state no mounted child claims anymore
+      // is dropped. This mirrors the index widget's `updateWidget`.
+      const narrowedUiState = reduceChildrenUiState(
+        localWidgets,
+        {},
+        {
+          searchParameters: container.getWidgetSearchParameters(cleanedState, {
+            uiState: previousUiState,
+          }),
+          helper,
+        }
+      );
+
+      // The search parameters are then computed again from that narrowed
+      // `uiState`, so that they can't hold state the `uiState` doesn't describe.
+      const newState = container.getWidgetSearchParameters(cleanedState, {
+        uiState: narrowedUiState,
+      });
+
+      if (nextWidget.getRenderState) {
+        const renderState = nextWidget.getRenderState(
+          instantSearchInstance.renderState[container.getIndexId()] || {},
+          createInitArgs(
+            instantSearchInstance,
+            container,
+            instantSearchInstance._initialUiState
+          )
+        );
+        storeRenderState({
+          renderState,
+          instantSearchInstance,
+          parent: container,
+        });
+      }
+
+      if (nextWidget.init) {
+        nextWidget.init(
+          createInitArgs(
+            instantSearchInstance,
+            container,
+            instantSearchInstance._initialUiState
+          )
+        );
+      }
+
+      if (newState !== helper.state) {
+        helper.setState(newState);
+      }
+
+      return container;
     },
 
     refreshUiState() {

--- a/packages/instantsearch.js/src/connectors/feeds/__tests__/FeedContainer-test.ts
+++ b/packages/instantsearch.js/src/connectors/feeds/__tests__/FeedContainer-test.ts
@@ -6,6 +6,7 @@ import { SearchParameters, SearchResults } from 'algoliasearch-helper';
 
 import { createInstantSearch } from '../../../../test/createInstantSearch';
 import { createWidget } from '../../../../test/createWidget';
+import { connectPagination, connectRefinementList } from '../../../connectors';
 import { index } from '../../../widgets';
 import { createFeedContainer } from '../FeedContainer';
 
@@ -362,6 +363,126 @@ describe('FeedContainer', () => {
       expect(container.getWidgets()).toEqual(
         expect.arrayContaining([widget1, widget2])
       );
+    });
+  });
+
+  describe('updateWidget', () => {
+    const virtualPagination = connectPagination(() => {});
+    const virtualRefinementList = connectRefinementList(() => {});
+
+    const createContainer = () => {
+      const instantSearchInstance = createInstantSearch();
+      const parent = index({ indexName: 'test' });
+      parent.getHelper = () => instantSearchInstance.helper!;
+
+      return {
+        instantSearchInstance,
+        container: createFeedContainer(
+          'products',
+          parent,
+          instantSearchInstance
+        ),
+      };
+    };
+
+    it('replaces the widget in place, keeping its position', () => {
+      const { container } = createContainer();
+      const first = createWidget();
+      const pagination = virtualPagination({});
+      const nextPagination = virtualPagination({ padding: 4 });
+      const last = createWidget();
+
+      container.addWidgets([first, pagination, last]);
+      container.updateWidget(pagination, nextPagination);
+
+      expect(container.getWidgets()).toEqual([first, nextPagination, last]);
+    });
+
+    it('moves the parent over to the next widget', () => {
+      const { container } = createContainer();
+      const pagination = virtualPagination({});
+      const nextPagination = virtualPagination({ padding: 4 });
+
+      container.addWidgets([pagination]);
+      container.updateWidget(pagination, nextPagination);
+
+      expect(pagination.parent).toBeUndefined();
+      expect(nextPagination.parent).toBe(container);
+    });
+
+    it('keeps the state the next widget still claims', () => {
+      const { container, instantSearchInstance } = createContainer();
+      const pagination = virtualPagination({});
+
+      container.addWidgets([pagination]);
+      container.init({} as any);
+
+      instantSearchInstance.helper!.setPage(3);
+
+      container.updateWidget(pagination, virtualPagination({ padding: 4 }));
+
+      expect(instantSearchInstance.helper!.state.page).toBe(3);
+    });
+
+    it('forgets the state the next widget no longer claims', () => {
+      const { container, instantSearchInstance } = createContainer();
+      const refinementList = virtualRefinementList({ attribute: 'brand' });
+
+      // The container merges its children's search parameters into the parent
+      // helper only once initialized, so `brand` is declared as a facet.
+      container.init({} as any);
+      container.addWidgets([refinementList]);
+
+      instantSearchInstance.helper!.addDisjunctiveFacetRefinement(
+        'brand',
+        'Apple'
+      );
+
+      container.updateWidget(
+        refinementList,
+        virtualRefinementList({ attribute: 'categories' })
+      );
+
+      expect(
+        instantSearchInstance.helper!.state.disjunctiveFacetsRefinements
+      ).toEqual({ categories: [] });
+    });
+
+    it('disposes the previous widget and inits the next one', () => {
+      const { container } = createContainer();
+      const previousWidget = createWidget();
+      const nextWidget = createWidget();
+
+      container.addWidgets([previousWidget]);
+      container.init({} as any);
+
+      container.updateWidget(previousWidget, nextWidget);
+
+      expect(previousWidget.dispose).toHaveBeenCalledTimes(1);
+      expect(nextWidget.init).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not init the next widget before the container is initialized', () => {
+      const { container } = createContainer();
+      const previousWidget = createWidget();
+      const nextWidget = createWidget();
+
+      container.addWidgets([previousWidget]);
+      container.updateWidget(previousWidget, nextWidget);
+
+      expect(nextWidget.init).not.toHaveBeenCalled();
+      expect(container.getWidgets()).toEqual([nextWidget]);
+    });
+
+    it('returns the container for chaining', () => {
+      const { container } = createContainer();
+      const pagination = virtualPagination({});
+
+      container.addWidgets([pagination]);
+
+      expect(
+        container.updateWidget(pagination, virtualPagination({ padding: 4 }))
+      ).toBe(container);
     });
   });
 

--- a/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
+++ b/packages/instantsearch.js/src/widgets/index/__tests__/index-test.ts
@@ -961,6 +961,194 @@ See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widge
     });
   });
 
+  describe('updateWidget', () => {
+    it('throws an error with a widget that does not implement `dispose`', () => {
+      const instance = index({ indexName: 'indexName' });
+      const widget = createWidget();
+      delete (widget as any).dispose;
+
+      expect(() => {
+        instance.updateWidget(widget, virtualSearchBox({}));
+      }).toThrowErrorMatchingInlineSnapshot(`
+        "The widget definition expects a \`dispose\` method.
+
+        See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
+      `);
+    });
+
+    it('throws an error with a widget that implements neither `init` nor `render`', () => {
+      const instance = index({ indexName: 'indexName' });
+      const searchBox = virtualSearchBox({});
+
+      instance.addWidgets([searchBox]);
+
+      expect(() => {
+        instance.updateWidget(searchBox, { dispose() {} } as any);
+      }).toThrowErrorMatchingInlineSnapshot(`
+        "The widget definition expects a \`render\` and/or an \`init\` method.
+
+        See documentation: https://www.algolia.com/doc/api-reference/widgets/index-widget/js/"
+      `);
+    });
+
+    it('replaces the widget in place, keeping its position', () => {
+      const instance = index({ indexName: 'indexName' });
+      const searchBox = virtualSearchBox({});
+      const pagination = virtualPagination({});
+      const nextPagination = virtualPagination({ padding: 4 });
+      const refinementList = virtualRefinementList({ attribute: 'brand' });
+
+      instance.addWidgets([searchBox, pagination, refinementList]);
+      instance.updateWidget(pagination, nextPagination);
+
+      expect(instance.getWidgets()).toEqual([
+        searchBox,
+        nextPagination,
+        refinementList,
+      ]);
+    });
+
+    it('appends the next widget when the previous one is not mounted', () => {
+      const instance = index({ indexName: 'indexName' });
+      const searchBox = virtualSearchBox({});
+      const pagination = virtualPagination({});
+
+      instance.addWidgets([searchBox]);
+      instance.updateWidget(pagination, virtualPagination({ padding: 4 }));
+
+      expect(instance.getWidgets()).toHaveLength(2);
+    });
+
+    it('moves the parent over to the next widget', () => {
+      const instance = index({ indexName: 'indexName' });
+      const pagination = virtualPagination({});
+      const nextPagination = virtualPagination({ padding: 4 });
+
+      instance.addWidgets([pagination]);
+      instance.updateWidget(pagination, nextPagination);
+
+      expect(pagination.parent).toBeUndefined();
+      expect(nextPagination.parent).toBe(instance);
+    });
+
+    it('returns the instance to be able to chain the calls', () => {
+      const instance = index({ indexName: 'indexName' });
+      const pagination = virtualPagination({});
+
+      expect(
+        instance
+          .addWidgets([pagination])
+          .updateWidget(pagination, virtualPagination({ padding: 4 }))
+      ).toBe(instance);
+    });
+
+    it('does not throw an error without the `init` step', () => {
+      const instance = index({ indexName: 'indexName' });
+      const pagination = virtualPagination({});
+
+      instance.addWidgets([pagination]);
+
+      expect(() => {
+        instance.updateWidget(pagination, virtualPagination({ padding: 4 }));
+      }).not.toThrow();
+    });
+
+    describe('with a started instance', () => {
+      it('keeps the `uiState` the next widget still claims', () => {
+        const instance = index({ indexName: 'indexName' });
+        const instantSearchInstance = createInstantSearch();
+        const pagination = virtualPagination({});
+
+        instance.addWidgets([virtualSearchBox({}), pagination]);
+        instance.init(
+          createIndexInitOptions({
+            instantSearchInstance,
+            parent: null,
+            uiState: { indexName: { page: 4 } },
+          })
+        );
+
+        expect(instance.getHelper()!.state.page).toEqual(3);
+
+        instance.updateWidget(pagination, virtualPagination({ padding: 4 }));
+
+        expect(instance.getHelper()!.state.page).toEqual(3);
+        expect(instance.getWidgetUiState({})).toEqual({
+          indexName: { page: 4 },
+        });
+      });
+
+      it('forgets the `uiState` the next widget no longer claims', () => {
+        const instance = index({ indexName: 'indexName' });
+        const instantSearchInstance = createInstantSearch();
+        const refinementList = virtualRefinementList({ attribute: 'brand' });
+
+        instance.addWidgets([virtualSearchBox({}), refinementList]);
+        instance.init(
+          createIndexInitOptions({
+            instantSearchInstance,
+            parent: null,
+            uiState: { indexName: { refinementList: { brand: ['Apple'] } } },
+          })
+        );
+
+        expect(
+          instance.getHelper()!.state.disjunctiveFacetsRefinements
+        ).toEqual({ brand: ['Apple'] });
+
+        instance.updateWidget(
+          refinementList,
+          virtualRefinementList({ attribute: 'categories' })
+        );
+
+        expect(
+          instance.getHelper()!.state.disjunctiveFacetsRefinements
+        ).toEqual({ categories: [] });
+        expect(instance.getWidgetUiState({})).toEqual({ indexName: {} });
+      });
+
+      it('disposes the previous widget and inits the next one', () => {
+        const instance = index({ indexName: 'indexName' });
+        const instantSearchInstance = createInstantSearch();
+        const previousWidget = createWidget();
+        const nextWidget = createWidget();
+
+        instance.addWidgets([previousWidget]);
+        instance.init(
+          createIndexInitOptions({ instantSearchInstance, parent: null })
+        );
+
+        instance.updateWidget(previousWidget, nextWidget);
+
+        expect(previousWidget.dispose).toHaveBeenCalledTimes(1);
+        expect(nextWidget.init).toHaveBeenCalledTimes(1);
+        // The previous widget was only initialized by the `init` step above.
+        expect(previousWidget.init).toHaveBeenCalledTimes(1);
+      });
+
+      it('notifies the instance of the `uiState` change only once', () => {
+        const instance = index({ indexName: 'indexName' });
+        const instantSearchInstance = createInstantSearch();
+        const pagination = virtualPagination({});
+
+        instance.addWidgets([virtualSearchBox({}), pagination]);
+        instance.init(
+          createIndexInitOptions({ instantSearchInstance, parent: null })
+        );
+
+        castToJestMock(instantSearchInstance.onInternalStateChange).mockClear();
+
+        // A `removeWidgets` + `addWidgets` pair writes to the helper twice, and
+        // therefore notifies twice.
+        instance.updateWidget(pagination, virtualPagination({ padding: 4 }));
+
+        expect(
+          instantSearchInstance.onInternalStateChange
+        ).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
   describe('createURL', () => {
     it('default url returns #', () => {
       const instance = index({ indexName: 'indexName' });

--- a/packages/instantsearch.js/src/widgets/index/index.ts
+++ b/packages/instantsearch.js/src/widgets/index/index.ts
@@ -162,6 +162,20 @@ export type IndexWidget<TUiState extends UiState = UiState> = Omit<
   removeWidgets: (
     widgets: Array<Widget | IndexWidget | Widget[]>
   ) => IndexWidget;
+  /**
+   * Replaces a widget by another one, in place.
+   *
+   * Unlike a `removeWidgets` + `addWidgets` pair, the previous widget's `uiState`
+   * is handed over to the next one, so that state owned by a widget whose
+   * parameters changed is preserved, as long as the replacing widget still claims
+   * the same `uiState` keys. State that no mounted widget claims anymore is
+   * dropped, like on a regular unmount. The widget also keeps its position among
+   * the index' widgets, which a remove/add pair doesn't.
+   */
+  updateWidget: (
+    previousWidget: Widget | IndexWidget,
+    nextWidget: Widget | IndexWidget
+  ) => IndexWidget;
 
   init: (options: IndexInitOptions) => void;
   render: (options: IndexRenderOptions) => void;
@@ -625,6 +639,141 @@ const index = (widgetParams: IndexWidgetParams): IndexWidget => {
         } else {
           localInstantSearchInstance.scheduleSearch();
         }
+      }
+
+      return this;
+    },
+
+    updateWidget(previousWidget, nextWidget) {
+      if (typeof previousWidget.dispose !== 'function') {
+        throw new Error(
+          withUsage('The widget definition expects a `dispose` method.')
+        );
+      }
+
+      if (
+        typeof nextWidget.init !== 'function' &&
+        typeof nextWidget.render !== 'function'
+      ) {
+        throw new Error(
+          withUsage(
+            'The widget definition expects a `render` and/or an `init` method.'
+          )
+        );
+      }
+
+      // The `uiState` as it is before the previous widget is detached, so that
+      // the state it owns can be handed over to the next widget.
+      const previousUiState = localUiState;
+
+      previousWidget.parent = undefined;
+      nextWidget.parent = this;
+      if (!isIndexWidget(nextWidget)) {
+        addWidgetId(nextWidget);
+      }
+
+      // The next widget takes the place of the previous one, so that the order
+      // in which widgets contribute to the search parameters is unchanged.
+      const nextWidgets = localWidgets.slice();
+      const position = nextWidgets.indexOf(previousWidget);
+      if (position === -1) {
+        nextWidgets.push(nextWidget);
+      } else {
+        nextWidgets[position] = nextWidget;
+      }
+      localWidgets = nextWidgets;
+
+      recomputeLocalRequestDependencies();
+
+      if (!localInstantSearchInstance) {
+        return this;
+      }
+
+      // We still dispose the previous widget, for its side effects. The search
+      // state it returns is only used as a base when shared state isn't preserved
+      // on unmount, like in `removeWidgets`.
+      const disposedState = previousWidget.dispose({
+        helper: helper!,
+        state: helper!.state,
+        recommendState: helper!.recommendState,
+        parent: this,
+      });
+      const cleanedRecommendState =
+        disposedState instanceof algoliasearchHelper.RecommendParameters
+          ? disposedState
+          : helper!.recommendState;
+      const cleanedSearchState =
+        disposedState &&
+        !(disposedState instanceof algoliasearchHelper.RecommendParameters)
+          ? disposedState
+          : helper!.state;
+
+      const initialSearchParameters = localInstantSearchInstance.future
+        .preserveSharedStateOnUnmount
+        ? new algoliasearchHelper.SearchParameters({
+            index: this.getIndexName(),
+          })
+        : cleanedSearchState;
+
+      // We hand the previous `uiState` over to the next widgets, then read the
+      // `uiState` back from them. Widgets only pick up the state they claim, so
+      // this drops state that no mounted widget owns anymore (an attribute that
+      // changed, for instance) instead of seeding it with `previousUiState`.
+      localUiState = getLocalWidgetsUiState(localWidgets, {
+        searchParameters: getLocalWidgetsSearchParameters(localWidgets, {
+          uiState: previousUiState,
+          initialSearchParameters,
+        }),
+        helper: helper!,
+      });
+
+      // The search parameters are then computed again from that narrowed
+      // `uiState`, so that they can't hold state the `uiState` doesn't describe.
+      const newState = getLocalWidgetsSearchParameters(localWidgets, {
+        uiState: localUiState,
+        initialSearchParameters,
+      });
+
+      privateHelperSetState(helper!, {
+        state: newState,
+        recommendState: getLocalWidgetsRecommendParameters(localWidgets, {
+          uiState: localUiState,
+          initialRecommendParameters: cleanedRecommendState,
+        }),
+        _uiState: localUiState,
+      });
+
+      if (nextWidget.getRenderState) {
+        const renderState = nextWidget.getRenderState(
+          localInstantSearchInstance.renderState[this.getIndexId()] || {},
+          createInitArgs(
+            localInstantSearchInstance,
+            this,
+            localInstantSearchInstance._initialUiState
+          )
+        );
+
+        storeRenderState({
+          renderState,
+          instantSearchInstance: localInstantSearchInstance,
+          parent: this,
+        });
+      }
+
+      if (nextWidget.init) {
+        nextWidget.init(
+          createInitArgs(
+            localInstantSearchInstance,
+            this,
+            localInstantSearchInstance._initialUiState
+          )
+        );
+      }
+
+      if (isolated) {
+        this.scheduleLocalSearch();
+      } else {
+        localInstantSearchInstance.scheduleSearch();
       }
 
       return this;

--- a/packages/react-instantsearch-core/src/hooks/__tests__/useConnector.test.tsx
+++ b/packages/react-instantsearch-core/src/hooks/__tests__/useConnector.test.tsx
@@ -12,7 +12,10 @@ import {
 } from '@instantsearch/testutils';
 import { render, waitFor, renderHook } from '@testing-library/react';
 import { SearchParameters, SearchResults } from 'algoliasearch-helper';
+import connectConfigure from 'instantsearch.js/es/connectors/configure/connectConfigure';
 import connectHits from 'instantsearch.js/es/connectors/hits/connectHits';
+import connectPagination from 'instantsearch.js/es/connectors/pagination/connectPagination';
+import connectRefinementList from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
 import React, { StrictMode, useState } from 'react';
 
 import { Index } from '../../components/Index';
@@ -24,6 +27,7 @@ import { noop } from '../../lib/noop';
 import { useConnector } from '../useConnector';
 
 import type { UseHitsProps } from '../../connectors/useHits';
+import type { PlainSearchParameters } from 'algoliasearch-helper';
 import type { Connector } from 'instantsearch.js';
 import type {
   HitsConnectorParams,
@@ -703,8 +707,9 @@ describe('useConnector', () => {
     rerender(<App attribute="categories" />);
 
     await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(2));
-    expect(indexContext.current!.removeWidgets).toHaveBeenCalledTimes(1);
-    expect(indexContext.current!.addWidgets).toHaveBeenCalledTimes(2);
+    expect(indexContext.current!.updateWidget).toHaveBeenCalledTimes(1);
+    expect(indexContext.current!.removeWidgets).toHaveBeenCalledTimes(0);
+    expect(indexContext.current!.addWidgets).toHaveBeenCalledTimes(1);
     expect(getByTestId('attribute')).toHaveTextContent('categories');
   });
 
@@ -739,11 +744,12 @@ describe('useConnector', () => {
     rerender(<App dependsOn="none" />);
 
     await waitFor(() =>
-      expect(indexContext.current!.removeWidgets).toHaveBeenCalledTimes(1)
+      expect(indexContext.current!.updateWidget).toHaveBeenCalledTimes(1)
     );
-    expect(indexContext.current!.addWidgets).toHaveBeenLastCalledWith([
-      expect.objectContaining({ dependsOn: 'none' }),
-    ]);
+    expect(indexContext.current!.updateWidget).toHaveBeenLastCalledWith(
+      expect.objectContaining({ dependsOn: 'search' }),
+      expect.objectContaining({ dependsOn: 'none' })
+    );
   });
 
   test('rerenders the widget on state change', async () => {
@@ -776,13 +782,14 @@ describe('useConnector', () => {
 
     await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(2));
     expect(getByTestId('attribute')).toHaveTextContent('categories');
-    expect(indexContext.current!.removeWidgets).toHaveBeenCalledTimes(1);
-    expect(indexContext.current!.addWidgets).toHaveBeenCalledTimes(2);
+    expect(indexContext.current!.updateWidget).toHaveBeenCalledTimes(1);
+    expect(indexContext.current!.removeWidgets).toHaveBeenCalledTimes(0);
+    expect(indexContext.current!.addWidgets).toHaveBeenCalledTimes(1);
   });
 
   // Ideally we would like to avoid this behavior, but we don't have any way
   // to memo function props, so they're always considered as new reference.
-  test('always removes/adds the widget on rerenders when using an unstable function prop', async () => {
+  test('always updates the widget on rerenders when using an unstable function prop', async () => {
     const searchClient = createSearchClient({});
     const { InstantSearchSpy, indexContext } = createInstantSearchSpy();
 
@@ -807,7 +814,140 @@ describe('useConnector', () => {
     // still be able to optimize this render count to `1`, but `2` is acceptable
     // for now compared to an infinite loop.
     await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(2));
-    expect(indexContext.current!.removeWidgets).toHaveBeenCalledTimes(1);
-    expect(indexContext.current!.addWidgets).toHaveBeenCalledTimes(2);
+    expect(indexContext.current!.updateWidget).toHaveBeenCalledTimes(1);
+    expect(indexContext.current!.removeWidgets).toHaveBeenCalledTimes(0);
+    expect(indexContext.current!.addWidgets).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([true, false])(
+    'keeps the widget uiState on a prop change (preserveSharedStateOnUnmount: %s)',
+    async (preserveSharedStateOnUnmount) => {
+      const searchClient = createSearchClient({});
+
+      function Pagination({ padding }: { padding: number }) {
+        const { currentRefinement } = useConnector(connectPagination, {
+          padding,
+        });
+
+        return <div data-testid="page">{currentRefinement}</div>;
+      }
+
+      function App({ padding }: { padding: number }) {
+        return (
+          <InstantSearch
+            searchClient={searchClient}
+            indexName="indexName"
+            initialUiState={{ indexName: { page: 4 } }}
+            future={{ preserveSharedStateOnUnmount }}
+          >
+            <Pagination padding={padding} />
+          </InstantSearch>
+        );
+      }
+
+      const { rerender, getByTestId } = render(<App padding={2} />);
+
+      await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
+      expect(getByTestId('page')).toHaveTextContent('3');
+
+      rerender(<App padding={3} />);
+
+      await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(2));
+      expect(getByTestId('page')).toHaveTextContent('3');
+    }
+  );
+
+  test('forgets the uiState the new widget params no longer claim', async () => {
+    const searchClient = createSearchClient({});
+    const { InstantSearchSpy, searchContext } = createInstantSearchSpy();
+
+    function RefinementList({ attribute }: { attribute: string }) {
+      useConnector(connectRefinementList, { attribute });
+
+      return null;
+    }
+
+    function App({ attribute }: { attribute: string }) {
+      return (
+        <InstantSearchSpy
+          searchClient={searchClient}
+          indexName="indexName"
+          initialUiState={{
+            indexName: { refinementList: { brand: ['Apple'] } },
+          }}
+          future={{ preserveSharedStateOnUnmount: true }}
+        >
+          <RefinementList attribute={attribute} />
+        </InstantSearchSpy>
+      );
+    }
+
+    const { rerender } = render(<App attribute="brand" />);
+
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
+    expect(searchContext.current!.getUiState()).toEqual({
+      indexName: { refinementList: { brand: ['Apple'] } },
+    });
+
+    rerender(<App attribute="categories" />);
+
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(2));
+    // The refinement on `brand` is dropped: no mounted widget claims it anymore.
+    expect(searchContext.current!.getUiState()).toEqual({ indexName: {} });
+  });
+
+  test('keeps the widget in place among its siblings on a prop change', async () => {
+    const searchClient = createSearchClient({});
+
+    function Configure({
+      searchParameters,
+    }: {
+      searchParameters: PlainSearchParameters;
+    }) {
+      useConnector(connectConfigure, { searchParameters });
+
+      return null;
+    }
+
+    function App({ analyticsTag }: { analyticsTag: string }) {
+      return (
+        <InstantSearch
+          searchClient={searchClient}
+          indexName="indexName"
+          future={{ preserveSharedStateOnUnmount: true }}
+        >
+          <Configure
+            searchParameters={{
+              hitsPerPage: 10,
+              analyticsTags: [analyticsTag],
+            }}
+          />
+          {/* This widget comes last, so it wins on `hitsPerPage`. */}
+          <Configure searchParameters={{ hitsPerPage: 20 }} />
+        </InstantSearch>
+      );
+    }
+
+    const { rerender } = render(<App analyticsTag="a" />);
+
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(1));
+    expect(searchClient.search).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        params: expect.objectContaining({ hitsPerPage: 20 }),
+      }),
+    ]);
+
+    // Updating the first widget must not move it after the second one.
+    rerender(<App analyticsTag="b" />);
+
+    await waitFor(() => expect(searchClient.search).toHaveBeenCalledTimes(2));
+    expect(searchClient.search).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        params: expect.objectContaining({
+          hitsPerPage: 20,
+          analyticsTags: ['b'],
+        }),
+      }),
+    ]);
   });
 });

--- a/packages/react-instantsearch-core/src/lib/useWidget.ts
+++ b/packages/react-instantsearch-core/src/lib/useWidget.ts
@@ -64,8 +64,8 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
 
       // Warning: if an unstable function prop is provided, `dequal` is not able
       // to keep its reference and therefore will consider that props did change.
-      // This unsollicitely replaces the widget, which is wasteful (it causes a
-      // search), even though `updateWidget` below keeps its state.
+      // This unintentionally replaces the widget, which is wasteful (it causes
+      // a search), even though `updateWidget` below keeps its state.
       // If users face this issue, we should advise them to provide stable function
       // references.
       const arePropsEqual = dequal(props, prevPropsRef.current);

--- a/packages/react-instantsearch-core/src/lib/useWidget.ts
+++ b/packages/react-instantsearch-core/src/lib/useWidget.ts
@@ -64,19 +64,19 @@ export function useWidget<TWidget extends Widget | IndexWidget, TProps>({
 
       // Warning: if an unstable function prop is provided, `dequal` is not able
       // to keep its reference and therefore will consider that props did change.
-      // This could unsollicitely remove/add the widget, therefore forget its state,
-      // and could be a source of confusion.
+      // This unsollicitely replaces the widget, which is wasteful (it causes a
+      // search), even though `updateWidget` below keeps its state.
       // If users face this issue, we should advise them to provide stable function
       // references.
       const arePropsEqual = dequal(props, prevPropsRef.current);
 
-      // If props did change, then we execute the cleanup function instantly
-      // and then add the widget back. This lets us add the widget without
+      // If props did change, then we replace the widget instantly instead of
       // waiting for the scheduled cleanup function to finish (that we canceled
-      // above).
+      // above). `updateWidget` hands the previous widget's `uiState` over to the
+      // new one, so that a parameter change doesn't reset the state the widget
+      // still owns — which would otherwise break routing.
       if (!arePropsEqual) {
-        parentIndex.removeWidgets([previousWidget]);
-        parentIndex.addWidgets([widget]);
+        parentIndex.updateWidget(previousWidget, widget);
       }
     }
 

--- a/packages/vue-instantsearch/src/mixins/__tests__/widget.test.js
+++ b/packages/vue-instantsearch/src/mixins/__tests__/widget.test.js
@@ -13,11 +13,13 @@ const createFakeComponent = (props = {}) => ({
 const createFakeIndexWidget = () => ({
   addWidgets: jest.fn(),
   removeWidgets: jest.fn(),
+  updateWidget: jest.fn(),
 });
 
 const createFakeInstance = () => ({
   addWidgets: jest.fn(),
   removeWidgets: jest.fn(),
+  updateWidget: jest.fn(),
   mainIndex: createFakeIndexWidget(),
   started: true,
 });
@@ -126,14 +128,16 @@ describe('on root index', () => {
 
     expect(wrapper.vm.state).toBe(null);
 
-    expect(instance.mainIndex.removeWidgets).toHaveBeenCalledTimes(1);
-    expect(instance.mainIndex.removeWidgets).toHaveBeenCalledWith([widget]);
-
     expect(factory).toHaveBeenCalledTimes(2);
     expect(factory).toHaveBeenCalledWith(nextWidgetParams);
 
-    expect(instance.mainIndex.addWidgets).toHaveBeenCalledTimes(2);
-    expect(instance.mainIndex.addWidgets).toHaveBeenCalledWith([widget]);
+    expect(instance.mainIndex.removeWidgets).toHaveBeenCalledTimes(0);
+    expect(instance.mainIndex.addWidgets).toHaveBeenCalledTimes(1);
+    expect(instance.mainIndex.updateWidget).toHaveBeenCalledTimes(1);
+    expect(instance.mainIndex.updateWidget).toHaveBeenCalledWith(
+      widget,
+      widget
+    );
   });
 
   it('updates local state on connector render', () => {
@@ -309,14 +313,13 @@ describe('on child index', () => {
 
     expect(wrapper.vm.state).toBe(null);
 
-    expect(indexWidget.removeWidgets).toHaveBeenCalledTimes(1);
-    expect(indexWidget.removeWidgets).toHaveBeenCalledWith([widget]);
-
     expect(factory).toHaveBeenCalledTimes(2);
     expect(factory).toHaveBeenCalledWith(nextWidgetParams);
 
-    expect(indexWidget.addWidgets).toHaveBeenCalledTimes(2);
-    expect(indexWidget.addWidgets).toHaveBeenCalledWith([widget]);
+    expect(indexWidget.removeWidgets).toHaveBeenCalledTimes(0);
+    expect(indexWidget.addWidgets).toHaveBeenCalledTimes(1);
+    expect(indexWidget.updateWidget).toHaveBeenCalledTimes(1);
+    expect(indexWidget.updateWidget).toHaveBeenCalledWith(widget, widget);
   });
 
   it('updates local state on connector render', () => {
@@ -447,18 +450,15 @@ describe('general', () => {
 
     expect(wrapper.vm.state).toBe(null);
 
-    expect(instance.mainIndex.removeWidgets).toHaveBeenCalledTimes(1);
-    expect(instance.mainIndex.removeWidgets).toHaveBeenCalledWith([widget]);
-
     expect(factory).toHaveBeenCalledTimes(2);
     expect(factory).toHaveBeenCalledWith(nextWidgetParams);
 
-    expect(instance.mainIndex.addWidgets).toHaveBeenCalledTimes(2);
-    expect(instance.mainIndex.addWidgets.mock.calls[1][0]).toEqual([
-      {
-        ...widget,
-        ...additionalProperties,
-      },
-    ]);
+    expect(instance.mainIndex.removeWidgets).toHaveBeenCalledTimes(0);
+    expect(instance.mainIndex.addWidgets).toHaveBeenCalledTimes(1);
+    expect(instance.mainIndex.updateWidget).toHaveBeenCalledTimes(1);
+    expect(instance.mainIndex.updateWidget.mock.calls[0][1]).toEqual({
+      ...widget,
+      ...additionalProperties,
+    });
   });
 });

--- a/packages/vue-instantsearch/src/mixins/widget.js
+++ b/packages/vue-instantsearch/src/mixins/widget.js
@@ -72,12 +72,12 @@ Read more on using connectors: https://alg.li/vue-custom`
     widgetParams: {
       handler(nextWidgetParams) {
         this.state = null;
-        this.getParentIndex().removeWidgets([this.widget]);
+        const previousWidget = this.widget;
         this.widget = _objectSpread(
           this.factory(nextWidgetParams),
           additionalProperties
         );
-        this.getParentIndex().addWidgets([this.widget]);
+        this.getParentIndex().updateWidget(previousWidget, this.widget);
       },
       deep: true,
     },

--- a/tests/utils/createInstantSearchSpy.tsx
+++ b/tests/utils/createInstantSearchSpy.tsx
@@ -41,6 +41,9 @@ export function createInstantSearchSpy() {
                       indexContextValue!.removeWidgets = jest.fn(
                         indexContextValue!.removeWidgets.bind(indexContextValue)
                       );
+                      indexContextValue!.updateWidget = jest.fn(
+                        indexContextValue!.updateWidget.bind(indexContextValue)
+                      );
                     }
 
                     // @ts-ignore `React.RefObject` is typed as immutable


### PR DESCRIPTION
**Summary**

Fixes #7201. Refs #6635.

Widgets get replaced when their parameters change — a changed `attribute` would otherwise leave a widget holding state it no longer owns. React (`useWidget`) and Vue (the `widgetParams` watcher) did that with a `removeWidgets` + `addWidgets` pair, and the state is lost *between* the two calls: `removeWidgets` ends by recomputing `localUiState` from the **remaining** widgets, so the replaced widget's slice is already gone when `addWidgets` rebuilds the search parameters from it. With routing, a parameter that only resolves after the first render wipes the state that came from the URL:

```ts
const { isDesktopView } = useBreakpoint();          // false, then true
usePagination({ padding: isDesktopView ? 3 : 2 });  // 2 -> 3, and `page` is lost
```

`index.updateWidget(previousWidget, nextWidget)` replaces a widget atomically instead. It hands the previous `uiState` over to the next widget, reads the `uiState` back from the mounted widgets, then recomputes the search parameters from that narrowed `uiState`. State the next widget still claims survives (`padding`, `limit`, `sortBy`, …); state nothing claims anymore is dropped, as on a regular unmount (`attribute`). No per-connector list of "impactless" parameters is needed — connectors already encode which state they own.

That second pass is what makes it safe: without it, `<Configure hitsPerPage={10}/>` → `<Configure filters="…"/>` leaked `hitsPerPage: 10`, because `connectConfigure.getWidgetSearchParameters` merges `uiState.configure` by design.

It also fixes an ordering bug. `filter().concat()` moved the replaced widget to the end of `localWidgets`, which is the reduce order for both derivations — so changing an unrelated prop on the first of two `<Configure>` widgets flipped which one won on `hitsPerPage`. `updateWidget` swaps in place.

To note:
- #6635 is the same root cause, but `dispose` is still called on the previous widget (connectors need it for `unmountFn` and teardown), so that report's literal expectation isn't met.

**Result**

A change in the parameter of a widget no longer causes its state to be lost.

Measured cost of one prop change with four widgets mounted — the replacement is cheaper than the pair it replaces:

| | `getLocalWidgetsUiState` | `getLocalWidgetsSearchParameters` | helper `change` events | searches |
|---|---|---|---|---|
| `removeWidgets` + `addWidgets` | 3 | 2 | 2 | 1 |
| `updateWidget` | 2 | 2 | **1** | 1 |

One fewer helper `change` event means one fewer `onInternalStateChange`, so one fewer scheduled router write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

