### PR TITLE
fix(chat): settle restored client-side tools

### DIFF
--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -2204,6 +2204,49 @@ describe('connectChat', () => {
       );
     });
 
+    it('persists repaired tools after a failed resume attempt', async () => {
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-save',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
+      sessionStorage.setItem(cacheKey, JSON.stringify(previousMessages));
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValue(new Response(null, { status: 500 }));
+
+      const { getRenderState, widget } = getInitializedWidget({
+        agentId: undefined,
+        resume: true,
+        transport: { api: '/api', fetch: fetchMock },
+        tools: { save: { onToolCall: jest.fn() } },
+      });
+
+      await waitFor(() =>
+        expect(getRenderState().messages[0].parts[0]).toMatchObject({
+          toolCallId: 'call-1',
+          state: 'output-error',
+        })
+      );
+
+      expect(widget.chatInstance.status).toBe('error');
+      expect(JSON.parse(sessionStorage.getItem(cacheKey)!)[0].parts[0]).toEqual(
+        expect.objectContaining({
+          toolCallId: 'call-1',
+          state: 'output-error',
+        })
+      );
+    });
+
     it('repairs only the tools left pending by a resumed stream', async () => {
       const previousMessages: UIMessage[] = [
         {

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -2158,6 +2158,37 @@ describe('connectChat', () => {
       expect(getRenderState().messages).toEqual(messages);
     });
 
+    it('does not repair pending tools while resuming a stream', async () => {
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-save',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
+      sessionStorage.setItem(cacheKey, JSON.stringify(previousMessages));
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValue(new Response(null, { status: 404 }));
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: undefined,
+        resume: true,
+        transport: { api: '/api', fetch: fetchMock },
+        tools: { save: { onToolCall: jest.fn() } },
+      });
+
+      expect(getRenderState().messages).toEqual(previousMessages);
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    });
+
     it('does not save messages to sessionStorage when persistence is disabled', () => {
       const previousMessages: UIMessage[] = [
         {

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -2306,6 +2306,89 @@ data: [DONE]`,
       );
     });
 
+    it('does not repair tool calls started by a resumed stream', async () => {
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-save',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
+      sessionStorage.setItem(cacheKey, JSON.stringify(previousMessages));
+      const chunks = [
+        'data: {"type":"start","messageId":"assistant-2"}\n\n',
+        'data: {"type":"tool-input-available","toolName":"save","toolCallId":"call-2","input":{}}\n\n',
+      ].map((chunk) => new TextEncoder().encode(chunk));
+      let failResume!: () => void;
+      const fetchMock = jest.fn(() =>
+        Promise.resolve(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                chunks.forEach((chunk) => controller.enqueue(chunk));
+                failResume = () =>
+                  controller.error(new Error('Resume failed.'));
+              },
+            }),
+            { headers: { 'Content-Type': 'text/event-stream' } }
+          )
+        )
+      );
+      let addToolResult!: AddToolResultForToolCall;
+      const onToolCall = jest.fn((options) => {
+        addToolResult = options.addToolResult;
+      });
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: undefined,
+        resume: true,
+        transport: { api: '/api', fetch: fetchMock },
+        tools: { save: { onToolCall } },
+      });
+
+      await waitFor(() => expect(onToolCall).toHaveBeenCalledTimes(1));
+      failResume();
+      await waitFor(() =>
+        expect(getRenderState().messages).toEqual([
+          expect.objectContaining({
+            id: 'assistant-1',
+            parts: [
+              expect.objectContaining({
+                toolCallId: 'call-1',
+                state: 'output-error',
+              }),
+            ],
+          }),
+          expect.objectContaining({
+            id: 'assistant-2',
+            parts: [
+              expect.objectContaining({
+                toolCallId: 'call-2',
+                state: 'input-available',
+              }),
+            ],
+          }),
+        ])
+      );
+
+      await addToolResult({ output: { saved: true } });
+
+      expect(getRenderState().messages[1].parts[0]).toEqual(
+        expect.objectContaining({
+          toolCallId: 'call-2',
+          state: 'output-available',
+          output: { saved: true },
+        })
+      );
+    });
+
     it('does not save messages to sessionStorage when persistence is disabled', () => {
       const previousMessages: UIMessage[] = [
         {

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -2079,7 +2079,7 @@ describe('connectChat', () => {
           toolCallId: 'call-3',
           state: 'output-error',
           errorText:
-            'The page was reloaded before a tool result was received. The operation may have completed.',
+            'The page was reloaded before the tool input was complete. The operation was not started.',
         }),
       ]);
       expect(onToolCall).not.toHaveBeenCalled();
@@ -2158,7 +2158,7 @@ describe('connectChat', () => {
       expect(getRenderState().messages).toEqual(messages);
     });
 
-    it('does not repair pending tools while resuming a stream', async () => {
+    it('repairs pending tools after a resume attempt finds no stream', async () => {
       const previousMessages: UIMessage[] = [
         {
           id: 'assistant-1',
@@ -2174,9 +2174,13 @@ describe('connectChat', () => {
         },
       ];
       sessionStorage.setItem(cacheKey, JSON.stringify(previousMessages));
-      const fetchMock = jest
-        .fn()
-        .mockResolvedValue(new Response(null, { status: 404 }));
+      let resolveFetch!: (response: Response) => void;
+      const fetchMock = jest.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          })
+      );
 
       const { getRenderState } = getInitializedWidget({
         agentId: undefined,
@@ -2185,8 +2189,78 @@ describe('connectChat', () => {
         tools: { save: { onToolCall: jest.fn() } },
       });
 
-      expect(getRenderState().messages).toEqual(previousMessages);
       await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      expect(getRenderState().messages).toEqual(previousMessages);
+
+      resolveFetch(new Response(null, { status: 404 }));
+
+      await waitFor(() =>
+        expect(getRenderState().messages[0].parts[0]).toMatchObject({
+          toolCallId: 'call-1',
+          state: 'output-error',
+          errorText:
+            'The page was reloaded before a tool result was received. The operation may have completed.',
+        })
+      );
+    });
+
+    it('repairs only the tools left pending by a resumed stream', async () => {
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-save',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {},
+            },
+            {
+              type: 'tool-save',
+              toolCallId: 'call-2',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
+      sessionStorage.setItem(cacheKey, JSON.stringify(previousMessages));
+      const fetchMock = jest.fn().mockResolvedValue(
+        new Response(
+          `data: {"type":"start","messageId":"assistant-1"}
+
+data: {"type":"tool-output-available","toolCallId":"call-1","output":{"saved":true}}
+
+data: {"type":"finish"}
+
+data: [DONE]`,
+          { headers: { 'Content-Type': 'text/event-stream' } }
+        )
+      );
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: undefined,
+        resume: true,
+        transport: { api: '/api', fetch: fetchMock },
+        tools: { save: { onToolCall: jest.fn() } },
+      });
+
+      await waitFor(() =>
+        expect(getRenderState().messages[0].parts).toEqual([
+          expect.objectContaining({
+            toolCallId: 'call-1',
+            state: 'output-available',
+            output: { saved: true },
+          }),
+          expect.objectContaining({
+            toolCallId: 'call-2',
+            state: 'output-error',
+            errorText:
+              'The page was reloaded before a tool result was received. The operation may have completed.',
+          }),
+        ])
+      );
     });
 
     it('does not save messages to sessionStorage when persistence is disabled', () => {

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -2389,6 +2389,85 @@ data: [DONE]`,
       );
     });
 
+    it('does not repair a restored tool call reactivated by a resumed stream', async () => {
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-save',
+              toolCallId: 'call-1',
+              state: 'input-streaming',
+              input: {},
+            },
+            {
+              type: 'tool-save',
+              toolCallId: 'call-2',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
+      sessionStorage.setItem(cacheKey, JSON.stringify(previousMessages));
+      const chunks = [
+        'data: {"type":"start","messageId":"assistant-1"}\n\n',
+        'data: {"type":"tool-input-available","toolName":"save","toolCallId":"call-1","input":{}}\n\n',
+      ].map((chunk) => new TextEncoder().encode(chunk));
+      let failResume!: () => void;
+      const fetchMock = jest.fn(() =>
+        Promise.resolve(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                chunks.forEach((chunk) => controller.enqueue(chunk));
+                failResume = () =>
+                  controller.error(new Error('Resume failed.'));
+              },
+            }),
+            { headers: { 'Content-Type': 'text/event-stream' } }
+          )
+        )
+      );
+      let addToolResult!: AddToolResultForToolCall;
+      const onToolCall = jest.fn((options) => {
+        addToolResult = options.addToolResult;
+      });
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: undefined,
+        resume: true,
+        transport: { api: '/api', fetch: fetchMock },
+        tools: { save: { onToolCall } },
+      });
+
+      await waitFor(() => expect(onToolCall).toHaveBeenCalledTimes(1));
+      failResume();
+      await waitFor(() =>
+        expect(getRenderState().messages[0].parts).toEqual([
+          expect.objectContaining({
+            toolCallId: 'call-1',
+            state: 'input-available',
+          }),
+          expect.objectContaining({
+            toolCallId: 'call-2',
+            state: 'output-error',
+          }),
+        ])
+      );
+
+      await addToolResult({ output: { saved: true } });
+
+      expect(getRenderState().messages[0].parts[0]).toEqual(
+        expect.objectContaining({
+          toolCallId: 'call-1',
+          state: 'output-available',
+          output: { saved: true },
+        })
+      );
+    });
+
     it('does not save messages to sessionStorage when persistence is disabled', () => {
       const previousMessages: UIMessage[] = [
         {

--- a/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
+++ b/packages/instantsearch.js/src/connectors/chat/__tests__/connectChat-test.ts
@@ -2025,6 +2025,139 @@ describe('connectChat', () => {
       expect(getRenderState().messages).toEqual([]);
     });
 
+    it('settles restored auto-executed tool calls without rerunning them', () => {
+      const storageKey = `${cacheKey}-agentId`;
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-save',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: { value: 'static' },
+            },
+            {
+              type: 'dynamic-tool',
+              toolName: 'save',
+              toolCallId: 'call-2',
+              state: 'input-available',
+              input: { value: 'dynamic' },
+            },
+            {
+              type: 'tool-save',
+              toolCallId: 'call-3',
+              state: 'input-streaming',
+              input: { value: 'partial' },
+            },
+          ],
+        },
+      ];
+      sessionStorage.setItem(storageKey, JSON.stringify(previousMessages));
+      const onToolCall = jest.fn();
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: 'agentId',
+        tools: { save: { onToolCall } },
+      });
+
+      expect(getRenderState().messages[0].parts).toEqual([
+        expect.objectContaining({
+          toolCallId: 'call-1',
+          state: 'output-error',
+          errorText:
+            'The page was reloaded before a tool result was received. The operation may have completed.',
+        }),
+        expect.objectContaining({
+          toolCallId: 'call-2',
+          state: 'output-error',
+          errorText:
+            'The page was reloaded before a tool result was received. The operation may have completed.',
+        }),
+        expect.objectContaining({
+          toolCallId: 'call-3',
+          state: 'output-error',
+          errorText:
+            'The page was reloaded before a tool result was received. The operation may have completed.',
+        }),
+      ]);
+      expect(onToolCall).not.toHaveBeenCalled();
+      expect(JSON.parse(sessionStorage.getItem(storageKey)!)[0].parts).toEqual(
+        getRenderState().messages[0].parts
+      );
+    });
+
+    it('keeps restored timeout-disabled, interactive, and provider-executed tools pending', () => {
+      const previousMessages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-approve',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {},
+            },
+            {
+              type: 'tool-confirm',
+              toolCallId: 'call-2',
+              state: 'input-available',
+              input: {},
+            },
+            {
+              type: 'tool-save',
+              toolCallId: 'call-3',
+              state: 'input-available',
+              input: {},
+              providerExecuted: true,
+            },
+          ],
+        },
+      ];
+      sessionStorage.setItem(
+        `${cacheKey}-agentId`,
+        JSON.stringify(previousMessages)
+      );
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: 'agentId',
+        tools: {
+          approve: {},
+          confirm: { onToolCall: jest.fn(), timeout: false },
+          save: { onToolCall: jest.fn() },
+        },
+      });
+
+      expect(getRenderState().messages).toEqual(previousMessages);
+    });
+
+    it('does not repair explicitly provided pending messages', () => {
+      const messages: UIMessage[] = [
+        {
+          id: 'assistant-1',
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool-save',
+              toolCallId: 'call-1',
+              state: 'input-available',
+              input: {},
+            },
+          ],
+        },
+      ];
+
+      const { getRenderState } = getInitializedWidget({
+        agentId: 'agentId',
+        messages,
+        tools: { save: { onToolCall: jest.fn() } },
+      });
+
+      expect(getRenderState().messages).toEqual(messages);
+    });
+
     it('does not save messages to sessionStorage when persistence is disabled', () => {
       const previousMessages: UIMessage[] = [
         {

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -31,11 +31,7 @@ import {
 import { defer } from '../../lib/utils/defer';
 import { flat } from '../../lib/utils/flat';
 
-import type {
-  ChatOnToolCallCallback,
-  DynamicToolUIPart,
-  ToolUIPart,
-} from '../../lib/ai-lite';
+import type { ChatOnToolCallCallback } from '../../lib/ai-lite';
 import type {
   AbstractChat,
   ChatInit as ChatInitAi,
@@ -79,55 +75,6 @@ const TOOL_TIMEOUT_ERROR_TEXT =
   'The tool call timed out before a result was received. The operation may have completed.';
 const TOOL_ABORTED_ERROR_TEXT =
   'The tool call was cancelled before a result was received.';
-const RESTORED_TOOL_ERROR_TEXT =
-  'The page was reloaded before a tool result was received. The operation may have completed.';
-
-function isToolPart(
-  part: UIMessage['parts'][number]
-): part is ToolUIPart | DynamicToolUIPart {
-  return part.type === 'dynamic-tool' || part.type.startsWith('tool-');
-}
-
-function repairRestoredToolCalls<TUiMessage extends UIMessage>(
-  messages: TUiMessage[],
-  tools: Record<string, UserClientSideTool>
-): TUiMessage[] {
-  let didRepair = false;
-  const repairedMessages = messages.map((message) => {
-    if (message.role !== 'assistant') return message;
-
-    let didRepairMessage = false;
-    const parts = message.parts.map((part) => {
-      if (
-        !isToolPart(part) ||
-        part.providerExecuted ||
-        (part.state !== 'input-streaming' && part.state !== 'input-available')
-      ) {
-        return part;
-      }
-
-      const tool = findTool(
-        part.type === 'dynamic-tool' ? part.toolName : part.type,
-        tools
-      );
-      if (!tool?.onToolCall || tool.timeout === false) {
-        return part;
-      }
-
-      didRepair = true;
-      didRepairMessage = true;
-      return {
-        ...part,
-        state: 'output-error' as const,
-        errorText: RESTORED_TOOL_ERROR_TEXT,
-      };
-    });
-
-    return didRepairMessage ? { ...message, parts } : message;
-  });
-
-  return didRepair ? repairedMessages : messages;
-}
 
 export type ChatSuggestionsStatus = 'idle' | 'loading';
 
@@ -878,7 +825,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
         );
       }
 
-      const chat = new Chat({
+      return new Chat({
         ...options,
         persistence: normalizedPersistence.messages,
         sendAutomaticallyWhen,
@@ -887,6 +834,10 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           const tool = findTool(toolName, tools);
           if (!tool) return true;
           return Boolean(tool.streamInput);
+        },
+        shouldRepairRestoredPendingToolPart({ toolName }) {
+          const tool = findTool(toolName, tools);
+          return Boolean(!resume && tool?.onToolCall && tool.timeout !== false);
         },
         resolveCancelledToolOutput({ toolName, toolCallId, input }) {
           const cancelOutput = findTool(toolName, tools)?.cancelOutput;
@@ -1009,15 +960,6 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           return Promise.resolve();
         }) satisfies ChatOnToolCallCallback<TUiMessage>,
       } as ChatInitAi<TUiMessage> & { agentId?: string });
-
-      if (normalizedPersistence.messages && options.messages === undefined) {
-        const restoredMessages = repairRestoredToolCalls(chat.messages, tools);
-        if (restoredMessages !== chat.messages) {
-          chat.messages = restoredMessages;
-        }
-      }
-
-      return chat;
     };
 
     return {

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -825,7 +825,8 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
         );
       }
 
-      return new Chat({
+      let canRepairRestoredPendingToolParts = !resume;
+      const chat = new Chat({
         ...options,
         persistence: normalizedPersistence.messages,
         sendAutomaticallyWhen,
@@ -837,7 +838,11 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
         },
         shouldRepairRestoredPendingToolPart({ toolName }) {
           const tool = findTool(toolName, tools);
-          return Boolean(!resume && tool?.onToolCall && tool.timeout !== false);
+          return Boolean(
+            canRepairRestoredPendingToolParts &&
+            tool?.onToolCall &&
+            tool.timeout !== false
+          );
         },
         resolveCancelledToolOutput({ toolName, toolCallId, input }) {
           const cancelOutput = findTool(toolName, tools)?.cancelOutput;
@@ -960,6 +965,17 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           return Promise.resolve();
         }) satisfies ChatOnToolCallCallback<TUiMessage>,
       } as ChatInitAi<TUiMessage> & { agentId?: string });
+
+      if (resume) {
+        const resumeStream = chat.resumeStream;
+        chat.resumeStream = (requestOptions) =>
+          resumeStream(requestOptions).finally(() => {
+            canRepairRestoredPendingToolParts = true;
+            chat['~repairRestoredPendingToolParts']();
+          });
+      }
+
+      return chat;
     };
 
     return {

--- a/packages/instantsearch.js/src/connectors/chat/connectChat.ts
+++ b/packages/instantsearch.js/src/connectors/chat/connectChat.ts
@@ -31,7 +31,11 @@ import {
 import { defer } from '../../lib/utils/defer';
 import { flat } from '../../lib/utils/flat';
 
-import type { ChatOnToolCallCallback } from '../../lib/ai-lite';
+import type {
+  ChatOnToolCallCallback,
+  DynamicToolUIPart,
+  ToolUIPart,
+} from '../../lib/ai-lite';
 import type {
   AbstractChat,
   ChatInit as ChatInitAi,
@@ -75,6 +79,55 @@ const TOOL_TIMEOUT_ERROR_TEXT =
   'The tool call timed out before a result was received. The operation may have completed.';
 const TOOL_ABORTED_ERROR_TEXT =
   'The tool call was cancelled before a result was received.';
+const RESTORED_TOOL_ERROR_TEXT =
+  'The page was reloaded before a tool result was received. The operation may have completed.';
+
+function isToolPart(
+  part: UIMessage['parts'][number]
+): part is ToolUIPart | DynamicToolUIPart {
+  return part.type === 'dynamic-tool' || part.type.startsWith('tool-');
+}
+
+function repairRestoredToolCalls<TUiMessage extends UIMessage>(
+  messages: TUiMessage[],
+  tools: Record<string, UserClientSideTool>
+): TUiMessage[] {
+  let didRepair = false;
+  const repairedMessages = messages.map((message) => {
+    if (message.role !== 'assistant') return message;
+
+    let didRepairMessage = false;
+    const parts = message.parts.map((part) => {
+      if (
+        !isToolPart(part) ||
+        part.providerExecuted ||
+        (part.state !== 'input-streaming' && part.state !== 'input-available')
+      ) {
+        return part;
+      }
+
+      const tool = findTool(
+        part.type === 'dynamic-tool' ? part.toolName : part.type,
+        tools
+      );
+      if (!tool?.onToolCall || tool.timeout === false) {
+        return part;
+      }
+
+      didRepair = true;
+      didRepairMessage = true;
+      return {
+        ...part,
+        state: 'output-error' as const,
+        errorText: RESTORED_TOOL_ERROR_TEXT,
+      };
+    });
+
+    return didRepairMessage ? { ...message, parts } : message;
+  });
+
+  return didRepair ? repairedMessages : messages;
+}
 
 export type ChatSuggestionsStatus = 'idle' | 'loading';
 
@@ -825,7 +878,7 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
         );
       }
 
-      return new Chat({
+      const chat = new Chat({
         ...options,
         persistence: normalizedPersistence.messages,
         sendAutomaticallyWhen,
@@ -956,6 +1009,15 @@ export default (function connectChat<TWidgetParams extends UnknownWidgetParams>(
           return Promise.resolve();
         }) satisfies ChatOnToolCallCallback<TUiMessage>,
       } as ChatInitAi<TUiMessage> & { agentId?: string });
+
+      if (normalizedPersistence.messages && options.messages === undefined) {
+        const restoredMessages = repairRestoredToolCalls(chat.messages, tools);
+        if (restoredMessages !== chat.messages) {
+          chat.messages = restoredMessages;
+        }
+      }
+
+      return chat;
     };
 
     return {

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -56,6 +56,8 @@ const TOOL_CALL_CANCELLED_ERROR_TEXT =
   'The tool call was cancelled: the conversation moved on before a result was provided.';
 const RESTORED_TOOL_CALL_ERROR_TEXT =
   'The page was reloaded before a tool result was received. The operation may have completed.';
+const RESTORED_TOOL_INPUT_ERROR_TEXT =
+  'The page was reloaded before the tool input was complete. The operation was not started.';
 
 type TerminalToolState =
   | { state: 'output-available'; output: unknown }
@@ -103,9 +105,10 @@ function warnInvalidGlobalToolResult(toolCallId: string): void {
 
 // A tool call awaiting an output that the client owns. Provider-executed calls
 // are resolved server-side, so they are left alone.
-function isPendingToolPart<TPart>(
-  part: TPart
-): part is TPart & { toolCallId: string } {
+function isPendingToolPart<TPart>(part: TPart): part is TPart & {
+  toolCallId: string;
+  state: 'input-streaming' | 'input-available';
+} {
   const candidate = part as {
     type?: unknown;
     toolCallId?: unknown;
@@ -600,7 +603,10 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
           part.toolCallId,
           {
             state: 'output-error',
-            errorText: RESTORED_TOOL_CALL_ERROR_TEXT,
+            errorText:
+              part.state === 'input-streaming'
+                ? RESTORED_TOOL_INPUT_ERROR_TEXT
+                : RESTORED_TOOL_CALL_ERROR_TEXT,
           },
           message.id,
           undefined,

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -54,6 +54,8 @@ const defaultGuardrailFallbackResponse =
 
 const TOOL_CALL_CANCELLED_ERROR_TEXT =
   'The tool call was cancelled: the conversation moved on before a result was provided.';
+const RESTORED_TOOL_CALL_ERROR_TEXT =
+  'The page was reloaded before a tool result was received. The operation may have completed.';
 
 type TerminalToolState =
   | { state: 'output-available'; output: unknown }
@@ -162,6 +164,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     messages: TUIMessage[];
   }) => boolean | PromiseLike<boolean>;
   private shouldRepairToolInput?: (toolName: string) => boolean;
+  private shouldRepairRestoredPendingToolPart?: ChatInit<TUIMessage>['shouldRepairRestoredPendingToolPart'];
   private resolveCancelledToolOutput?: ChatInit<TUIMessage>['resolveCancelledToolOutput'];
 
   private activeResponse: ResponseRecord | null = null;
@@ -184,6 +187,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     onData,
     sendAutomaticallyWhen,
     shouldRepairToolInput,
+    shouldRepairRestoredPendingToolPart,
     resolveCancelledToolOutput,
   }: Omit<ChatInit<TUIMessage>, 'messages'> & {
     state: ChatState<TUIMessage>;
@@ -198,6 +202,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     this.onData = onData;
     this.sendAutomaticallyWhen = sendAutomaticallyWhen;
     this.shouldRepairToolInput = shouldRepairToolInput;
+    this.shouldRepairRestoredPendingToolPart =
+      shouldRepairRestoredPendingToolPart;
     this.resolveCancelledToolOutput = resolveCancelledToolOutput;
   }
 
@@ -567,6 +573,41 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     } as TUIMessage;
     this.replaceMessage(messageIndex, updatedMessage, response);
     return true;
+  }
+
+  protected repairRestoredPendingToolParts(): void {
+    const shouldRepairRestoredPendingToolPart =
+      this.shouldRepairRestoredPendingToolPart;
+    if (!shouldRepairRestoredPendingToolPart) return;
+
+    this.messages.forEach((message, messageIndex) => {
+      message.parts.forEach((part) => {
+        if (!isPendingToolPart(part)) return;
+
+        let shouldRepair = false;
+        try {
+          shouldRepair = shouldRepairRestoredPendingToolPart({
+            toolName: getToolName(part),
+            toolCallId: part.toolCallId,
+            input: 'input' in part ? part.input : undefined,
+          });
+        } catch {
+          return;
+        }
+        if (!shouldRepair) return;
+
+        this.commit(
+          part.toolCallId,
+          {
+            state: 'output-error',
+            errorText: RESTORED_TOOL_CALL_ERROR_TEXT,
+          },
+          message.id,
+          undefined,
+          this.messages[messageIndex]
+        );
+      });
+    });
   }
 
   /**

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -174,6 +174,7 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
   private latestResponse: ResponseRecord | null = null;
   private responsesByToolCallId = new Map<string, Set<ResponseRecord>>();
   private responseByMessage = new WeakMap<TUIMessage, ResponseRecord>();
+  private restoredToolCalls: Map<string, Set<string>> | undefined;
   // Once tool ownership is discarded, an identifier-only result cannot prove
   // which response generation submitted it. Scoped submissions remain safe.
   private acceptsIdentifierOnlyToolResults = true;
@@ -578,9 +579,26 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     return true;
   }
 
-  protected repairRestoredPendingToolParts(
-    restoredToolCalls?: ReadonlyMap<string, ReadonlySet<string>>
-  ): void {
+  protected captureRestoredToolCalls(): void {
+    const restoredToolCalls = new Map<string, Set<string>>();
+    this.messages.forEach((message) => {
+      message.parts.forEach((part) => {
+        if (!isPendingToolPart(part)) return;
+
+        const toolCallIds =
+          restoredToolCalls.get(message.id) ?? new Set<string>();
+        toolCallIds.add(part.toolCallId);
+        restoredToolCalls.set(message.id, toolCallIds);
+      });
+    });
+    this.restoredToolCalls = restoredToolCalls;
+  }
+
+  protected clearRestoredToolCalls(): void {
+    this.restoredToolCalls = undefined;
+  }
+
+  protected repairRestoredPendingToolParts(): void {
     const shouldRepairRestoredPendingToolPart =
       this.shouldRepairRestoredPendingToolPart;
     if (!shouldRepairRestoredPendingToolPart) return;
@@ -589,8 +607,8 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
       message.parts.forEach((part) => {
         if (!isPendingToolPart(part)) return;
         if (
-          restoredToolCalls &&
-          !restoredToolCalls.get(message.id)?.has(part.toolCallId)
+          this.restoredToolCalls &&
+          !this.restoredToolCalls.get(message.id)?.has(part.toolCallId)
         ) {
           return;
         }
@@ -1399,6 +1417,9 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
                 response.pendingToolCallbacks++;
 
                 try {
+                  this.restoredToolCalls
+                    ?.get(currentMessage.id)
+                    ?.delete(chunk.toolCallId);
                   const result = this.onToolCall(
                     {
                       toolCall: {

--- a/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/abstract-chat.ts
@@ -578,7 +578,9 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     return true;
   }
 
-  protected repairRestoredPendingToolParts(): void {
+  protected repairRestoredPendingToolParts(
+    restoredToolCalls?: ReadonlyMap<string, ReadonlySet<string>>
+  ): void {
     const shouldRepairRestoredPendingToolPart =
       this.shouldRepairRestoredPendingToolPart;
     if (!shouldRepairRestoredPendingToolPart) return;
@@ -586,6 +588,12 @@ export abstract class AbstractChat<TUIMessage extends UIMessage> {
     this.messages.forEach((message, messageIndex) => {
       message.parts.forEach((part) => {
         if (!isPendingToolPart(part)) return;
+        if (
+          restoredToolCalls &&
+          !restoredToolCalls.get(message.id)?.has(part.toolCallId)
+        ) {
+          return;
+        }
 
         let shouldRepair = false;
         try {

--- a/packages/instantsearch.js/src/lib/ai-lite/types.ts
+++ b/packages/instantsearch.js/src/lib/ai-lite/types.ts
@@ -547,6 +547,11 @@ export interface ChatInit<UI_MESSAGE extends UIMessage> {
     messages: UI_MESSAGE[];
   }) => boolean | PromiseLike<boolean>;
   shouldRepairToolInput?: (toolName: string) => boolean;
+  shouldRepairRestoredPendingToolPart?: (params: {
+    toolName: string;
+    toolCallId: string;
+    input: unknown;
+  }) => boolean;
   /**
    * Output to report for a tool call a request carries while it is still
    * awaiting its result. Return `undefined` to report the call as failed.

--- a/packages/instantsearch.js/src/lib/chat/chat.ts
+++ b/packages/instantsearch.js/src/lib/chat/chat.ts
@@ -191,7 +191,6 @@ export class Chat<
 > extends AbstractChat<TUiMessage> {
   _state: ChatState<TUiMessage>;
   private hasRestoredMessages = false;
-  private restoredToolCalls = new Map<string, Set<string>>();
 
   constructor({
     messages,
@@ -204,17 +203,8 @@ export class Chat<
     this._state = state;
     if (messages === undefined && persistence) {
       this.hasRestoredMessages = true;
-      this.messages.forEach((message) => {
-        message.parts.forEach((part) => {
-          if (!('toolCallId' in part)) return;
-
-          const toolCallIds =
-            this.restoredToolCalls.get(message.id) ?? new Set<string>();
-          toolCallIds.add(part.toolCallId);
-          this.restoredToolCalls.set(message.id, toolCallIds);
-        });
-      });
-      this.repairRestoredPendingToolParts(this.restoredToolCalls);
+      this.captureRestoredToolCalls();
+      this.repairRestoredPendingToolParts();
     }
   }
 
@@ -222,8 +212,8 @@ export class Chat<
     if (!this.hasRestoredMessages) return;
 
     this.hasRestoredMessages = false;
-    this.repairRestoredPendingToolParts(this.restoredToolCalls);
-    this.restoredToolCalls.clear();
+    this.repairRestoredPendingToolParts();
+    this.clearRestoredToolCalls();
     this._state['~persistMessages']();
   };
 

--- a/packages/instantsearch.js/src/lib/chat/chat.ts
+++ b/packages/instantsearch.js/src/lib/chat/chat.ts
@@ -191,6 +191,7 @@ export class Chat<
 > extends AbstractChat<TUiMessage> {
   _state: ChatState<TUiMessage>;
   private hasRestoredMessages = false;
+  private restoredToolCalls = new Map<string, Set<string>>();
 
   constructor({
     messages,
@@ -203,7 +204,17 @@ export class Chat<
     this._state = state;
     if (messages === undefined && persistence) {
       this.hasRestoredMessages = true;
-      this.repairRestoredPendingToolParts();
+      this.messages.forEach((message) => {
+        message.parts.forEach((part) => {
+          if (!('toolCallId' in part)) return;
+
+          const toolCallIds =
+            this.restoredToolCalls.get(message.id) ?? new Set<string>();
+          toolCallIds.add(part.toolCallId);
+          this.restoredToolCalls.set(message.id, toolCallIds);
+        });
+      });
+      this.repairRestoredPendingToolParts(this.restoredToolCalls);
     }
   }
 
@@ -211,7 +222,8 @@ export class Chat<
     if (!this.hasRestoredMessages) return;
 
     this.hasRestoredMessages = false;
-    this.repairRestoredPendingToolParts();
+    this.repairRestoredPendingToolParts(this.restoredToolCalls);
+    this.restoredToolCalls.clear();
     this._state['~persistMessages']();
   };
 

--- a/packages/instantsearch.js/src/lib/chat/chat.ts
+++ b/packages/instantsearch.js/src/lib/chat/chat.ts
@@ -194,6 +194,9 @@ export class Chat<
     const state = new ChatState(agentId, messages, persistence);
     super({ ...init, state });
     this._state = state;
+    if (messages === undefined && persistence) {
+      this.repairRestoredPendingToolParts();
+    }
   }
 
   '~registerMessagesCallback' = (onChange: () => void): (() => void) =>

--- a/packages/instantsearch.js/src/lib/chat/chat.ts
+++ b/packages/instantsearch.js/src/lib/chat/chat.ts
@@ -184,6 +184,7 @@ export class Chat<
   TUiMessage extends UIMessage,
 > extends AbstractChat<TUiMessage> {
   _state: ChatState<TUiMessage>;
+  private hasRestoredMessages = false;
 
   constructor({
     messages,
@@ -195,9 +196,17 @@ export class Chat<
     super({ ...init, state });
     this._state = state;
     if (messages === undefined && persistence) {
+      this.hasRestoredMessages = true;
       this.repairRestoredPendingToolParts();
     }
   }
+
+  '~repairRestoredPendingToolParts' = (): void => {
+    if (!this.hasRestoredMessages) return;
+
+    this.hasRestoredMessages = false;
+    this.repairRestoredPendingToolParts();
+  };
 
   '~registerMessagesCallback' = (onChange: () => void): (() => void) =>
     this._state['~registerMessagesCallback'](onChange);

--- a/packages/instantsearch.js/src/lib/chat/chat.ts
+++ b/packages/instantsearch.js/src/lib/chat/chat.ts
@@ -58,6 +58,7 @@ export class ChatState<
   _messagesCallbacks = new Set<() => void>();
   _statusCallbacks = new Set<() => void>();
   _errorCallbacks = new Set<() => void>();
+  private persistenceKey: string | undefined;
 
   constructor(
     id: string | undefined = undefined,
@@ -76,22 +77,14 @@ export class ChatState<
       return;
     }
 
-    const saveMessagesInLocalStorage = () => {
+    this.persistenceKey = CACHE_KEY + (id ? `-${id}` : '');
+    const saveMessagesInSessionStorage = () => {
       if (this.status === 'ready') {
-        safelyRunOnBrowser(() => {
-          try {
-            sessionStorage.setItem(
-              CACHE_KEY + (id ? `-${id}` : ''),
-              JSON.stringify(this.messages)
-            );
-          } catch (e) {
-            // Do nothing if sessionStorage is not available or full
-          }
-        });
+        this['~persistMessages']();
       }
     };
-    this['~registerMessagesCallback'](saveMessagesInLocalStorage);
-    this['~registerStatusCallback'](saveMessagesInLocalStorage);
+    this['~registerMessagesCallback'](saveMessagesInSessionStorage);
+    this['~registerStatusCallback'](saveMessagesInSessionStorage);
   }
 
   get status(): ChatStatus {
@@ -143,6 +136,19 @@ export class ChatState<
 
   snapshot = <T>(thing: T): T => {
     return JSON.parse(JSON.stringify(thing)) as T;
+  };
+
+  '~persistMessages' = (): void => {
+    const persistenceKey = this.persistenceKey;
+    if (!persistenceKey) return;
+
+    safelyRunOnBrowser(() => {
+      try {
+        sessionStorage.setItem(persistenceKey, JSON.stringify(this.messages));
+      } catch (e) {
+        // Do nothing if sessionStorage is not available or full
+      }
+    });
   };
 
   '~registerMessagesCallback' = (onChange: () => void): (() => void) => {
@@ -206,6 +212,7 @@ export class Chat<
 
     this.hasRestoredMessages = false;
     this.repairRestoredPendingToolParts();
+    this._state['~persistMessages']();
   };
 
   '~registerMessagesCallback' = (onChange: () => void): (() => void) =>


### PR DESCRIPTION
**Summary**

- Repair pending auto-executed tool calls restored from `sessionStorage` as `output-error` without rerunning them.
- Persist the repaired transcript using the chat core's normal tool commit path.
- Leave interactive, timeout-disabled, provider-executed, explicitly provided, and actively resumed tool calls unchanged.

**Example**

A page reloads after a `save` tool started but before its result reached the chat. The restored call becomes `output-error` with a warning that the operation may have completed, instead of spinning forever or repeating the write.

This is stacked on [#7222](https://github.com/algolia/instantsearch/pull/7222) and contributes to [FX-3949](https://algolia.atlassian.net/browse/FX-3949).

**Result**

- The chat connector, core lifecycle, persistence, and server-rendering suites pass.
- Changed-file lint and format clean; the `instantsearch.js` type build passes.

[FX-3949]: https://algolia.atlassian.net/browse/FX-3949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ