### PR TITLE
fix(chat): time out stalled client-side tools

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -313,6 +313,7 @@ export type InferUIMessageToolCall<TUIMessage extends UIMessage> =
 export type ChatOnToolCallCallback<TUIMessage extends UIMessage = UIMessage> =
   (options: {
     toolCall: InferUIMessageToolCall<TUIMessage>;
+    signal: AbortSignal;
   }) => void | PromiseLike<void>;
 
 /**
@@ -805,8 +806,16 @@ export type ClientSideTool = {
       NonNullable<ChatInit<UIMessage>['onToolCall']>
     >[0]['toolCall'] & {
       addToolResult: AddToolResultForToolCall;
+      signal: AbortSignal;
     }
   ) => void | PromiseLike<void>;
+  /**
+   * Maximum time in milliseconds for `onToolCall` to submit a result.
+   * Set to `false` to disable the timeout.
+   *
+   * @default 20000
+   */
+  timeout?: number | false;
   /**
    * Output reported for this tool call when a request is sent while it is still
    * waiting for a result, for example `{ confirmed: false }` for a confirmation

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -28,6 +28,7 @@ import type {
 } from '../../../lib/ai-lite';
 import type { InstantSearch, IndexWidget, Widget } from '../../../types';
 import type { ChatConnectorParams } from '../connectChat';
+import type { AddToolResultForToolCall } from 'instantsearch-ui-components';
 
 jest.mock('../../../lib/utils/sendChatMessageFeedback', () => ({
   sendChatMessageFeedback: jest.fn(() => Promise.resolve(new Response('{}'))),
@@ -1669,6 +1670,193 @@ describe('connectChat', () => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
+    it.each([
+      ['default timeout', undefined, 20_000],
+      ['configured timeout', 10, 10],
+    ] as const)(
+      'uses the %s for an unsettled tool and aborts its signal',
+      async (_name, timeout, timeoutDelay) => {
+        jest.useFakeTimers();
+
+        try {
+          let toolSignal!: AbortSignal;
+          let markToolStarted!: () => void;
+          const toolStarted = new Promise<void>((resolve) => {
+            markToolStarted = resolve;
+          });
+          const fetchMock = jest
+            .fn()
+            .mockResolvedValueOnce(
+              chatStream([
+                { type: 'start', messageId: 'assistant-1' },
+                {
+                  type: 'tool-input-available',
+                  toolName: 'save',
+                  toolCallId: 'call-1',
+                  input: {},
+                },
+                { type: 'finish' },
+              ])
+            )
+            .mockResolvedValueOnce(
+              chatStream([
+                { type: 'start', messageId: 'assistant-2' },
+                { type: 'finish' },
+              ])
+            );
+          const { widget } = getInitializedWidget({
+            agentId: undefined,
+            persistence: false,
+            transport: { fetch: fetchMock },
+            tools: {
+              save: {
+                timeout,
+                onToolCall({ signal }) {
+                  toolSignal = signal;
+                  markToolStarted();
+                },
+              },
+            },
+          });
+
+          const send = widget.chatInstance.sendMessage({ text: 'save this' });
+          await toolStarted;
+          await Promise.resolve();
+
+          jest.advanceTimersByTime(timeoutDelay - 1);
+          expect(toolSignal.aborted).toBe(false);
+
+          jest.advanceTimersByTime(1);
+          await send;
+
+          const assistant = widget.chatInstance.messages.find(
+            (message) => message.id === 'assistant-1'
+          );
+          expect(toolSignal.aborted).toBe(true);
+          expect(assistant?.parts[0]).toMatchObject({
+            state: 'output-error',
+            errorText:
+              'The tool call timed out before a result was received. The operation may have completed.',
+          });
+          expect(widget.chatInstance.status).toBe('ready');
+          expect(fetchMock).toHaveBeenCalledTimes(2);
+        } finally {
+          jest.useRealTimers();
+        }
+      }
+    );
+
+    it('allows a configured tool timeout to be disabled', async () => {
+      jest.useFakeTimers();
+
+      try {
+        let toolSignal!: AbortSignal;
+        let addToolResult!: AddToolResultForToolCall;
+        let markToolStarted!: () => void;
+        const toolStarted = new Promise<void>((resolve) => {
+          markToolStarted = resolve;
+        });
+        const fetchMock = jest.fn().mockResolvedValue(
+          chatStream([
+            { type: 'start', messageId: 'assistant-1' },
+            {
+              type: 'tool-input-available',
+              toolName: 'save',
+              toolCallId: 'call-1',
+              input: {},
+            },
+            { type: 'finish' },
+          ])
+        );
+        const { widget } = getInitializedWidget({
+          agentId: undefined,
+          persistence: false,
+          transport: { fetch: fetchMock },
+          sendAutomaticallyWhen: () => false,
+          tools: {
+            save: {
+              timeout: false,
+              onToolCall(params) {
+                toolSignal = params.signal;
+                addToolResult = params.addToolResult;
+                markToolStarted();
+              },
+            },
+          },
+        });
+
+        const send = widget.chatInstance.sendMessage({ text: 'save this' });
+        await toolStarted;
+        await Promise.resolve();
+
+        jest.advanceTimersByTime(20_000);
+        expect(toolSignal.aborted).toBe(false);
+
+        await addToolResult({ output: { saved: true } });
+        await send;
+
+        const assistant = widget.chatInstance.messages.find(
+          (message) => message.id === 'assistant-1'
+        );
+        expect(assistant?.parts[0]).toMatchObject({
+          state: 'output-available',
+          output: { saved: true },
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('aborts and settles a configured tool when the response is stopped', async () => {
+      let toolSignal!: AbortSignal;
+      let markToolStarted!: () => void;
+      const toolStarted = new Promise<void>((resolve) => {
+        markToolStarted = resolve;
+      });
+      const fetchMock = jest.fn().mockResolvedValue(
+        chatStream([
+          { type: 'start', messageId: 'assistant-1' },
+          {
+            type: 'tool-input-available',
+            toolName: 'save',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          { type: 'finish' },
+        ])
+      );
+      const { widget } = getInitializedWidget({
+        agentId: undefined,
+        persistence: false,
+        transport: { fetch: fetchMock },
+        tools: {
+          save: {
+            timeout: false,
+            onToolCall({ signal }) {
+              toolSignal = signal;
+              markToolStarted();
+              return new Promise<void>(() => {});
+            },
+          },
+        },
+      });
+
+      const send = widget.chatInstance.sendMessage({ text: 'save this' });
+      await toolStarted;
+      await widget.chatInstance.stop();
+      await send;
+
+      const assistant = widget.chatInstance.messages.find(
+        (message) => message.id === 'assistant-1'
+      );
+      expect(toolSignal.aborted).toBe(true);
+      expect(assistant?.parts[0]).toMatchObject({
+        state: 'output-error',
+        errorText: 'The tool call was cancelled before a result was received.',
+      });
+      expect(widget.chatInstance.status).toBe('ready');
+    });
+
     describe('cancelling a tool call the user never answered', () => {
       const pendingToolCallResponse = () =>
         chatStream([
@@ -1704,7 +1892,7 @@ describe('connectChat', () => {
           agentId: undefined,
           persistence: false,
           transport: { fetch: fetchMock },
-          tools: { confirm: { onToolCall: awaitUser } },
+          tools: { confirm: { onToolCall: awaitUser, timeout: false } },
         });
 
         await widget.chatInstance.sendMessage({ text: 'buy the first one' });
@@ -1729,7 +1917,9 @@ describe('connectChat', () => {
           agentId: undefined,
           persistence: false,
           transport: { fetch: fetchMock },
-          tools: { confirm: { onToolCall: awaitUser, cancelOutput } },
+          tools: {
+            confirm: { onToolCall: awaitUser, cancelOutput, timeout: false },
+          },
         });
 
         await widget.chatInstance.sendMessage({ text: 'buy the first one' });
@@ -1758,7 +1948,9 @@ describe('connectChat', () => {
           agentId: undefined,
           persistence: false,
           transport: { fetch: fetchMock },
-          tools: { confirm: { onToolCall: awaitUser, cancelOutput } },
+          tools: {
+            confirm: { onToolCall: awaitUser, cancelOutput, timeout: false },
+          },
         });
 
         await widget.chatInstance.sendMessage({ text: 'buy the first one' });
@@ -1785,7 +1977,9 @@ describe('connectChat', () => {
           agentId: undefined,
           persistence: false,
           transport: { fetch: fetchMock },
-          tools: { confirm: { onToolCall: awaitUser, cancelOutput } },
+          tools: {
+            confirm: { onToolCall: awaitUser, cancelOutput, timeout: false },
+          },
         });
 
         await widget.chatInstance.sendMessage({ text: 'buy the first one' });
@@ -1918,7 +2112,12 @@ data: [DONE]`,
               )
             ),
         },
-        tools: { algolia_search_index: { onToolCall: onSearchToolCall } },
+        tools: {
+          algolia_search_index: {
+            onToolCall: onSearchToolCall,
+            timeout: false,
+          },
+        },
       });
 
       const { chatInstance } = widget;
@@ -1973,6 +2172,7 @@ data: [DONE]`,
             onToolCall,
             matchesToolName: (toolName: string) =>
               toolName.startsWith('my_tool_'),
+            timeout: false,
           },
         },
       });

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -70,6 +70,12 @@ const withUsage = createDocumentationMessageGenerator({
   connector: true,
 });
 
+const DEFAULT_TOOL_TIMEOUT = 20_000;
+const TOOL_TIMEOUT_ERROR_TEXT =
+  'The tool call timed out before a result was received. The operation may have completed.';
+const TOOL_ABORTED_ERROR_TEXT =
+  'The tool call was cancelled before a result was received.';
+
 export type ChatSuggestionsStatus = 'idle' | 'loading';
 
 export type ChatRenderState<TUiMessage extends UIMessage = UIMessage> = {
@@ -845,7 +851,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
             return undefined;
           }
         },
-        onToolCall: (({ toolCall }, submitToolResult) => {
+        onToolCall: (({ toolCall, signal }, submitToolResult) => {
           const tool = findTool(toolCall.toolName, tools);
 
           if (!tool) {
@@ -863,12 +869,34 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           }
 
           if (tool.onToolCall) {
-            const addToolResult: AddToolResultForToolCall = (options) =>
-              submitToolResult({
+            const toolAbortController = new AbortController();
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
+            let settled = false;
+            let resolveExecution!: () => void;
+            let rejectExecution!: (error: unknown) => void;
+            const execution = new Promise<void>((resolve, reject) => {
+              resolveExecution = resolve;
+              rejectExecution = reject;
+            });
+            const cleanup = () => {
+              if (timeoutId !== undefined) {
+                clearTimeout(timeoutId);
+              }
+              signal.removeEventListener('abort', abortToolCall);
+            };
+            const addToolResult: AddToolResultForToolCall = (options) => {
+              if (settled) return Promise.resolve();
+
+              settled = true;
+              cleanup();
+              const submission = submitToolResult({
                 ...options,
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
               });
+              submission.then(resolveExecution, rejectExecution);
+              return submission;
+            };
             const addToolError = (error: unknown) => {
               const errorText =
                 error instanceof Error ? error.message : String(error ?? '');
@@ -878,17 +906,51 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
                 errorText: errorText || 'Tool call failed.',
               });
             };
+            function abortToolCall() {
+              const submission = addToolResult({
+                state: 'output-error',
+                errorText: TOOL_ABORTED_ERROR_TEXT,
+              });
+              toolAbortController.abort();
+              void submission.catch(() => undefined);
+            }
 
+            if (signal.aborted) {
+              abortToolCall();
+              return execution;
+            }
+
+            signal.addEventListener('abort', abortToolCall, { once: true });
+            if (tool.timeout !== false) {
+              timeoutId = setTimeout(() => {
+                const submission = addToolResult({
+                  state: 'output-error',
+                  errorText: TOOL_TIMEOUT_ERROR_TEXT,
+                });
+                toolAbortController.abort();
+                void submission.catch(() => undefined);
+              }, tool.timeout ?? DEFAULT_TOOL_TIMEOUT);
+            }
+
+            let toolExecution: void | PromiseLike<void>;
             try {
-              return Promise.resolve(
-                tool.onToolCall({
-                  ...toolCall,
-                  addToolResult,
-                })
-              ).catch(addToolError);
+              toolExecution = tool.onToolCall({
+                ...toolCall,
+                addToolResult,
+                signal: toolAbortController.signal,
+              });
             } catch (error) {
               return addToolError(error);
             }
+
+            const returnedExecution =
+              Promise.resolve(toolExecution).catch(addToolError);
+            if (tool.timeout === false) {
+              return Promise.race([returnedExecution.then(cleanup), execution]);
+            }
+
+            void returnedExecution.catch(() => undefined);
+            return execution;
           }
 
           return Promise.resolve();

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts
@@ -124,7 +124,7 @@ function createTestSetup(
       options: SendMessagesCall
     ) => Promise<ReadableStream<UIMessageChunk>>;
     onToolCall?: (
-      options: { toolCall: any },
+      options: { toolCall: any; signal: AbortSignal },
       addToolResult?: TestChat['addToolResult']
     ) => void | Promise<void>;
     onFinish?: ChatOnFinishCallback<UIMessage>;
@@ -1092,6 +1092,40 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
         expect(setup.sendMessages).toHaveBeenCalledTimes(1);
       }
     );
+
+    it('aborts the tool signal when the response is stopped', async () => {
+      let chat!: TestChat;
+      let toolSignal!: AbortSignal;
+      const toolCallStarted = deferred<undefined>();
+      const releaseToolCall = deferred<undefined>();
+      const setup = createTestSetup({
+        chunks: [
+          startChunk(),
+          {
+            type: 'tool-input-available',
+            toolName: 'search',
+            toolCallId: 'call-1',
+            input: {},
+          },
+          finishChunk(),
+        ],
+        onToolCall: ({ signal }) => {
+          toolSignal = signal;
+          toolCallStarted.resolve(undefined);
+          return releaseToolCall.promise;
+        },
+      });
+      chat = setup.chat;
+
+      const send = chat.sendMessage({ text: 'search' });
+      await toolCallStarted.promise;
+      await chat.stop();
+
+      expect(toolSignal.aborted).toBe(true);
+
+      releaseToolCall.resolve(undefined);
+      await send;
+    });
 
     it('settles an awaited late result after stop without continuing', async () => {
       let chat!: TestChat;
@@ -4627,13 +4661,14 @@ describe('AbstractChat.processStreamWithCallbacks', () => {
       });
       expect(onToolCall).toHaveBeenCalledTimes(1);
       expect(onToolCall).toHaveBeenCalledWith(
-        {
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
           toolCall: expect.objectContaining({
             toolName: 'search',
             toolCallId: 'call-1',
             input: { q: 'hello' },
           }),
-        },
+        }),
         expect.any(Function)
       );
     });

--- a/packages/instantsearch.js/src/lib/ai-lite/__tests__/public-types.test.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/__tests__/public-types.test.ts
@@ -21,9 +21,10 @@ describe('ai-lite public types', () => {
     const submitToolResult: ToolResultSubmission<SearchMessage> = () =>
       Promise.resolve();
     const onToolCall: ChatOnToolCallCallback<SearchMessage> = (
-      { toolCall },
+      { toolCall, signal },
       addToolResult
     ) => {
+      void signal;
       if (toolCall.dynamic) {
         return;
       }

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -1352,6 +1352,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                         input: chunk.input,
                         dynamic: 'dynamic' in chunk ? chunk.dynamic : undefined,
                       } as InferUIMessageToolCall<TUIMessage>,
+                      signal: response.abortController.signal,
                     },
                     (options) =>
                       response.isRetired

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -517,6 +517,7 @@ export type ToolResultSubmission<UI_MESSAGE extends UIMessage = UIMessage> = <
 export type ChatOnToolCallCallback<UI_MESSAGE extends UIMessage = UIMessage> = (
   options: {
     toolCall: InferUIMessageToolCall<UI_MESSAGE>;
+    signal: AbortSignal;
   },
   addToolResult: ToolResultSubmission<UI_MESSAGE>
 ) => void | PromiseLike<void>;


### PR DESCRIPTION
**Summary**

- Time out unsettled client-side tool calls after 20 seconds by default, with per-tool configuration and a `false` opt-out.
- Pass an `AbortSignal` to tool handlers and abort them on timeout or response cancellation.
- Settle timed-out calls as `output-error` with uncertain-completion messaging, then continue the response.

**Example**

A configured `save` tool never submits a result. After 20 seconds, its signal is aborted, the call becomes `output-error` with a warning that the operation may have completed, and the assistant can suggest recovery.

This is stacked on [#7219](https://github.com/algolia/instantsearch/pull/7219) and contributes to [FX-3949](https://algolia.atlassian.net/browse/FX-3949).

**Result**

- `yarn jest packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts packages/instantsearch.js/src/lib/ai-lite/__tests__/abstract-chat.test.ts packages/instantsearch.js/src/lib/ai-lite/__tests__/public-types.test.ts --runInBand`
- Changed-file lint and format clean; both package type builds pass.

[FX-3949]: https://algolia.atlassian.net/browse/FX-3949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ