### PR TITLE
fix(chat): drop the empty row a contentless turn leaves behind

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -667,18 +667,6 @@ export function createChatMessageComponent({
     const renderedParts = message.parts.map(renderMessagePart);
     const hasRenderedParts = renderedParts.some((part) => part != null);
 
-    // AbstractChat pushes an assistant message with no parts on the stream
-    // `start` chunk. An empty article still occupies a flex gap above the
-    // messages-end loader, so skip the row until something is visible.
-    //
-    // The default actions are chrome rather than content: a turn that ends
-    // without renderable content (aborted, or answered only by a tool hidden
-    // through `shouldRender`) would otherwise keep an empty row on screen for
-    // good, holding a Regenerate button for an answer that isn't there. A
-    // custom `actionsComponent` is the consumer's own content and does keep the
-    // row, but only while it is actually shown. The suggestions are hoisted out of the row instead of keeping it:
-    // `ChatMessages` passes an element for every settled turn, whether or not
-    // it has suggestions to show.
     if (
       !hasRenderedParts &&
       !loaderElement &&

--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -667,14 +667,25 @@ export function createChatMessageComponent({
     const renderedParts = message.parts.map(renderMessagePart);
     const hasRenderedParts = renderedParts.some((part) => part != null);
 
+    // AbstractChat pushes an assistant message with no parts on the stream
+    // `start` chunk. An empty article still occupies a flex gap above the
+    // messages-end loader, so skip the row until something is visible.
+    //
+    // The default actions are chrome rather than content: a turn that ends
+    // without renderable content (aborted, or answered only by a tool hidden
+    // through `shouldRender`) would otherwise keep an empty row on screen for
+    // good, holding a Regenerate button for an answer that isn't there. A
+    // custom `actionsComponent` is the consumer's own content and does keep the
+    // row, but only while it is actually shown. The suggestions are hoisted out of the row instead of keeping it:
+    // `ChatMessages` passes an element for every settled turn, whether or not
+    // it has suggestions to show.
     if (
       !hasRenderedParts &&
       !loaderElement &&
-      !suggestionsElement &&
-      !showActions &&
+      !(ActionsComponent && showActions) &&
       !FooterComponent
     ) {
-      return null;
+      return suggestionsElement ?? null;
     }
 
     return (

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -189,6 +189,60 @@ describe('ChatMessage', () => {
     });
   });
 
+  describe('a row with nothing to render', () => {
+    // A turn that ended without renderable content: aborted, or answered only
+    // by a tool hidden through `shouldRender`.
+    const message: ChatMessageBase = {
+      role: 'assistant',
+      id: '1',
+      parts: [{ type: 'step-start' }],
+    };
+
+    test('is not kept alive by the default actions', () => {
+      const { container } = render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={message}
+          actions={[{ title: 'Regenerate', onClick: jest.fn() }]}
+          context={createContext({ status: 'ready', messages: [message] })}
+        />
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    test('is kept by a custom actions component', () => {
+      const { container } = render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={message}
+          actionsComponent={() => <span className="custom-action" />}
+          context={createContext({ status: 'ready', messages: [message] })}
+        />
+      );
+
+      expect(container.querySelector('.custom-action')).not.toBeNull();
+    });
+
+    test('hands its suggestions on rather than keeping the row', () => {
+      const { container } = render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={message}
+          actions={[{ title: 'Regenerate', onClick: jest.fn() }]}
+          suggestionsElement={<span className="suggestions" />}
+          context={createContext({ status: 'ready', messages: [message] })}
+        />
+      );
+
+      expect(container.querySelector('article')).toBeNull();
+      expect(container.querySelector('.suggestions')).not.toBeNull();
+    });
+  });
+
   test('renders with custom class names', () => {
     const { container } = render(
       <ChatMessage

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -2235,6 +2235,33 @@ describe('ChatMessages', () => {
       ).toBeNull();
       expect(container.querySelector('.ais-ChatMessageLoader')).not.toBeNull();
     });
+
+    test('does not render an assistant row for a turn that ended without content', () => {
+      // The widget passes a suggestions element for every settled turn, and the
+      // default actions come with every assistant row — neither is a reason to
+      // keep an empty article (and its avatar) on screen for good.
+      const { container } = render(
+        <ChatMessages
+          {...baseProps}
+          status="ready"
+          messages={[
+            {
+              role: 'user',
+              id: '1',
+              parts: [{ type: 'text', text: 'hello' }],
+            },
+            { role: 'assistant', id: '2', parts: [{ type: 'step-start' }] },
+          ]}
+          suggestionsElement={<span className="suggestions" />}
+        />
+      );
+
+      expect(
+        container.querySelector('article[data-role="assistant"]')
+      ).toBeNull();
+      expect(container.querySelector('.ais-ChatMessage-action')).toBeNull();
+      expect(container.querySelector('.suggestions')).not.toBeNull();
+    });
   });
 
   describe('pending suggestions', () => {


### PR DESCRIPTION
**Summary**

Stacked on #7215. That PR skips the row until something is visible, which fixes the empty article next to the loader while an answer is on its way. It keeps the row alive for its actions and for its suggestions element, and both hold for every settled turn in the widget: `ChatMessages` passes a suggestions element whether or not there are suggestions to show, and the default actions come with every assistant row. So a turn that ends without renderable content — aborted, or answered only by a tool hidden through `shouldRender` — still leaves an empty article on screen for good: its avatar, its flex gap, and a Regenerate button for an answer that isn't there.

The default actions are chrome rather than content, so they no longer keep the row; a custom `actionsComponent` is the consumer's own content and still does. The suggestions are handed on in place of the row rather than keeping it, so they render at the same place in the list.

**Result**

- `yarn jest packages/instantsearch-ui-components/src/components/chat` — the row-with-nothing-to-render cases in `ChatMessage.test.tsx` (default actions don't keep it, a custom actions component does, suggestions are handed on) and the widget-shaped case in `ChatMessages.test.tsx` (settled turn, suggestions element present, default actions present → no article, no action button, suggestions still rendered).
- `yarn jest common-widgets -t "Chat widget common tests"`, the `instantsearch.js` chat widget and `react-instantsearch` widget suites pass; lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)