### PR TITLE
feat(prompt-suggestions): add agentic showcase examples

### DIFF
--- a/examples/js/showcase/src/components/WidgetSwitcher.tsx
+++ b/examples/js/showcase/src/components/WidgetSwitcher.tsx
@@ -12,12 +12,14 @@ export interface Widget {
 }
 
 interface Props {
+  title?: string;
   widgets: Widget[];
   destroy?: boolean;
   class?: string;
 }
 
 export function WidgetSwitcher({
+  title,
   widgets,
   destroy = false,
   class: className,
@@ -34,6 +36,14 @@ export function WidgetSwitcher({
     >
       <header class="-mx-1 -mt-1 mb-3 flex items-start gap-1 text-xs">
         <span class="flex flex-wrap items-center">
+          {title && (
+            <>
+              <span class="mx-1 cursor-default font-mono leading-relaxed text-neutral-400 dark:text-neutral-500">
+                {title}
+              </span>
+              <span class="text-neutral-300 dark:text-neutral-600">·</span>
+            </>
+          )}
           {widgets.map((widget, index) => (
             <Fragment key={index}>
               {index > 0 && (

--- a/examples/js/showcase/src/components/widgets/WidgetChat.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetChat.tsx
@@ -6,6 +6,7 @@ import {
 import { chat } from 'instantsearch.js/es/widgets';
 import { useEffect, useRef } from 'preact/hooks';
 
+import { SHOWCASE_AGENT_ID } from '../../constants';
 import { useSearch } from '../../context/search';
 
 import { renderCarouselHit } from './ProductCard';
@@ -13,8 +14,6 @@ import { renderCarouselHit } from './ProductCard';
 import type { ChatRenderState } from 'instantsearch.js/es/connectors/chat/connectChat';
 
 export type ChatLayout = 'inline' | 'overlay' | 'sidePanel';
-
-const CHAT_AGENT_ID = 'eedef238-5468-470d-bc37-f99fa741bd25';
 
 type Props = {
   layout: ChatLayout;
@@ -35,7 +34,7 @@ export function WidgetChat({ layout, indexName }: Props) {
     };
     const widget = chat({
       container: containerRef.current!,
-      agentId: CHAT_AGENT_ID,
+      agentId: SHOWCASE_AGENT_ID,
       feedback: true,
       templates: {
         layout: (data) => layouts[layoutRef.current](data),
@@ -46,7 +45,7 @@ export function WidgetChat({ layout, indexName }: Props) {
     return () => {
       search.removeWidgets([widget]);
     };
-  }, []);
+  }, [search]);
 
   useEffect(() => {
     // Trigger a chat re-render so the reactive `layout` template picks up

--- a/examples/js/showcase/src/components/widgets/WidgetPromptSuggestions.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetPromptSuggestions.tsx
@@ -1,5 +1,6 @@
 import { promptSuggestions } from 'instantsearch.js/es/widgets';
 
+import { SHOWCASE_AGENT_ID } from '../../constants';
 import { useWidget } from '../../hooks/useWidget';
 
 type Props = Pick<
@@ -8,8 +9,6 @@ type Props = Pick<
 > & {
   contextDescription: string;
 };
-
-const AGENT_ID = 'eedef238-5468-470d-bc37-f99fa741bd25';
 
 function WidgetPromptSuggestions({
   configurationId,
@@ -20,7 +19,7 @@ function WidgetPromptSuggestions({
   const ref = useWidget((el) =>
     promptSuggestions({
       container: el,
-      agentId: AGENT_ID,
+      agentId: SHOWCASE_AGENT_ID,
       configurationId,
       context,
       transformHits,

--- a/examples/js/showcase/src/components/widgets/WidgetPromptSuggestions.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetPromptSuggestions.tsx
@@ -1,0 +1,92 @@
+import { promptSuggestions } from 'instantsearch.js/es/widgets';
+
+import { useWidget } from '../../hooks/useWidget';
+
+type Props = Pick<
+  Parameters<typeof promptSuggestions>[0],
+  'configurationId' | 'context' | 'transformHits'
+> & {
+  contextDescription: string;
+};
+
+const AGENT_ID = 'eedef238-5468-470d-bc37-f99fa741bd25';
+
+function WidgetPromptSuggestions({
+  configurationId,
+  context,
+  contextDescription,
+  transformHits,
+}: Props) {
+  const ref = useWidget((el) =>
+    promptSuggestions({
+      container: el,
+      agentId: AGENT_ID,
+      configurationId,
+      context,
+      transformHits,
+    })
+  );
+
+  return (
+    <div class="flex flex-col gap-3">
+      <p class="text-xs text-neutral-500 dark:text-neutral-400">
+        Context: {contextDescription}
+      </p>
+      <div ref={ref} />
+    </div>
+  );
+}
+
+export function WidgetPromptSuggestionsPlp() {
+  return (
+    <WidgetPromptSuggestions
+      configurationId="algolia_prompt_suggestions_c567a834-c9f6-48af-8d7d-38e4741ff9c6"
+      contextDescription="current query, filters, and first five search results"
+      transformHits={(hits) =>
+        hits.slice(0, 5).map((hit) => ({
+          objectID: hit.objectID,
+          name: hit.name,
+          brand: hit.brand,
+          categories: hit.categories,
+          price: hit.price,
+          rating: hit.rating,
+        }))
+      }
+    />
+  );
+}
+
+export function WidgetPromptSuggestionsPdp() {
+  return (
+    <WidgetPromptSuggestions
+      configurationId="algolia_prompt_suggestions_df9c9163-926d-4d41-959f-1f31aa37fa8c"
+      contextDescription="Amazon Fire TV Stick product details"
+      context={{
+        focalProduct: {
+          objectID: 'amazon-fire-tv-stick',
+          name: 'Amazon Fire TV Stick',
+          brand: 'Amazon',
+          category: 'Streaming media players',
+          description:
+            'A compact streaming device with voice control and access to major streaming services.',
+          price: 39.99,
+        },
+      }}
+    />
+  );
+}
+
+export function WidgetPromptSuggestionsCustom() {
+  return (
+    <WidgetPromptSuggestions
+      configurationId="algolia_prompt_suggestions_8e802b98-8610-490f-96d8-17ce3d2be306"
+      contextDescription="Home entertainment buying guide for budget-conscious shoppers"
+      context={{
+        pageTitle: 'Home entertainment buying guide',
+        pageContent:
+          'Compare streaming and smart-home devices by compatibility, features, and price.',
+        audience: 'Budget-conscious shoppers',
+      }}
+    />
+  );
+}

--- a/examples/js/showcase/src/components/widgets/WidgetPromptSuggestions.tsx
+++ b/examples/js/showcase/src/components/widgets/WidgetPromptSuggestions.tsx
@@ -39,7 +39,7 @@ function WidgetPromptSuggestions({
 export function WidgetPromptSuggestionsPlp() {
   return (
     <WidgetPromptSuggestions
-      configurationId="algolia_prompt_suggestions_c567a834-c9f6-48af-8d7d-38e4741ff9c6"
+      configurationId="algolia_prompt_suggestions_553c8924-df38-403e-a302-f977a8963700"
       contextDescription="current query, filters, and first five search results"
       transformHits={(hits) =>
         hits.slice(0, 5).map((hit) => ({
@@ -58,7 +58,7 @@ export function WidgetPromptSuggestionsPlp() {
 export function WidgetPromptSuggestionsPdp() {
   return (
     <WidgetPromptSuggestions
-      configurationId="algolia_prompt_suggestions_df9c9163-926d-4d41-959f-1f31aa37fa8c"
+      configurationId="algolia_prompt_suggestions_15a040ea-25ed-41ac-9615-3184383c57d4"
       contextDescription="Amazon Fire TV Stick product details"
       context={{
         focalProduct: {
@@ -78,7 +78,7 @@ export function WidgetPromptSuggestionsPdp() {
 export function WidgetPromptSuggestionsCustom() {
   return (
     <WidgetPromptSuggestions
-      configurationId="algolia_prompt_suggestions_8e802b98-8610-490f-96d8-17ce3d2be306"
+      configurationId="algolia_prompt_suggestions_b31fd5dd-0d44-4567-b2a0-f6891c5b71a1"
       contextDescription="Home entertainment buying guide for budget-conscious shoppers"
       context={{
         pageTitle: 'Home entertainment buying guide',

--- a/examples/js/showcase/src/constants.ts
+++ b/examples/js/showcase/src/constants.ts
@@ -1,0 +1,1 @@
+export const SHOWCASE_AGENT_ID = 'eedef238-5468-470d-bc37-f99fa741bd25';

--- a/examples/js/showcase/src/views/AgenticView.tsx
+++ b/examples/js/showcase/src/views/AgenticView.tsx
@@ -7,6 +7,11 @@ import { WidgetAiAutocomplete } from '../components/widgets/WidgetAiAutocomplete
 import { WidgetChat, type ChatLayout } from '../components/widgets/WidgetChat';
 import { WidgetChatTrigger } from '../components/widgets/WidgetChatTrigger';
 import { WidgetHits } from '../components/widgets/WidgetHits';
+import {
+  WidgetPromptSuggestionsCustom,
+  WidgetPromptSuggestionsPdp,
+  WidgetPromptSuggestionsPlp,
+} from '../components/widgets/WidgetPromptSuggestions';
 import { WidgetSwitcher } from '../components/WidgetSwitcher';
 import { ChatLayoutContext } from '../context/chatLayout';
 import { SearchContext } from '../context/search';
@@ -62,7 +67,30 @@ export function AgenticView() {
             ]}
           />
 
-          {/* Row 2: ChatTrigger | Chat (hosts the layout switcher; the
+          {/* Row 2: PromptSuggestions */}
+          <WidgetSwitcher
+            title="promptSuggestions"
+            destroy
+            widgets={[
+              {
+                title: 'PLP',
+                body: WidgetPromptSuggestionsPlp,
+                docs: ['promptSuggestions'],
+              },
+              {
+                title: 'PDP',
+                body: WidgetPromptSuggestionsPdp,
+                docs: ['promptSuggestions'],
+              },
+              {
+                title: 'custom',
+                body: WidgetPromptSuggestionsCustom,
+                docs: ['promptSuggestions'],
+              },
+            ]}
+          />
+
+          {/* Row 3: ChatTrigger | Chat (hosts the layout switcher; the
               chat renders inline inside this tile, or floats/docks to the
               viewport for overlay/sidePanel).
               `min-w-0` lets the chat's grid-based carousel scroll horizontally
@@ -81,7 +109,7 @@ export function AgenticView() {
             </ChatLayoutSwitcher>
           </div>
 
-          {/* Row 3: Hits */}
+          {/* Row 4: Hits */}
           <WidgetSwitcher widgets={[{ title: 'hits', body: WidgetHits }]} />
         </div>
       </ChatLayoutContext.Provider>


### PR DESCRIPTION
## Summary
- add Prompt Suggestions examples for PLP, PDP, and custom contexts to the Agentic showcase
- switch between context modes without mounting inactive widgets
- show concise context descriptions and limit PLP hit data passed to chat

[FX-3990](https://algolia.atlassian.net/browse/FX-3990)

## Test plan
- [x] `yarn workspace example-instantsearch-showcase build`
- [x] `yarn tsc -p examples/js/showcase/tsconfig.json --noEmit`
- [x] `yarn lint:changed`

[FX-3990]: https://algolia.atlassian.net/browse/FX-3990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ