### PR TITLE
fix(chat): keep the actions on completed answers during a turn

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -426,8 +426,13 @@ export function createChatMessageComponent({
       (part) => part.isStreaming
     );
 
+    // `status` is the chat's, not the row's: gating every row on it took the
+    // actions off completed answers the moment a follow-up turn started,
+    // reflowing rows the turn hasn't touched. Only the row the turn is
+    // producing waits for the status to settle.
     const showActions =
-      Boolean(actions.length > 0 || ActionsComponent) && status === 'ready';
+      Boolean(actions.length > 0 || ActionsComponent) &&
+      (status === 'ready' || !isCurrentMessage);
 
     const cssClasses: Required<ChatMessageClassNames> = {
       root: cx(

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -142,6 +142,53 @@ describe('ChatMessage', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  describe('actions visibility', () => {
+    const message: ChatMessageBase = {
+      role: 'assistant',
+      id: '1',
+      parts: [{ type: 'text', text: 'The answer is 2001.' }],
+    };
+    const actions = [{ title: 'Regenerate', onClick: jest.fn() }];
+
+    test('keeps them on a completed row while a new turn runs', () => {
+      const { container } = render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={message}
+          actions={actions}
+          context={createContext({
+            status: 'streaming',
+            messages: [
+              message,
+              {
+                role: 'user',
+                id: '2',
+                parts: [{ type: 'text', text: 'And?' }],
+              },
+            ],
+          })}
+        />
+      );
+
+      expect(container.querySelector('.ais-ChatMessage-action')).not.toBeNull();
+    });
+
+    test('hides them on the row the turn is producing', () => {
+      const { container } = render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={message}
+          actions={actions}
+          context={createContext({ status: 'streaming', messages: [message] })}
+        />
+      );
+
+      expect(container.querySelector('.ais-ChatMessage-action')).toBeNull();
+    });
+  });
+
   test('renders with custom class names', () => {
     const { container } = render(
       <ChatMessage


### PR DESCRIPTION
**Summary**

`showActions` read the chat's status, not the row's: `status === 'ready'` is true only between turns, so sending a follow-up took copy/regenerate/feedback off *every* past answer and reflowed rows the turn hadn't touched. Only the row the turn is producing has a reason to wait for the status to settle — `isCurrentMessage` is already computed a few lines above.

**Result**

- `yarn jest packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx` — actions stay on a completed row while a later turn streams, and are still hidden on the row being produced.
- `yarn jest common-widgets -t "Chat widget common tests"`, the `instantsearch-ui-components` chat suites, the `instantsearch.js` chat widget and `react-instantsearch` widget suites pass; lint and format clean.

Independent of #7215/#7216/#7217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)