### PR TITLE
feat(chat): add opt-in failed tool retry

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessage.tsx
@@ -16,7 +16,7 @@ import {
   type ChatMessageReasoningPart,
   type ChatMessageReasoningTranslations,
 } from './ChatMessageReasoning';
-import { MenuIcon } from './icons';
+import { MenuIcon, ReloadIcon } from './icons';
 
 import type {
   AddToolResult,
@@ -83,6 +83,10 @@ export type ChatMessageTranslations = {
    * The label for message actions
    */
   actionsLabel: string;
+  /**
+   * The retry button text for failed tools
+   */
+  toolErrorRetryText?: string;
 } & Partial<ChatMessageReasoningTranslations>;
 
 export type ChatMessageClassNames = {
@@ -372,6 +376,7 @@ export function createChatMessageComponent({
     const translations: Required<ChatMessageTranslations> = {
       messageLabel: 'Message',
       actionsLabel: 'Message actions',
+      toolErrorRetryText: 'Retry',
       reasoningLabel: 'Reasoning',
       ...userTranslations,
     };
@@ -609,14 +614,43 @@ export function createChatMessageComponent({
           }
 
           if (!ToolLayoutComponent) {
-            return toolMessage.state === 'output-error' ? (
+            if (toolMessage.state !== 'output-error') {
+              return null;
+            }
+
+            const messageIndex = messages.findIndex(
+              (candidate) => candidate.id === message.id
+            );
+            const canRetry =
+              tool.retryOnError === true &&
+              Boolean(tool.onToolCall) &&
+              status === 'ready' &&
+              messageIndex >= 0 &&
+              !messages
+                .slice(messageIndex + 1)
+                .some((candidate) => candidate.role === 'user');
+
+            return (
               <div
                 key={`${message.id}-${index}`}
                 className="ais-ChatMessage-tool ais-ChatMessage-toolError"
               >
-                {toolMessage.errorText || 'Tool call failed.'}
+                <span className="ais-ChatMessage-toolError-message">
+                  {toolMessage.errorText || 'Tool call failed.'}
+                </span>
+                {canRetry && (
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    className="ais-ChatMessage-toolError-action"
+                    onClick={() => context.onReload(message.id)}
+                  >
+                    <ReloadIcon createElement={createElement} />
+                    {translations.toolErrorRetryText}
+                  </Button>
+                )}
               </div>
-            ) : null;
+            );
           }
 
           const toolSendEvent = tool.sendEvent || (() => {});

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -1866,6 +1866,7 @@ describe('ChatMessage', () => {
         context={createContext({
           tools: {
             default: {
+              onToolCall: jest.fn(),
               addToolResult: jest.fn(),
               applyFilters: jest.fn(),
             },
@@ -1944,6 +1945,48 @@ describe('ChatMessage', () => {
 
     expect(onReload).toHaveBeenCalledWith('assistant-1');
   });
+
+  test.each(['submitted', 'streaming', 'error'] as const)(
+    'does not offer retry while the chat status is %s',
+    (status) => {
+      const message: ChatMessageBase = {
+        role: 'assistant',
+        id: 'assistant-1',
+        parts: [
+          {
+            type: 'tool-save',
+            toolCallId: 'call-1',
+            input: {},
+            state: 'output-error',
+            errorText: 'The operation may have completed.',
+          },
+        ],
+      };
+      const { container } = render(
+        <ChatMessage
+          indexUiState={{}}
+          setIndexUiState={jest.fn()}
+          message={message}
+          context={createContext({
+            messages: [message],
+            status,
+            tools: {
+              save: {
+                retryOnError: true,
+                onToolCall: jest.fn(),
+                addToolResult: jest.fn(),
+                applyFilters: jest.fn(),
+              },
+            },
+          })}
+        />
+      );
+
+      expect(
+        container.querySelector('.ais-ChatMessage-toolError-action')
+      ).toBeNull();
+    }
+  );
 
   test('does not offer retry after a later user message', () => {
     const message: ChatMessageBase = {

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessage.test.tsx
@@ -1896,6 +1896,98 @@ describe('ChatMessage', () => {
       }),
       {}
     );
+    expect(
+      container.querySelector('.ais-ChatMessage-toolError-action')
+    ).toBeNull();
+  });
+
+  test('reloads a failed tool response when retry is enabled', async () => {
+    const message: ChatMessageBase = {
+      role: 'assistant',
+      id: 'assistant-1',
+      parts: [
+        {
+          type: 'tool-save',
+          toolCallId: 'call-1',
+          input: {},
+          state: 'output-error',
+          errorText: 'The operation may have completed.',
+        },
+      ],
+    };
+    const onReload = jest.fn();
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={message}
+        translations={{ toolErrorRetryText: 'Try again' }}
+        context={createContext({
+          messages: [message],
+          onReload,
+          tools: {
+            save: {
+              retryOnError: true,
+              onToolCall: jest.fn(),
+              addToolResult: jest.fn(),
+              applyFilters: jest.fn(),
+            },
+          },
+        })}
+      />
+    );
+
+    const retry = container.querySelector('.ais-ChatMessage-toolError-action')!;
+    expect(retry).toHaveTextContent('Try again');
+
+    await userEvent.click(retry);
+
+    expect(onReload).toHaveBeenCalledWith('assistant-1');
+  });
+
+  test('does not offer retry after a later user message', () => {
+    const message: ChatMessageBase = {
+      role: 'assistant',
+      id: 'assistant-1',
+      parts: [
+        {
+          type: 'tool-save',
+          toolCallId: 'call-1',
+          input: {},
+          state: 'output-error',
+          errorText: 'The operation may have completed.',
+        },
+      ],
+    };
+    const { container } = render(
+      <ChatMessage
+        indexUiState={{}}
+        setIndexUiState={jest.fn()}
+        message={message}
+        context={createContext({
+          messages: [
+            message,
+            {
+              role: 'user',
+              id: 'user-2',
+              parts: [{ type: 'text', text: 'What happened?' }],
+            },
+          ],
+          tools: {
+            save: {
+              retryOnError: true,
+              onToolCall: jest.fn(),
+              addToolResult: jest.fn(),
+              applyFilters: jest.fn(),
+            },
+          },
+        })}
+      />
+    );
+
+    expect(
+      container.querySelector('.ais-ChatMessage-toolError-action')
+    ).toBeNull();
   });
 
   test('passes the explicit messages override to tool components', () => {

--- a/packages/instantsearch-ui-components/src/components/chat/types.ts
+++ b/packages/instantsearch-ui-components/src/components/chat/types.ts
@@ -817,6 +817,16 @@ export type ClientSideTool = {
    */
   timeout?: number | false;
   /**
+   * Whether the default failed state shows a retry action.
+   *
+   * Retrying regenerates the assistant response and may execute the tool
+   * again. Enable this only when repeating the operation is safe. Custom
+   * layouts can implement recovery with `context.onReload`.
+   *
+   * @default false
+   */
+  retryOnError?: boolean;
+  /**
    * Output reported for this tool call when a request is sent while it is still
    * waiting for a result, for example `{ confirmed: false }` for a confirmation
    * prompt. Without it, the call is reported as failed.

--- a/packages/instantsearch.css/src/components/chat/_chat-message.scss
+++ b/packages/instantsearch.css/src/components/chat/_chat-message.scss
@@ -70,6 +70,17 @@
   display: none;
 }
 
+.ais-ChatMessage-toolError {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: calc(var(--ais-spacing) * 0.5);
+}
+
+.ais-ChatMessage-toolError-action svg {
+  width: calc(var(--ais-icon-size) * 0.8);
+}
+
 .ais-ChatMessage--neutral .ais-ChatMessage-message {
   background-color: rgba(var(--ais-muted-color-rgb), 0.1);
   padding: calc(var(--ais-spacing) * 0.75);

--- a/packages/instantsearch.js/src/widgets/chat/chat.tsx
+++ b/packages/instantsearch.js/src/widgets/chat/chat.tsx
@@ -793,6 +793,7 @@ const createRenderer = <THit extends RecordWithObjectID = RecordWithObjectID>({
       actionsLabel: templates.message?.actionsLabelText,
       messageLabel: templates.message?.messageLabelText,
       reasoningLabel: templates.message?.reasoningLabelText,
+      toolErrorRetryText: templates.message?.toolErrorRetryText,
     });
 
     userMessageTemplateRef.current = prepareTemplateProps({
@@ -1085,6 +1086,10 @@ export type ChatTemplates<THit extends NonNullable<object> = BaseHit> =
        * Label for reasoning disclosures
        */
       reasoningLabelText?: string;
+      /**
+       * Retry button text for failed tools
+       */
+      toolErrorRetryText?: string;
     }>;
 
     /**

--- a/tests/common/widgets/chat/index.ts
+++ b/tests/common/widgets/chat/index.ts
@@ -8,6 +8,7 @@ import { createStreamingTests } from './streaming';
 import { createTemplatesTests } from './templates';
 import { createToolCancellationTests } from './tool-cancellation';
 import { createToolResultTests } from './tool-results';
+import { createToolRetryTests } from './tool-retry';
 import { createTranslationsTests } from './translations';
 
 import type { TestOptions, TestSetup } from '../../common';
@@ -64,6 +65,7 @@ export function createChatWidgetTests(
     createTemplatesTests(setup, { act, skippedTests, flavor });
     createToolCancellationTests(setup, { act, skippedTests, flavor });
     createToolResultTests(setup, { act, skippedTests, flavor });
+    createToolRetryTests(setup, { act, skippedTests, flavor });
     createTranslationsTests(setup, { act, skippedTests, flavor });
   });
 }

--- a/tests/common/widgets/chat/tool-retry.ts
+++ b/tests/common/widgets/chat/tool-retry.ts
@@ -1,0 +1,158 @@
+import { createSearchClient } from '@instantsearch/mocks';
+import { wait } from '@instantsearch/testutils';
+import { waitFor } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
+
+import { openChat } from './utils';
+
+import type { ChatWidgetSetup } from '.';
+import type { TestOptions } from '../../common';
+import type {
+  HttpChatTransportInitOptions,
+  UIMessage,
+  UIMessageChunk,
+} from 'instantsearch.js/es/lib/ai-lite';
+import type { Tool } from 'instantsearch.js/es/widgets/chat/chat';
+
+function chunksToResponse(chunks: UIMessageChunk[]): Response {
+  return new Response(
+    `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join('')}data: [DONE]\n\n`,
+    { headers: { 'Content-Type': 'text/event-stream' } }
+  );
+}
+
+const toolCallChunks = (
+  messageId: string,
+  toolCallId: string
+): UIMessageChunk[] => [
+  { type: 'start', messageId },
+  {
+    type: 'tool-input-available',
+    toolName: 'save',
+    toolCallId,
+    input: { value: 'remember me' },
+  },
+  { type: 'finish' },
+];
+
+const textChunks = (messageId: string, text: string): UIMessageChunk[] => [
+  { type: 'start', messageId },
+  { type: 'text-start', id: `${messageId}-text` },
+  { type: 'text-delta', id: `${messageId}-text`, delta: text },
+  { type: 'text-end', id: `${messageId}-text` },
+  { type: 'finish' },
+];
+
+export function createToolRetryTests(
+  setup: ChatWidgetSetup,
+  { act }: Required<TestOptions>
+) {
+  describe('tool retry', () => {
+    test('regenerates the response and executes a fresh tool call', async () => {
+      const searchClient = createSearchClient();
+      const responses = [
+        toolCallChunks('assistant-1', 'call-1'),
+        textChunks('assistant-2', 'Please check whether the save completed.'),
+        toolCallChunks('assistant-3', 'call-2'),
+        textChunks('assistant-4', 'The save completed.'),
+      ];
+      const fetchMock = jest.fn(() =>
+        Promise.resolve(chunksToResponse(responses.shift()!))
+      );
+      const prepareRequest: NonNullable<
+        HttpChatTransportInitOptions<UIMessage>['prepareSendMessagesRequest']
+      > = ({ id, messages, trigger, messageId }) => ({
+        body: { id, messages, trigger, messageId },
+      });
+      const prepareSendMessagesRequest = jest.fn(prepareRequest);
+      const transport: HttpChatTransportInitOptions<UIMessage> = {
+        api: '/api',
+        fetch: fetchMock,
+        prepareSendMessagesRequest,
+      };
+      const executeTool: NonNullable<Tool['onToolCall']> = ({
+        toolCallId,
+        addToolResult,
+      }) => {
+        if (toolCallId === 'call-1') {
+          throw new Error('The save may have completed.');
+        }
+        return addToolResult({ output: { saved: true } });
+      };
+      const onToolCall = jest.fn(executeTool);
+
+      await setup({
+        instantSearchOptions: { indexName: 'indexName', searchClient },
+        widgetParams: {
+          javascript: {
+            transport,
+            persistence: false,
+            tools: {
+              save: {
+                retryOnError: true,
+                onToolCall,
+                templates: {},
+              },
+            },
+          },
+          react: {
+            transport,
+            persistence: false,
+            tools: {
+              save: {
+                retryOnError: true,
+                onToolCall,
+              },
+            },
+          },
+          vue: {},
+        },
+      });
+
+      await openChat(act);
+
+      userEvent.type(
+        document.querySelector('.ais-ChatPrompt-textarea')!,
+        'Save this'
+      );
+      userEvent.click(document.querySelector('.ais-ChatPrompt-submit')!);
+
+      await waitFor(() => {
+        expect(onToolCall).toHaveBeenCalledTimes(1);
+        expect(
+          document.querySelector('.ais-ChatMessage-toolError-action')
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        userEvent.click(
+          document.querySelector('.ais-ChatMessage-toolError-action')!
+        );
+        await wait(0);
+      });
+
+      await waitFor(() => {
+        expect(onToolCall).toHaveBeenCalledTimes(2);
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+        expect(
+          document.querySelector('.ais-ChatMessages')!.textContent
+        ).toContain('The save completed.');
+      });
+
+      expect(onToolCall.mock.calls.map(([call]) => call.toolCallId)).toEqual([
+        'call-1',
+        'call-2',
+      ]);
+      expect(
+        prepareSendMessagesRequest.mock.calls.map(
+          ([request]) => request.trigger
+        )
+      ).toEqual([
+        'submit-message',
+        'submit-message',
+        'regenerate-message',
+        'submit-message',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
**Summary**

Add an opt-in Retry action to the default failed-tool state with `retryOnError: true`. Retrying regenerates the failed assistant response, producing a fresh tool call that uses the existing timeout and abort lifecycle instead of reopening a terminal call.

The option defaults to false because the original write may already have completed. The action is hidden after a later user message to avoid discarding subsequent conversation, and custom layouts retain control through `context.onReload`.

Stacked on #7226. Part of FX-3949.

**Example**

```js
tools: {
  save: {
    retryOnError: true,
    onToolCall,
  },
}
```

A failed `save` tool now displays its uncertainty message with a visible Retry button. Clicking it regenerates that assistant turn and may execute `save` again.

**Result**

- Shared ChatMessage tests: 56 passed
- JS and React Chat common tests: 226 passed
- Chat CSS tests: 2 passed
- `instantsearch-ui-components`, `instantsearch.css`, `instantsearch.js`, and `react-instantsearch` builds passed
- Changed-file lint and format checks passed