### PR TITLE
fix(chat): render failed tools by default

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -609,7 +609,14 @@ export function createChatMessageComponent({
           }
 
           if (!ToolLayoutComponent) {
-            return null;
+            return toolMessage.state === 'output-error' ? (
+              <div
+                key={`${message.id}-${index}`}
+                className="ais-ChatMessage-tool ais-ChatMessage-toolError"
+              >
+                {toolMessage.errorText || 'Tool call failed.'}
+              </div>
+            ) : null;
           }
 
           const toolSendEvent = tool.sendEvent || (() => {});

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -1835,6 +1835,69 @@ describe('ChatMessage', () => {
     `);
   });
 
+  test('renders a default tool error only when no custom layout exists', () => {
+    const layoutComponent = jest.fn(() => (
+      <div className="custom-tool">Custom tool error</div>
+    ));
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={{
+          role: 'assistant',
+          id: '1',
+          parts: [
+            {
+              type: 'tool-default',
+              toolCallId: 'default',
+              input: {},
+              state: 'output-error',
+              errorText: 'The operation may have completed.',
+            },
+            {
+              type: 'tool-custom',
+              toolCallId: 'custom',
+              input: {},
+              state: 'output-error',
+              errorText: 'This should be handled by the custom layout.',
+            },
+          ],
+        }}
+        context={createContext({
+          tools: {
+            default: {
+              addToolResult: jest.fn(),
+              applyFilters: jest.fn(),
+            },
+            custom: {
+              layoutComponent,
+              addToolResult: jest.fn(),
+              applyFilters: jest.fn(),
+            },
+          },
+        })}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessage-toolError')
+    ).toHaveTextContent('The operation may have completed.');
+    expect(container.querySelector('.custom-tool')).toHaveTextContent(
+      'Custom tool error'
+    );
+    expect(container).not.toHaveTextContent(
+      'This should be handled by the custom layout.'
+    );
+    expect(layoutComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          message: expect.objectContaining({ state: 'output-error' }),
+        }),
+      }),
+      {}
+    );
+  });
+
   test('passes the explicit messages override to tool components', () => {
     const layoutComponent = jest.fn(({ context }) => (
       <div>{context.messages?.length}</div>


### PR DESCRIPTION
**Summary**

Render `output-error` tool parts with their error message when the tool has no custom layout. Custom layouts and `shouldRender` keep precedence.

Stacked on #7223. Part of FX-3949.

**Example**

Before: a timed-out tool without a layout disappears from the transcript.

After: the transcript shows “The tool call timed out before a result was received. The operation may have completed.”

**Result**

- Shared ChatMessage tests: 54 passed
- JS and React Chat common tests: 226 passed
- `instantsearch-ui-components`, `instantsearch.js`, and `react-instantsearch` builds passed
- Changed-file lint and format checks passed