### PR TITLE
fix(prompt-suggestions): fetch on init when a context is set

### DIFF
--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -1178,7 +1178,8 @@ describe('connectPromptSuggestions', () => {
     });
 
     it('does not fetch on init without a `context`', async () => {
-      const widget = connectPromptSuggestions(jest.fn())({
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
         agentId: 'a',
       });
       const helper = algoliasearchHelper(createSearchClient(), '');
@@ -1186,10 +1187,15 @@ describe('connectPromptSuggestions', () => {
       await flush(DEBOUNCE_WAIT);
 
       expect(global.fetch).not.toHaveBeenCalled();
+      // The auto-extracted path is left entirely on `render()`: init must not
+      // reach the "nothing to send" branch, whose `invalidate()` would add two
+      // outward renders on top of the first one.
+      expect(renderFn.mock.calls.map((call) => call[1])).toEqual([true]);
     });
 
     it('does not fetch on init when a function `context` returns undefined', async () => {
-      const widget = connectPromptSuggestions(jest.fn())({
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
         agentId: 'a',
         context: () => undefined,
       });
@@ -1198,10 +1204,12 @@ describe('connectPromptSuggestions', () => {
       await flush(DEBOUNCE_WAIT);
 
       expect(global.fetch).not.toHaveBeenCalled();
+      expect(renderFn.mock.calls.map((call) => call[1])).toEqual([true]);
     });
 
     it('does not fetch on init when the `context` resolves to an empty object', async () => {
-      const widget = connectPromptSuggestions(jest.fn())({
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
         agentId: 'a',
         context: () => ({}),
       });
@@ -1210,6 +1218,7 @@ describe('connectPromptSuggestions', () => {
       await flush(DEBOUNCE_WAIT);
 
       expect(global.fetch).not.toHaveBeenCalled();
+      expect(renderFn.mock.calls.map((call) => call[1])).toEqual([true]);
     });
 
     it('does not fetch a second time when results arrive after the init fetch', async () => {

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -547,6 +547,9 @@ describe('connectPromptSuggestions', () => {
       });
       const helper = algoliasearchHelper(createSearchClient(), '');
       widget.init!(createInitOptions({ helper }));
+      // A `context` fetches on init, so every count below includes that attempt.
+      await flush(0);
+      expect(prepare).toHaveBeenCalledTimes(1);
 
       widget.render!(
         createRenderOptions({
@@ -555,7 +558,7 @@ describe('connectPromptSuggestions', () => {
         })
       );
       await flush(DEBOUNCE_WAIT);
-      expect(prepare).toHaveBeenCalledTimes(1);
+      expect(prepare).toHaveBeenCalledTimes(2);
 
       widget.render!(
         createRenderOptions({
@@ -564,7 +567,7 @@ describe('connectPromptSuggestions', () => {
         })
       );
       await flush(DEBOUNCE_WAIT);
-      expect(prepare).toHaveBeenCalledTimes(2);
+      expect(prepare).toHaveBeenCalledTimes(3);
     });
 
     it('skips when only the `context` key order changes', async () => {
@@ -714,6 +717,10 @@ describe('connectPromptSuggestions', () => {
       });
       const helper = algoliasearchHelper(createSearchClient(), '');
       widget.init!(createInitOptions({ helper }));
+      // A `context` fetches on init, so every count below includes that
+      // attempt — which fails here like the rest.
+      await flush(10);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
 
       widget.render!(
         createRenderOptions({
@@ -723,7 +730,7 @@ describe('connectPromptSuggestions', () => {
       );
       await flush(DEBOUNCE_WAIT);
       await flush(10);
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
       expect(renderFn.mock.calls[renderFn.mock.calls.length - 1][0].error).toBe(
         streamError
       );
@@ -735,7 +742,7 @@ describe('connectPromptSuggestions', () => {
         })
       );
       await flush(DEBOUNCE_WAIT);
-      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
 
       widget.dispose!(createDisposeOptions({ helper }));
     });
@@ -1118,6 +1125,143 @@ describe('connectPromptSuggestions', () => {
       await flush(DEBOUNCE_WAIT);
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches on init with an explicit `context`, without any search', async () => {
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        context: { productName: 'Sneakers' },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string
+      );
+      expect(body.input).toEqual({ productName: 'Sneakers' });
+    });
+
+    it('resolves a function `context` for the init fetch', async () => {
+      const context = jest.fn(() => ({ productName: 'Sneakers' }));
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        context,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body as string
+      );
+      expect(body.input).toEqual({ productName: 'Sneakers' });
+    });
+
+    it('renders the first render before the init fetch starts', async () => {
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        context: { productName: 'Sneakers' },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      // The submit renders synchronously, so the `isFirstRender: true` render
+      // has to have gone out ahead of it.
+      expect(renderFn.mock.calls[0][1]).toBe(true);
+      expect(renderFn.mock.calls.length).toBeGreaterThan(1);
+      expect(renderFn.mock.calls[1][1]).toBe(false);
+      expect(renderFn.mock.calls[1][0].isLoading).toBe(true);
+    });
+
+    it('does not fetch on init without a `context`', async () => {
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch on init when a function `context` returns undefined', async () => {
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        context: () => undefined,
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch on init when the `context` resolves to an empty object', async () => {
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        context: () => ({}),
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch a second time when results arrive after the init fetch', async () => {
+      const widget = connectPromptSuggestions(jest.fn())({
+        agentId: 'a',
+        context: { productName: 'Sneakers' },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      await flush(0);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      // The payload ignores the results, so the render that follows asks the
+      // same question and must be skipped as a duplicate.
+      widget.render!(createRenderOptions({ helper, results: makeResults() }));
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('`refresh()` sends with no results when a `context` is set', async () => {
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        context: { productName: 'Sneakers' },
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+      // Wait out the init fetch so `refresh()` is not blocked by `isLoading`.
+      await flush(DEBOUNCE_WAIT);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+
+      const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      lastCall.refresh();
+      await flush(0);
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('`refresh()` sends nothing with no results and no `context`', async () => {
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+      });
+      const helper = algoliasearchHelper(createSearchClient(), '');
+      widget.init!(createInitOptions({ helper }));
+
+      const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      lastCall.refresh();
+      await flush(DEBOUNCE_WAIT);
+
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it('exposes `refresh()` which bypasses the debounce and refetches', async () => {

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -112,7 +112,11 @@ export type PromptSuggestionsRenderState = {
   onSuggestionClick: (prompt: string) => void;
   /** Hands the prompt to the `connectChat` widget on the same index. `true` if dispatched, else `false`. */
   sendToChat: (prompt: string) => boolean;
-  /** Imperative refetch that bypasses the debounce. No-op with no results or a fetch in-flight. */
+  /**
+   * Imperative refetch that bypasses the debounce. Usable from `init()` onwards,
+   * including on a mount that never produces search results. No-op while a fetch
+   * is in flight, or when there is nothing to send.
+   */
   refresh: () => void;
   /**
    * Whether the chat widget is currently busy (mid-stream) — surface as `disabled` on the pills.
@@ -142,8 +146,21 @@ export type PromptSuggestionsConnectorParams = PromptSuggestionsSource & {
   configurationId?: string;
   /** Transforms hits before use as context (default: first 5, metadata stripped). Ignored with `context`. */
   transformHits?: PromptSuggestionsTransformHits;
-  /** Explicit context, replacing the auto-extracted `{ query, filters, hitsSample }`. Object or per-fetch function. */
-  context?: Record<string, unknown> | (() => Record<string, unknown>);
+  /**
+   * Explicit context, replacing the auto-extracted `{ query, filters, hitsSample }`.
+   * Object or per-fetch function.
+   *
+   * Set, it makes the request independent of the search results, so the first
+   * fetch goes out on `init()` rather than waiting for a search to resolve.
+   *
+   * A function returning `undefined` falls back to auto-extraction, which needs
+   * results carrying at least one hit — so nothing is sent before those arrive.
+   * An empty object sends nothing at all, which is how a surface says it has
+   * nothing to describe yet.
+   */
+  context?:
+    | Record<string, unknown>
+    | (() => Record<string, unknown> | undefined);
   /** Transforms the parsed suggestions before exposing them. Receives `{ query, results }`. */
   transformItems?: PromptSuggestionsTransformItems;
 };
@@ -256,7 +273,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       // trigger keys on the search state, which is only a proxy for the payload,
       // so this is what decides whether a request would ask anything new.
       let lastSubmittedPayload: string | null = null;
-      let latestRenderOptions: RenderOptions | null = null;
+      let latestRenderOptions: InitOptions | RenderOptions | null = null;
       // Set in `dispose()`. A debounced or in-flight `fetch()` can resolve after
       // the widget is unmounted; this guard stops those late callbacks from
       // calling `renderFn` into a torn-down container.
@@ -310,7 +327,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
             return false;
           }
           const results =
-            latestRenderOptions?.results ??
+            getLatestResults() ??
             ('results' in renderOptions ? renderOptions.results : null) ??
             null;
           return openChat(chatRenderState, {
@@ -320,11 +337,16 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           });
         };
 
-      const resolvePageContext = (
+      // `context` may be a function, so the option alone says nothing about what
+      // a given fetch actually has to send. Resolve it once per fetch and let
+      // callers read the value rather than the option.
+      const resolveContext = (): Record<string, unknown> | undefined =>
+        typeof context === 'function' ? context() : context;
+
+      const buildPageContext = (
+        resolvedContext: Record<string, unknown> | undefined,
         results: SearchResults | null
       ): Record<string, unknown> | undefined => {
-        const resolvedContext =
-          typeof context === 'function' ? context() : context;
         // Explicit context replaces auto-extraction; otherwise derive it from
         // the current search state. The task's server-owned instructions decide
         // how to interpret the shape — the client doesn't label it.
@@ -342,16 +364,13 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         };
       };
 
-      const buildInput = (results: SearchResults): Record<string, unknown> =>
-        resolvePageContext(results) ?? {};
-
       // The same page context, flattened for the chat handoff: `turnContext` is
       // a flat `Record<string, string>` per the Agent Studio contract, so
       // non-string values (e.g. `hitsSample`) are serialized.
       const buildTurnContext = (
         results: SearchResults | null
       ): Record<string, string> | undefined => {
-        const pageContext = resolvePageContext(results);
+        const pageContext = buildPageContext(resolveContext(), results);
         if (!pageContext) {
           return undefined;
         }
@@ -362,6 +381,16 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           ])
           .filter(([, value]) => value.trim() !== '');
         return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+      };
+
+      // `latestRenderOptions` may be the `init()` options, which carry no
+      // `results` key at all, so the read has to be narrowed rather than
+      // optional-chained.
+      const getLatestResults = (): SearchResults | null => {
+        if (!latestRenderOptions || !('results' in latestRenderOptions)) {
+          return null;
+        }
+        return latestRenderOptions.results ?? null;
       };
 
       const renderOutward = (renderOptions: InitOptions | RenderOptions) => {
@@ -394,16 +423,25 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       };
 
       const fetchAndRender = (
-        results: SearchResults,
-        renderOptions: RenderOptions,
+        results: SearchResults | null,
+        renderOptions: InitOptions | RenderOptions,
         { force = false }: { force?: boolean } = {}
       ) => {
         if (disposed || !tasksState) return;
         const hadDroppedInnerRender = droppedInnerRender;
         refetchPending = false;
         droppedInnerRender = false;
-        const hasContext = context !== undefined;
-        if (!hasContext && !results?.hits?.length) {
+        const resolvedContext = resolveContext();
+        const input = buildPageContext(resolvedContext, results) ?? {};
+        // Two ways there is nothing worth sending: no context for this fetch and
+        // no hits to derive one from, or a context that resolved to something
+        // empty. The first reads the resolved value rather than the option, so
+        // `context: () => undefined` is gated exactly like an omitted `context`.
+        // Sending an empty input spends a model call on no information.
+        if (
+          (resolvedContext === undefined && !results?.hits?.length) ||
+          Object.keys(input).length === 0
+        ) {
           tasksState.invalidate();
           suggestions = [];
           isLoading = false;
@@ -413,7 +451,6 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           return;
         }
 
-        const input = buildInput(results);
         const payload = taskPayloadKey(input);
 
         // A moved search state does not always mean a different question: with an
@@ -441,10 +478,14 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
 
       const refresh = () => {
         if (isLoading) return;
-        const results = latestRenderOptions?.results;
-        if (!results || !latestRenderOptions) return;
+        if (!latestRenderOptions) return;
+        const results = getLatestResults();
         clearTimeout(debounceTimer);
-        lastStateSignature = getStateSignature(results);
+        // Only meaningful with results: without them there is no signature for a
+        // later automatic fetch to compare against.
+        if (results) {
+          lastStateSignature = getStateSignature(results);
+        }
         fetchAndRender(results, latestRenderOptions, { force: true });
       };
 
@@ -532,6 +573,11 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
 
           tasksWidget.init!(initOptions);
 
+          // Set after the inner init so its initial no-op render is still
+          // ignored, and before the first outward render so `refresh()` has a
+          // render target even on a mount where `render()` never sees results.
+          latestRenderOptions = initOptions;
+
           renderFn(
             {
               ...getWidgetRenderState(initOptions),
@@ -539,6 +585,16 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
             },
             true
           );
+
+          // With an explicit `context` the payload never reads the results, so
+          // waiting for a search is waiting on something the request does not
+          // use — and a page that triggers no search (a `searchFunction` query
+          // gate, or a mount made only for the widgets) would wait forever.
+          // Fetch here instead, after the first render so the `isFirstRender`
+          // one still arrives first. `fetchAndRender` sends nothing when the
+          // context resolves to nothing, which is what keeps the auto-extracted
+          // path — the one that does need results — on `render()` alone.
+          fetchAndRender(null, initOptions);
         },
 
         render(renderOptions) {
@@ -565,11 +621,9 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
             error = undefined;
             clearTimeout(debounceTimer);
             debounceTimer = setTimeout(() => {
-              if (latestRenderOptions?.results) {
-                fetchAndRender(
-                  latestRenderOptions.results,
-                  latestRenderOptions
-                );
+              const latestResults = getLatestResults();
+              if (latestResults && latestRenderOptions) {
+                fetchAndRender(latestResults, latestRenderOptions);
               }
             }, DEBOUNCE_MS);
           }

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -113,8 +113,7 @@ export type PromptSuggestionsRenderState = {
   /** Hands the prompt to the `connectChat` widget on the same index. `true` if dispatched, else `false`. */
   sendToChat: (prompt: string) => boolean;
   /**
-   * Imperative refetch that bypasses the debounce. Usable from `init()` onwards,
-   * including on a mount that never produces search results. No-op while a fetch
+   * Imperative refetch that bypasses the debounce. No-op while a fetch
    * is in flight, or when there is nothing to send.
    */
   refresh: () => void;
@@ -148,15 +147,8 @@ export type PromptSuggestionsConnectorParams = PromptSuggestionsSource & {
   transformHits?: PromptSuggestionsTransformHits;
   /**
    * Explicit context, replacing the auto-extracted `{ query, filters, hitsSample }`.
-   * Object or per-fetch function.
-   *
-   * Set, it makes the request independent of the search results, so the first
-   * fetch goes out on `init()` rather than waiting for a search to resolve.
-   *
-   * A function returning `undefined` falls back to auto-extraction, which needs
-   * results carrying at least one hit — so nothing is sent before those arrive.
-   * An empty object sends nothing at all, which is how a surface says it has
-   * nothing to describe yet.
+   * Object or per-fetch function. If you return `undefined`, auto-extraction is used.
+   * An empty object return skips the fetch
    */
   context?:
     | Record<string, unknown>

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -583,10 +583,18 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           // use — and a page that triggers no search (a `searchFunction` query
           // gate, or a mount made only for the widgets) would wait forever.
           // Fetch here instead, after the first render so the `isFirstRender`
-          // one still arrives first. `fetchAndRender` sends nothing when the
-          // context resolves to nothing, which is what keeps the auto-extracted
-          // path — the one that does need results — on `render()` alone.
-          fetchAndRender(null, initOptions);
+          // one still arrives first.
+          //
+          // There are no results yet by definition, so "is there anything to
+          // send" reduces to "did the context resolve to something". Checking it
+          // here rather than letting `fetchAndRender` reject the call keeps init
+          // out of the "nothing to send" branch, whose `invalidate()` would add
+          // two outward renders to every mount that has no context — leaving the
+          // auto-extracted path, the one that does need results, untouched.
+          const initialContext = resolveContext();
+          if (initialContext && Object.keys(initialContext).length > 0) {
+            fetchAndRender(null, initOptions);
+          }
         },
 
         render(renderOptions) {

--- a/tests/common/widgets/prompt-suggestions/options.ts
+++ b/tests/common/widgets/prompt-suggestions/options.ts
@@ -354,6 +354,96 @@ export function createOptionsTests(
       );
     });
 
+    test('requests suggestions with an explicit context when no search is triggered', async () => {
+      const searchClient = createResultsClient([
+        { objectID: '1', name: 'Product 1' },
+      ]);
+      const fetchMock = mockAgentFetch();
+      const context = { title: 'A product', brand: 'A brand' };
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+          // The common query gate: a page with no query never searches, so the
+          // widget never gets results. With an explicit `context` the request
+          // does not read them, so it must not wait for them either.
+          searchFunction(helper) {
+            if (helper.state.query) {
+              helper.search();
+            }
+          },
+        },
+        widgetParams: {
+          javascript: {
+            agentId: 'test-agent-id',
+            configurationId: 'prompt-suggestions',
+            context,
+          },
+          react: {
+            agentId: 'test-agent-id',
+            configurationId: 'prompt-suggestions',
+            context,
+          },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(DEBOUNCE_MS + 50);
+      });
+
+      expect(searchClient.search).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0] as unknown as [
+        string,
+        RequestInit,
+      ];
+      expect(JSON.parse(init.body as string).input).toEqual(context);
+
+      const pills = document.querySelectorAll(
+        '.ais-PromptSuggestions-suggestion'
+      );
+      expect(pills).toHaveLength(SUGGESTIONS.length);
+    });
+
+    test('requests nothing without a context when no search is triggered', async () => {
+      const searchClient = createResultsClient([
+        { objectID: '1', name: 'Product 1' },
+      ]);
+      const fetchMock = mockAgentFetch();
+
+      await setup({
+        instantSearchOptions: {
+          indexName: 'indexName',
+          searchClient,
+          searchFunction(helper) {
+            if (helper.state.query) {
+              helper.search();
+            }
+          },
+        },
+        widgetParams: {
+          javascript: {
+            agentId: 'test-agent-id',
+            configurationId: 'prompt-suggestions',
+          },
+          react: {
+            agentId: 'test-agent-id',
+            configurationId: 'prompt-suggestions',
+          },
+          vue: {},
+        },
+      });
+
+      await act(async () => {
+        await wait(DEBOUNCE_MS + 50);
+      });
+
+      // Auto-extraction has nothing to extract from, so nothing goes out.
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     test('sends only the provided context and skips auto-extraction', async () => {
       const searchClient = createResultsClient([
         { objectID: '1', name: 'Product 1' },


### PR DESCRIPTION
**Summary**

The only path that fires a suggestions request is the widget's `render()`, which InstantSearch calls after a search resolves. A page that triggers no search gets no suggestions at all — even with an explicit `context`. That covers a PDP mounting InstantSearch only for the widgets, and the common `searchFunction: (helper) => { if (helper.state.query) helper.search() }` query gate. The widget renders empty and silent, and `refresh()` is no escape hatch: it returned early without results, so on such a mount it was a permanent no-op.

With an explicit `context` the payload never reads the results — `resolvePageContext` returns the context and never touches them — so waiting for a search waits on something the request does not use. The first fetch now goes out on `init()`, and `refresh()` can send without results.

The gate that decides whether there is anything to send now reads the *resolved* context rather than the presence of the option. `context` may be a function, so the option alone says nothing about a given fetch: `context: () => undefined` is gated exactly like an omitted `context` (falling back to auto-extraction, which needs hits), and a context resolving to `{}` sends nothing rather than spending a model call on an empty input.

The auto-extracted path is untouched — it genuinely needs results, so it stays on `render()` and its debounce.

No double request when results do arrive afterwards: the payload ignores them, so the debounced fetch computes a byte-identical payload and the memoization from #7212 skips it.

**Result**

- `connectPromptSuggestions` fetches on `init()` when the context resolves to something non-empty, after the `isFirstRender` render so ordering is unchanged.
- `refresh()` works from `init()` onwards, including on a mount that never produces results.
- A context resolving to `undefined` or `{}` sends nothing, on every path.
- Connector coverage for the init fetch, the function-context and empty-context gates, the no-double-fetch case, render ordering, and both `refresh()` shapes.
- Common-suite coverage behind the `searchFunction` query gate, for both the explicit-context and no-context cases (JS + React).

**Notes**

- Two existing connector tests shifted their call counts by one, since a `context`-carrying widget now makes an attempt at init. Their intent (no skip on an unserializable payload; retry after a failure) is unchanged.
- A previous attempt at this, #7196, bundled the fix with an `autoFetch` option. That option was rejected in favour of payload memoization, which shipped as #7212 — but the init-fetch half went out with the closed branch. This is that half, rebased, without the option.
- Out of scope: a function `context` that is empty at init and becomes non-empty later without any search (a record picker with nothing selected). Nothing re-triggers it, and `refresh` is currently passed to no layout in either flavor. That is FX-3995's surface.

FX-4002 · [repro](https://stackblitz.com/edit/react-aj4sp2dp?file=src%2FApp.js,src%2Findex.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)