### PR TITLE
fix(chat): hide suggestions until response finishes

### DIFF
--- a/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/ChatMessages.tsx
@@ -315,8 +315,7 @@ export type ChatMessagesProps<
    */
   suggestionsElement?: VNode;
   /**
-   * Whether the suggestions for the current turn are still on their way. Mounts
-   * `suggestionsElement` early so it can render its own loading state.
+   * Whether the suggestions for the current turn are still on their way.
    */
   suggestionsLoading?: boolean;
   /**
@@ -933,21 +932,13 @@ export function createChatMessagesComponent({
       />
     ) : undefined;
 
-    // Waits for the answer's text and for the loader to step aside, so two
-    // progress affordances never stack up.
-    const showPendingSuggestions =
-      suggestionsLoading &&
-      !showLoader &&
-      lastMessage !== undefined &&
-      hasTextContent(lastMessage);
-
     return (
       <div
         {...props}
         className={cx(cssClasses.root, props.className)}
         role="log"
         aria-live="polite"
-        aria-busy={isProcessing ? 'true' : undefined}
+        aria-busy={isProcessing || suggestionsLoading ? 'true' : undefined}
       >
         <div className={cx(cssClasses.scroll)} ref={scrollRef}>
           <div
@@ -998,7 +989,7 @@ export function createChatMessagesComponent({
                 messageTranslations={messageTranslations}
                 context={context}
                 suggestionsElement={
-                  (status === 'ready' || showPendingSuggestions) &&
+                  status === 'ready' &&
                   message.role === 'assistant' &&
                   index === messages.length - 1
                     ? suggestionsElement

--- a/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
+++ b/packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx
@@ -2264,7 +2264,7 @@ describe('ChatMessages', () => {
     });
   });
 
-  describe('pending suggestions', () => {
+  describe('suggestions visibility', () => {
     const baseProps = {
       indexUiState: {},
       setIndexUiState: jest.fn(),
@@ -2287,8 +2287,8 @@ describe('ChatMessages', () => {
       },
     ];
 
-    test('mounts the suggestions element before the turn settles', () => {
-      const { container } = render(
+    test('waits for the turn to settle before mounting suggestions', () => {
+      const { container, rerender } = render(
         <ChatMessages
           {...baseProps}
           status="streaming"
@@ -2298,21 +2298,18 @@ describe('ChatMessages', () => {
         />
       );
 
-      expect(container.querySelector('.suggestions')).not.toBeNull();
-    });
+      expect(container.querySelector('.suggestions')).toBeNull();
 
-    test('waits for the answer to have text', () => {
-      const { container } = render(
+      rerender(
         <ChatMessages
           {...baseProps}
-          status="streaming"
-          messages={[{ role: 'assistant', id: '1', parts: [] }]}
-          suggestionsLoading
+          status="ready"
+          messages={answered}
           suggestionsElement={<span className="suggestions" />}
         />
       );
 
-      expect(container.querySelector('.suggestions')).toBeNull();
+      expect(container.querySelector('.suggestions')).not.toBeNull();
     });
   });
 

--- a/tests/common/widgets/chat/options.tsx
+++ b/tests/common/widgets/chat/options.tsx
@@ -1321,7 +1321,7 @@ export function createOptionsTests(
     });
 
     describe('suggestions', () => {
-      test('holds placeholders until the turn produces its suggestions', async () => {
+      test('shows suggestions after the turn settles', async () => {
         const searchClient = createSearchClient();
         const chat = new Chat({});
 
@@ -1366,8 +1366,8 @@ export function createOptionsTests(
         });
 
         expect(
-          document.querySelector('.ais-ChatPromptSuggestions-skeletonItem')
-        ).toBeInTheDocument();
+          document.querySelector('.ais-ChatPromptSuggestions')
+        ).not.toBeInTheDocument();
 
         await act(async () => {
           chat._state.messages = [


### PR DESCRIPTION
**Summary**

Hide prompt suggestion placeholders while the assistant response is streaming. Suggestions are mounted only after the turn reaches `ready`, keeping the response as the sole loading affordance.

https://github.com/user-attachments/assets/e697c4da-8248-478a-bdd0-7190ab62da6d

**Result**

- `yarn jest packages/instantsearch-ui-components/src/components/chat/__tests__/ChatMessages.test.tsx packages/instantsearch-ui-components/src/components/chat/__tests__/Chat.test.tsx --runInBand --watchman=false`
- `yarn lint:changed`
- Built `instantsearch-ui-components` and `instantsearch.js`