### PR TITLE
fix(prompt-suggestions): send raw prompt to chat

### DIFF
--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts
@@ -1585,11 +1585,9 @@ describe('connectPromptSuggestions', () => {
       lastCall.onSuggestionClick('try this');
 
       expect(setOpen).toHaveBeenCalledWith(true);
-      // The raw suggestion is wrapped in a grounding prompt, and the page
-      // context is attached as a flat `turnContext` (hitsSample serialized).
       expect(sendMessage).toHaveBeenCalledWith(
         {
-          text: expect.stringContaining('Suggestion: try this'),
+          text: 'try this',
           metadata: {
             turnContext: {
               hitsSample: JSON.stringify([

--- a/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
+++ b/packages/instantsearch.js/src/connectors/prompt-suggestions/connectPromptSuggestions.ts
@@ -80,10 +80,6 @@ function taskPayloadKey(payload: Record<string, unknown>): string | null {
   }
 }
 
-function buildSuggestionMessage(suggestion: string): string {
-  return `The user clicked this on-page suggestion. Use the current page context first, then search only if needed.\n\nSuggestion: ${suggestion}`;
-}
-
 /** Custom transport for the task request. Alias of the generic `TaskTransportOptions`, kept for API stability. */
 export type PromptSuggestionsTransport = TaskTransportOptions;
 
@@ -329,7 +325,7 @@ const connectPromptSuggestions: PromptSuggestionsConnector =
             ('results' in renderOptions ? renderOptions.results : null) ??
             null;
           return openChat(chatRenderState, {
-            message: buildSuggestionMessage(prompt),
+            message: prompt,
             referer: 'prompt-suggestions-widget',
             turnContext: buildTurnContext(results),
           });


### PR DESCRIPTION
**Summary**

Fixes [FX-4005](https://algolia.atlassian.net/browse/FX-4005).

Prompt Suggestions now sends the selected prompt verbatim to Chat while preserving its page `turnContext` and `x-algolia-referer` attribution. This prevents the internal handoff instruction from appearing in the shopper's user message.

**Result**

- `yarn jest packages/instantsearch.js/src/connectors/prompt-suggestions/__tests__/connectPromptSuggestions-test.ts --runInBand --watchman=false` (57 tests passed)
- `yarn lint:changed`

[FX-4005]: https://algolia.atlassian.net/browse/FX-4005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ