### PR TITLE
feat(prompt-suggestions): error when no chat widget is mounted

### DIFF
--- a/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
@@ -763,12 +763,31 @@ const testSetups: TestSetupsMap<TestSuites, 'javascript'> = {
       .start();
   },
   createPromptSuggestionsWidgetTests({ instantSearchOptions, widgetParams }) {
+    // The widget hands clicked suggestions to a `chat` on the same index, and
+    // errors without one, so the default setup mounts both. `renderChat: false`
+    // is how a test asks for the unconfigured page.
+    const { renderChat = true, ...promptSuggestionsWidgetParams } =
+      widgetParams;
+
     instantsearch(instantSearchOptions)
       .addWidgets([
         promptSuggestions({
           container: document.body.appendChild(document.createElement('div')),
-          ...widgetParams,
+          ...promptSuggestionsWidgetParams,
         }),
+        ...(renderChat
+          ? [
+              chat({
+                container: document.body.appendChild(
+                  document.createElement('div')
+                ),
+                // A dedicated id: the `agentId` the chat suites use keys
+                // persisted messages in `localStorage` that leak across tests
+                // in this file.
+                agentId: 'promptSuggestionsChatAgentId',
+              }),
+            ]
+          : []),
       ])
       .on('error', () => {
         /*

--- a/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
+++ b/packages/instantsearch.js/src/__tests__/common-widgets.test.tsx
@@ -782,7 +782,7 @@ const testSetups: TestSetupsMap<TestSuites, 'javascript'> = {
                   document.createElement('div')
                 ),
                 // A dedicated id: the `agentId` the chat suites use keys
-                // persisted messages in `localStorage` that leak across tests
+                // persisted messages in `sessionStorage` that leak across tests
                 // in this file.
                 agentId: 'promptSuggestionsChatAgentId',
               }),

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -1529,6 +1529,88 @@ describe('connectPromptSuggestions', () => {
       expect(initCall.sendToChat('hello')).toBe(false);
     });
 
+    it('withholds sendToChat once the mount window closes with no chat', async () => {
+      const search = createInstantSearch();
+      // No chat in renderState.
+      search.renderState = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      widget.init!(
+        createInitOptions({
+          instantSearchInstance: search,
+          helper: search.helper!,
+        })
+      );
+
+      // A chat further down a React tree is only added after this widget's
+      // `init`, so the handler is still handed out at that point.
+      expect(renderFn.mock.calls[0][0].sendToChat).toEqual(
+        expect.any(Function)
+      );
+
+      // The deferred check has now settled the question: there is no chat, so
+      // there is nothing for a click to reach.
+      await flush(0);
+      widget.render!(
+        createRenderOptions({
+          instantSearchInstance: search,
+          helper: search.helper!,
+          results: makeResults({ query: '' }),
+        })
+      );
+
+      const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      expect(lastCall.sendToChat).toBeUndefined();
+      expect(lastCall.onSuggestionClick).toEqual(expect.any(Function));
+      expect(() => lastCall.onSuggestionClick('try this')).not.toThrow();
+    });
+
+    it('keeps sendToChat when a chat is registered after init', async () => {
+      const sendMessage = jest.fn();
+      const search = createInstantSearch();
+      search.renderState = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const renderFn = jest.fn();
+      const widget = connectPromptSuggestions(renderFn)({
+        agentId: 'a',
+        configurationId: 'prompt-suggestions',
+      });
+      widget.init!(
+        createInitOptions({
+          instantSearchInstance: search,
+          helper: search.helper!,
+        })
+      );
+
+      // The chat lands after `init` but before the deferred check runs.
+      search.renderState = {
+        [search.helper!.state.index]: {
+          chat: { sendMessage, setOpen: jest.fn(), status: 'ready' },
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      await flush(0);
+      widget.render!(
+        createRenderOptions({
+          instantSearchInstance: search,
+          helper: search.helper!,
+          results: makeResults({ query: '' }),
+        })
+      );
+
+      const lastCall = renderFn.mock.calls[renderFn.mock.calls.length - 1][0];
+      expect(lastCall.sendToChat).toEqual(expect.any(Function));
+    });
+
     it('isChatBusy is true while the chat is mid-stream', async () => {
       const search = createInstantSearch();
       search.renderState = {

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -2,6 +2,7 @@ import { isChatBusy as isChatStreaming, openChat } from '../../lib/chat';
 import {
   checkRendering,
   createDocumentationMessageGenerator,
+  defer,
   getRefinements,
   noop,
   warning,
@@ -110,8 +111,16 @@ export type PromptSuggestionsRenderState = {
   error: Error | undefined;
   /** Default click handler, calling `sendToChat(prompt)`. Override via the `onSuggestionClick` prop. */
   onSuggestionClick: (prompt: string) => void;
-  /** Hands the prompt to the `connectChat` widget on the same index. `true` if dispatched, else `false`. */
-  sendToChat: (prompt: string) => boolean;
+  /**
+   * Hands the prompt to the `connectChat` widget on the same index. `true` if
+   * dispatched, else `false`.
+   *
+   * `undefined` once the widget has established that no chat widget is mounted
+   * on the same index — there is nothing to send to. The widget layer treats
+   * that as a misconfiguration unless an `onSuggestionClick` override owns the
+   * click.
+   */
+  sendToChat?: (prompt: string) => boolean;
   /** Imperative refetch that bypasses the debounce. No-op with no results or a fetch in-flight. */
   refresh: () => void;
   /**
@@ -261,6 +270,9 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
       // the widget is unmounted; this guard stops those late callbacks from
       // calling `renderFn` into a torn-down container.
       let disposed = false;
+      // Whether the "is a chat widget mounted on this index?" question has been
+      // settled — see `validateChat`.
+      let hasValidatedChat = false;
       // True between a state-signature change and the debounced refetch that
       // follows it. While pending, the search state has already moved on, so a
       // still-in-flight request from the previous state must not paint its
@@ -301,12 +313,6 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         (prompt: string): boolean => {
           const chatRenderState = getChatRenderState(renderOptions);
           if (!chatRenderState || !chatRenderState.sendMessage) {
-            if (__DEV__) {
-              warning(
-                false,
-                `No chat widget found in render state. Make sure a \`connectChat\` widget is mounted on the same index, or pass an \`onSuggestionClick\` prop to handle the click yourself.`
-              );
-            }
             return false;
           }
           const results =
@@ -467,13 +473,19 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
           : false;
 
         const send = sendToChat(renderOptions);
+        // `sendToChat` is withheld only once the mount window has closed: a chat
+        // widget further down a React tree is added after this widget's `init`,
+        // so until `validateChat` runs its absence is not yet conclusive and
+        // withholding the handler would make a valid setup look broken.
+        const canSendToChat =
+          Boolean(chatRenderState?.sendMessage) || !hasValidatedChat;
 
         return {
           suggestions: transformed,
           isLoading,
           error,
-          onSuggestionClick: send,
-          sendToChat: send,
+          onSuggestionClick: canSendToChat ? send : noop,
+          sendToChat: canSendToChat ? send : undefined,
           refresh,
           isChatBusy,
           widgetParams,
@@ -497,6 +509,22 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         }
         adoptInnerState(renderState);
       };
+
+      // Deferred because a chat widget can be registered after this one: React
+      // adds widgets in mount order, so a `chat` further down the tree only
+      // lands after this widget's `init` has run. Until this closes the window,
+      // `sendToChat` is handed out optimistically.
+      const validateChat = defer((renderOptions: InitOptions) => {
+        if (hasValidatedChat) return;
+        hasValidatedChat = true;
+        if (getChatRenderState(renderOptions)?.sendMessage) return;
+        // A render may already have gone out with the optimistic `sendToChat`;
+        // re-render so the widget layer sees the settled answer. When nothing
+        // has rendered yet, the first results render carries it.
+        if (latestRenderOptions) {
+          renderOutward(latestRenderOptions);
+        }
+      });
 
       let tasksParams: TasksConnectorParams;
       if (agentId) {
@@ -526,11 +554,16 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
 
       return {
         $$type: 'ais.promptSuggestions',
+        // Clicking a suggestion opens the chat, so this widget counts as an
+        // entry point for `connectChat`'s trigger validation.
+        opensChat: true as const,
 
         init(initOptions) {
           const { instantSearchInstance } = initOptions;
 
           tasksWidget.init!(initOptions);
+
+          validateChat(initOptions);
 
           renderFn(
             {
@@ -586,6 +619,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
         dispose(disposeOptions: DisposeOptions) {
           disposed = true;
           clearTimeout(debounceTimer);
+          validateChat.cancel();
           tasksWidget.dispose!(disposeOptions);
           unmountFn();
         },

--- a/packages/instantsearch.js/src/widgets/prompt-suggestions/__tests__/prompt-suggestions.test.tsx
+++ b/packages/instantsearch.js/src/widgets/prompt-suggestions/__tests__/prompt-suggestions.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils/wait';
+import algoliasearchHelper from 'algoliasearch-helper';
+
+import { createSingleSearchResponse } from '../../../../../../tests/mocks/createAPIResponse';
+import { createInstantSearch } from '../../../../test/createInstantSearch';
+import {
+  createDisposeOptions,
+  createInitOptions,
+  createRenderOptions,
+} from '../../../../test/createWidget';
+import promptSuggestions from '../prompt-suggestions';
+
+import type { InstantSearch } from '../../../types';
+import type { SearchResults } from 'algoliasearch-helper';
+
+function makeResults(): SearchResults {
+  const helper = algoliasearchHelper(createSearchClient(), '');
+  return new algoliasearchHelper.SearchResults(helper.state, [
+    createSingleSearchResponse({
+      hits: [{ objectID: '1' }] as unknown as SearchResults['hits'],
+      query: 'q',
+    }),
+  ]);
+}
+
+function withChat(search: InstantSearch) {
+  search.renderState = {
+    [search.helper!.state.index]: {
+      chat: { sendMessage: jest.fn(), setOpen: jest.fn(), status: 'ready' },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('promptSuggestions', () => {
+  it('throws without a `container`', () => {
+    expect(() =>
+      promptSuggestions({
+        // @ts-expect-error
+        container: undefined,
+        agentId: 'a',
+      })
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "The \`container\` option is required.
+
+      See documentation: https://www.algolia.com/doc/api-reference/widgets/prompt-suggestions/js/"
+    `);
+  });
+
+  describe('missing chat widget', () => {
+    it('throws once no chat widget is found on the index', async () => {
+      const search = createInstantSearch();
+      // No chat in renderState.
+      search.renderState = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const widget = promptSuggestions({
+        container: document.createElement('div'),
+        agentId: 'a',
+      });
+
+      widget.init!(
+        createInitOptions({
+          instantSearchInstance: search,
+          helper: search.helper!,
+        })
+      );
+      // The absence is only conclusive once the deferred mount check has run:
+      // a chat can still be registered after this widget's `init`.
+      await wait(0);
+
+      expect(() =>
+        widget.render!(
+          createRenderOptions({
+            instantSearchInstance: search,
+            helper: search.helper!,
+            results: makeResults(),
+          })
+        )
+      ).toThrowErrorMatchingInlineSnapshot(`
+        "No \`chat\` widget is mounted on this index, so there is nothing to send a clicked suggestion to. Mount a \`chat\` widget on the same index, or pass \`onSuggestionClick\` to handle the click yourself.
+
+        See documentation: https://www.algolia.com/doc/api-reference/widgets/prompt-suggestions/js/"
+      `);
+    });
+
+    it('does not throw while a chat can still be registered', () => {
+      const search = createInstantSearch();
+      search.renderState = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const widget = promptSuggestions({
+        container: document.createElement('div'),
+        agentId: 'a',
+      });
+
+      widget.init!(
+        createInitOptions({
+          instantSearchInstance: search,
+          helper: search.helper!,
+        })
+      );
+
+      // No `wait(0)`: the mount window is still open, so a render here must not
+      // condemn a setup whose chat is further down a React tree.
+      expect(() =>
+        widget.render!(
+          createRenderOptions({
+            instantSearchInstance: search,
+            helper: search.helper!,
+            results: makeResults(),
+          })
+        )
+      ).not.toThrow();
+
+      // The mount check is still pending; unmount so it doesn't fire (and
+      // throw) into the next test.
+      widget.dispose!(createDisposeOptions({ helper: search.helper! }));
+    });
+
+    it('does not throw when an `onSuggestionClick` override owns the click', async () => {
+      const search = createInstantSearch();
+      search.renderState = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const widget = promptSuggestions({
+        container: document.createElement('div'),
+        agentId: 'a',
+        onSuggestionClick: jest.fn(),
+      });
+
+      widget.init!(
+        createInitOptions({
+          instantSearchInstance: search,
+          helper: search.helper!,
+        })
+      );
+      await wait(0);
+
+      expect(() =>
+        widget.render!(
+          createRenderOptions({
+            instantSearchInstance: search,
+            helper: search.helper!,
+            results: makeResults(),
+          })
+        )
+      ).not.toThrow();
+    });
+
+    it('does not throw when a chat widget is mounted', async () => {
+      const search = createInstantSearch();
+      withChat(search);
+
+      const widget = promptSuggestions({
+        container: document.createElement('div'),
+        agentId: 'a',
+      });
+
+      widget.init!(
+        createInitOptions({
+          instantSearchInstance: search,
+          helper: search.helper!,
+        })
+      );
+      await wait(0);
+
+      expect(() =>
+        widget.render!(
+          createRenderOptions({
+            instantSearchInstance: search,
+            helper: search.helper!,
+            results: makeResults(),
+          })
+        )
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/instantsearch.js/src/widgets/prompt-suggestions/prompt-suggestions.tsx
+++ b/packages/instantsearch.js/src/widgets/prompt-suggestions/prompt-suggestions.tsx
@@ -28,6 +28,9 @@ const withUsage = createDocumentationMessageGenerator({
   name: 'prompt-suggestions',
 });
 
+const NO_CHAT_WIDGET_MESSAGE =
+  'No `chat` widget is mounted on this index, so there is nothing to send a clicked suggestion to. Mount a `chat` widget on the same index, or pass `onSuggestionClick` to handle the click yourself.';
+
 const PromptSuggestions = createPromptSuggestionsComponent({
   createElement: h,
   Fragment: 'fragment',
@@ -136,8 +139,17 @@ const createRenderer =
       return;
     }
 
+    if (!sendToChat && !onSuggestionClickOverride) {
+      throw new Error(withUsage(NO_CHAT_WIDGET_MESSAGE));
+    }
+
     const handleClick = onSuggestionClickOverride
-      ? (prompt: string) => onSuggestionClickOverride(prompt, { sendToChat })
+      ? (prompt: string) =>
+          onSuggestionClickOverride(prompt, {
+            // `sendToChat` is only absent when the override above owns the
+            // click, in which case falling through to the chat is a no-op.
+            sendToChat: sendToChat ?? (() => false),
+          })
       : onSuggestionClick;
 
     if (templates?.layout) {

--- a/packages/react-instantsearch/src/__tests__/common-widgets.test.tsx
+++ b/packages/react-instantsearch/src/__tests__/common-widgets.test.tsx
@@ -465,7 +465,7 @@ const testSetups: TestSetupsMap<TestSuites, 'react'> = {
         <PromptSuggestions {...promptSuggestionsWidgetParams} />
         {/*
           A dedicated id: the `agentId` the chat suites use keys persisted
-          messages in `localStorage` that leak across tests in this file.
+          messages in `sessionStorage` that leak across tests in this file.
         */}
         {renderChat && <Chat agentId="promptSuggestionsChatAgentId" />}
         <GlobalErrorSwallower />

--- a/packages/react-instantsearch/src/__tests__/common-widgets.test.tsx
+++ b/packages/react-instantsearch/src/__tests__/common-widgets.test.tsx
@@ -454,9 +454,20 @@ const testSetups: TestSetupsMap<TestSuites, 'react'> = {
     );
   },
   createPromptSuggestionsWidgetTests({ instantSearchOptions, widgetParams }) {
+    // The widget hands clicked suggestions to a <Chat> on the same index, and
+    // errors without one, so the default setup renders both. `renderChat: false`
+    // is how a test asks for the unconfigured page.
+    const { renderChat = true, ...promptSuggestionsWidgetParams } =
+      widgetParams;
+
     render(
       <InstantSearch {...instantSearchOptions}>
-        <PromptSuggestions {...widgetParams} />
+        <PromptSuggestions {...promptSuggestionsWidgetParams} />
+        {/*
+          A dedicated id: the `agentId` the chat suites use keys persisted
+          messages in `localStorage` that leak across tests in this file.
+        */}
+        {renderChat && <Chat agentId="promptSuggestionsChatAgentId" />}
         <GlobalErrorSwallower />
       </InstantSearch>
     );

--- a/packages/react-instantsearch/src/widgets/PromptSuggestions.tsx
+++ b/packages/react-instantsearch/src/widgets/PromptSuggestions.tsx
@@ -82,8 +82,19 @@ export function PromptSuggestions({
     }
   );
 
+  if (!sendToChat && !onSuggestionClickOverride) {
+    throw new Error(
+      'No <Chat> widget is mounted on this index, so there is nothing to send a clicked suggestion to. Mount a <Chat> on the same index, or pass `onSuggestionClick` to handle the click yourself.'
+    );
+  }
+
   const handleClick = onSuggestionClickOverride
-    ? (prompt: string) => onSuggestionClickOverride(prompt, { sendToChat })
+    ? (prompt: string) =>
+        onSuggestionClickOverride(prompt, {
+          // `sendToChat` is only absent when the override above owns the click,
+          // in which case falling through to the chat is a no-op.
+          sendToChat: sendToChat ?? (() => false),
+        })
     : onSuggestionClick;
 
   if (LayoutComponent) {

--- a/packages/react-instantsearch/src/widgets/__tests__/PromptSuggestions.test.tsx
+++ b/packages/react-instantsearch/src/widgets/__tests__/PromptSuggestions.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment @instantsearch/testutils/jest-environment-jsdom.ts
+ */
+
+import { createSearchClient } from '@instantsearch/mocks';
+import { InstantSearchTestWrapper } from '@instantsearch/testutils';
+import { wait } from '@instantsearch/testutils/wait';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+
+import { Chat } from '../Chat';
+import { PromptSuggestions } from '../PromptSuggestions';
+
+describe('PromptSuggestions', () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    // React logs every error thrown from a render, on top of rethrowing it.
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  describe('missing Chat widget', () => {
+    it('throws once no <Chat> is found on the index', async () => {
+      const searchClient = createSearchClient({});
+
+      await expect(async () => {
+        render(
+          <InstantSearchTestWrapper searchClient={searchClient}>
+            <PromptSuggestions
+              agentId="agentId"
+              configurationId="prompt-suggestions"
+            />
+          </InstantSearchTestWrapper>
+        );
+
+        // The absence is only conclusive once the deferred mount check has run:
+        // a <Chat> further down the tree is only added after this widget's
+        // `init`.
+        await act(async () => {
+          await wait(0);
+        });
+      }).rejects.toThrow(/No <Chat> widget is mounted on this index/);
+    });
+
+    it('renders when a <Chat> is mounted on the same index', async () => {
+      const searchClient = createSearchClient({});
+
+      render(
+        <InstantSearchTestWrapper searchClient={searchClient}>
+          <PromptSuggestions
+            agentId="agentId"
+            configurationId="prompt-suggestions"
+          />
+          <Chat agentId="agentId" />
+        </InstantSearchTestWrapper>
+      );
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(
+        document.querySelector('.ais-PromptSuggestions')
+      ).toBeInTheDocument();
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    it('renders when an `onSuggestionClick` override owns the click', async () => {
+      const searchClient = createSearchClient({});
+
+      render(
+        <InstantSearchTestWrapper searchClient={searchClient}>
+          <PromptSuggestions
+            agentId="agentId"
+            configurationId="prompt-suggestions"
+            onSuggestionClick={() => {}}
+          />
+        </InstantSearchTestWrapper>
+      );
+
+      await act(async () => {
+        await wait(0);
+      });
+
+      expect(
+        document.querySelector('.ais-PromptSuggestions')
+      ).toBeInTheDocument();
+      expect(consoleError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/common/widgets/autocomplete/templates.tsx
+++ b/tests/common/widgets/autocomplete/templates.tsx
@@ -29,6 +29,13 @@ export function createTemplatesTests(
   { act }: Required<TestOptions>
 ) {
   describe('templates', () => {
+    afterEach(() => {
+      // Two tests below stub `Storage.prototype.getItem` to seed recent
+      // searches. Left in place it answers every later storage read in the file
+      // — including another widget's persisted state — with recent searches.
+      jest.restoreAllMocks();
+    });
+
     test('renders indices headers', async () => {
       const searchClient = createMockedSearchClient(
         createMultiSearchResponse(

--- a/tests/common/widgets/prompt-suggestions/index.ts
+++ b/tests/common/widgets/prompt-suggestions/index.ts
@@ -11,8 +11,9 @@ import type { PromptSuggestionsProps } from 'react-instantsearch';
 type JSBaseWidgetParams = Parameters<PromptSuggestionsWidget>[0];
 /**
  * Whether the setup also mounts a `chat` widget on the index. `true` by
- * default: without one the widget errors, since a clicked suggestion has
- * nowhere to go.
+ * default: with no chat and no `onSuggestionClick` override the widget errors,
+ * since a clicked suggestion has nowhere to go. Set it to `false` for a test
+ * that passes its own `onSuggestionClick`, or one that asserts the error.
  */
 type ChatPresenceParams = { renderChat?: boolean };
 

--- a/tests/common/widgets/prompt-suggestions/index.ts
+++ b/tests/common/widgets/prompt-suggestions/index.ts
@@ -9,12 +9,21 @@ import type { PromptSuggestionsWidget } from 'instantsearch.js/es/widgets/prompt
 import type { PromptSuggestionsProps } from 'react-instantsearch';
 
 type JSBaseWidgetParams = Parameters<PromptSuggestionsWidget>[0];
+/**
+ * Whether the setup also mounts a `chat` widget on the index. `true` by
+ * default: without one the widget errors, since a clicked suggestion has
+ * nowhere to go.
+ */
+type ChatPresenceParams = { renderChat?: boolean };
+
 export type JSPromptSuggestionsWidgetParams = Omit<
   JSBaseWidgetParams,
   'container'
 > &
-  PromptSuggestionsConnectorParams;
-export type ReactPromptSuggestionsWidgetParams = PromptSuggestionsProps;
+  PromptSuggestionsConnectorParams &
+  ChatPresenceParams;
+export type ReactPromptSuggestionsWidgetParams = PromptSuggestionsProps &
+  ChatPresenceParams;
 
 type PromptSuggestionsWidgetParams = {
   javascript: JSPromptSuggestionsWidgetParams;
@@ -38,6 +47,10 @@ export function createPromptSuggestionsWidgetTests(
 ) {
   beforeEach(() => {
     document.body.innerHTML = '';
+    // The setup mounts a `chat` alongside the widget, and a chat restores its
+    // conversation from `sessionStorage`: without this it inherits whatever the
+    // chat suites left behind in the same file.
+    sessionStorage.clear();
   });
 
   skippableDescribe(

--- a/tests/common/widgets/prompt-suggestions/options.ts
+++ b/tests/common/widgets/prompt-suggestions/options.ts
@@ -496,7 +496,10 @@ export function createOptionsTests(
       expect(document.body.textContent).toContain('Custom Suggestion A');
     });
 
-    test('runs the onSuggestionClick override when a pill is clicked', async () => {
+    // An `onSuggestionClick` override owns the click, so this setup needs no
+    // chat widget — and must not be reported as the misconfigured page that
+    // renders pills leading nowhere.
+    test('runs the onSuggestionClick override when a pill is clicked, with no chat widget mounted', async () => {
       const searchClient = createResultsClient([
         { objectID: '1', name: 'Product 1' },
       ]);
@@ -510,11 +513,13 @@ export function createOptionsTests(
             agentId: 'test-agent-id',
             configurationId: 'prompt-suggestions',
             onSuggestionClick,
+            renderChat: false,
           },
           react: {
             agentId: 'test-agent-id',
             configurationId: 'prompt-suggestions',
             onSuggestionClick,
+            renderChat: false,
           },
           vue: {},
         },


### PR DESCRIPTION
**Summary**

FX-4003. A page with `promptSuggestions` but no `chat` widget on the same index renders pills that look clickable and lead nowhere.

`connectPromptSuggestions` now exposes `sendToChat` as optional and withholds it once it has established that no chat is mounted on the index (`onSuggestionClick` falls back to a no-op). Both flavors' widgets throw on that state unless an `onSuggestionClick` override owns the click, which is the supported chat-less setup.

The check is deferred from `init`, mirroring `connectChat`'s entry-point validation: React adds widgets in mount order, so a `<Chat>` further down the tree only lands after this widget's `init`, and until the window closes `sendToChat` is handed out optimistically. A server render never closes the window, so it never throws.

The connector's widget also carries `opensChat: true`: a suggestion click opens the chat, so a `chat` + `promptSuggestions` page no longer warns that the chat has no way to be opened.

Two test-side changes come with it:

- The shared `promptSuggestions` setups mount a `chat` alongside the widget, with `renderChat: false` for the tests that want the unconfigured page.
- `tests/common/widgets/autocomplete/templates.tsx` stubs `Storage.prototype.getItem` to seed recent searches; it now restores it, so the stub stops answering every later storage read in the file — including another widget's persisted state.

**Result**

```
yarn jest common-widgets common-connectors    # 6 suites, 1111 passed
yarn jest packages/instantsearch.js/src/connectors/prompt-suggestions   # 48 passed
yarn jest packages/instantsearch.js/src/widgets/prompt-suggestions      # 5 passed
yarn jest packages/react-instantsearch/src/widgets/__tests__/PromptSuggestions.test.tsx   # 3 passed
yarn lint:changed                             # 0 errors
```

New coverage: connector-level tests that `sendToChat` is withheld once the mount window closes with no chat and kept when a chat is registered after `init`; per-flavor widget tests for the throw, for the still-open mount window, for the `onSuggestionClick` override, and for a mounted chat; the cross-flavor override test now runs with no chat mounted.

`yarn type-check` and `packages/instantsearch-ui-components/__tests__/types.test.ts` fail identically on `master` (stale `dist` types for Chat reasoning) — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
