### PR TITLE
fix(chat): restore automatic scrolling

### DIFF
--- a/packages/instantsearch-ui-components/src/lib/__tests__/stickToBottom.test.tsx
+++ b/packages/instantsearch-ui-components/src/lib/__tests__/stickToBottom.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+import { act, fireEvent, render } from '@testing-library/preact';
+import { createElement } from 'preact';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'preact/hooks';
+
+import { createStickToBottom } from '../stickToBottom';
+
+import type { StickToBottomInstance } from '../stickToBottom';
+
+const useStickToBottom = createStickToBottom({
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+});
+
+describe('useStickToBottom', () => {
+  let instance: StickToBottomInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    global.ResizeObserver = class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function Harness() {
+    instance = useStickToBottom();
+
+    return createElement(
+      'div',
+      { ref: instance.scrollRef, style: { overflow: 'auto' } },
+      createElement('div', { ref: instance.contentRef })
+    );
+  }
+
+  test('releases the scroll guard when content grows after returning to the bottom', () => {
+    const { container } = render(createElement(Harness, null));
+    const scroll = container.firstElementChild as HTMLDivElement;
+    let scrollHeight = 500;
+
+    Object.defineProperties(scroll, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: {
+        configurable: true,
+        get: () => scrollHeight,
+      },
+    });
+    scroll.scrollTop = 400;
+
+    fireEvent.wheel(scroll, { deltaY: -120 });
+    expect(instance.state.isAtBottom).toBe(false);
+
+    scroll.scrollTop = 280;
+    fireEvent.scroll(scroll);
+    scroll.scrollTop = 400;
+    fireEvent.scroll(scroll);
+
+    scrollHeight = 640;
+
+    act(() => {
+      jest.advanceTimersByTime(2);
+    });
+
+    expect(instance.state.escapedFromLock).toBe(false);
+    expect(instance.state.isAtBottom).toBe(true);
+  });
+});

--- a/packages/instantsearch-ui-components/src/lib/stickToBottom.ts
+++ b/packages/instantsearch-ui-components/src/lib/stickToBottom.ts
@@ -440,6 +440,7 @@ export function createStickToBottom({
 
         const { scrollTop, ignoreScrollToTop } = state;
         let { lastScrollTop = scrollTop } = state;
+        const isNearBottom = state.isNearBottom;
 
         state.lastScrollTop = scrollTop;
         state.ignoreScrollToTop = undefined;
@@ -453,7 +454,7 @@ export function createStickToBottom({
           lastScrollTop = ignoreScrollToTop;
         }
 
-        setIsNearBottom(state.isNearBottom);
+        setIsNearBottom(isNearBottom);
 
         /**
          * Scroll events may come before a ResizeObserver event,
@@ -493,7 +494,7 @@ export function createStickToBottom({
             setEscapedFromLock(false);
           }
 
-          if (!state.escapedFromLock && state.isNearBottom) {
+          if (!state.escapedFromLock && isNearBottom) {
             setIsAtBottom(true);
           }
         }, 1);

--- a/packages/instantsearch.js/src/widgets/chat/__tests__/chat-autoscroll.test.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/__tests__/chat-autoscroll.test.tsx
@@ -4,6 +4,7 @@
 import { createSearchClient } from '@instantsearch/mocks';
 import { wait } from '@instantsearch/testutils/wait';
 import { waitFor } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 
 import instantsearch from '../../../index.es';
 import chat from '../chat';
@@ -49,7 +50,7 @@ describe('chat auto-scroll while streaming', () => {
     scrollToBottomSpy.mockClear();
   });
 
-  test('re-pins to the bottom on message updates during streaming', async () => {
+  test('scrolls to a submitted message, then preserves position while streaming', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
 
@@ -76,18 +77,11 @@ describe('chat auto-scroll while streaming', () => {
     search.start();
     await wait(0);
 
-    const chatRenderState = (
-      search.renderState.indexName as {
-        chat: { sendMessage: (message: { text: string }) => void };
-      }
-    ).chat;
+    const prompt = container.querySelector('textarea')!;
+    userEvent.type(prompt, 'hi{enter}');
 
-    chatRenderState.sendMessage({ text: 'hi' });
-
-    // While streaming, message/status updates must re-pin to the bottom, using
-    // the "only if already at the bottom" gate so it can't fight a user who
-    // scrolled up.
     await waitFor(() => {
+      expect(scrollToBottomSpy).toHaveBeenCalledWith();
       expect(scrollToBottomSpy).toHaveBeenCalledWith({
         preserveScrollPosition: true,
       });

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -2,7 +2,7 @@
 
 import { createChatComponent, findTool } from 'instantsearch-ui-components';
 import { Fragment, h, render } from 'preact';
-import { useEffect, useMemo, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 
 import TemplateComponent from '../../components/Template/Template';
 import connectChat from '../../connectors/chat/connectChat';
@@ -285,6 +285,15 @@ function ChatWrapper({
       initial: 'smooth',
       resize: 'smooth',
     });
+  const sendMessageAndScrollToBottom = useCallback<
+    ChatRenderState['sendMessage']
+  >(
+    (...args) => {
+      scrollToBottom();
+      return sendMessage(...args);
+    },
+    [scrollToBottom, sendMessage]
+  );
 
   // Keep the conversation pinned to the bottom while streaming. The stick-to-
   // bottom ResizeObserver only reacts to content *height* changes, but tool
@@ -308,7 +317,7 @@ function ChatWrapper({
       classNames={cssClasses}
       open={chatOpen}
       maximized={maximized}
-      sendMessage={sendMessage}
+      sendMessage={sendMessageAndScrollToBottom}
       regenerate={regenerate}
       stop={stop}
       error={error}
@@ -353,7 +362,7 @@ function ChatWrapper({
         userMessageProps: messagesProps.userMessageProps,
         translations: messagesProps.translations,
         messageTranslations: messagesProps.messageTranslations,
-        sendMessage: messagesProps.sendMessage,
+        sendMessage: sendMessageAndScrollToBottom,
         setInput: messagesProps.setInput,
       }}
       promptProps={{
@@ -364,7 +373,7 @@ function ChatWrapper({
           setChatInput((event.currentTarget as HTMLInputElement).value);
         },
         onSubmit: () => {
-          sendMessage({ text: chatInput });
+          sendMessageAndScrollToBottom({ text: chatInput });
           setChatInput('');
         },
         onStop: () => {
@@ -376,7 +385,9 @@ function ChatWrapper({
         autoFocus: promptProps.autoFocus,
       }}
       suggestionsProps={{
-        onSuggestionClick: suggestionsProps.onSuggestionClick,
+        onSuggestionClick: (suggestion) => {
+          sendMessageAndScrollToBottom({ text: suggestion });
+        },
         suggestions: suggestionsProps.suggestions,
         isLoading: suggestionsProps.isLoading,
       }}

--- a/packages/react-instantsearch/src/widgets/Chat.tsx
+++ b/packages/react-instantsearch/src/widgets/Chat.tsx
@@ -16,6 +16,7 @@ import {
 import React, {
   createElement,
   Fragment,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
@@ -395,9 +396,18 @@ function ChatInner<
     '~isOpenStatePersistenceEnabled'?: boolean;
   };
 
+  const sendMessageAndScrollToBottom = useCallback<typeof sendMessage>(
+    (...args) => {
+      scrollToBottom();
+      return sendMessage(...args);
+    },
+    [scrollToBottom, sendMessage]
+  );
+
   useImperativeHandle(ref, () => ({
     setOpen,
-    sendMessage: (params: { text: string }) => sendMessage(params),
+    sendMessage: (params: { text: string }) =>
+      sendMessageAndScrollToBottom(params),
     setInput,
   }));
 
@@ -457,7 +467,7 @@ function ChatInner<
       title={title}
       open={open}
       maximized={maximized}
-      sendMessage={sendMessage as ChatUiProps['sendMessage']}
+      sendMessage={sendMessageAndScrollToBottom as ChatUiProps['sendMessage']}
       regenerate={regenerate}
       stop={stop}
       error={error}
@@ -483,7 +493,7 @@ function ChatInner<
         onReload: (messageId) => regenerate({ messageId }),
         onNewConversation: clearMessages,
         onClose: () => setOpen(false),
-        sendMessage: sendMessage as ChatUiProps['sendMessage'],
+        sendMessage: sendMessageAndScrollToBottom as ChatUiProps['sendMessage'],
         setInput,
         onFeedback,
         feedbackState,
@@ -531,7 +541,7 @@ function ChatInner<
           setInput((event.currentTarget as HTMLInputElement).value);
         },
         onSubmit: () => {
-          sendMessage({ text: input });
+          sendMessageAndScrollToBottom({ text: input });
           setInput('');
         },
         onStop: () => {
@@ -548,7 +558,7 @@ function ChatInner<
         suggestions,
         isLoading: suggestionsStatus === 'loading',
         onSuggestionClick: (suggestion) => {
-          sendMessage({ text: suggestion });
+          sendMessageAndScrollToBottom({ text: suggestion });
         },
       }}
       classNames={classNames}

--- a/packages/react-instantsearch/src/widgets/__tests__/Chat.autoscroll.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/Chat.autoscroll.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { InstantSearch } from 'react-instantsearch-core';
+
+import { ChatInlineLayout } from '../../components/ChatInlineLayout';
+import { Chat } from '../Chat';
+
+jest.mock('../../lib/useStickToBottom', () => {
+  const scrollToBottom = jest.fn();
+  return {
+    __esModule: true,
+    useStickToBottom: () => ({
+      scrollRef: { current: null },
+      contentRef: { current: null },
+      scrollToBottom,
+      isAtBottom: true,
+    }),
+    scrollToBottomSpy: scrollToBottom,
+  };
+});
+
+const { scrollToBottomSpy }: { scrollToBottomSpy: jest.Mock } =
+  jest.requireMock('../../lib/useStickToBottom');
+
+const stream = [
+  '{"type":"start","messageId":"a1"}',
+  '{"type":"start-step"}',
+  '{"type":"text-start","id":"t1"}',
+  '{"type":"text-delta","id":"t1","delta":"Hello"}',
+  '{"type":"text-end","id":"t1"}',
+  '{"type":"finish-step"}',
+  '{"type":"finish"}',
+  '[DONE]',
+]
+  .map((data) => `data: ${data}\n\n`)
+  .join('');
+
+describe('Chat auto-scroll', () => {
+  test('scrolls to a submitted message', async () => {
+    render(
+      <InstantSearch indexName="indexName" searchClient={createSearchClient()}>
+        <Chat
+          disableTriggerValidation={true}
+          layoutComponent={ChatInlineLayout}
+          persistence={false}
+          requiresSearch={false}
+          transport={{
+            fetch: () =>
+              Promise.resolve(
+                new Response(stream, {
+                  headers: { 'Content-Type': 'text/event-stream' },
+                })
+              ),
+          }}
+        />
+      </InstantSearch>
+    );
+
+    const prompt = screen.getByRole('textbox');
+    userEvent.type(prompt, 'hi{enter}');
+
+    await waitFor(() => {
+      expect(scrollToBottomSpy).toHaveBeenCalledWith();
+    });
+  });
+});


### PR DESCRIPTION
**Summary**

FX-3935

- Preserve the near-bottom state captured when a scroll event occurs so delayed layout changes cannot latch the scroll guard.
- Scroll to the latest message on explicit submissions in InstantSearch.js and React while preserving the user's position during streaming updates.
- Add regression coverage for the guard race and submission behavior.

**Result**

- `yarn jest packages/instantsearch-ui-components/src/lib/__tests__/stickToBottom.test.tsx packages/instantsearch.js/src/widgets/chat/__tests__/chat-autoscroll.test.tsx packages/react-instantsearch/src/widgets/__tests__/Chat.autoscroll.test.tsx --runInBand`
- `yarn lint:changed`