### PR TITLE
fix(chat): keep loader until assistant message exists

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -1115,9 +1115,13 @@ const getShowLoader = <TMessage extends ChatMessageBase>(
   if (status === 'submitted') return true;
 
   const lastMessage = messages[messages.length - 1];
+  // `processStream` sets `streaming` before the `start` chunk pushes the
+  // assistant. Until then the last message is still the user's, and its text
+  // must not be read as the answer or the loader hides and comes back.
+  if (lastMessage?.role !== 'assistant') return true;
   // Parts that render nothing must not answer for the turn's progress, or the
   // loader flips on a part that changed nothing on screen.
-  const lastPart = findLastProgressPart(lastMessage?.parts);
+  const lastPart = findLastProgressPart(lastMessage.parts);
 
   if (!lastPart) return true;
   // An active disclosure carries its own progress affordance, so the loader would

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -1854,6 +1854,33 @@ describe('ChatMessages', () => {
         return utils;
       }
 
+      test('keeps the loader up after streaming starts before the assistant message exists', () => {
+        // `processStream` sets `streaming` before the `start` chunk pushes the
+        // assistant. The last message is still the user's, and its text must
+        // not be read as the answer.
+        const user = {
+          role: 'user' as const,
+          id: '1',
+          parts: [{ type: 'text' as const, text: 'hello' }],
+        };
+
+        const { container, rerender } = render(
+          <ChatMessages {...baseProps} status="submitted" messages={[user]} />
+        );
+
+        expect(loader(container)).not.toBeNull();
+
+        rerender(
+          <ChatMessages {...baseProps} status="streaming" messages={[user]} />
+        );
+
+        act(() => {
+          jest.advanceTimersByTime(200);
+        });
+
+        expect(loader(container)).not.toBeNull();
+      });
+
       test('holds the loader briefly so it cannot flash', () => {
         const { container, rerender } = render(
           <ChatMessages {...baseProps} status="submitted" messages={[]} />


### PR DESCRIPTION
**Summary**

`processStream` sets status to `streaming` before the `start` chunk pushes the assistant message. In that gap `getShowLoader` read the last message — still the user's text — as "the answer has started" and hid the loader. After 200ms it disappeared; when `start` arrived it came back after the 250ms show delay.

Ignore non-assistant last messages while streaming so the loader stays up until the assistant actually exists.

Related: #7215 (empty assistant placeholder; separate root cause).

**Result**

- `yarn jest packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx -t "keeps the loader up after streaming starts"`