### PR TITLE
fix(prompt-suggestions): skip a duplicate task request

### DIFF
--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -335,7 +335,10 @@ describe('connectPromptSuggestions', () => {
       expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
-    it('refetches whenever the results `queryID` changes', async () => {
+    it('does not refetch when only the results `queryID` changes', async () => {
+      // The payload carries the query, the filters and the hits — never the
+      // `queryID`. A new `queryID` over otherwise identical results asks the
+      // agent the same question, so it must not spend a second model call.
       const renderFn = jest.fn();
       const widget = connectPromptSuggestions(renderFn)({
         agentId: 'a',
@@ -360,7 +363,381 @@ describe('connectPromptSuggestions', () => {
         })
       );
       await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('refetches when the `queryID` and the hits both change', async () => {
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'shoes', queryID: 'q1' }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({
+            query: 'shoes',
+            queryID: 'q2',
+            hits: [{ objectID: '9' }],
+          }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
       expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('sends nothing when the search state moves but the `context` payload does not', async () => {
+      // The waste this exists to remove: with an explicit `context` the payload
+      // ignores the results, so every search-state change used to bill a model
+      // call for a byte-identical request.
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: { focalProduct: { id: '42' } },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'a', hits: [{ objectID: 'h1' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'b', hits: [{ objectID: 'h2' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the current suggestions in place when a request is skipped', async () => {
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: { focalProduct: { id: '42' } },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'a', hits: [{ objectID: 'h1' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      await flush(10);
+      expect(
+        renderFn.mock.calls[renderFn.mock.calls.length - 1][0].suggestions
+      ).toEqual(['a', 'b', 'c']);
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'b', hits: [{ objectID: 'h2' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+
+      const last = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(last.suggestions).toEqual(['a', 'b', 'c']);
+      expect(last.isLoading).toBe(false);
+      expect(last.error).toBeUndefined();
+    });
+
+    it('`refresh()` sends even when the payload is unchanged', async () => {
+      // Regenerate is the same control as Generate: it resends identical inputs
+      // on purpose and expects a new answer. The skip covers the automatic path
+      // only.
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+      await flush(10);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      renderFn.mock.calls[renderFn.mock.calls.length - 1][0].refresh();
+      await flush(0);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('still sends when a `context` value serializes differently', async () => {
+      // Regression: comparing the raw object read a `Date` as a key-less object,
+      // so two different instants compared equal and the second request was
+      // dropped even though its body differed.
+      let viewedAt = new Date('2026-01-01T00:00:00.000Z');
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: () => ({ viewedAt }),
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'a', hits: [{ objectID: 'h1' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      viewedAt = new Date('2026-06-01T00:00:00.000Z');
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'b', hits: [{ objectID: 'h2' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      const bodies = (global.fetch as jest.Mock).mock.calls.map(
+        ([, init]) => JSON.parse((init as RequestInit).body as string).input
+      );
+      expect(bodies[0].viewedAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(bodies[1].viewedAt).toBe('2026-06-01T00:00:00.000Z');
+    });
+
+    it('does not skip when the payload cannot be serialized', async () => {
+      // An unserializable payload has no comparable identity, so it must never
+      // claim a match: two identical uncomparable payloads both attempt a
+      // request rather than one being dropped as a duplicate.
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      // A circular payload can't be stringified, so the request itself can't be
+      // built. `prepareSendMessagesRequest` runs on every attempt before the body
+      // is serialized, which is what counts attempts here.
+      const prepare = jest.fn(() => ({ body: { sent: true } }));
+      const widget = connectPromptSuggestions(jest.fn())({
+        configurationId: 'prompt-suggestions',
+        transport: {
+          api: 'https://example.test/agents',
+          prepareSendMessagesRequest: prepare,
+        },
+        context: () => ({ circular }),
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'a', hits: [{ objectID: 'h1' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(prepare).toHaveBeenCalledTimes(1);
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'b', hits: [{ objectID: 'h2' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(prepare).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips when only the `context` key order changes', async () => {
+      // `stableKey` sorts keys because key order is not part of the question
+      // being asked. Without the sort a re-ordered payload reads as new and bills
+      // a model call for an answer already on screen.
+      let pageContext: Record<string, unknown> = { brand: 'acme', id: '42' };
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: () => pageContext,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'a', hits: [{ objectID: 'h1' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      pageContext = { id: '42', brand: 'acme' };
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'b', hits: [{ objectID: 'h2' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('rebuilds the suggestions after the hits empty and come back identical', async () => {
+      // Emptying the hits throws the output away, so the same payload has to be
+      // allowed to rebuild it. Without the memo reset in that branch the
+      // identical follow-up is skipped as a duplicate and the pills never return.
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'q', hits: [{ objectID: '1' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      await flush(10);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(
+        renderFn.mock.calls[renderFn.mock.calls.length - 1][0].suggestions
+      ).toEqual(['a', 'b', 'c']);
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'q', hits: [] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(
+        renderFn.mock.calls[renderFn.mock.calls.length - 1][0].suggestions
+      ).toEqual([]);
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'q', hits: [{ objectID: '1' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      await flush(10);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(
+        renderFn.mock.calls[renderFn.mock.calls.length - 1][0].suggestions
+      ).toEqual(['a', 'b', 'c']);
+    });
+
+    it('reconciles a render dropped while a refetch was pending', async () => {
+      // A search-state change while a request is in flight makes
+      // `handleInnerRender` drop the render that delivers the output. Before the
+      // memo the debounced refetch always repainted it; a skip sends nothing, so
+      // the skip itself has to reconcile — otherwise `isLoading` stays true with
+      // no suggestions, and the state is terminal, because `refresh()` is blocked
+      // by its own `isLoading` guard and an unchanged payload keeps skipping.
+      global.fetch = jest.fn(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(
+              () =>
+                resolve(textStreamResponse(['{"suggestions":["a","b","c"]}'])),
+              60
+            );
+          })
+      ) as unknown as typeof fetch;
+
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        // A static object, so the payload can never change again.
+        context: { focalProduct: { id: '42' } },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      widget.render!(
+        createRenderOptions({ helper, results: makeResults({ queryID: 'q1' }) })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      // Supersede the in-flight request and restart the debounce, so its result
+      // arrives while the render is being dropped.
+      widget.render!(
+        createRenderOptions({ helper, results: makeResults({ queryID: 'q2' }) })
+      );
+      await flush(DEBOUNCE_WAIT + 80);
+
+      const last = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(last.isLoading).toBe(false);
+      expect(last.suggestions).toEqual(['a', 'b', 'c']);
+      expect(last.error).toBeUndefined();
+    });
+
+    it('retries the same payload after a failed request', async () => {
+      // A skipped duplicate must never strand an error on screen: the failed
+      // payload was never answered, so the next attempt has to go out.
+      const streamError = new Error('stream failed');
+      global.fetch = jest.fn(() =>
+        Promise.resolve(textStreamResponse([], streamError))
+      ) as unknown as typeof fetch;
+
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+        context: { focalProduct: { id: '42' } },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'a', hits: [{ objectID: 'h1' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      await flush(10);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(renderFn.mock.calls[renderFn.mock.calls.length - 1][0].error).toBe(
+        streamError
+      );
+
+      widget.render!(
+        createRenderOptions({
+          helper,
+          results: makeResults({ query: 'b', hits: [{ objectID: 'h2' }] }),
+        })
+      );
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+
+      widget.dispose!(createDisposeOptions({ helper }));
     });
 
     it('does not refetch when the `queryID` is unchanged', async () => {

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -46,6 +46,39 @@ function parseSuggestions(data: unknown): string[] {
   return suggestions.filter((s: unknown): s is string => typeof s === 'string');
 }
 
+// Key order is not significant to the request, so a plain `JSON.stringify` would
+// report two identical payloads as different.
+function stableKey(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableKey).join(',')}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableKey(record[key])}`)
+    .join(',')}}`;
+}
+
+/**
+ * Comparable identity of a task payload, or `null` when it cannot be compared.
+ */
+function taskPayloadKey(payload: Record<string, unknown>): string | null {
+  try {
+    // Round-trip first so the comparison sees what the request will actually
+    // carry: `JSON.stringify` applies `toJSON` (a `Date` becomes its ISO string)
+    // and drops the values the wire drops. Walking the raw object instead would
+    // read a `Date` as a key-less object and call two different instants equal.
+    return stableKey(JSON.parse(JSON.stringify(payload)));
+  } catch {
+    // Circular or otherwise unserializable. Never claim a match on a payload we
+    // could not read; let the request go out and fail where it does today.
+    return null;
+  }
+}
+
 function buildSuggestionMessage(suggestion: string): string {
   return `The user clicked this on-page suggestion. Use the current page context first, then search only if needed.\n\nSuggestion: ${suggestion}`;
 }
@@ -219,6 +252,10 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       let error: Error | undefined;
       let debounceTimer: ReturnType<typeof setTimeout> | undefined;
       let lastStateSignature: string | null = null;
+      // The payload of the last request that was actually sent. The automatic
+      // trigger keys on the search state, which is only a proxy for the payload,
+      // so this is what decides whether a request would ask anything new.
+      let lastSubmittedPayload: string | null = null;
       let latestRenderOptions: RenderOptions | null = null;
       // Set in `dispose()`. A debounced or in-flight `fetch()` can resolve after
       // the widget is unmounted; this guard stops those late callbacks from
@@ -229,6 +266,10 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       // still-in-flight request from the previous state must not paint its
       // suggestions, its inner render is ignored until the new `submit` starts.
       let refetchPending = false;
+      // True when `refetchPending` made an inner render be dropped. The fetch
+      // that dropped it was expected to render in its place; if that fetch turns
+      // out to send nothing, it has to reconcile the dropped state instead.
+      let droppedInnerRender = false;
 
       const getStateSignature = (results: SearchResults): string => {
         if (results.queryID) {
@@ -334,22 +375,68 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         );
       };
 
+      // Copies an inner render's state into this widget's and re-renders on the
+      // client.
+      const adoptInnerState = (renderState: TasksRenderState) => {
+        error = renderState.error;
+        if (renderState.error) {
+          // A failed task (including a mid-stream `error` event) must not leave
+          // any streamed partial visible.
+          suggestions = [];
+        } else if (renderState.isLoading || renderState.output !== undefined) {
+          // Only adopt the inner output once a request is loading or has
+          // produced one, so the initial no-op render doesn't clobber pills.
+          suggestions = parseSuggestions(renderState.output);
+        }
+        isLoading = renderState.isLoading;
+        if (!latestRenderOptions) return;
+        renderOutward(latestRenderOptions);
+      };
+
       const fetchAndRender = (
         results: SearchResults,
-        renderOptions: RenderOptions
+        renderOptions: RenderOptions,
+        { force = false }: { force?: boolean } = {}
       ) => {
         if (disposed || !tasksState) return;
+        const hadDroppedInnerRender = droppedInnerRender;
         refetchPending = false;
+        droppedInnerRender = false;
         const hasContext = context !== undefined;
         if (!hasContext && !results?.hits?.length) {
           tasksState.invalidate();
           suggestions = [];
           isLoading = false;
+          // The output is gone, so the same payload must be allowed to rebuild it.
+          lastSubmittedPayload = null;
           renderOutward(renderOptions);
           return;
         }
 
-        tasksState.submit(buildInput(results));
+        const input = buildInput(results);
+        const payload = taskPayloadKey(input);
+
+        // A moved search state does not always mean a different question: with an
+        // explicit `context` the payload ignores the results entirely, so a new
+        // `queryID` or a new hit order produces a byte-identical request. Sending
+        // it again spends a model call on an answer already on screen. Leave the
+        // current suggestions alone and send nothing. `force` is the explicit
+        // path (`refresh()`), which must always reach the network.
+        if (!force && payload !== null && payload === lastSubmittedPayload) {
+          // Nothing goes out, so nothing will render — but the state change that
+          // scheduled this fetch also made `handleInnerRender` drop the render
+          // that was carrying the previous request's result. Reconcile it here or
+          // the widget keeps that request's `isLoading: true` with no
+          // suggestions, and nothing later clears it: `refresh()` is blocked by
+          // its own `isLoading` guard and an unchanged payload keeps skipping.
+          if (hadDroppedInnerRender) {
+            adoptInnerState(tasksState);
+          }
+          return;
+        }
+
+        lastSubmittedPayload = payload;
+        tasksState.submit(input);
       };
 
       const refresh = () => {
@@ -358,7 +445,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         if (!results || !latestRenderOptions) return;
         clearTimeout(debounceTimer);
         lastStateSignature = getStateSignature(results);
-        fetchAndRender(results, latestRenderOptions);
+        fetchAndRender(results, latestRenderOptions, { force: true });
       };
 
       const getWidgetRenderState = (
@@ -397,20 +484,18 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       // resolve/error) into this widget's state and re-renders on the client.
       const handleInnerRender = (renderState: TasksRenderState) => {
         tasksState = renderState;
-        if (refetchPending) return;
-        error = renderState.error;
         if (renderState.error) {
-          // A failed task (including a mid-stream `error` event) must not leave
-          // any streamed partial visible.
-          suggestions = [];
-        } else if (renderState.isLoading || renderState.output !== undefined) {
-          // Only adopt the inner output once a request is loading or has
-          // produced one, so the initial no-op render doesn't clobber pills.
-          suggestions = parseSuggestions(renderState.output);
+          // Keep a failed payload retryable: without this the next automatic
+          // attempt with the same payload would be skipped as a duplicate and
+          // the error would have no way to clear. Set before the `refetchPending`
+          // return so a failure that lands mid-refetch is not swallowed.
+          lastSubmittedPayload = null;
         }
-        isLoading = renderState.isLoading;
-        if (!latestRenderOptions) return;
-        renderOutward(latestRenderOptions);
+        if (refetchPending) {
+          droppedInnerRender = true;
+          return;
+        }
+        adoptInnerState(renderState);
       };
 
       let tasksParams: TasksConnectorParams;


### PR DESCRIPTION
## Summary

Prompt Suggestions spends a model call on every search-state change, even when the request it would send is identical. With an explicit `context` the payload ignores the results, so a new `queryID` or hit order asks the same question.

The connector now compares the built payload against the last one it sent and skips the request when they match.

## Result

- On a skip the suggestions on screen stay. Nothing is cleared, no error is set, no spinner appears.
- `refresh()` always reaches the network, so Regenerate is unaffected.
- A failed request and an emptied hit list reset the comparison, so neither can strand the widget.
- No new option or prop. A consumer counting one request per search-state change will see fewer.
- The comparison is on `buildInput`'s output, not the final request body, so a `prepareSendMessagesRequest` that injects a varying value no longer sends one request per change.
- The `queryID` test now asserts the skip, since those results build an identical payload. Changing the hits too still refetches.

Replaces the `autoFetch` option proposed in #7196, whose `refresh()` changes are independent.

Related: [FX-3997](https://algolia.atlassian.net/browse/FX-3997)


[FX-3997]: https://algolia.atlassian.net/browse/FX-3997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ