### PR TITLE
ci: run release-templates once per release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+    outputs:
+      released: ${{ steps.release-commit.outputs.released }}
     steps:
       - name: Mint GitHub App token
         id: app-token
@@ -352,3 +354,25 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           SLACK_INCOMING_HOOK: ${{ secrets.SLACK_INCOMING_HOOK }}
         run: yarn shipjs trigger
+
+      # The same signal `shipjs trigger` uses to decide whether to release, so
+      # the gate and the release agree by construction. A prefix match and not
+      # an equality check: the squash merge appends the pull request number, so
+      # the real subject reads `chore: release (#7209)`.
+      - name: Report whether a release happened
+        id: release-commit
+        run: |
+          case "$(git log -1 --pretty=%s)" in
+            "chore: release"*) printf 'released=true\n' >> "$GITHUB_OUTPUT" ;;
+            *) printf 'released=false\n' >> "$GITHUB_OUTPUT" ;;
+          esac
+
+  # Called from here, and no longer triggered by the release tags: a Ship.js
+  # release pushes one tag per changed package, and a tag trigger starts one run
+  # per matched tag, so the templates used to build twice per release.
+  release-templates:
+    name: release templates
+    needs: release-if-needed
+    if: needs.release-if-needed.outputs.released == 'true'
+    uses: ./.github/workflows/release-templates.yml
+    secrets: inherit

--- a/.github/workflows/release-templates.yml
+++ b/.github/workflows/release-templates.yml
@@ -1,18 +1,28 @@
 name: release-templates
 
 on:
-  push:
-    tags:
-      - 'instantsearch.js@*'
-      - 'create-instantsearch-app@*'
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.FX_BOT_APP_ID }}
+          private-key: ${{ secrets.FX_BOT_PRIVATE_KEY }}
+          owner: algolia
+          repositories: instantsearch
 
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
 
@@ -25,14 +35,19 @@ jobs:
         run: yarn workspace create-instantsearch-app release-templates
 
       - name: 🚀  push templates
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           cd packages/create-instantsearch-app/build
           UNCOMMITTED_CHANGES=`git status --porcelain`
           if [ ! -z "$UNCOMMITTED_CHANGES" ]; then
-            git config --global user.name "InstantSearch"
-            git config --global user.email "66688561+instantsearch-bot@users.noreply.github.com"
-            git commit -a -m "feat(template): Update templates"
-            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+            USER_ID=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)
+            git config user.name "${APP_SLUG}[bot]"
+            git config user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "feat(template): Update templates"
+            git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/$GITHUB_REPOSITORY
             git push origin templates
             echo "✅  Templates have been compiled to the branch templates."
           else


### PR DESCRIPTION
**Summary**

This PR makes the templates build run once per release instead of twice, and fixes two defects in the same path.

The workflow triggered on two tag patterns, and a Ship.js release pushes both tags. GitHub starts one run per matched tag, so every release started two identical runs. The two runs raced for the `templates` branch, and the loser failed at every release.

The commit step used `git commit -a`, which stages no untracked file. A newly added template therefore never reached the `templates` branch. CodeSandbox serves that branch, so those demos are absent today.

The workflow is now a reusable workflow called from CI after the publish, and only when a release actually happened. It also pushes with the FX bot app token instead of `GITHUB_TOKEN`, and moves `actions/checkout` and `actions/setup-node` from v3 to v7.