### PR TITLE
fix(chat): settle failed client-side tools

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -452,9 +452,9 @@ export interface AbstractChat<TUIMessage extends UIMessage> {
 }
 export type AddToolResult = AbstractChat<UIMessage>['addToolResult'];
 
-export type AddToolResultWithOutput = (
-  params: { output: unknown }
-) => ReturnType<AddToolResult>;
+export type AddToolResultWithOutput = (params: {
+  output: unknown;
+}) => ReturnType<AddToolResult>;
 
 export type AddToolResultForToolCall = (
   params:

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -430,18 +430,44 @@ export interface AbstractChat<TUIMessage extends UIMessage> {
 
   clearError: () => void;
 
-  addToolResult: <TTool extends keyof InferUIMessageTools<TUIMessage>>(params: {
-    tool: TTool;
-    toolCallId: string;
-    output: InferUIMessageTools<TUIMessage>[TTool]['output'];
-  }) => Promise<void>;
+  addToolResult: <TTool extends keyof InferUIMessageTools<TUIMessage>>(
+    params: {
+      tool: TTool;
+      toolCallId: string;
+    } & (
+      | {
+          state?: 'output-available';
+          output: InferUIMessageTools<TUIMessage>[TTool]['output'];
+          errorText?: never;
+        }
+      | {
+          state: 'output-error';
+          output?: never;
+          errorText: string;
+        }
+    )
+  ) => Promise<void>;
 
   stop: () => Promise<void>;
 }
 export type AddToolResult = AbstractChat<UIMessage>['addToolResult'];
 
 export type AddToolResultWithOutput = (
-  params: Pick<Parameters<AddToolResult>[0], 'output'>
+  params: { output: unknown }
+) => ReturnType<AddToolResult>;
+
+export type AddToolResultForToolCall = (
+  params:
+    | {
+        state?: 'output-available';
+        output: unknown;
+        errorText?: never;
+      }
+    | {
+        state: 'output-error';
+        output?: never;
+        errorText: string;
+      }
 ) => ReturnType<AddToolResult>;
 
 type SearchToolExtraFields = {
@@ -778,9 +804,9 @@ export type ClientSideTool = {
     params: Parameters<
       NonNullable<ChatInit<UIMessage>['onToolCall']>
     >[0]['toolCall'] & {
-      addToolResult: AddToolResultWithOutput;
+      addToolResult: AddToolResultForToolCall;
     }
-  ) => void;
+  ) => void | PromiseLike<void>;
   /**
    * Output reported for this tool call when a request is sent while it is still
    * waiting for a result, for example `{ confirmed: false }` for a confirmation

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1582,15 +1582,39 @@ describe('connectChat', () => {
     it.each([
       [
         'throws',
-        () => {
-          throw new Error('The operation may have completed.');
+        {
+          onToolCall: () => {
+            throw new Error('The operation may have completed.');
+          },
+          errorText: 'The operation may have completed.',
         },
       ],
       [
         'rejects',
-        () => Promise.reject(new Error('The operation may have completed.')),
+        {
+          onToolCall: () =>
+            Promise.reject(new Error('The operation may have completed.')),
+          errorText: 'The operation may have completed.',
+        },
       ],
-    ])('settles a configured tool that %s', async (_name, onToolCall) => {
+      [
+        'throws undefined',
+        {
+          onToolCall: () => {
+            throw undefined;
+          },
+          errorText: 'Tool call failed.',
+        },
+      ],
+      [
+        'rejects null',
+        {
+          onToolCall: () => Promise.reject(null),
+          errorText: 'Tool call failed.',
+        },
+      ],
+    ])('settles a configured tool that %s', async (_name, toolCase) => {
+      const { onToolCall, errorText } = toolCase;
       const fetchMock = jest
         .fn()
         .mockResolvedValueOnce(
@@ -1634,7 +1658,7 @@ describe('connectChat', () => {
         type: 'tool-save',
         toolCallId: 'call-1',
         state: 'output-error',
-        errorText: 'The operation may have completed.',
+        errorText,
       });
       expect(widget.chatInstance.status).toBe('ready');
       expect(widget.chatInstance.error).toBeUndefined();

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -1579,6 +1579,72 @@ describe('connectChat', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
+    it.each([
+      [
+        'throws',
+        () => {
+          throw new Error('The operation may have completed.');
+        },
+      ],
+      [
+        'rejects',
+        () => Promise.reject(new Error('The operation may have completed.')),
+      ],
+    ])('settles a configured tool that %s', async (_name, onToolCall) => {
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValueOnce(
+          chatStream([
+            { type: 'start', messageId: 'assistant-1' },
+            {
+              type: 'tool-input-available',
+              toolName: 'save',
+              toolCallId: 'call-1',
+              input: {},
+            },
+            { type: 'finish' },
+          ])
+        )
+        .mockResolvedValueOnce(
+          chatStream([
+            { type: 'start', messageId: 'assistant-2' },
+            { type: 'text-start', id: 'text-1' },
+            {
+              type: 'text-delta',
+              id: 'text-1',
+              delta: 'Please check whether the save completed.',
+            },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish' },
+          ])
+        );
+      const { widget } = getInitializedWidget({
+        agentId: undefined,
+        persistence: false,
+        transport: { fetch: fetchMock },
+        tools: { save: { onToolCall } },
+      });
+
+      await widget.chatInstance.sendMessage({ text: 'save this' });
+
+      const assistant = widget.chatInstance.messages.find(
+        (message) => message.id === 'assistant-1'
+      );
+      expect(assistant?.parts[0]).toMatchObject({
+        type: 'tool-save',
+        toolCallId: 'call-1',
+        state: 'output-error',
+        errorText: 'The operation may have completed.',
+      });
+      expect(widget.chatInstance.status).toBe('ready');
+      expect(widget.chatInstance.error).toBeUndefined();
+      expect(widget.chatInstance.messages.at(-1)?.parts[0]).toMatchObject({
+        type: 'text',
+        text: 'Please check whether the save completed.',
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
     describe('cancelling a tool call the user never answered', () => {
       const pendingToolCallResponse = () =>
         chatStream([

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -869,13 +869,15 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
               });
-            const addToolError = (error: unknown) =>
-              addToolResult({
+            const addToolError = (error: unknown) => {
+              const errorText =
+                error instanceof Error ? error.message : String(error ?? '');
+
+              return addToolResult({
                 state: 'output-error',
-                errorText:
-                  (error instanceof Error ? error.message : String(error)) ||
-                  'Tool call failed.',
+                errorText: errorText || 'Tool call failed.',
               });
+            };
 
             try {
               return Promise.resolve(

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -57,7 +57,7 @@ import type {
   SearchResults,
 } from 'algoliasearch-helper';
 import type {
-  AddToolResultWithOutput,
+  AddToolResultForToolCall,
   UserClientSideTool,
   ClientSideTools,
   ClientSideTool,
@@ -863,17 +863,30 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           }
 
           if (tool.onToolCall) {
-            const addToolResult: AddToolResultWithOutput = ({ output }) =>
+            const addToolResult: AddToolResultForToolCall = (options) =>
               submitToolResult({
-                output,
+                ...options,
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
               });
+            const addToolError = (error: unknown) =>
+              addToolResult({
+                state: 'output-error',
+                errorText:
+                  (error instanceof Error ? error.message : String(error)) ||
+                  'Tool call failed.',
+              });
 
-            return tool.onToolCall({
-              ...toolCall,
-              addToolResult,
-            });
+            try {
+              return Promise.resolve(
+                tool.onToolCall({
+                  ...toolCall,
+                  addToolResult,
+                })
+              ).catch(addToolError);
+            } catch (error) {
+              return addToolError(error);
+            }
           }
 
           return Promise.resolve();

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -954,7 +954,7 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       }
     );
 
-    it('accepts a tool error without state from JavaScript and continues the response', async () => {
+    it('infers state-less JavaScript errors without overriding explicit success', async () => {
       const setup = createTestSetup({
         chunksByRequest: [
           [
@@ -965,16 +965,32 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
               toolCallId: 'call-1',
               input: {},
             },
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-2',
+              input: {},
+            },
             finishChunk(),
           ],
           [startChunk('msg-2'), finishChunk()],
         ],
-        onToolCall: ({ toolCall }, addToolResult) =>
-          addToolResult!({
+        onToolCall: ({ toolCall }, addToolResult) => {
+          const result =
+            toolCall.toolCallId === 'call-1'
+              ? { errorText: 'The operation may have completed.' }
+              : {
+                  state: 'output-available' as const,
+                  output: 'result',
+                  errorText: undefined,
+                };
+
+          return addToolResult!({
             tool: toolCall.toolName,
             toolCallId: toolCall.toolCallId,
-            errorText: 'The operation may have completed.',
-          } as Parameters<NonNullable<typeof addToolResult>>[0]),
+            ...result,
+          } as Parameters<NonNullable<typeof addToolResult>>[0]);
+        },
         sendAutomaticallyWhen: () => true,
       });
 
@@ -983,6 +999,10 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
         state: 'output-error',
         errorText: 'The operation may have completed.',
+      });
+      expect(assistantToolPart(setup.state, 'call-2')).toMatchObject({
+        state: 'output-available',
+        output: 'result',
       });
       expect(setup.state.status).toBe('ready');
       expect(setup.sendMessages).toHaveBeenCalledTimes(2);

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -954,7 +954,7 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       }
     );
 
-    it('accepts an explicit tool error and continues the response', async () => {
+    it('accepts a tool error without state from JavaScript and continues the response', async () => {
       const setup = createTestSetup({
         chunksByRequest: [
           [
@@ -973,9 +973,8 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
           addToolResult!({
             tool: toolCall.toolName,
             toolCallId: toolCall.toolCallId,
-            state: 'output-error',
             errorText: 'The operation may have completed.',
-          }),
+          } as Parameters<NonNullable<typeof addToolResult>>[0]),
         sendAutomaticallyWhen: () => true,
       });
 

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -954,6 +954,41 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       }
     );
 
+    it('accepts an explicit tool error and continues the response', async () => {
+      const setup = createTestSetup({
+        chunksByRequest: [
+          [
+            startChunk(),
+            {
+              type: 'tool-input-available',
+              toolName: 'search',
+              toolCallId: 'call-1',
+              input: {},
+            },
+            finishChunk(),
+          ],
+          [startChunk('msg-2'), finishChunk()],
+        ],
+        onToolCall: ({ toolCall }, addToolResult) =>
+          addToolResult!({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            state: 'output-error',
+            errorText: 'The operation may have completed.',
+          }),
+        sendAutomaticallyWhen: () => true,
+      });
+
+      await setup.chat.sendMessage({ text: 'search' });
+
+      expect(assistantToolPart(setup.state, 'call-1')).toMatchObject({
+        state: 'output-error',
+        errorText: 'The operation may have completed.',
+      });
+      expect(setup.state.status).toBe('ready');
+      expect(setup.sendMessages).toHaveBeenCalledTimes(2);
+    });
+
     it('keeps a successful onFinish and reports a rejected continuation predicate once', async () => {
       let chat!: TestChat;
       const onError = jest.fn();

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/public-types.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/public-types.test.ts
@@ -39,6 +39,18 @@ describe('ai-lite public types', () => {
     }) => {
       void toolCall;
     };
+    const onToolError: ChatOnToolCallCallback<SearchMessage> = (
+      { toolCall },
+      addToolResult
+    ) =>
+      toolCall.dynamic
+        ? undefined
+        : addToolResult({
+            tool: toolCall.toolName,
+            toolCallId: toolCall.toolCallId,
+            state: 'output-error',
+            errorText: 'Search failed.',
+          });
     const init: Pick<ChatInit<SearchMessage>, 'onToolCall'> = {
       onToolCall({ toolCall }, addToolResult) {
         if (toolCall.dynamic) {
@@ -62,9 +74,11 @@ describe('ai-lite public types', () => {
       submitToolResult,
       onToolCall,
       legacyOnToolCall,
+      onToolError,
       init.onToolCall,
       legacyInit.onToolCall,
     ]).toEqual([
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
       expect.any(Function),

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -25,6 +25,7 @@ import type {
   InferUIMessageTools,
   ProviderMetadata,
   ToolResultSubmission,
+  ToolResultSubmissionOptions,
   UIMessage,
   UIMessageChunk,
   ChatOnErrorCallback,
@@ -57,6 +58,16 @@ const TOOL_CALL_CANCELLED_ERROR_TEXT =
 type TerminalToolState =
   | { state: 'output-available'; output: unknown }
   | { state: 'output-error'; errorText: string };
+
+function getTerminalToolState(
+  options:
+    | { state?: 'output-available'; output: unknown }
+    | { state: 'output-error'; errorText: string }
+): TerminalToolState {
+  return options.state === 'output-error'
+    ? { state: 'output-error', errorText: options.errorText }
+    : { state: 'output-available', output: options.output };
+}
 
 function getToolName(part: { type: string; toolName?: string }): string {
   if (part.type === 'dynamic-tool') {
@@ -505,7 +516,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
   private commit(
     toolCallId: string,
-    output: unknown,
+    terminalState: TerminalToolState,
     messageId?: string,
     response?: ResponseRecord,
     expectedMessage?: TUIMessage
@@ -532,10 +543,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       return false;
     }
     const updatedParts = [...message.parts];
-    updatedParts[partIndex] = withTerminalToolState(part, {
-      state: 'output-available',
-      output,
-    });
+    updatedParts[partIndex] = withTerminalToolState(part, terminalState);
 
     const updatedMessage = {
       ...message,
@@ -691,14 +699,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
   private submitToolResult<TTool extends keyof InferUIMessageTools<TUIMessage>>(
     response: ResponseRecord | undefined,
-    {
-      toolCallId,
-      output,
-    }: {
-      tool: TTool;
-      toolCallId: string;
-      output: InferUIMessageTools<TUIMessage>[TTool]['output'];
-    },
+    options: ToolResultSubmissionOptions<TUIMessage, TTool>,
     messageId = response?.messageId,
     expectedMessage = messageId
       ? this.messages.find((message) => message.id === messageId)
@@ -708,13 +709,19 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
 
     const commitResult = (): Promise<void> => {
       if (
-        !this.commit(toolCallId, output, messageId, response, expectedMessage)
+        !this.commit(
+          options.toolCallId,
+          getTerminalToolState(options),
+          messageId,
+          response,
+          expectedMessage
+        )
       ) {
         return Promise.resolve();
       }
 
-      if (response?.requiredToolCallIds.has(toolCallId)) {
-        response.resolvedToolCallIds.add(toolCallId);
+      if (response?.requiredToolCallIds.has(options.toolCallId)) {
+        response.resolvedToolCallIds.add(options.toolCallId);
       }
       return this.continueResponse(response);
     };
@@ -773,7 +780,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       if (
         !this.commit(
           options.toolCallId,
-          options.output,
+          getTerminalToolState(options),
           message.id,
           undefined,
           message
@@ -790,11 +797,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     TTool extends keyof InferUIMessageTools<TUIMessage>,
   >(
     message: TUIMessage,
-    options: {
-      tool: TTool;
-      toolCallId: string;
-      output: InferUIMessageTools<TUIMessage>[TTool]['output'];
-    }
+    options: ToolResultSubmissionOptions<TUIMessage, TTool>
   ): Promise<void> => {
     const hasToolCall = (candidate: TUIMessage): boolean =>
       candidate.parts?.some(

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -64,13 +64,21 @@ function getTerminalToolState(
     | { state?: 'output-available'; output: unknown }
     | { state: 'output-error'; errorText: string }
 ): TerminalToolState {
-  if (options.state === 'output-error' || 'errorText' in options) {
+  if (options.state === 'output-error') {
     return {
       state: 'output-error',
-      errorText:
-        typeof options.errorText === 'string'
-          ? options.errorText
-          : 'Tool call failed.',
+      errorText: options.errorText || 'Tool call failed.',
+    };
+  }
+
+  if (
+    options.state === undefined &&
+    'errorText' in options &&
+    typeof options.errorText === 'string'
+  ) {
+    return {
+      state: 'output-error',
+      errorText: options.errorText || 'Tool call failed.',
     };
   }
 

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -64,9 +64,17 @@ function getTerminalToolState(
     | { state?: 'output-available'; output: unknown }
     | { state: 'output-error'; errorText: string }
 ): TerminalToolState {
-  return options.state === 'output-error'
-    ? { state: 'output-error', errorText: options.errorText }
-    : { state: 'output-available', output: options.output };
+  if (options.state === 'output-error' || 'errorText' in options) {
+    return {
+      state: 'output-error',
+      errorText:
+        typeof options.errorText === 'string'
+          ? options.errorText
+          : 'Tool call failed.',
+    };
+  }
+
+  return { state: 'output-available', output: options.output };
 }
 
 function getToolName(part: { type: string; toolName?: string }): string {

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -489,13 +489,30 @@ export type IdGenerator = () => string;
 
 export type ChatOnErrorCallback = (error: Error) => void;
 
-export type ToolResultSubmission<UI_MESSAGE extends UIMessage = UIMessage> = <
+export type ToolResultSubmissionOptions<
+  UI_MESSAGE extends UIMessage,
   TOOL extends keyof InferUIMessageTools<UI_MESSAGE>,
->(options: {
+> = {
   tool: TOOL;
   toolCallId: string;
-  output: InferUIMessageTools<UI_MESSAGE>[TOOL]['output'];
-}) => Promise<void>;
+} & (
+  | {
+      state?: 'output-available';
+      output: InferUIMessageTools<UI_MESSAGE>[TOOL]['output'];
+      errorText?: never;
+    }
+  | {
+      state: 'output-error';
+      output?: never;
+      errorText: string;
+    }
+);
+
+export type ToolResultSubmission<UI_MESSAGE extends UIMessage = UIMessage> = <
+  TOOL extends keyof InferUIMessageTools<UI_MESSAGE>,
+>(
+  options: ToolResultSubmissionOptions<UI_MESSAGE, TOOL>
+) => Promise<void>;
 
 export type ChatOnToolCallCallback<UI_MESSAGE extends UIMessage = UIMessage> = (
   options: {


### PR DESCRIPTION
**Summary**

- settle configured client-side tools as `output-error` when their handlers throw or reject
- allow `addToolResult` to explicitly submit an error and automatically continue the conversation
- preserve turn-level errors for missing tool implementations

**Example**

A configured `save` tool throws or rejects. Instead of remaining pending, the tool call becomes `output-error` and the assistant can explain the failure or suggest recovery.

This is the first incremental recovery step for [FX-3949](https://algolia.atlassian.net/browse/FX-3949). Timeout and abort handling will follow separately.

**Result**

- `yarn jest packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts packages/instantsearch.js/src/lib/ai-lite/__tests__/public-types.test.ts packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts --runInBand`
- Changed-file lint and format clean; the `instantsearch-ui-components` and `instantsearch.js` builds pass.

[FX-3949]: https://algolia.atlassian.net/browse/FX-3949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ