### PR TITLE
fix(chat): hide empty assistant placeholder

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -2,7 +2,11 @@
 import { compiler } from 'markdown-to-jsx';
 
 import { cx, startsWith } from '../../lib';
-import { findTool, isReasoningPartActive } from '../../lib/utils/chat';
+import {
+  findTool,
+  isPartTextEmpty,
+  isReasoningPartActive,
+} from '../../lib/utils/chat';
 import { collectChatRecords } from '../../lib/utils/chatRecords';
 import { createButtonComponent } from '../Button';
 
@@ -528,14 +532,9 @@ export function createChatMessageComponent({
         );
       }
       if (part.type === 'text') {
-        // Back-compat shim for sessions started before the move from a
-        // `<context>{...}</context>` text part to `metadata.turnContext`.
-        // Safe to remove once existing sessionStorage transcripts have
-        // rolled over (~2 weeks after release).
-        if (
-          part.text.startsWith('<context>') &&
-          part.text.endsWith('</context>')
-        ) {
+        // `text-start` creates the part before the first delta; rendering it
+        // would leave an empty assistant row next to the loader.
+        if (isPartTextEmpty(part)) {
           return null;
         }
         if (TextComponent) {
@@ -662,6 +661,22 @@ export function createChatMessageComponent({
       return null;
     }
 
+    const renderedParts = message.parts.map(renderMessagePart);
+    const hasRenderedParts = renderedParts.some((part) => part != null);
+
+    // AbstractChat pushes an assistant message with no parts on the stream
+    // `start` chunk. An empty article still occupies a flex gap above the
+    // messages-end loader, so skip the row until something is visible.
+    if (
+      !hasRenderedParts &&
+      !loaderElement &&
+      !suggestionsElement &&
+      !showActions &&
+      !FooterComponent
+    ) {
+      return null;
+    }
+
     return (
       <article
         {...props}
@@ -677,7 +692,7 @@ export function createChatMessageComponent({
 
           <div className={cx(cssClasses.content)}>
             <div className={cx(cssClasses.message)}>
-              {message.parts.map(renderMessagePart)}
+              {renderedParts}
               {loaderElement}
             </div>
 

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -532,8 +532,6 @@ export function createChatMessageComponent({
         );
       }
       if (part.type === 'text') {
-        // `text-start` creates the part before the first delta; rendering it
-        // would leave an empty assistant row next to the loader.
         if (isPartTextEmpty(part)) {
           return null;
         }
@@ -664,9 +662,6 @@ export function createChatMessageComponent({
     const renderedParts = message.parts.map(renderMessagePart);
     const hasRenderedParts = renderedParts.some((part) => part != null);
 
-    // AbstractChat pushes an assistant message with no parts on the stream
-    // `start` chunk. An empty article still occupies a flex gap above the
-    // messages-end loader, so skip the row until something is visible.
     if (
       !hasRenderedParts &&
       !loaderElement &&

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -76,7 +76,11 @@ describe('ChatMessage', () => {
       <ChatMessage
         indexUiState={{}}
         setIndexUiState={jest.fn()}
-        message={{ role: 'user', id: '1', parts: [] }}
+        message={{
+          role: 'user',
+          id: '1',
+          parts: [{ type: 'text', text: 'Hello' }],
+        }}
         context={createContext()}
       />
     );
@@ -94,12 +98,48 @@ describe('ChatMessage', () => {
             >
               <div
                 class="ais-ChatMessage-message"
-              />
+              >
+                <span>
+                  <span>
+                    Hello
+                  </span>
+                </span>
+              </div>
             </div>
           </div>
         </article>
       </div>
     `);
+  });
+
+  test('does not render an empty message', () => {
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{ role: 'assistant', id: '1', parts: [] }}
+        context={createContext()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('does not render a text part that has no content yet', () => {
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [{ type: 'text', text: '', state: 'streaming' }],
+        }}
+        context={createContext({ status: 'streaming' })}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
   });
 
   test('renders with custom class names', () => {
@@ -110,7 +150,7 @@ describe('ChatMessage', () => {
         message={{
           role: 'user',
           id: '1',
-          parts: [],
+          parts: [{ type: 'text', text: 'Hello' }],
         }}
         classNames={{
           root: 'root',
@@ -137,7 +177,13 @@ describe('ChatMessage', () => {
             >
               <div
                 class="ais-ChatMessage-message message"
-              />
+              >
+                <span>
+                  <span>
+                    Hello
+                  </span>
+                </span>
+              </div>
             </div>
           </div>
         </article>

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -2157,6 +2157,57 @@ describe('ChatMessages', () => {
       ).toBeNull();
       expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
     });
+
+    test('does not render an empty assistant placeholder next to the loader', () => {
+      // AbstractChat pushes `{ role: 'assistant', parts: [] }` on the stream
+      // `start` chunk, before any part exists. That row must not sit above
+      // the messages-end loader — it is an empty article plus a flex gap.
+      const { container } = render(
+        <ChatMessages
+          {...baseProps}
+          status="streaming"
+          messages={[
+            {
+              role: 'user',
+              id: '1',
+              parts: [{ type: 'text', text: 'hello' }],
+            },
+            { role: 'assistant', id: '2', parts: [] },
+          ]}
+        />
+      );
+
+      expect(
+        container.querySelector('article[data-role="assistant"]')
+      ).toBeNull();
+      expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
+    });
+
+    test('does not render an assistant row for an unwritten text part next to the loader', () => {
+      const { container } = render(
+        <ChatMessages
+          {...baseProps}
+          status="streaming"
+          messages={[
+            {
+              role: 'user',
+              id: '1',
+              parts: [{ type: 'text', text: 'hello' }],
+            },
+            {
+              role: 'assistant',
+              id: '2',
+              parts: [{ type: 'text', text: '', state: 'streaming' }],
+            },
+          ]}
+        />
+      );
+
+      expect(
+        container.querySelector('article[data-role="assistant"]')
+      ).toBeNull();
+      expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
+    });
   });
 
   describe('pending suggestions', () => {


### PR DESCRIPTION
**Summary**

AbstractChat pushes an assistant message with no parts on the stream `start` chunk. ChatMessage still rendered that empty article, which opened a flex gap above the messages-end loader.

Skip the row until a part, inline loader, suggestions, actions, or footer is actually visible. Empty `text-start` parts are treated the same way via `isPartTextEmpty` (this still covers leftover `<context>` transcripts).

**Result**

- `yarn jest packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx`